### PR TITLE
gemini-cli: update to 0.46.0

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                gemini-cli
-version             0.45.2
+version             0.46.0
 revision            0
 
 categories          llm
@@ -21,9 +21,9 @@ homepage            https://geminicli.com
 npm.rootname        @google/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  c6610de240caa44f9487dc994b02dc35f0cb21d6 \
-                    sha256  ccf71663720170c34dc4254b82d82424f1fa81a23ab2f00f608ec8588777c683 \
-                    size    23793956
+checksums           rmd160  9fa2ba597298628a4ad26f4c6c789bab8abf0ade \
+                    sha256  0f36bcd29dcb69ac484427fad57006579b4b559f4b36ecbf893e9f960e1bbc40 \
+                    size    19945379
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to Gemini CLI 0.46.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?