### PR TITLE
Dotnet-{8,9,10,cli}: update to latest versions

### DIFF
--- a/dotnet/aspnetcore-runtime-10/Portfile
+++ b/dotnet/aspnetcore-runtime-10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-10
-version             10.0.8
+version             10.0.9
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  170485b136ef8a43c6c2c73ec24a571e2df435b1 \
-                            sha256  d26876411676568723ab0d79f49e03f7468d404393ab85e2825988e4d49ea5e6 \
-                            size    48323638
+        checksums           rmd160  4652bf2fd0ddb166d17da1c15c2ad0b09a59416f \
+                            sha256  bdc7b4672051cfa0ab066c447c47d4ceb6e8a04292ed0dbf17a0b3c66ef81a6a \
+                            size    48288983
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  a1886df08dc88ed295ade462ab64629a9ca31b3e \
-                            sha256  298b70316c06a8f6fde3910d49c312a53b5a9e837cdfb1e4cbd1ddf1afcfa28c \
-                            size    45464914
+        checksums           rmd160  cb87c3f462551711fafcd5288b298a75b2a426c7 \
+                            sha256  dd95224ba8ddd23533150bf4c22a7d060752b851113c5705c57327a8b2eba591 \
+                            size    45419746
     }
     default {
         known_fail yes

--- a/dotnet/aspnetcore-runtime-8/Portfile
+++ b/dotnet/aspnetcore-runtime-8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-8
-version             8.0.27
+version             8.0.28
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  8ce8dabbc0911b9c4b89aedc8ce67349969c7e68 \
-                            sha256  db5b55b7f57bd2cb14c09ab79d3858ec5ceafafb2026e2d120d0b098a679246d \
-                            size    41368985
+        checksums           rmd160  0f148e6623b4746cae5613e30d32eaed28bd65b2 \
+                            sha256  7d70a2fbb2c23aa108831682ab485266279bbc1f403a6f2614c970844589a90f \
+                            size    41375790
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  f6984373718fccfd361aa03377a08c987ac95d03 \
-                            sha256  150b63b54691bf75277a630e3621f7f45bc34cdc7b3f4249228ef48d33029fe3 \
-                            size    39473325
+        checksums           rmd160  53479afd9911e565d025c5183565bd4f28873f29 \
+                            sha256  376929815ed8c6ba2e25434c25a4c0512f175b1850db57c69009649f63794110 \
+                            size    39479016
     }
     default {
         known_fail yes

--- a/dotnet/aspnetcore-runtime-9/Portfile
+++ b/dotnet/aspnetcore-runtime-9/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-9
-version             9.0.16
+version             9.0.17
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  09d023131b3a00bddbfa989e1034e8ebe55e7711 \
-                            sha256  00108a8375502b9093b045c4fd1a82e6dbe2d6be3e54653c7451fe9b8f46e66a \
-                            size    43596678
+        checksums           rmd160  e0c440f202a8bae7419f84960df7fd2b434a80fd \
+                            sha256  1d0ffc5df3547127e2bf3b651b638b46b496e5c0bb24d32f91373f4f72d52c14 \
+                            size    43608810
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  2d0f0b3d551b5de27b87215629fb4bd96c01a8d1 \
-                            sha256  b6d27a56c61751ebfba5d7bbb523f64ffa14db63f33fd5b98245c87073080669 \
-                            size    41346470
+        checksums           rmd160  e3781dbf02df232fed96d5479d85540dfa71a2d9 \
+                            sha256  ab2a0af353b35ef26245f26827184b5f4fc2eb61da1cb3dffdce6c7e8b76543c \
+                            size    41343889
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -24,7 +24,7 @@
 PortSystem          1.0
 
 name                dotnet-cli
-version             10.0.8
+version             10.0.9
 revision            0
 categories          dotnet
 license             MIT
@@ -51,15 +51,15 @@ master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  1c0481aafe989584c449374145b349b079b46702 \
-                            sha256  accae79ba01b470c2a32836b29f16f33ab31b6856b477e101295180519c68c47 \
-                            size    35579269
+        checksums           rmd160  9597fd90504ea9720cf9207eca2ef30e2099ee51 \
+                            sha256  7b422da669fc057461fa781024fe89fd1819359a3a9b3a42b3380bcfe1a7b916 \
+                            size    35550776
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  c731a0fd844972bca7ca21253a983c7e6f3fad1b \
-                            sha256  bc34affe79b00b9c9241026bbe89e9bc472d330bf4a8fa5f01e4631bdf1622d6 \
-                            size    33232776
+        checksums           rmd160  1fc113a9ea1478d8117d083ac3f8e488061d9941 \
+                            sha256  3e85dbc5c392486bfcd5228344a3a4d8e19932092033699e344c9167aef4a995 \
+                            size    33198536
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-10/Portfile
+++ b/dotnet/dotnet-runtime-10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-10
-version             10.0.8
+version             10.0.9
 revision            0
 categories          dotnet
 license             MIT
@@ -24,15 +24,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  1c0481aafe989584c449374145b349b079b46702 \
-                            sha256  accae79ba01b470c2a32836b29f16f33ab31b6856b477e101295180519c68c47 \
-                            size    35579269
+        checksums           rmd160  9597fd90504ea9720cf9207eca2ef30e2099ee51 \
+                            sha256  7b422da669fc057461fa781024fe89fd1819359a3a9b3a42b3380bcfe1a7b916 \
+                            size    35550776
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  c731a0fd844972bca7ca21253a983c7e6f3fad1b \
-                            sha256  bc34affe79b00b9c9241026bbe89e9bc472d330bf4a8fa5f01e4631bdf1622d6 \
-                            size    33232776
+        checksums           rmd160  1fc113a9ea1478d8117d083ac3f8e488061d9941 \
+                            sha256  3e85dbc5c392486bfcd5228344a3a4d8e19932092033699e344c9167aef4a995 \
+                            size    33198536
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-8/Portfile
+++ b/dotnet/dotnet-runtime-8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-8
-version             8.0.27
+version             8.0.28
 revision            0
 categories          dotnet
 license             MIT
@@ -24,15 +24,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  deb5f18f1c89167ea9d466d98c5d9e6e231fae6a \
-                            sha256  a460e5d5aebd4bf0dc2b55714c1d7b8795c49bfd62e45f7cca5a56975e5f123a \
-                            size    30710288
+        checksums           rmd160  e4298b3a847cc63ee5ad7a3909d51dd544e194bb \
+                            sha256  0acbfcc1c1a819fd49e12ecbcc8ed18d1b008f57a458d5a54b7b1fbcdf317eed \
+                            size    30711710
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  d4267955cbcc51238bcb9fe26b9c8c984f535310 \
-                            sha256  a1237fee1f58a0d2de7d097277cf3d21472ee492426f5024f783ebe4913ee69b \
-                            size    29081851
+        checksums           rmd160  21d1b884fb47eea00d4da0799df92de943ddf474 \
+                            sha256  2838e6890a86f3354a0a3bcaeb35ec2df9328f5f77fda2066cc81f232da35658 \
+                            size    29085166
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-9/Portfile
+++ b/dotnet/dotnet-runtime-9/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-9
-version             9.0.16
+version             9.0.17
 revision            0
 categories          dotnet
 license             MIT
@@ -24,15 +24,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  fdd8f862df3b2a520cb2a0a1335bee87ea5c8baf \
-                            sha256  4b8f9d386170d68de37565095aaafc6f39544ad9b730ceed33dabbe49f23f50a \
-                            size    32730806
+        checksums           rmd160  57fc061744698668e212c497bd63523171ab7e5e \
+                            sha256  536510daa0a3fb79865546f28b02d0d0a8e1db3c2a3e63a88ce9adc572ca41b2 \
+                            size    32731779
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  db6f242c8681a435a4a3974da950553e3dcd85a8 \
-                            sha256  74b20dbdffec4644d2dd9885d9922697cb79379f2c9e81ad2b25c6a1067b085a \
-                            size    30806333
+        checksums           rmd160  820270319cfcef220fd5887920a7a2624295350a \
+                            sha256  f667e1ac8530bcff80335f358f3fd8d31b593b4f78b33d8f425609b05c2c148b \
+                            size    30806305
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-sdk-10/Portfile
+++ b/dotnet/dotnet-sdk-10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-10
-version             10.0.300
+version             10.0.301
 revision            0
 categories          dotnet devel
 license             MIT
@@ -26,16 +26,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  cf1a13c79abfdeac30896c1b5ec773b47ce16092 \
-                            sha256  7c1e46f16e6dd75c714db67b85fef6750d1b5b8c0d6c1c4a8fd3ab8f048b6958 \
-                            size    234149547
+        checksums           rmd160  4debc0da7768243b8fef586486f20d54c6be5973 \
+                            sha256  81c4e0950509a60a5540d243b3271cdf48e588866425416714537d6f15c74ad9 \
+                            size    233445469
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  f3c8d9de71dfb79a746685a96c2d7b847049b81d \
-                            sha256  240e542e7f43771b6fc6de8b67c9ae67b388d041e1db2f105ab5cae89a345cfe \
-                            size    226431690
+        checksums           rmd160  2d470fffbe2be2206920d256897bd4241939ff51 \
+                            sha256  766ffd361c23af25498b9814480142a2071e3b74c2e95123258bb1230b5f15a3 \
+                            size    225656110
     }
     default {
         known_fail yes
@@ -61,7 +61,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 10.0.8
+    set dotnet_runtime_version 10.0.9
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref

--- a/dotnet/dotnet-sdk-8/Portfile
+++ b/dotnet/dotnet-sdk-8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-8
-version             8.0.421
+version             8.0.422
 revision            0
 categories          dotnet devel
 license             MIT
@@ -26,16 +26,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  a916fdeffcb9aa4cc06f26d55d20e6f5bf8d03fb \
-                            sha256  14f7122ad9638cea91dfe30a95c577731bbebae3334bfe33a23f9b229e706ecc \
-                            size    214960088
+        checksums           rmd160  40b5064dc1676ae29655beb959c4783d40440bf2 \
+                            sha256  716ee82df91f3277fe289636e90b0c5da454f8e1cf40f25eeed9d4c0b4e7d06e \
+                            size    214985499
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  4a41ca2c75833405b2b054e51e4ef74997bc17b3 \
-                            sha256  d5c77d53877162f8b769907731f4f4478ea2e3201bb8f0a0ddea72df6fea4eb9 \
-                            size    209833600
+        checksums           rmd160  4c3804a70008b1be005d147140c80cefbd04726c \
+                            sha256  a005e428dc002c08f6fe1848fd7bbb46014498528806904a7e7ce764387c56a6 \
+                            size    209823818
     }
     default {
         known_fail yes
@@ -61,7 +61,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 8.0.27
+    set dotnet_runtime_version 8.0.28
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref

--- a/dotnet/dotnet-sdk-9/Portfile
+++ b/dotnet/dotnet-sdk-9/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-9
-version             9.0.314
+version             9.0.315
 revision            0
 categories          dotnet devel
 license             MIT
@@ -26,16 +26,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  a504c0c2b87f7c87ca83c8ec6fa72ec35ac82d8a \
-                            sha256  f12a5e7bfa8b12c0e033c556422f8088a8cb82499e76f4420a5468a98dab80f7 \
-                            size    215750653
+        checksums           rmd160  7c9247c943f67f167bb1459732fc2df980937f93 \
+                            sha256  56861cdea4166751a318333fbe8795b7273b378b941e6f6ca5fcfb403a0fb362 \
+                            size    215731959
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  f79bd0be7e5cb074e59099824112263eda2dd3b0 \
-                            sha256  1b5c30edf1fa3c433c3fe578c2a4fdabfb5af5539c4169db4de36231e12c8b44 \
-                            size    210326217
+        checksums           rmd160  68db0dc857fd863a459a6e3e86b41f8d802ada18 \
+                            sha256  e66e1ee8a054c5641676c17dec1de70bd462ea9b1d0d843684bb8fea99a7d553 \
+                            size    210330266
     }
     default {
         known_fail yes
@@ -61,7 +61,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 9.0.16
+    set dotnet_runtime_version 9.0.17
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref


### PR DESCRIPTION
see : https://macports.mathiesen.info/macports/bin/dotnet/ for scripts
```
dotnet-sdk-9:          : update to 9.0.315
dotnet-sdk-8:          : update to 8.0.422
dotnet-sdk-10:         : update to 10.0.301
dotnet-runtime-9:      : update to 9.0.17
dotnet-runtime-8:      : update to 8.0.28
dotnet-runtime-10:     : update to 10.0.9
dotnet-cli:            : update to 10.0.9
aspnetcore-runtime-9:  : update to 9.0.17
aspnetcore-runtime-8:  : update to 8.0.28
aspnetcore-runtime-10: : update to 10.0.9
```
