### PR TITLE
hdf5: allow destroot to succed without variant fortran

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -90,6 +90,14 @@ default_variants +fortran
 variant fortran description {Build fortran libs} {
     configure.args-replace  -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_FORTRAN:BOOL=ON
     configure.args-append   -DHDF5_INSTALL_MOD_FORTRAN:BOOL=ON
+
+    post-destroot {
+        foreach f [ glob ${destroot}${prefix}/mod/static/* ] {
+            move $f ${destroot}${prefix}/include/
+        }
+
+        delete ${destroot}${prefix}/mod
+    }
 }
 
 post-destroot {
@@ -98,12 +106,6 @@ post-destroot {
     foreach f [ glob -type f ${destroot}${prefix}/share/* ] {
         move $f ${destroot}${prefix}/share/hdf5/
     }
-
-    foreach f [ glob ${destroot}${prefix}/mod/static/* ] {
-        move $f ${destroot}${prefix}/include/
-    }
-
-    delete ${destroot}${prefix}/mod
 }
 
 test.run            yes


### PR DESCRIPTION
Fixes:

```
---> Fetching archive for hdf5
---> Archive not available for hdf5, building locally
---> Building hdf5
---> Staging hdf5 into destroot
Error: Failed to destroot hdf5: no files matched glob pattern "/opt/local/var/macports/build/hdf5-905a24d3/work/destroot/opt/local/mod/static/*"
```

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@eborisch (6d9281424a2790c6f50d4157775f6529c0641844)