### PR TITLE
mp3rgain: update to 2.8.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.7.3 v
+github.setup        M-Igashi mp3rgain 2.8.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8141aa539acb2f7960cf90552beec8226327dd0b \
-                    sha256  28e136b33217b5c30701232a532b382fa426fdd061ab5c10f9a421aee6fc6be4 \
-                    size    333449
+                    rmd160  b19e163c0dc6ed5d92ba7064ba04a761046f0849 \
+                    sha256  385a39fc99e187e20464793f1690c56972ed14fe4daa19525eec5ea1601698c8 \
+                    size    340865
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -47,7 +47,7 @@ cargo.crates \
     either                       1.15.0           48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode               1.0.0            34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     flate2                       1.1.9            843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
-    id3                          1.16.4           965c5e6a62a241f2f673df956ea5f52c27780bc1031855890a551ed9b869e2d1 \
+    id3                          1.17.0           70d6d9f23a28c6feab60d7b4a339e004809019ec9d5fd964b3f4c655ff9bc141 \
     indicatif                    0.18.4           25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
     itoa                         1.0.18           8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     js-sys                       0.3.94           2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9 \


### PR DESCRIPTION
Update `audio/mp3rgain` to version 2.8.0.

- Bumped `github.setup` to 2.8.0, reset `revision` to 0
- Recomputed rmd160 / sha256 / size for the v2.8.0 source tarball
- `cargo.crates`: id3 updated 1.16.4 -> 1.17.0

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.8.0