### PR TITLE
llmfit: update to 0.9.31

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.29 v
+github.setup            AlexsJones llmfit 0.9.31 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  73dab0562e0ed93d48821e5bb4bc2e4cdfbb92c0 \
-                        sha256  7949480d03849e5b05aec61c85c107daeb415de58af4097d17aed905c2a156be \
-                        size    3448613
+                        rmd160  5f1201a3b073a5a0715f058d243a35b108d8a3ec \
+                        sha256  8fc87ecd3608b4a007c4ee8300ad129eb5578f4daf31a20ff985b84654be9a31 \
+                        size    3455375
 
 categories              llm
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
