### PR TITLE
claude-code: update to 2.1.168

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.167
-revision            1
+version             2.1.168
+revision            0
 
 categories          llm
 maintainers         {breun @breun} openmaintainer
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  c2e13dcd047bf526e23a5fdea05c23dad579f66b \
-                 sha256  a5087977bee95ca84598c8b940fc68165c449722ab410db45f610d148e9c2d0e \
-                 size    222552976
+    checksums    rmd160  bdda2e3f237a7fe17ea73e9f17ae98142eafddf8 \
+                 sha256  688f3d9fa0955878c291a58febe9e4daa061326da217ada740d97c5e17634a26 \
+                 size    222569488
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  c9ae1a618316b9a0b820130d0b9e34ae01fbbef8 \
-                 sha256  fb3cbe9200b3eeba7ae06ee43fdb4b4b2b231d5fa8040d0e47954a7f374d1530 \
-                 size    220038816
+    checksums    rmd160  5427d84c145ddea5bb0ec00963e18318f42a1b63 \
+                 sha256  377f0ecedba8246bdabdf312ce8b7cc8ae1160997b26f5edca352a4a8d61dc78 \
+                 size    220055328
 } else {
     set arch_classifier unsupported_arch
     distfiles

--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -77,7 +77,7 @@ destroot {
     puts $launch_script "#!/bin/sh"
     set launch_command "DISABLE_UPDATES=1"
     if {![variant_isset telemetry]} {
-        append launch_command " DISABLE_UPDATES=1"
+        append launch_command " DISABLE_TELEMETRY=1"
     }
     append launch_command " ${binary} \"$@\""
     puts $launch_script $launch_command


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.168.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?