### PR TITLE
k9s: update to 0.51.0

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.50.18 v
+go.setup            github.com/derailed/k9s 0.51.0 v
 go.offline_build    no
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0845fb3edfc855495a6b86ea9ae446f4c16811c4 \
-                    sha256  4a438b4bc480c05ba6f78a1573ee7e1dad7956ef3e30912ae22c744cea031f96 \
-                    size    6822889
+checksums           rmd160  3c65a9645d4d1a4341ac812c73f372344a1e046e \
+                    sha256  e2c3851c909b87f9cfafa262e426f4a89023ca4e745cba5cab6d0153f76e7dcd \
+                    size    6838746
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

Update to k9s 0.51.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?