### PR TITLE
vnc: Fix builds by setting C89 and disabling c++11-narrowing warning.

### DIFF
--- a/x11/vnc/Portfile
+++ b/x11/vnc/Portfile
@@ -31,6 +31,8 @@ configure.dir   ${worksrcpath}/unix
 build.dir       ${configure.dir}
 
 configure.args  --with-x --with-installed-zlib
+configure.cflags-append     -std=c89
+configure.cxxflags-append   -Wno-c++11-narrowing
 
 destroot.cmd    ./vncinstall
 destroot.target


### PR DESCRIPTION
Build fails for implicit int return and char narrowing warnings. These flags permit the build to complete. (Tested on Tahoe / Arm.)