### PR TITLE
bind9: remove dead link from notes

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -136,9 +136,6 @@ notes "******************************************************
 * You may want to generate a key (for rndc):
 * $ sudo rndc-confgen -a
 *
-* Remember to secure your configuration:
-* http://www.cymru.com/Documents/secure-bind-template.html
-*
 * The bind9 port now sets up named to run as non-root, you may
 * need to adjust your named.conf to put the pidfile and any
 * logging into a directory where this new user can write files.


### PR DESCRIPTION
trivial change only to `notes`

cymru.com serves 404 today.
The page was not scraped by archive.org.
I sent an inquiry to Team Cymru some time ago but have not heard back.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
