### PR TITLE
ImageMagick7: Update to 7.1.2.25

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -11,7 +11,6 @@ legacysupport.newest_darwin_requires_legacy 10
 ###### OBSOLETE NOTE FROM IM6:
 # Keep relevant lines in sync between ImageMagick and p5-perlmagick.
 
-###### OBSOLETE NOTE FROM IM6:
 # Before updating to a newer version, install phpNN-imagick.
 # After updating, run `phpNN -v`.
 # If the following warning appears, revbump php-imagick.
@@ -20,12 +19,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-version             7.1.2-21
+version             7.1.2-25
 revision            0
 use_xz              yes
-checksums           rmd160  df0be725bb58029e150d6e8652c0be4d21389c77 \
-                    sha256  56450bf5d65b63abb09568abb2c40b493ab913418f92df135ed661471da0eb0d \
-                    size    10798804
+checksums           rmd160  391a90d4839dff6b28cd522686357826ec3b5ad9 \
+                    sha256  2b2070802de374871737ff1a516b3d9d1e66643779b7ed9c52e2534db7772006 \
+                    size    10807420
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

* Update ImageMagick7:  7.1.2.21 --> 7.1.2.25.
* Restore comment about rev bumping php-imagick.
* php-imagick was recently switched from IM6 to IM7.

###### Type(s)

###### Tested on

CI only.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?