### PR TITLE
binutils: update to 2.46.1

### DIFF
--- a/devel/binutils/Portfile
+++ b/devel/binutils/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 
 name                binutils
-version             2.46.0
+version             2.46.1
 revision            0
 
-checksums           rmd160  cf936fe24a82aa43696ea442b6f52441af4015e2 \
-                    sha256  d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2 \
-                    size    28548776
+checksums           rmd160  f617d2a1b62aff9c2d4f3f8ae6722d501563c2e0 \
+                    sha256  e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4 \
+                    size    28636456
 
 description         FSF Binutils for native development.
 long_description    Free Software Foundation development toolchain ("binutils") \


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?