### PR TITLE
mbuffer: Update to 20260511

### DIFF
--- a/net/mbuffer/Portfile
+++ b/net/mbuffer/Portfile
@@ -5,7 +5,7 @@ PortGroup               openssl 1.0
 PortGroup               legacysupport 1.1
 
 name                    mbuffer
-version                 20260301
+version                 20260511
 revision                0
 categories              net
 license                 GPL-3
@@ -19,9 +19,9 @@ master_sites            https://www.maier-komor.de/software/${name}
 
 extract.suffix          .tgz
 
-checksums               rmd160  7d5e8c457ad82798c4cb81d9e95fb4bd79b39b0b \
-                        sha256  b7b2fe86e24b2f309c4250d6a38a43e2c8ee2f984561910249648c383cdbc2d0 \
-                        size    156642
+checksums               rmd160  2c14cbbe38243b586dd61d14403807d6a13dafb3 \
+                        sha256  13bab36f39408f7a08fb368913290ad0f117c934bab602094e18fcc123ec5783 \
+                        size    156683
 
 # Provide openssl manually despite PG setup detected
 # ld: library 'crypto' not found


### PR DESCRIPTION
#### Description

Update mbuffer to 20260511

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?\

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
