### PR TITLE
py-flask-cors: Fix typo in dependency statement

### DIFF
--- a/python/py-flask-cors/Portfile
+++ b/python/py-flask-cors/Portfile
@@ -37,7 +37,7 @@ checksums           rmd160  4d6cca293fbd97ee4659c3dfc9b21023d1931b89 \
 python.versions     310 311 312 313 314
 
 if {${name} ne ${subport}} {
-    epends_build-append \
+    depends_build-append \
                     port:py${python.version}-setuptools_scm
 
     depends_lib-append \


### PR DESCRIPTION
#### Description

Fix typo in Portfile, unbreak CI builds.
Fixes bad commit:
https://github.com/macports/macports-ports/commit/0a06a7947d8eed2234376143b74d8ad5494c6832

###### Type(s)

- [x] bugfix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?