### PR TITLE
claude-code: update to 2.1.170

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.169
+version             2.1.170
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  975ccb243ce863d2f5ae0dd18038e8897e98148a \
-                 sha256  6d8d510c715b899307b7d29a1062d43e62c99370c55330dac3ec1851a2fbf7c8 \
-                 size    224435344
+    checksums    rmd160  aa03cee82c1e2d9ef42a2562c6feb71962f30198 \
+                 sha256  914f23a70bbed5d9ae567e3e04b86206ed9971b371bc9baca3f79c8885bfddb4 \
+                 size    224616976
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  7d5714fca600926a3d323ed0d1e3d7c7f2162080 \
-                 sha256  86d8b820ad7eed50e50a130706d3dc5ef70696f91194de1b3897a842182afe3a \
-                 size    221921184
+    checksums    rmd160  0618ab0e1abf85ddaaf1680bc23c15078d1c6c14 \
+                 sha256  e903646d8b7a31882a80ecd27569a27d8ac57b3708745f349709632c84117fdf \
+                 size    222102816
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.170.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?