### PR TITLE
opencv4: fix py-subport link failure when ffmpeg8 headers shadow ffmpeg4

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -416,9 +416,9 @@ foreach python_branch ${python_branches} {
     subport py${python_version}-${name} {
         # NOTE: Only rev-bump subports, for major changes/additions
         if {${opencv_latest}} {
-            revision 4
+            revision 5
         } else {
-            revision 21
+            revision 22
         }
 
         conflicts-append \
@@ -434,6 +434,18 @@ foreach python_branch ${python_branches} {
                     port:${name} \
                     port:py${python_version}-numpy \
                     port:python${python_version}
+
+        # patch-ffmpeg8.diff guards its API choice with LIBAVCODEC_BUILD.
+        # When the active ffmpeg port (ffmpeg 8) is installed it puts headers
+        # into ${prefix}/include, which the compiler finds before the ffmpeg4
+        # headers, causing LIBAVCODEC_BUILD to resolve to ffmpeg8's value
+        # (62.x > threshold 62.11) even though we link against ffmpeg4.
+        # The patch then emits a call to av_packet_side_data_get, which does
+        # not exist in the ffmpeg4 dylibs, producing a link error.
+        # Prepend the ffmpeg4 include path so the preprocessor sees the
+        # correct LIBAVCODEC_BUILD (58.x) and takes the ffmpeg4 code path.
+        configure.cppflags-prepend \
+                    -I${prefix}/libexec/ffmpeg4/include
 
         configure.args-replace \
                     -DBUILD_opencv_python3:BOOL=OFF \


### PR DESCRIPTION
## Problem

The Python subports (`pyXX-opencv4`) fail to build with a linker error when
`ffmpeg` (8.x) is installed alongside `ffmpeg4`:

```
Undefined symbols for architecture arm64:
  "_av_packet_side_data_get", referenced from:
      CvCapture_FFMPEG::get_rotation_angle() in cap_ffmpeg.cpp.o
ld: symbol(s) not found for architecture arm64
```

## Root cause

`patch-ffmpeg8.diff` guards its API choice with `LIBAVCODEC_BUILD`:

- `< CALC_FFMPEG_VERSION(62,11,100)` → use deprecated `av_stream_get_side_data()` (present in ffmpeg4)
- `≥ CALC_FFMPEG_VERSION(62,11,100)` → use `av_packet_side_data_get()` (FFmpeg 6.1+, present in ffmpeg8)

The Python subports are correctly configured to **link** against `ffmpeg4` via
`PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig"`. However, the CMake
build also adds `-I${prefix}/include` for other dependencies, and since the
active `ffmpeg` port (8.x) installs its headers into `${prefix}/include`, the
**compiler** finds the ffmpeg8 headers first.

As a result, `LIBAVCODEC_BUILD` resolves to ffmpeg8's value (`62.28` on
macOS 26) — above the threshold — and the compiler emits a call to
`av_packet_side_data_get`. At link time, this symbol is missing from the
`ffmpeg4` dylibs.

## Fix

Prepend `${prefix}/libexec/ffmpeg4/include` to `CPPFLAGS` inside the Python
subport block. This ensures the preprocessor sees ffmpeg4's `LIBAVCODEC_BUILD`
(`58.x`) and takes the ffmpeg4-compatible code path, matching the linked
libraries.

The parent `opencv4` port is unaffected — it uses the `+ffmpeg8` variant by
default, which correctly updates both `PKG_CONFIG_PATH` and the include path.

## Testing

Tested on macOS 26 / Apple Silicon with:
- `ffmpeg4 @4.4.7_3+gpl2`
- `ffmpeg @8.1.1_0+gpl2+nonfree` (active)

```
sudo port install py314-opencv4
```

Builds and installs cleanly. `import cv2` works.

## Checklist

- [x] `port lint --nitpick` passes
- [x] Tested on affected platform (macOS 26, arm64)
- [x] Revision bumped for Python subports (4 → 5 / 21 → 22)