### PR TITLE
py-pytorch: fix +mps build with Xcode 16.2 (macOS 15 SDK) on macOS 14

### DIFF
--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -59,6 +59,13 @@ platform darwin {
         variant mps description {Enable Apple Metal Performance Shaders (MPS) support} {
             use_xcode       yes
 
+            # Align the sysroot with the Xcode SDK so AvailabilityMacros.h defines
+            # __MAC_15_0 (and __MAC_26_0 etc.), preventing the forward-compat shims
+            # in MPSGraphSequoiaOps.h from being compiled when the Xcode SDK already
+            # provides those Metal/MPS symbols via its framework headers.
+            configure.sdkroot \
+                [exec xcrun --sdk macosx --show-sdk-path]
+
             build.env-append \
                 APPLE=ON \
                 USE_MPS=ON \
@@ -114,7 +121,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-packaging \
         port:py${python.version}-zstd
 
-    # remove unnecessary dependencies and version pinning 
+    # remove unnecessary dependencies and version pinning
     patchfiles-append       patch-pyproject_toml.diff
 
     # Patch to fix init issue with google-glog 0.5.0, caused by breaking API change.
@@ -161,7 +168,7 @@ if {${name} ne ${subport}} {
 
         post-patch {
             xinstall -d     ${ccache_dir}
-        }               
+        }
 
         configure.env-append   CCACHE_DIR=${ccache_dir} USE_CCACHE=ON
         build.env-append       CCACHE_DIR=${ccache_dir} USE_CCACHE=ON


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

CI fails because it times out, but py314-pytorch builds properly on macOS 14 on CI.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

(untested locally)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
