### PR TITLE
hfd5: Re-enable MPI builds

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -137,7 +137,16 @@ hdf5 has been installed in an unsupported "Experimental" mode due to\
 }
 
 if {[ mpi_variant_isset ]} {
-    configure.args-append       -DHDF5_ENABLE_PARALLEL=ON
+    # -DMPIEXEC_MAX_NUMPROCS=6 sets number of jobs used in 'make check'
+    configure.args-append       -DHDF5_ENABLE_PARALLEL=ON \
+                                -DHDF5_ALLOW_UNSUPPORTED=ON \
+                                -DMPIEXEC_MAX_NUMPROCS=6
+    notes-append {
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+hdf5 has been installed in an unsupported "Experimental" mode due to\
+selecing an MPI variant. Mixing MPI and C++ HDF5 calls is experimental.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    }
 }
 
 if {[variant_isset fortran] && ![fortran_variant_isset]} {


### PR DESCRIPTION
Maintainer update.

No rev-bump as non-default (and previously broken) variant impacted.