### PR TITLE
claude-code: update to 2.1.175

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.173
+version             2.1.175
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  daa9350d3a511b8bc0d6a928f8c683c68434d04f \
-                 sha256  5a35c1de2b13245e9b3bd72c4df4f068adce14f6d417a3f68bf0bb4372271687 \
-                 size    225909040
+    checksums    rmd160  f0782797263199a7606ac4f27bd6680e60f12e27 \
+                 sha256  3770f2cb42d3f776e62a59aa16230843dc7b8422b36be9b1532e02a6e92e7fa8 \
+                 size    226734640
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  f100932e3b37866e3c1735c106b14c0f637c1b98 \
-                 sha256  235c1bacdcc7f9d8d92368c95a0c66c26fcac98f878f21b10c73af340bc331ab \
-                 size    223390752
+    checksums    rmd160  f65c73c6f8e4544ece7f7eb031de9f8e25027e45 \
+                 sha256  6b75bf132c866ed409bf913c318ca32011e73ffb12d3cd67ecc37bc4ee9ec65d \
+                 size    224216352
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.175.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?