### PR TITLE
micronaut: update to 5.0.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.0.1 v
+github.setup    micronaut-projects micronaut-starter 5.0.2 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  2a58f254b042755c19b0ef336c7cb93b244f33ec \
-                 sha256  4152cfb1d7e515fb551e7f2b663e50d3bc2c5f79614220ac1b9d10756d4dbb89 \
-                 size    33764815
+    checksums    rmd160  c9ab8d59c0854c2349a34ae141d9a08cd6fffdd4 \
+                 sha256  c9fce15598a2f38afa62f632e92d370d25fed6f22b4f9a64334208b9bfeb36fb \
+                 size    33773853
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  a1850552a37392368a196dc1888fb3f35281ab03 \
-                 sha256  8b8cb1fcefed1f443cfe358e43320c9f3432755e83006aef60c74dd88aba32c1 \
-                 size    38508889
+    checksums    rmd160  0c4992fac04ed896f1ba3b6cc702f76a26b5328e \
+                 sha256  e5b85f3787526145d6a0ef9e58cb3b775288c68678accbd2159d77b207978e11 \
+                 size    38528422
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.0.2.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?