### PR TITLE
py-altair: update to 6.2.1

### DIFF
--- a/python/py-altair/Portfile
+++ b/python/py-altair/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-altair
-version             6.1.0
+version             6.2.1
 revision            0
 
 categories-append   devel graphics
@@ -22,11 +22,13 @@ long_description    {*}${description}
 
 homepage            https://altair-viz.github.io/
 
-checksums           rmd160  bd9c24aba6723acec5fa2c32ed88e2c8ec945324 \
-                    sha256  dda699216cf85b040d968ae5a569ad45957616811e38760a85e5118269daca67 \
-                    size    765519
+checksums           rmd160  4503dad8b51ee761bca00772d72395d76198e76b \
+                    sha256  ca0298fa20b1a4fae22eff8847b95f74912bd90544013ad36af192119883ea64 \
+                    size    766468
 
 if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-versioningit
+
     depends_lib-append  port:py${python.version}-jinja2 \
                         port:py${python.version}-jsonschema \
                         port:py${python.version}-narwhals \


### PR DESCRIPTION
Update `py-altair` from 6.1.0 to 6.2.1.

Upstream release: https://github.com/vega/altair/releases/tag/v6.2.1

Verified locally:
- `port lint --nitpick` passes
- `port test` passes