### PR TITLE
netatalk: add missing talloc dependency, bump revision to 1

### DIFF
--- a/net/netatalk/Portfile
+++ b/net/netatalk/Portfile
@@ -17,7 +17,7 @@ long_description    Netatalk is a freely-available Open Source AFP fileserver. \
 if {${subport} eq ${name}} {
     github.setup        Netatalk netatalk 4-5-0 netatalk-
     version             4.5.0
-    revision            0
+    revision            1
     github.tarball_from releases
     distname            netatalk-${version}
     use_xz              yes
@@ -42,6 +42,7 @@ if {${subport} eq ${name}} {
                         port:libevent \
                         port:libgcrypt \
                         port:iniparser \
+                        port:talloc \
                         port:bstring
 
     configure.args-append -Dwith-init-style=none \


### PR DESCRIPTION
#### Description

Add `port:talloc` as an explicit dependency. talloc is required for all
Spotlight backends including the cnid backend enabled in 4.5.0. Without
it, meson silently disables Spotlight at configure time — talloc is
declared `required: false` so the build succeeds, but
`use_spotlight_cnid` stays false and no backend is linked into afpd.

Bump revision to 1 so users already at 4.5.0_0 receive the fix.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 15.7.7 24G720 arm64 / Command Line Tools 16.4.0.0.1.1747106510
macOS 26.5 25F71 arm64 / Command Line Tools 26.5.0.0.1777544298

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?