### PR TITLE
lima: Update to 2.1.2

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 2.1.1 v
+go.setup            github.com/lima-vm/lima 2.1.2 v
 go.offline_build    no
 revision            0
 
@@ -28,9 +28,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  b01c90ce75e3a08433f11852b224ea8b1cc56299 \
-                    sha256  c1cb9f2a5d35715937bbf21566d58f89fc221ab285a42ddcc30fd6fdaab2c15a \
-                    size    7795047
+checksums           rmd160  c2d52c4d949919fa5f9e6055c525dd94420b7c15 \
+                    sha256  23fa5f4621e355236a10200c4e4f61eae9f69c805c57a107247847b51522ab8a \
+                    size    7810777
 
 build.cmd           make
 build.args-append   native


### PR DESCRIPTION
#### Description

lima: Update to 2.1.2


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
