### PR TITLE
octave: fix +docs build with TeX Live 2026

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -666,6 +666,13 @@ variant docs description {build documentation files} {
         port:texlive-fonts-recommended
 
     configure.args-replace --disable-docs --enable-docs
+
+    # octave bundles an older texinfo.tex; replace it with the MacPorts version
+    # to avoid float cross-reference failures with TeX Live 2026
+    post-patch {
+        copy -force ${prefix}/share/texmf/tex/texinfo/texinfo.tex \
+            ${worksrcpath}/build-aux/texinfo.tex
+    }
 }
 default_variants-append +docs
 


### PR DESCRIPTION
octave 11.3.0 bundles texinfo.tex 2025-06-18.21, which generates float cross-references in the .aux file that TeX Live 2026's etex cannot process on the second pass (Undefined control sequence on tab: labels). Replace the bundled copy with MacPorts' texinfo.tex (2025-12-23.13) before running texi2dvi.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
