### PR TITLE
qdmr: update to 0.15.0

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           app 1.1
 PortGroup           qt6 1.0
 
-github.setup        hmatuschek qdmr 0.14.1 v
+github.setup        hmatuschek qdmr 0.15.0 v
 github.tarball_from archive
 maintainers         @hmatuschek \
                     {ra1nb0w @ra1nb0w} \
@@ -27,9 +27,9 @@ long_description    {*}${description}: \
 
 homepage            https://dm3mat.darc.de/qdmr/
 
-checksums           rmd160  d755d2352b61d240bac082efe3ab092ae9c2c562 \
-                    sha256  cb584c500f98897a959d7242292261ae7d8deafc7d0f709fc53d811e40d27f11 \
-                    size    7266522
+checksums           rmd160  6ba5825425da6685847470b53cb0529507234bd9 \
+                    sha256  63fd6b2061ebcfee54fc1c6df77e21484a544e694723725b70b49ca4990138d3 \
+                    size    7636796
 
 qt6.depends_lib \
     qtserialport \


### PR DESCRIPTION
#### Description

Update qDMR to upstream release 0.15.0.

Upstream release notes: https://github.com/hmatuschek/qdmr/releases/tag/v0.15.0

Notable upstream changes include:
- Added AnyTone D168UV support.
- Updated AnyTone D878UV (II) support to firmware 4.0.
- Fixes for DM-32UV detection and codeplug handling.
- Added common audio settings.
- Updated repeater map/API handling.

MacPorts specific changes:
- Updated version from 0.14.1 to 0.15.0.
- Updated rmd160, sha256, and size checksums.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26 arm64

###### Verification

Have you

- [X] followed our Commit Message Guidelines?
- [X] squashed and minimized your commits?
- [X] checked that there are not other open pull requests for the same change?
- [X] checked your Portfile with `port lint`? Result: 0 errors and 0 warnings.
- [ ] tried existing tests with `sudo port test`?
- [ ] tested basic functionality of all binary files?

I did not run a full `sudo port test`/install from this PR branch.