### PR TITLE
openssl3: Update to 3.6.3

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            30
+revision            31
 
 categories          devel security
 license             MIT

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,14 +11,14 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 # For former rollback to 3.1.x release where needed. Must now stay.
 epoch               1
-github.setup        openssl openssl ${major_v}.6.2 openssl-
+github.setup        openssl openssl ${major_v}.6.3 openssl-
 name                openssl3
 revision            0
 
 github.tarball_from releases
-checksums           rmd160  bff0f8c1831d9c112422182be482bc15d3e87c8c \
-                    sha256  aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f \
-                    size    54913556
+checksums           rmd160  550c37050d1a45c79b577b674e78265b0456d833 \
+                    sha256  243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1 \
+                    size    54953005
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                openssh
 version             10.3p1
-revision            1
+revision            2
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                33
+revision                34
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

Fixes numerous CVEs, see

  https://openssl-library.org/news/secadv/20260609.txt

for the upstream advisory.

CVE: CVE-2026-45447
CVE: CVE-2026-34182
CVE: CVE-2026-34183
CVE: CVE-2026-35188
CVE: CVE-2026-42764
CVE: CVE-2026-45445
CVE: CVE-2026-7383
CVE: CVE-2026-9076
CVE: CVE-2026-34180
CVE: CVE-2026-34181
CVE: CVE-2026-42765
CVE: CVE-2026-42766
CVE: CVE-2026-42767
CVE: CVE-2026-42768
CVE: CVE-2026-42769
CVE: CVE-2026-42770
CVE: CVE-2026-42771
CVE: CVE-2026-45446

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
