### PR TITLE
gallery-dl: update to 1.32.2

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -10,7 +10,6 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-
 checksums           rmd160  005ec0c62f0300563fe38aa9cd414345ec2c8692 \
                     sha256  93bdbd07ef6d24a8452291e53621e10407e22e430b2e13df9d81b924ce68f767 \
                     size    1191960
@@ -26,9 +25,11 @@ platforms           {darwin any}
 license             GPL-2
 
 # python version should be kept in sync with yt-dlp
-python.default_version 314
+python.default_version \
+                    314
 
-depends_build-append port:py${python.version}-setuptools
+depends_build-append \
+                    port:py${python.version}-setuptools
 
 depends_lib-append  port:py${python.version}-brotli \
                     port:py${python.version}-requests \
@@ -37,12 +38,13 @@ depends_lib-append  port:py${python.version}-brotli \
 default_variants    +yt-dlp
 
 variant ffmpeg description {Add ffmpeg dependency to enable Pixiv Ugoira to WebM conversion} {
-    PortGroup           ffmpeg 1.0
-    ffmpeg.version      8
+    PortGroup       ffmpeg 1.0
+    ffmpeg.version  8
 }
 
 variant ytdlp description {Add yt-dlp dependency to enable video downloads} {
-     depends_run-append port:yt-dlp
+    depends_run-append \
+                    port:yt-dlp
 }
 
 post-destroot {

--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,16 +4,16 @@ PortSystem          1.0
 PortGroup           codeberg 1.0
 PortGroup           python 1.0
 
-codeberg.setup      mikf gallery-dl 1.32.1 v
+codeberg.setup      mikf gallery-dl 1.32.2 v
 
 categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
 
-checksums           rmd160  12735f3cc8751c86072954a4f5961e2aacfebeaf \
-                    sha256  4e542728476fdfc1ab58f26c975d0e48c925e51ae17e864b6e47a34599cb5e48 \
-                    size    1188481
+checksums           rmd160  005ec0c62f0300563fe38aa9cd414345ec2c8692 \
+                    sha256  93bdbd07ef6d24a8452291e53621e10407e22e430b2e13df9d81b924ce68f767 \
+                    size    1191960
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites
@@ -37,7 +37,8 @@ depends_lib-append  port:py${python.version}-brotli \
 default_variants    +yt-dlp
 
 variant ffmpeg description {Add ffmpeg dependency to enable Pixiv Ugoira to WebM conversion} {
-    depends_run-append path:bin/ffmpeg8:ffmpeg8
+    PortGroup           ffmpeg 1.0
+    ffmpeg.version      8
 }
 
 variant ytdlp description {Add yt-dlp dependency to enable video downloads} {


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
