### PR TITLE
libheif: fallback to pre-C++20 release on macOS < 10.13, fix compilation

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -21,7 +21,7 @@ platform darwin {
     # Fallback to last pre-C++20 release for 10.12 and earlier
     # On 10.6 is a failure happens during the linking phase
     # even with the latest compatible version of ld
-    if {${os.major} < 17} {
+    if {${os.major} < 17 && ${configure.cxx_stdlib} eq "libc++"} {
         set port_latest no
     }
 }

--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -18,10 +18,10 @@ legacysupport.use_mp_libcxx yes
 
 set port_latest yes
 platform darwin {
-    # Fallback to last pre-C++20 release for 10.5 and earlier
+    # Fallback to last pre-C++20 release for 10.12 and earlier
     # On 10.6 is a failure happens during the linking phase
     # even with the latest compatible version of ld
-    if {${os.major} < 11} {
+    if {${os.major} < 17} {
         set port_latest no
     }
 }


### PR DESCRIPTION
#### Description

libheif compilation is broken on Mac OS 10.12. Same fix for 10.5 now needed for 10.12 (maybe slightly higher as well).

###### Type(s)

- [ X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29 x86_64
Command Line Tools 9.2.0.0.1.1510905681

###### Verification <!-- (delete not applicable items) -->
Have you

- [X ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X ] checked your Portfile with `port lint`?
- [ X] tried existing tests with `sudo port test`?
- [ X] tried a full install with `sudo port -vst install`?
- [ X] tested basic functionality of all binary files?
- [ X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
