### PR TITLE
goto: update to 1.6.0

### DIFF
--- a/net/goto/Portfile
+++ b/net/goto/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/grafviktor/goto 1.5.1 v
+go.setup            github.com/grafviktor/goto 1.6.0 v
 revision            0
 categories          net
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -20,9 +20,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  d54c294141e0b6f341f6639148ad5e6e8150e582 \
-                        sha256  4a796167a6fdf00f1ebffe1551ac2415dc534abb16f670bb2e8f4aba12f29b5c \
-                        size    2167768
+                        rmd160  60a19bfd19ab9b29c53681ff8008ac8c6ac2aaec \
+                        sha256  50ce0ed1cc86a15c70ec03309886099bf882338277983241972c9cc7531c9265 \
+                        size    2199889
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -40,15 +40,20 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  d79cf17861409d200e3399f2af049446ee18b20b21fce9433f789582100ddc42 \
                         size    8972460 \
                     golang.org/x/sys \
-                        lock    v0.30.0 \
-                        rmd160  4cd711df5da2e159b6efbb7fa42ae0a3a3f6eb53 \
-                        sha256  76cfe40018bfa5418c1d19d47d8353c3375594013e2b2feea49f06018d2a3102 \
-                        size    1523466 \
+                        lock    v0.42.0 \
+                        rmd160  9bf28fd4fb2566093e52db9828dace0cad68ece6 \
+                        sha256  95cce678922f8cd653b53365de74085c97ca91d3f0c1ac20d96df2f0657d4e02 \
+                        size    1540175 \
                     golang.org/x/sync \
-                        lock    v0.11.0 \
-                        rmd160  5f5e2d8060a9e83ab2b46126f341c2cd2a101aac \
-                        sha256  9b21cdaa445f07a2bd1eeeed58189cfd1cce5bcc563d4c4fae4d7ac2713ef428 \
-                        size    18142 \
+                        lock    v0.19.0 \
+                        rmd160  9c20b956e5432e91456e7dc1b5a2239681e8edec \
+                        sha256  a2526739ca79d5231debc5c0af41a2b9d0cfccf58b8d7aa77d80472dc7235871 \
+                        size    18195 \
+                    github.com/xo/terminfo \
+                        lock    abceb7e1c41e \
+                        rmd160  03f45e9801b38da949e34fec0c1881c96d6fa37d \
+                        sha256  c8f968af54b9283119a9132ff6748f081afdd6b52deef111f6ac680c00a01f19 \
+                        size    35179 \
                     github.com/stretchr/testify \
                         lock    v1.8.4 \
                         rmd160  8e1645055c9b1d8e117df7974034e74b7f600d27 \
@@ -74,88 +79,91 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
-                    github.com/muesli/termenv \
-                        lock    v0.15.2 \
-                        rmd160  92510cd14a2e3c0e723b77064fc1e3a51e5c3666 \
-                        sha256  bd0a1109c77528f0c1310814758ebf283a29c79df2eb9cc4e506d31afc41eb08 \
-                        size    422810 \
                     github.com/muesli/cancelreader \
                         lock    v0.2.2 \
                         rmd160  cbc757f0d680959cea46000a5dd74e63ddbb8a15 \
                         sha256  33f793cd6fbf7733ed7cba381920606b4917ba472148f85a5fd0965477146fc8 \
                         size    9431 \
-                    github.com/muesli/ansi \
-                        lock    276c6243b2f6 \
-                        rmd160  bbc37c92ce2b54f538eb0d5f32edefd7074d540a \
-                        sha256  0b4beac5757eb25d0c45f9f931e2b241168e16c2bd58d21e5aafce7e33c669ee \
-                        size    5249 \
                     github.com/mattn/go-runewidth \
-                        lock    v0.0.16 \
-                        rmd160  297825c4365b5f723ae485e726259ebb620ecd66 \
-                        sha256  6c9e81a6b46220612b97ebc35e8d29d1907fd225a9ce3e40b7cebd64cc58d09c \
-                        size    18496 \
-                    github.com/mattn/go-localereader \
-                        lock    v0.0.1 \
-                        rmd160  7afdbbc0f4978c6f54c25df0d86ff3c66db19ce2 \
-                        sha256  75a68e82a83b37aee40ad81dfcfce54d2f999945282bb198add16a49b8ec7f46 \
-                        size    1738 \
-                    github.com/mattn/go-isatty \
                         lock    v0.0.20 \
-                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
-                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
-                        size    4717 \
+                        rmd160  eeaf7b9dc9491f1dffa87df1026565cdbf8718b5 \
+                        sha256  2a0d80bda12f28f6da6f45d1af4be0bc9124f406ec3c9be9ace071e09fd8af38 \
+                        size    21190 \
                     github.com/lucasb-eyer/go-colorful \
-                        lock    v1.2.0 \
-                        rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
-                        sha256  fbad1aade4444bf51409f5b6a008cc14c7a7cdd1af856841fc1170605fae3914 \
-                        size    970841 \
-                    github.com/erikgeiser/coninput \
-                        lock    1c3628e74d0f \
-                        rmd160  77744cb442933c6c38c33aa830419834ba8e0ed6 \
-                        sha256  39ca6afc6b66e6c6a1772b497fdd0bb97471fac341c966fcae14ff6019629638 \
-                        size    8951 \
+                        lock    v1.3.0 \
+                        rmd160  f32cca200fcf4db4d0e51cc457baf68f212d8965 \
+                        sha256  4168f7454b19120873f75a67d1eeb7be312ea852542e21db1a96b65e514e56c2 \
+                        size    982361 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
+                    github.com/clipperhouse/uax29/v2 \
+                        lock    v2.7.0 \
+                        rmd160  9cd62348ce0722d85ff21f2f91a05a68f877aa08 \
+                        sha256  66d66a451f74709ab74902e7bca146abf376dbf0bc701b713ee600e3d3d6a5b3 \
+                        size    320846 \
+                    github.com/clipperhouse/displaywidth \
+                        lock    v0.11.0 \
+                        rmd160  26a2f5e784f0414e55714156bab744b0d901c5c1 \
+                        sha256  d9587478830f552e284be30f010c2e57be7679d5c883a256b9df4b6889827347 \
+                        size    250271 \
+                    github.com/charmbracelet/x/windows \
+                        lock    windows/v0.2.2 \
+                        rmd160  30a67b4f32053e9c28206faf5381ab048fcd3672 \
+                        sha256  5fe11ef3de22b2f041d91559f08f93662f7e1298be3100d2a013a757a1bad3c5 \
+                        size    305063 \
+                    github.com/charmbracelet/x/termios \
+                        lock    termios/v0.1.1 \
+                        rmd160  7c4bc99cd489695077a1df168544033ad5f22625 \
+                        sha256  d6f35927873dce32d3a632d42050093fad74df99a738350c9496bfa77ee7157b \
+                        size    237451 \
                     github.com/charmbracelet/x/term \
-                        lock    term/v0.2.1 \
-                        rmd160  9b421c7662beb66fb61e79380038326ebc3633bd \
-                        sha256  5f9b486ad633575d90f003c9e7772076cb6289269bbd1d1ec224ae3d5f992358 \
-                        size    146770 \
+                        lock    term/v0.2.2 \
+                        rmd160  bf64de8c6de1ada687ddb996fa0372feb50550f4 \
+                        sha256  7361d37cbc6fd64ea39a10c50a611f58715928bf01fbbb5cb4ecd1a93e6bdeb6 \
+                        size    395863 \
                     github.com/charmbracelet/x/ansi \
-                        lock    ansi/v0.8.0 \
-                        rmd160  7b44d4324c7ce054a0c9a47e4e5983e4819cb7c6 \
-                        sha256  a26409ce7068276b666a2dc74279a653f6495db8e5c847cd79ca33db26ed720b \
-                        size    236985 \
-                    github.com/charmbracelet/lipgloss \
-                        lock    v1.0.0 \
-                        rmd160  b4a8052a00570c33d05585d87b28a5e0c2f8a855 \
-                        sha256  d4539b433ef3156c3ba85bab9a3bf97a61c8a4cc1f409050b00ebfe08bb98b01 \
-                        size    77872 \
-                    github.com/charmbracelet/bubbletea \
-                        lock    v1.3.3 \
-                        rmd160  fb4a30dae12b3cc5f13f713fb8746f2e80a7d767 \
-                        sha256  6f9b8842761fd9ca03d23f315c89a6e90b8df3c22dd9375e7eab59f2d31ae186 \
-                        size    2187413 \
-                    github.com/charmbracelet/bubbles \
-                        lock    v0.20.0 \
-                        rmd160  51f43b7a0ef9ce31d129937ace6340fd0f06d32a \
-                        sha256  9f0f4ba39bf8fe1280fe240785f86554fdfbb4a9800ca6ca97cb54ae7149976d \
-                        size    73364 \
+                        lock    ansi/v0.11.6 \
+                        rmd160  00a4a0fd678c64f7e0fc0d70de62594737aed28e \
+                        sha256  920fd5e616a1749dbb80b483360db378ee9db96ed120900814ae963a4a259b05 \
+                        size    518326 \
+                    github.com/charmbracelet/ultraviolet \
+                        lock    524a6607adb8 \
+                        rmd160  bbf1ca85d0ab8b43f94a461ec0e7bc09f652ff2f \
+                        sha256  ada83dc7da1630ec16f468ea4eed8ba7e64716476df607770c7bd2ed2e8944bc \
+                        size    164366 \
+                    github.com/charmbracelet/colorprofile \
+                        lock    v0.4.2 \
+                        rmd160  ca3c722b40d8bc6528f967a0a14ac11059c163fa \
+                        sha256  63e5980c12d9404e3496643e41f44452d243c942d0b0006fb05bf2d3aa0352c1 \
+                        size    15566 \
                     github.com/caarlos0/env/v10 \
                         lock    v10.0.0 \
                         rmd160  b768a2c099c41007a1152112f191a79213743f47 \
                         sha256  c08ae73739476b60c98baa93d974462fa130145793efd179a649856faca2a009 \
                         size    22062 \
-                    github.com/aymanbagabas/go-osc52/v2 \
-                        lock    v2.0.1 \
-                        rmd160  8669f2bdcf2704bbc8df6af7e5fd396215737b9b \
-                        sha256  0904dc990e2f1e5bbe290e02f418940def4168b63e36914e3bf76ff2ac1fb2a5 \
-                        size    5889 \
                     github.com/atotto/clipboard \
                         lock    v0.1.4 \
                         rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
-                        size    5023
+                        size    5023 \
+                    charm.land/lipgloss/v2 \
+                        repo    github.com/charmbracelet/lipgloss \
+                        lock    v2.0.1 \
+                        rmd160  fd68d7014009bd510a1ba1a4b080dfd01672235a \
+                        sha256  92797ed3af26d325388c5404b5dd419aeb5182eb5faf223220dee24969d145ce \
+                        size    138686 \
+                    charm.land/bubbletea/v2 \
+                        repo    github.com/charmbracelet/bubbletea \
+                        lock    v2.0.2 \
+                        rmd160  9d4fdc44d944ce579ddeaf064fcfde5a37a5ab39 \
+                        sha256  44704c3818f804a5ce55d5c7cc35292f6a7f167df0f474f68d8b03a557e7260a \
+                        size    2244614 \
+                    charm.land/bubbles/v2 \
+                        repo    github.com/charmbracelet/bubbles \
+                        lock    v2.0.0 \
+                        rmd160  bb870acb6a14000e45e42eee654b2990c4546b29 \
+                        sha256  67c95209d27939276ef698a4197f9b2547d7872b0914ade5376154f04f3d7207 \
+                        size    99993


### PR DESCRIPTION
#### Description
https://github.com/grafviktor/goto/releases/tag/v1.6.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
