### PR TITLE
pake: new port

### DIFF
--- a/devel/pake/Portfile
+++ b/devel/pake/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                pake
+version             3.11.7
+revision            0
+
+categories          devel www
+supported_archs     arm64 x86_64
+maintainers         {@Dynoooooo} openmaintainer
+license             MIT
+installs_libs       no
+
+description         Turn any webpage into a desktop app with one command
+long_description    Pake is a command-line tool that packages webpages as \
+                    lightweight desktop applications using Tauri.
+
+homepage            https://github.com/tw93/Pake
+
+npm.rootname        pake-cli
+npm.nodejs_version  22
+npm.version         10
+
+checksums           rmd160  23da594d46017ca1fcea71b3d947749188aedc3c \
+                    sha256  93bdd93ebe316233690dc9eaabe9871db33336f52b26f07e5a487e624cb5c620 \
+                    size    12735334
+
+depends_run-append  path:bin/npm:npm10 \
+                    path:bin/cargo:cargo
+
+post-destroot {
+    set wrapper ${destroot}${prefix}/bin/pake
+    set package_dir ${prefix}/lib/node_modules/${npm.rootname}
+
+    delete ${wrapper}
+
+    set fd [open ${wrapper} w]
+    puts ${fd} "#!/bin/sh"
+    puts ${fd} "set -eu"
+    puts ${fd} "PATH=\"${prefix}/bin:${prefix}/sbin:\${PATH:-/usr/bin:/bin}\""
+    puts ${fd} "export PATH"
+    puts ${fd} ""
+    puts ${fd} "src=\"${package_dir}\""
+    puts ${fd} {base="${PAKE_MACPORTS_HOME:-${HOME}/Library/Application Support/pake-cli}"}
+    puts ${fd} "state=\"\${base}/${version}-93bdd93e\""
+    puts ${fd} ""
+    puts ${fd} {if [ ! -d "${state}" ]; then}
+    puts ${fd} {    parent=$(/usr/bin/dirname "${state}")}
+    puts ${fd} {    /bin/mkdir -p "${parent}"}
+    puts ${fd} {    /bin/rm -rf "${state}.tmp"}
+    puts ${fd} {    /usr/bin/ditto "${src}" "${state}.tmp"}
+    puts ${fd} {    /bin/mv "${state}.tmp" "${state}"}
+    puts ${fd} {fi}
+    puts ${fd} ""
+    puts ${fd} "exec \"${prefix}/bin/node\" \"\${state}/dist/cli.js\" \"\$@\""
+    close ${fd}
+
+    file attributes ${wrapper} -permissions 0755
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 ${destroot}${package_dir}/LICENSE \
+        ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
Adds a new port for Pake 3.11.7, packaged from the pake-cli npm tarball. Tested with port lint --nitpick and port checksum.