### PR TITLE
weechat: update to 4.9.2

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.9.1
+version             4.9.2
 revision            0
-checksums           rmd160  2df71c305caa04772f6ba1115b6e4b3584f521fe \
-                    sha256  04960b56e1dd86127f63cf8fd01bbff77c8142f40ae8a941ac3db642d310cde9 \
-                    size    2794772
+checksums           rmd160  11af2dbebf71dcd312f026e8f720c0d498d9abe4 \
+                    sha256  d1389a9e521bda0c4ebfa108e2abf885ee6c5150c385299f5dca0181a43a0914 \
+                    size    2797372
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.9.2
###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.2 17C52

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?