### PR TITLE
vtk: Update to 9.6.2

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -26,15 +26,15 @@ compiler.blacklist-append {clang < 1100}
 # Gitlab instance and VTK custom download page are both Anubis blocked.
 # On Github, only tags are mirrored, not releases.
 
-github.setup        Kitware vtk 9.6.1 v
+github.setup        Kitware vtk 9.6.2 v
 github.tarball_from archive
-revision            2
+revision            0
 categories          graphics devel
 license             BSD
 
-checksums           rmd160  1d40fead9fe3ac94c09a7ec7a4f6a460d7aeaec1 \
-                    sha256  a989db4ed5f7f35948f1f09b816dfcee3cc426f24828a3f94941c5eba8d4297c \
-                    size    54861772
+checksums           rmd160  5b25818b50f7922633ecb8a92de511c8eca189f8 \
+                    sha256  de5c02499c550aa09052b2d5f3823a8cae54c72ce1b0014afcde2dabd8e390ea \
+                    size    54875775
 
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
                     openmaintainer
@@ -51,19 +51,37 @@ mpi.setup
 set proj_version    proj9
 
 depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
+                    port:freetype \
                     port:hdf5 \
+                    port:jsoncpp \
+                    port:libharu \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:libpng \
                     port:libxml2 \
+                    port:lz4 \
+                    port:netcdf \
                     port:${proj_version} \
+                    port:pugixml \
+                    port:sqlite3 \
                     port:tiff \
-                    port:viskores
+                    port:zlib
 
 configure.args-append \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_eigen:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_freetype:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_jsoncpp:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_libharu:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_jpeg:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_png:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libproj:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_lz4:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_netcdf:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_pugixml:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_sqlite:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_tiff:BOOL=ON \
-                    -DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=ON
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_zlib:BOOL=ON
 
 mpi.enforce_variant hdf5
 
@@ -156,7 +174,7 @@ variant qt5 description {Add Qt5 support.} {
 }
 
 # Supported pythons
-set python_versions {310 311 312 313}
+set python_versions {310 311 312 313 314}
 
 foreach pyver ${python_versions} {
     # Conflicting python versions


### PR DESCRIPTION
#### Description

* Update vtk 9.6.1 --> 9.6.2.
* Switch a few more bundled dependencies to external ports.
* Remove viskores dependency.  Not working as expected.  Not needed.
* Add python 314 support.

This is a continuation of broken pull request #32870, which contains previous history.

###### Type(s)

###### Tested on

macOS 15.7.3
Xcode 26.0.1
Command Line Tools 26.0.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `port -s install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?