### PR TITLE
ocaml-lua: update to 1.8

### DIFF
--- a/lang/ocaml-lua/Portfile
+++ b/lang/ocaml-lua/Portfile
@@ -1,12 +1,13 @@
-PortSystem          1.0
-PortGroup           ocaml 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name                ocaml-lua
-version             1.0
-revision            3
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           ocaml 1.1
+
+github.setup        pdonadeo ocaml-lua 1.8 v
+revision            0
 categories          lang devel ocaml
-platforms           darwin
-license             Permissive
+license             MIT
 maintainers         nomaintainer
 description         OCaml bindings to Lua API
 long_description    \
@@ -14,24 +15,24 @@ long_description    \
     application to exchange data with Lua programs and also to extend Lua with \
     OCaml functions.
 
-homepage            http://ocaml-lua.forge.ocamlcore.org/
-master_sites        http://forge.ocamlcore.org/frs/download.php/992/
-distname            ocaml-lua-v1.0
-checksums           rmd160  0e5a9529e99f18f3dbeee572899995cf2c23283b \
-                    sha256  299150ae522e0bdc0d43b4ad10e80d9d90d19572b0afba4040bb47e95ea8486b
+homepage            https://github.com/pdonadeo/ocaml-lua
 
-depends_lib         port:ocaml port:ocaml-findlib port:lua
+github.tarball_from archive
 
-use_oasis           yes
-use_oasis_doc       yes
+checksums           rmd160  7d3722ec9398d87e7ffdf878e3c49586b07a47f9 \
+                    sha256  8f1575411c1db2ed2736846b1b29d6d1b34fe440a81cdb7e0b0c1c7c87534f67 \
+                    size    589247
 
-patch {
-    reinplace "s|-llua|-L${prefix}/lib -llua|g" ${worksrcpath}/myocamlbuild.ml
+ocaml.build_type    dune
+dune.packages       ocaml-lua
+
+# Lua 5.1.5 sources are bundled; extract them before dune builds
+pre-build {
+    system -W ${worksrcpath}/src/lua_c "tar xf lua-5.1.5.tar.gz"
+    system -W ${worksrcpath}/src/lua_c/lua-5.1.5 "patch -p1 -i ../lua.patch"
+    file rename ${worksrcpath}/src/lua_c/lua-5.1.5 ${worksrcpath}/src/lua_c/lua515
 }
 
-configure.args-append "--override docdir ${destroot}${prefix}/share/doc/${name}" --disable-lua51
-
 livecheck.type      regex
-livecheck.url       https://forge.ocamlcore.org/frs/?group_id=167
-livecheck.regex     ocaml-lua-v(\[0-9.\]+)${extract.suffix}
-
+livecheck.url       https://github.com/pdonadeo/ocaml-lua/releases
+livecheck.regex     {v(\d+\.\d+)}


### PR DESCRIPTION
Modernize Portfile to use github and ocaml 1.1 PortGroups, switch to dune build system. Lua 5.1.5 sources are bundled in the distfile.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
