### PR TITLE
container: update to 1.0.0

### DIFF
--- a/devel/container/Portfile
+++ b/devel/container/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        apple container 0.12.3
+github.setup        apple container 1.0.0
 github.tarball_from archive
 
 revision            0
@@ -19,9 +19,9 @@ long_description    container is a tool that you can use to create and run Linux
                     registry. You can push images that you build to those registries \
                     as well, and run the images in any other OCI-compatible application.
 
-checksums           rmd160  c1adf7893a28544a11d6ab7efce456c55a5e7007 \
-                    sha256  aa5e4225b46b416b8c6c8f0a7f8d2b4ed3166278313fe45f7eb2d7a469c34403 \
-                    size    916500
+checksums           rmd160  40cd973eac96c2d2e06cef3f9c2c765ad7edc99e \
+                    sha256  9f5379d400d23b6f296b7bae8f71f982dfdc1d52bf072ac81318472a734d21f7 \
+                    size    993889
 
 # The version number for macosx is the darwin version number (os.major)
 platforms           {macosx >= 25}


### PR DESCRIPTION
#### Description

Update `container` to latest release `1.0.0`.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
