### PR TITLE
libheif: Fall back to 1.22.2, fix legacy builds

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -27,12 +27,12 @@ platform darwin {
 }
 
 if {${port_latest}} {
-    github.setup            strukturag libheif 1.23.0 v
+    github.setup            strukturag libheif 1.22.2 v
     revision                0
 
-    checksums               rmd160  a2690fbe15adefc6b6826e2842f8347d97ade4cb \
-                            sha256  4c9182b18897617182eed12ab5eb9f9d855b3aa3a736d6bdb31abc034ec7d393 \
-                            size    2064049
+    checksums               rmd160  b6306bd92e1951af0859a8e8ccef14674e16be04 \
+                            sha256  eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3 \
+                            size    2049684
 
     compiler.cxx_standard   2020
 } else {


### PR DESCRIPTION
#### Description

* Fall back libheif 1.23.0 --> 1.22.2.
* Avoid C++20 compiler problem with new code in 1.23.0:
    error: no member named 'ranges' in namespace 'std'
* Fix legacy builds for macOS 10.7 through 10.14.
* Fix ImageMagick and other popular ports for these legacy OS versions.
* Replaces more complicated PR #33032.
* Also see https://trac.macports.org/ticket/74078.

This is a stopgap for quick reliable relief.  `libheif` needs a `libheif-devel` port for further debugging of this intricate problem.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- ⛔ checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
      -- This is an alternative for  #33032.
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?