### PR TITLE
superfile: update to 1.6.0

### DIFF
--- a/sysutils/superfile/Portfile
+++ b/sysutils/superfile/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/yorukot/superfile 1.5.0 v
+go.setup            github.com/yorukot/superfile 1.6.0 v
 go.offline_build    no
 revision            0
 
@@ -16,9 +16,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  68eeaf6673bac0b0de07a917e4b47d1e2e6d2694 \
-                    sha256  bb394f73817d164b9756613ccd850fb3dd5fd5ee898defd86b27eecd4cec48bf \
-                    size    21111895
+checksums           rmd160  1508e172812680f83369b2ca1b7141e2cec18af9 \
+                    sha256  7340ce9e3e7db401164310dd5d2d1dfa3ccf76118ac49d192b0fac2a292c5b0d \
+                    size    20789564
 
 build.args-append   -o ./spf
 


### PR DESCRIPTION
#### Description

Update superfile to v1.6.0

###### Tested on

macOS 26.5.1 25F80 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
