### PR TITLE
skaffold: update to 2.22.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.21.0 v
+github.setup        GoogleContainerTools skaffold 2.22.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  9f0adffb8cb13f51796a5fa3238126cb18cc9bca \
-                    sha256  fb53efc2f4aad693b61ca3b732f8bc8315495bfdf8ca959b32f0ee16f6521f86 \
-                    size    63760636
+checksums           rmd160  36a93446292d2281686f80e8640dfd7178710dcc \
+                    sha256  fd8b34970c3230df8fce5358f5e0c6ee74f892659a7fea4b2bdc135f46b22eef \
+                    size    75000387
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.22.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?