### PR TITLE
immich-go: new port, version 0.31.0

### DIFF
--- a/graphics/immich-go/Portfile
+++ b/graphics/immich-go/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/simulot/immich-go 0.31.0 v
+go.offline_build    no
+revision            0
+
+checksums           rmd160  7bacc4e8c53287734872cafce20cc6194460a264 \
+                    sha256  b24fd12f28d9691853cae1f48ff846b33794a36a4d356912060d019314789fd4 \
+                    size    89749890
+
+categories          graphics net
+installs_libs       no
+license             AGPL-3
+maintainers         {acm.org:cardi @cardi} \
+                    openmaintainer
+
+description         Command-line tool for uploading photo collections to Immich
+long_description    immich-go is an open-source tool designed to streamline \
+                    uploading large photo collections to a self-hosted Immich \
+                    server. It supports Google Photos Takeout archives, local \
+                    folders, ZIP archives, and transfer between Immich servers, \
+                    with duplicate detection and metadata preservation.
+
+build.args          -ldflags \"-X ${go.package}/app.Version=${version}\"
+
+destroot {
+    xinstall -d ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description
immich-go: new port, version 0.31.0

###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.2 17C52

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?