### PR TITLE
claude-code: update to 2.1.165

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.162
+version             2.1.165
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  3dbe6e93dd37d0d6c07b18e48fb45b39c7063d74 \
-                 sha256  53f2749bf24e5a80b23b017d0877f61c9894a3c06222141515b37a94c6051d41 \
-                 size    221116432
+    checksums    rmd160  b7694c760922832bef38d662a0ababc391265f67 \
+                 sha256  3cb50cb3c9a065bd2d88250ceb3f2647ce16f89f384dede1f7de2676fa526af0 \
+                 size    222041104
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5e467759cf3bc92d40ddf4f2a1d07b662949e53b \
-                 sha256  2d407dd2a63243ac900f64331589b9fcd29a2159a73289070af685f4085a17d2 \
-                 size    218602272
+    checksums    rmd160  83857adc69d303e889a1ebaa7b3fc7c56c57bd44 \
+                 sha256  19ed536dd0e94dade3f8c49c3c6ddeff22b06f5d5c86b30f1c88eeb9a04f45e5 \
+                 size    219526944
 } else {
     set arch_classifier unsupported_arch
     distfiles
@@ -73,7 +73,7 @@ destroot {
     # Create launch script
     set launch_script [open ${destroot}${prefix}/bin/claude w 0755]
     puts $launch_script "#!/bin/sh"
-    puts $launch_script "DISABLE_UPDATES=1 DISABLE_TELEMETRY=1 ${binary} $@"
+    puts $launch_script "DISABLE_UPDATES=1 DISABLE_TELEMETRY=1 ${binary} \"$@\""
     close $launch_script
 }
 


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.165, and fix argument pass-through from wrapper script.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?