### PR TITLE
pi-coding-agent: update to 0.79.1

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.78.0
+version             0.79.1
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  ad9b9712cdcf0160be9c366af3159cb0307a8d43 \
-                    sha256  a047da75801d9135e368a4711d06d0ca4b6ab708801ab82fd1366dde1eedd0ee \
-                    size    4680396
+checksums           rmd160  ccf150dbf3c87f6a2cec780d08998468b0484865 \
+                    sha256  a96bbf2c0fa8d2885eb1c86144d924653380653891ccb8e6bf40f66137f597dd \
+                    size    4745708
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
