### PR TITLE
spring-boot-cli: update to 4.1.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         4.0.6
+version         4.1.0
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  08b13066d5f6719fa3c010e055e999bdc8454dc5 \
-                sha256  fe38608b7921e20ac6f5e8670966995c0cada9b3e77caadfd0f1094c62085918 \
-                size    7186664
+checksums       rmd160  c856f4bea4792778db5208a69dc8595c4603a3c9 \
+                sha256  48f2db51b0a482adee0e6faadec431ec9d0185f449ceb90bc2d07c2dbc2841e6 \
+                size    7366961
 
 worksrcdir      spring-${version}
 
@@ -42,7 +42,7 @@ use_configure   no
 # Oldest supported Long Term Support version
 java.version    17+
 # Latest supported Long Term Support version
-java.fallback   openjdk21
+java.fallback   openjdk25
 
 build {}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 4.1.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?