### PR TITLE
netcdf: Enable CDF5 support for arm64

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 epoch                       3
 github.setup                Unidata netcdf-c 4.10.0 v
-revision                    2
+revision                    3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer
 categories                  science
@@ -56,13 +56,18 @@ compiler.blacklist-append   *gcc-4.* {clang < 400}
 test.run                    yes
 test.target                 test
 
-default_variants +netcdf4 +dap
-if {(!${universal_possible} || ![variant_isset universal]) && (${build_arch} == "x86_64" || ${build_arch} == "ppc64")} {
-    default_variants-append +cdf5
+default_variants            +netcdf4 +dap
+if {(!${universal_possible}
+    || ![variant_isset universal])
+        && (   ${build_arch} == "x86_64"
+            || ${build_arch} == "ppc64"
+            || ${build_arch} == "arm64")
+    } {
+        default_variants-append +cdf5
 }
 
 if {[variant_isset netcdf4]} {
-    mpi.enforce_variant         hdf5
+    mpi.enforce_variant     hdf5
 }
 
 variant netcdf4 description {enable support for netcdf-4 API} {


### PR DESCRIPTION
#### Description

* Enable CDF5 support for arm64.
* Minor whitespace and indentation changes.
* Closes: https://trac.macports.org/ticket/74074

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?