### PR TITLE
claude-code: update to 2.1.167

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.165
+version             2.1.167
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  b7694c760922832bef38d662a0ababc391265f67 \
-                 sha256  3cb50cb3c9a065bd2d88250ceb3f2647ce16f89f384dede1f7de2676fa526af0 \
-                 size    222041104
+    checksums    rmd160  c2e13dcd047bf526e23a5fdea05c23dad579f66b \
+                 sha256  a5087977bee95ca84598c8b940fc68165c449722ab410db45f610d148e9c2d0e \
+                 size    222552976
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  83857adc69d303e889a1ebaa7b3fc7c56c57bd44 \
-                 sha256  19ed536dd0e94dade3f8c49c3c6ddeff22b06f5d5c86b30f1c88eeb9a04f45e5 \
-                 size    219526944
+    checksums    rmd160  c9ae1a618316b9a0b820130d0b9e34ae01fbbef8 \
+                 sha256  fb3cbe9200b3eeba7ae06ee43fdb4b4b2b231d5fa8040d0e47954a7f374d1530 \
+                 size    220038816
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.167.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?