### PR TITLE
goto: update to 1.6.1

### DIFF
--- a/net/goto/Portfile
+++ b/net/goto/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/grafviktor/goto 1.6.0 v
+go.setup            github.com/grafviktor/goto 1.6.1 v
 revision            0
 categories          net
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -20,9 +20,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  60a19bfd19ab9b29c53681ff8008ac8c6ac2aaec \
-                        sha256  50ce0ed1cc86a15c70ec03309886099bf882338277983241972c9cc7531c9265 \
-                        size    2199889
+                        rmd160  fb28d841a1f2c4b0c052af9e226cebea7501861a \
+                        sha256  72db993bdd57ade836c723e65119ec2331335c496b4dbf4e1bee5ac59ec61b85 \
+                        size    2199849
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \


### PR DESCRIPTION
#### Description
https://github.com/grafviktor/goto/releases/tag/v1.6.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
