### PR TITLE
dillo: new port

### DIFF
--- a/www/dillo/Portfile
+++ b/www/dillo/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               legacysupport 1.1
+PortGroup               openssl 1.0
+
+name                    dillo
+version                 3.3.0
+revision                0
+homepage                https://dillo-browser.org
+categories              www net
+maintainers             {ijams.me:nate @exprez135} \
+                        openmaintainer
+license                 GPL-3
+
+master_sites            https://dillo-browser.org/release/${version}/
+
+description             A fast and small graphical web browser.
+long_description        ${name} is a fast and small graphical web browser\
+                        written in C and C++ with its own rendering engine\
+                        with support for HTTP, HTTPS, FTP and local files.
+
+checksums               rmd160  70e63d6bc7ddbd8bca2e55cf583e4a1b51ee3cfe \
+                        sha256  db1863261d5efbd27b090e430c88064082b891cea1edf7a14e234cca51754f60 \
+                        size    1368668
+
+depends_lib-append      path:lib/libfltk.dylib:fltk \
+                        port:webp
+
+post-patch {
+    if {[string match *gcc-4.* ${configure.compiler}]} {
+        reinplace "s|-Wno-cast-function-type||" ${worksrcpath}/configure
+    }
+}
+
+# Experimental support for FLTK v1.4+ is currently required.
+configure.args-append   --enable-experimental-fltk
+
+livecheck.url           ${homepage}/release/
+livecheck.regex         {>Version ([0-9.]+)<}


### PR DESCRIPTION
#### Description

Dillo is a little web browser: https://dillo-browser.org/.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
