### PR TITLE
neomutt: update to version 20260504

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        neomutt neomutt 20240329
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            1
+github.setup        neomutt neomutt 20260504
+github.tarball_from archive
+revision            0
 categories          mail
 license             GPL-2+
 maintainers         {l2dy @l2dy} openmaintainer
@@ -22,9 +21,9 @@ long_description    Mutt is a small but very powerful text-based MIME \
                     groups of messages.
 homepage            https://neomutt.org
 
-checksums           rmd160  b9721c5d480077d9a9a6b473a786d8393c2fb0da \
-                    sha256  37a95ddb7463990c64386b4f4b8d34cdb8e1691d508d86192c2e64de611f7d90 \
-                    size    3832735
+checksums           rmd160  d3dec8b8a6794f14823da04b789b07af658b7342 \
+                    sha256  93fd8344c12cd857f084f8d7cc1187479f79036ab9725cfdbc81c0cc845f1615 \
+                    size    4200095
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
@@ -44,7 +43,7 @@ post-patch {
               docs/gen-map-doc
 
     reinplace -W ${worksrcpath} "s|/usr/bin/|${prefix}/bin/|g" \
-              contrib/smime_keys \
+              smime/smime_keys \
               docs/manual.xml.head
     reinplace -W ${worksrcpath} "s|/usr/libexec/|${prefix}/libexec/|g" \
               docs/manual.xml.head


### PR DESCRIPTION
#### Description

I've removed ```reinplace -W ${worksrcpath} "s|/usr/bin/|${prefix}/bin/|g" \
              contrib/smime_keys \
              docs/manual.xml.head``` from post-patch because it was causing an error: not found message during building and doesn't seem necessary any more (no contrib/smime_keys directory in source code anymore).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
