### PR TITLE
nvm: update to 0.40.5

### DIFF
--- a/devel/nvm/Portfile
+++ b/devel/nvm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        nvm-sh nvm 0.40.3 v
+github.setup        nvm-sh nvm 0.40.5 v
 github.tarball_from archive
 
 categories          devel
@@ -15,9 +15,9 @@ maintainers         {@FranklinYu hotmail.com:franklinyu} openmaintainer
 description         Node version manager
 long_description    NVM is a simple shell script to manage multiple active Node.js versions.
 
-checksums           rmd160  6efb5987afd96e9c3f697ac6efb0d828a0b24c3b \
-                    sha256  5f4d6aaa04a177dc93c985e31dbc411ab6b8c6e1e21d8015dbc1372625fcd1d0 \
-                    size    346428
+checksums           rmd160  19b25921671b94f7bc0254ec6af1b22b18105697 \
+                    sha256  9f350650afc5e4cfcc6af9fc327b2a6112c5700ad848bbe517254db64aee5061 \
+                    size    372458
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Update nvm to version 0.40.5.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.3 25D125 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?