### PR TITLE
claude-code: update to 2.1.176

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.175
+version             2.1.176
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  f0782797263199a7606ac4f27bd6680e60f12e27 \
-                 sha256  3770f2cb42d3f776e62a59aa16230843dc7b8422b36be9b1532e02a6e92e7fa8 \
-                 size    226734640
+    checksums    rmd160  3b98b31d02b6f72df1bb1bd88c95112de0424c55 \
+                 sha256  68cc0e17ab0b741c87eba77ae097d6da49d335952cdd9ca4c3dc75d9d5496222 \
+                 size    227626288
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  f65c73c6f8e4544ece7f7eb031de9f8e25027e45 \
-                 sha256  6b75bf132c866ed409bf913c318ca32011e73ffb12d3cd67ecc37bc4ee9ec65d \
-                 size    224216352
+    checksums    rmd160  9793f0d170d20094b6c4f22c53ce7eb28aa4a227 \
+                 sha256  f3f1b0c098510bd5d472b15f5541bb261f5939aeb52e488760bc53fb54c1803d \
+                 size    225108000
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.176.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?