### PR TITLE
ocaml-dune: add dune-site subport and integrate dune-site build

### DIFF
--- a/ocaml/ocaml-dune/Portfile
+++ b/ocaml/ocaml-dune/Portfile
@@ -6,6 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-dune
 github.setup        ocaml dune 3.22.2
+revision            2
 categories          ocaml devel
 license             MIT
 maintainers         {landonf @landonf} openmaintainer
@@ -35,6 +36,20 @@ if { ${subport} eq ${name} } {
                         DUNE_CONFIG__COPY_FILE=portable
     }
     build.target        release
+
+    post-build {
+        system -W ${worksrcpath} "./_boot/dune.exe build \
+            @install -p dune,dune-private-libs,dune-site --profile dune-bootstrap"
+    }
+
+    post-destroot {
+        system -W ${worksrcpath} "./_boot/dune.exe install \
+            --destdir ${destroot} \
+            --prefix ${prefix} \
+            --docdir ${prefix}/share/doc \
+            --libdir ${ocaml.package_dir} \
+            dune-private-libs dune-site"
+    }
 }
 
 # See: https://trac.macports.org/ticket/68463
@@ -56,4 +71,17 @@ subport ocaml-dune-build-info {
 
 subport ocaml-xdg {
     ocaml.build_type    dune
+}
+
+subport ocaml-dune-site {
+    depends_lib-append  port:ocaml-dune
+    fetch.type          none
+    extract.suffix
+    patchfiles
+    use_configure       no
+    build               {}
+    destroot            {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}
+        system "touch ${destroot}${prefix}/share/doc/${name}/README"
+    }
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
