### PR TITLE
ImageMagick, p5-perlmagick: Update to 6.9.13-50

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -13,12 +13,12 @@ legacysupport.newest_darwin_requires_legacy 11
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-46
+version                     6.9.13-50
 revision                    0
 
-checksums                   rmd160  1361bb5a5d5b115a1963ba7bad5e771e648dfcad \
-                            sha256  012216e6e20985185922ced98e8e971cc91319e15df154255a49a716b06742d2 \
-                            size    9634252
+checksums                   rmd160  df530172d65e3acf80318ffabc1fa4dd2f8613d3 \
+                            sha256  f45877cb5d758b0460e73435a9fd40b9133c4b02bb48ccfb49bbaccacb9ad13a \
+                            size    9637808
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,12 +7,12 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.13-46
+perl5.setup         PerlMagick 6.9.13-50
 revision            0
 
-checksums           rmd160  1361bb5a5d5b115a1963ba7bad5e771e648dfcad \
-                    sha256  012216e6e20985185922ced98e8e971cc91319e15df154255a49a716b06742d2 \
-                    size    9634252
+checksums           rmd160  df530172d65e3acf80318ffabc1fa4dd2f8613d3 \
+                    sha256  f45877cb5d758b0460e73435a9fd40b9133c4b02bb48ccfb49bbaccacb9ad13a \
+                    size    9637808
 
 set my_name         ImageMagick
 maintainers         {ryandesign @ryandesign}


### PR DESCRIPTION
#### Description

* Update ImageMagick 6.9.13-46 --> 6.9.13-50.
* Keep p5-perlmagick in sync.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?