### PR TITLE
qpid-proton: build as C++17 to fix jsoncpp link failure

### DIFF
--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -8,7 +8,7 @@ PortGroup           cmake 1.1
 github.setup        apache qpid-proton 0.39.0
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            1
+revision            2
 
 description         Qpid Proton is a high-performance, lightweight AMQP \
                     1.0 messaging library.
@@ -36,7 +36,7 @@ depends_lib-append  port:jsoncpp \
 cmake.build_type    RelWithDebInfo
 
 compiler.c_standard    1999
-compiler.cxx_standard  2011
+compiler.cxx_standard  2017
 
 # Enabling lto may break the build, avoid it by default.
 configure.args-append \
@@ -56,6 +56,11 @@ configure.args-append \
 # Revert a breakage caused by this commit:
 # https://github.com/apache/qpid-proton/commit/6f2fdeb633575114c5f92f1387a21eba992b422a
 patchfiles-append   patch-fix-macOS-build.diff
+
+# Build as C++17: jsoncpp (>= 1.9.6) only exports its std::string_view ABI when
+# built as C++17, but qpid-proton 0.39.0 hardcodes C++11, which references the
+# removed const char* Json::Value::get() overloads and fails to link.
+patchfiles-append   patch-cxx17-jsoncpp.diff
 
 test.cmd            ${filespath}/runtests.sh
 test.run            yes                                                 

--- a/net/qpid-proton/files/patch-cxx17-jsoncpp.diff
+++ b/net/qpid-proton/files/patch-cxx17-jsoncpp.diff
@@ -1,0 +1,13 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -76,7 +76,9 @@
+   enable_language(CXX)
+
+   # This effectively checks for cmake version 3.1 or later
+-  set(CMAKE_CXX_STANDARD 11)
++  # jsoncpp (>= 1.9.6) exposes a std::string_view ABI under C++17; building the
++  # C++ binding as C++11 references removed const char* overloads -> link errors.
++  set(CMAKE_CXX_STANDARD 17)
+   set(CMAKE_CXX_EXTENSIONS OFF)
+ endif()
+


### PR DESCRIPTION
#### Description

`qpid-proton` 0.39.0 fails to link its C++ binding against MacPorts' current `jsoncpp` (1.9.7):

```
Undefined symbols for architecture arm64:
  "Json::Value::get(char const*, Json::Value const&) const",
      referenced from: proton::parse(...) in connect_config.cpp.o
ld: symbol(s) not found for architecture arm64
```

**Root cause:** jsoncpp's `<json/value.h>` gates its API on `__cplusplus >= 201703L`. Built as C++17 (as the MacPorts `jsoncpp` port is), it exports only the `std::string_view` overloads (`Json::Value::get(std::string_view, const Value&)`) and drops the legacy `const char*` ones. qpid-proton hardcodes `set(CMAKE_CXX_STANDARD 11)`, so `connect_config.cpp` compiles a reference to the removed `get(const char*, …)` symbol, which `libjsoncpp.dylib` no longer provides → link failure.

**Fix:** patch the bundled `CMakeLists.txt` to build as C++17 and bump `compiler.cxx_standard` to 2017, so the binding matches the jsoncpp ABI. (A `-DCMAKE_CXX_STANDARD=17` configure arg is insufficient — proton's unconditional `set()` shadows it, so a source patch is required.)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

#### Tested on

macOS 26 (Tahoe), arm64, Xcode CLT. `sudo port build qpid-proton` succeeds; `libqpid-proton-cpp.dylib` links cleanly and now references `Json::Value::get(std::string_view, …)` against `libjsoncpp.27.dylib`.

#### Verification

- [x] Have you followed the [guidelines for contributing](https://guide.macports.org/#project.contributing)?
- [x] Have you ensured that the relevant subport(s) build correctly?

cc maintainer @roddiekieley (port is `openmaintainer`).