### PR TITLE
mise: Update to 2026.6.5

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.5.18 v
+github.setup        jdx mise 2026.6.5 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dd678392c370f945eba3bcab8e0e5fe47c918c5f \
-                    sha256  f1a3b31060484207b1618746b526571c29ee7150e509c4229f33b1e512b2d667 \
-                    size    6991207
+                    rmd160  969adb607ee0a61b5cfbc00669eb7e288c2eac3f \
+                    sha256  81d9b27a067cf6f91d071b9520a78598524747df1e894f9fcd4d03ae339d7748 \
+                    size    7139880
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -87,7 +87,7 @@ cargo.crates \
     adler2                               2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
     aead                                 0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
     aes                                  0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
-    aes                                  0.9.0  66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8 \
+    aes                                  0.9.1  f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138 \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
     age                                 0.11.3  a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5 \
     age-core                            0.11.0  e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99 \
@@ -113,7 +113,7 @@ cargo.crates \
     astral-reqwest-middleware            0.5.1  98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9 \
     astral-tokio-tar                     0.6.2  cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277 \
     astral_async_http_range_reader      0.11.0  4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f \
-    astral_async_zip                    0.0.17  ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba \
+    astral_async_zip                    0.0.18  c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes           0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
     async-compression                   0.4.42  e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac \
@@ -166,9 +166,9 @@ cargo.crates \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
-    bitflags                            2.11.1  c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
+    bitflags                            2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
     bitvec                               1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
-    blake2                              0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
+    blake2                         0.11.0-rc.6  061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690 \
     blake3                               1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-buffer                        0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
@@ -192,14 +192,14 @@ cargo.crates \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.62  a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98 \
+    cc                                  1.2.63  556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                          0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                             0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
     chacha20                            0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
     chacha20poly1305                    0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
-    chrono                              0.4.44  c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0 \
+    chrono                              0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     chrono-tz                            0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                      0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                            0.14.15  7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23 \
@@ -214,7 +214,7 @@ cargo.crates \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
     clx                                  2.1.0  20daab9df9e49b0478215055d38362d5973043b7a4af836a58968760755e9a9f \
     cmake                               0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
-    cmov                                 0.5.3  3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746 \
+    cmov                                 0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     cmpv2                                0.2.0  961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39 \
     cms                                  0.2.3  7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730 \
     coalesced_map                        0.1.3  b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de \
@@ -229,7 +229,7 @@ cargo.crates \
     compression-codecs                  0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
     compression-core                    0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
     concurrent-queue                     2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
-    configparser                         3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
+    configparser                         3.2.0  b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4 \
     confique                             0.4.0  06b4f5ec222421e22bb0a8cbaa36b1d2b50fd45cdd30c915ded34108da78b29f \
     confique-macro                      0.0.13  e4d1754680cd218e7bcb4c960cc9bae3444b5197d64563dccccfdf83cab9e1a7 \
     console                             0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
@@ -262,7 +262,7 @@ cargo.crates \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    ctor                                 1.0.6  6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5 \
+    ctor                                 1.0.7  01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -289,7 +289,7 @@ cargo.crates \
     directories                          6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs                                 6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                             0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    displaydoc                           0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
+    displaydoc                           0.2.6  1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
     document-features                   0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                             0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     duct                                 1.1.1  7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684 \
@@ -317,7 +317,7 @@ cargo.crates \
     exec                                 0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                            1.1.1  e6e6e9a6990c24970375077a97a392146b5be2155a957d9a4e5337ca0bde0c26 \
     eyre                                0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
-    fancy-regex                         0.17.0  72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8 \
+    fancy-regex                         0.18.0  e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277 \
     faster-hex                          0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
     fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
@@ -364,63 +364,62 @@ cargo.crates \
     getrandom                            0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
     ghash                                0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                               0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
-    gix                                 0.83.0  6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567 \
-    gix-actor                           0.41.0  272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8 \
-    gix-archive                         0.32.0  9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342 \
-    gix-attributes                      0.33.0  fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000 \
-    gix-bitmap                           0.3.1  1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894 \
-    gix-blame                           0.13.0  14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a \
-    gix-chunk                            0.7.1  edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320 \
-    gix-command                          0.9.0  86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8 \
-    gix-commitgraph                     0.37.0  fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb \
-    gix-config                          0.56.0  8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410 \
-    gix-config-value                    0.18.0  13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2 \
-    gix-credentials                     0.38.0  65ca11598b70811d7b16ff90945a6e57dfe521e85b744e51636965fe39cc8f60 \
-    gix-date                            0.15.3  b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543 \
-    gix-diff                            0.63.0  dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a \
-    gix-dir                             0.25.0  32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c \
-    gix-discover                        0.51.0  17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34 \
-    gix-error                            0.2.3  e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613 \
-    gix-features                        0.48.0  af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f \
-    gix-filter                          0.30.0  dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08 \
-    gix-fs                              0.21.1  1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86 \
-    gix-glob                            0.26.0  08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c \
-    gix-hash                            0.25.0  bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2 \
-    gix-hashtable                       0.15.0  d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b \
-    gix-ignore                          0.21.0  6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5 \
-    gix-imara-diff                       0.2.1  39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82 \
-    gix-index                           0.51.0  54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db \
-    gix-lock                            23.0.0  09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1 \
-    gix-mailmap                         0.33.0  023d3a6561cbebe45b89e0764d48928ad970667076f16fa5889e6f86d8432086 \
-    gix-merge                           0.16.0  74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881 \
-    gix-negotiate                       0.31.0  103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c \
-    gix-object                          0.60.0  a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7 \
-    gix-odb                             0.80.0  aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba \
-    gix-pack                            0.70.0  daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa \
-    gix-packetline                      0.21.3  362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6 \
-    gix-path                            0.12.0  671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e \
-    gix-pathspec                        0.18.0  2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855 \
-    gix-prompt                          0.15.0  e041a626c64cb69e4117fcdf80da8d0e454fba3b1f420412792d191f52251aee \
-    gix-protocol                        0.61.0  aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd \
-    gix-quote                            0.7.1  6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be \
-    gix-ref                             0.63.0  d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167 \
-    gix-refspec                         0.41.0  61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761 \
-    gix-revision                        0.45.0  1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8 \
-    gix-revwalk                         0.31.0  313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0 \
-    gix-sec                             0.14.0  f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6 \
-    gix-shallow                         0.12.0  29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27 \
-    gix-status                          0.30.0  68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65 \
-    gix-submodule                       0.30.0  9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91 \
-    gix-tempfile                        23.0.0  691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb \
-    gix-trace                           0.1.19  6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e \
-    gix-transport                       0.57.0  ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018 \
-    gix-traverse                        0.57.0  a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c \
-    gix-url                             0.36.0  35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece \
-    gix-utils                            0.3.2  4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c \
-    gix-validate                        0.11.1  e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5 \
-    gix-worktree                        0.52.0  d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd \
-    gix-worktree-state                  0.30.0  8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800 \
-    gix-worktree-stream                 0.32.0  9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213 \
+    gix                                 0.84.0  ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce \
+    gix-actor                           0.41.1  8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f \
+    gix-archive                         0.33.0  16909cacc78936ab96f6c3be08379d0a2e88bfa3a7527972d2ed75c7517ef31e \
+    gix-attributes                      0.33.1  8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02 \
+    gix-bitmap                           0.3.2  52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283 \
+    gix-blame                           0.14.0  4d39a0c14af94c2edaa5eefe06d5ef2cdea55316ae9a9321314288e3f55fa4c0 \
+    gix-chunk                            0.7.2  9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb \
+    gix-command                          0.9.1  00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6 \
+    gix-commitgraph                     0.37.1  7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb \
+    gix-config                          0.57.0  4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de \
+    gix-config-value                    0.18.1  ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab \
+    gix-credentials                     0.38.1  f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d \
+    gix-date                            0.15.4  a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c \
+    gix-diff                            0.64.0  3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b \
+    gix-dir                             0.26.0  21bb2a53a6fd917ec499ed0bfb5b6887de7a15bd79197dcea7c987938749a9f1 \
+    gix-discover                        0.52.0  77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7 \
+    gix-error                            0.2.4  e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b \
+    gix-features                        0.48.1  1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc \
+    gix-filter                          0.31.0  ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa \
+    gix-fs                              0.21.2  6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe \
+    gix-glob                            0.26.1  d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756 \
+    gix-hash                            0.25.1  cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce \
+    gix-hashtable                       0.15.1  b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563 \
+    gix-ignore                          0.21.1  d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d \
+    gix-imara-diff                       0.2.2  19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19 \
+    gix-index                           0.52.0  4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d \
+    gix-lock                            23.0.1  65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c \
+    gix-mailmap                         0.33.1  195fd20808055824531be2fd0d34136d900e5fbca3ffb0a3c07e8beeefb9c828 \
+    gix-negotiate                       0.32.0  890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55 \
+    gix-object                          0.61.0  d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525 \
+    gix-odb                             0.81.0  7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d \
+    gix-pack                            0.71.0  e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174 \
+    gix-packetline                      0.21.4  bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126 \
+    gix-path                            0.12.1  afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6 \
+    gix-pathspec                        0.18.1  3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f \
+    gix-prompt                          0.15.1  3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8 \
+    gix-protocol                        0.62.0  51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee \
+    gix-quote                            0.7.2  a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef \
+    gix-ref                             0.64.0  4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b \
+    gix-refspec                         0.42.0  b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3 \
+    gix-revision                        0.46.0  0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f \
+    gix-revwalk                         0.32.0  85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6 \
+    gix-sec                             0.14.1  ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3 \
+    gix-shallow                         0.12.1  a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97 \
+    gix-status                          0.31.0  22042e385d28a34275e029d98f4970285045be14b9073658ca897923f2ed8700 \
+    gix-submodule                       0.31.0  3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781 \
+    gix-tempfile                        23.0.1  27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22 \
+    gix-trace                           0.1.20  44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678 \
+    gix-transport                       0.57.1  7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff \
+    gix-traverse                        0.58.0  e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed \
+    gix-url                             0.36.1  65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2 \
+    gix-utils                            0.3.3  66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771 \
+    gix-validate                        0.11.2  7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3 \
+    gix-worktree                        0.53.0  cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1 \
+    gix-worktree-state                  0.31.0  4bffae8b3ca258fdd50370cd51f06deb4c76a3b43db3868bc28dde45ffa77d69 \
+    gix-worktree-stream                 0.33.0  d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557 \
     glob                                 0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     globset                             0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
@@ -441,7 +440,7 @@ cargo.crates \
     hmac                                0.13.0  6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
     homedir                              0.3.6  68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527 \
     http                                0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
-    http                                 1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
+    http                                 1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
@@ -454,7 +453,7 @@ cargo.crates \
     humansize                            2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                            2.3.0  135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424 \
     hybrid-array                        0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
-    hyper                                1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
+    hyper                               1.10.1  55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
     hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                          0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
@@ -475,7 +474,7 @@ cargo.crates \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                         1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
-    ignore                              0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
+    ignore                              0.4.26  b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d \
     impl-tools                          0.11.4  0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208 \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
@@ -497,8 +496,8 @@ cargo.crates \
     itertools                           0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jiff                                0.2.25  6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65 \
-    jiff-static                         0.2.25  3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c \
+    jiff                                0.2.28  4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102 \
+    jiff-static                         0.2.28  782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47 \
     jiff-tzdb                            0.1.6  c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076 \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
@@ -506,7 +505,7 @@ cargo.crates \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                              0.3.99  142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11 \
+    js-sys                             0.3.100  f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162 \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
@@ -523,15 +522,15 @@ cargo.crates \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                            0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    link-section                        0.17.2  4d1e908a416d6e9f725743b84a36feea40c4c131e805fbc26d61f9f451f36080 \
-    linktime-proc-macro                  0.1.0  a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81 \
+    libredox                            0.1.17  f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3 \
+    link-section                        0.18.2  c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f \
+    linktime-proc-macro                  0.2.0  8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     litrs                                1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                            0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                                 0.4.30  616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5 \
+    log                                 0.4.32  953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
@@ -541,13 +540,13 @@ cargo.crates \
     luajit-src                 210.6.6+707c12b  a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295 \
     lzma-rs                              0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     lzma-rust                            0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
-    lzma-rust2                          0.16.3  5e9ceaec84b54518262de7cf06b8b43e83c808349960f1610b21b0bfc9640f20 \
+    lzma-rust2                          0.16.4  ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02 \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
-    memchr                               2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
+    memchr                               2.8.1  6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8 \
     memmap2                             0.9.10  714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3 \
     memoffset                            0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                               7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
@@ -556,7 +555,7 @@ cargo.crates \
     minimal-lexical                      0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                      0.2.5  22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e \
     miniz_oxide                          0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                                  1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
+    mio                                  1.2.1  02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
     mlua                                0.11.6  ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab \
     mlua-sys                            0.10.0  0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8 \
     mlua_derive                         0.11.0  465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2 \
@@ -600,7 +599,7 @@ cargo.crates \
     os_pipe                              1.2.3  7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967 \
     outref                               0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     owo-colors                           4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
-    papergrid                           0.17.0  6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1 \
+    papergrid                           0.18.0  d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e \
     parking                              2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                         0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                    0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
@@ -608,7 +607,7 @@ cargo.crates \
     pastey                               0.2.3  2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4 \
     path-absolutize                      3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
     path-dedot                           3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
-    path_resolver                       0.2.10  2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1 \
+    path_resolver                       0.2.11  83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660 \
     pbkdf2                              0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     pbkdf2                              0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
     pem                                  3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
@@ -634,7 +633,7 @@ cargo.crates \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    platforms                           3.10.0  f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63 \
+    platforms                           3.11.0  366f9622ebb8981452cd68eba56dd73eccc76fa093dc1d7dd5f5495da05cc977 \
     plist                                1.9.0  092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1 \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                              0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
@@ -675,20 +674,20 @@ cargo.crates \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.43.2  188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd \
-    rattler_cache                        0.8.2  c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557 \
-    rattler_conda_types                 0.46.4  6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02 \
-    rattler_digest                       1.3.0  3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab \
-    rattler_macros                       1.1.0  9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5 \
-    rattler_menuinst                    0.2.62  0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8 \
-    rattler_networking                  0.27.2  19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27 \
-    rattler_package_streaming           0.26.2  eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9 \
-    rattler_pty                         0.2.12  30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e \
+    rattler                             0.44.3  95d047508f114f4a0b9d215f309042799f117c66c08fb381113e5e0ed20640e9 \
+    rattler_cache                        0.9.1  7bca0097ce72d097d4381802a4107fb7ee45fc59025feeb2a893cfbeb44ef4b1 \
+    rattler_conda_types                 0.47.0  883f32f7a7729524bf7724e5c7077cc13f8913a28cdf320c83a93d2e2029dcf2 \
+    rattler_digest                       1.3.1  2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69 \
+    rattler_macros                       1.1.1  ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff \
+    rattler_menuinst                    0.2.65  5ea4f082855a8e0df75d0073b9f78e8fb13e8ee9205cb88eec1b3f8b1a030741 \
+    rattler_networking                  0.28.0  5cbe3eb2914bd715ca7dde169979bce15a8e3c6f0850a039d3ab67110180f73a \
+    rattler_package_streaming           0.26.3  411276a9c5c5a1735be82b201e25287df6c7af312fbd7d66ef0b64d4bb170df0 \
+    rattler_pty                         0.2.13  ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a \
     rattler_redaction                    0.2.1  2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b \
-    rattler_repodata_gateway            0.29.2  76d033dc7d25fedc1918719b6d084983436d1cea15621ab5f4c8d722c9020376 \
-    rattler_shell                       0.27.2  b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43 \
-    rattler_solve                        7.1.1  eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316 \
-    rattler_virtual_packages             2.4.1  b0820759e1171d6ef08237cc7683181cb7aa954d3586b24142333ffe8c7efb5b \
+    rattler_repodata_gateway            0.29.4  a2d5aa7ec70dca63533386ebb55cf8f4a38a5f94e0a496978fd986cdb3b6b00e \
+    rattler_shell                       0.27.5  8e492bf2653b421279f245f135ca694ee4b8ea2f470443f5c6fc60b02ea0b1c5 \
+    rattler_solve                        7.1.2  af99e94a11cac58a5d70efbca4b71f5ba4a2f833d2e343f470ab2f29dc1a15b9 \
+    rattler_virtual_packages             3.0.0  ef425f0790fd4bb3b3121b4a14e9f2b5a0a261f8345c9d1a189353b40136fda5 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
@@ -703,7 +702,7 @@ cargo.crates \
     regex-syntax                        0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
     rend                                 0.5.3  cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
-    reqwest                             0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
+    reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     resolvo                             0.10.3  2985c35f7dd19ed00659031b77ce05d1828a12eb9c6b37104da21b09d218fc24 \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
@@ -727,7 +726,7 @@ cargo.crates \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                             0.23.40  ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
-    rustls-native-certs                  0.8.3  612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
+    rustls-native-certs                  0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
     rustls-pki-types                    1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
@@ -738,7 +737,6 @@ cargo.crates \
     ryu-js                               1.0.2  dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15 \
     salsa20                             0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                            1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    scc                                  2.4.0  46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc \
     schannel                            0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     schemars                             0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
     schemars                             1.2.1  a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc \
@@ -746,7 +744,6 @@ cargo.crates \
     scoped-tls                           1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                           1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                              0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
-    sdd                                 3.0.10  490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
     seccompiler                          0.5.0  a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884 \
     secrecy                             0.10.3  e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a \
     security-framework                   3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
@@ -767,15 +764,16 @@ cargo.crates \
     serde_json                         1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_json_canonicalizer             0.3.2  fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2 \
     serde_plain                          1.0.2  9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50 \
-    serde_regex                          1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
+    serde_regex                          1.2.0  bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012 \
     serde_repr                          0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
+    serde_spanned                        0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
     serde_spanned                        1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                     0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                          3.20.0  e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2 \
-    serde_with_macros                   3.20.0  b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac \
+    serde_with                          3.21.0  76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c \
+    serde_with_macros                   3.21.0  84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660 \
     serde_yaml               0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
-    serial_test                          3.4.0  911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f \
-    serial_test_derive                   3.4.0  0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9 \
+    serial_test                          3.5.0  699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
+    serial_test_derive                   3.5.0  94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
     sevenz-rust                          0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sevenz-rust2                        0.20.2  29225600349ef74beda5a9fffb36ac660a24613c0bde9315d0c49be1d51e9c24 \
     sha1                                0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
@@ -790,6 +788,7 @@ cargo.crates \
     shell-words                          1.1.1  dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77 \
     shellexpand                          3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                                1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    shlex                                2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
     sigchld                              0.2.4  47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1 \
     signal-hook                         0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook                          0.4.4  b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d \
@@ -816,7 +815,7 @@ cargo.crates \
     snafu                                0.8.9  6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2 \
     snafu-derive                         0.8.9  c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451 \
     snap                                 1.1.1  1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b \
-    socket2                              0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
+    socket2                              0.6.4  52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
     socks                                0.3.4  f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b \
     spin                                 0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spki                                 0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
@@ -840,7 +839,7 @@ cargo.crates \
     sysctl                               0.5.5  ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea \
     system-configuration                 0.7.0  a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
     system-configuration-sys             0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
-    tabled                              0.20.0  e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d \
+    tabled                              0.21.0  b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff \
     tabled_derive                       0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
     tap                                  1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     taplo                               0.14.0  c221a50eef1a5493074f11ca1ed62bef28c05a4d925002944cc686b2e783a5b3 \
@@ -849,9 +848,9 @@ cargo.crates \
     tera                                1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
     termcolor                            1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                        0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
-    test-log                            0.2.20  2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3 \
-    test-log-core                       0.2.20  37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c \
-    test-log-macros                     0.2.20  9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320 \
+    test-log                            0.2.21  9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1 \
+    test-log-core                       0.2.21  c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b \
+    test-log-macros                     0.2.21  944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d \
     testing_table                        0.3.0  0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc \
     text-size                            1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     textwrap                            0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
@@ -875,10 +874,14 @@ cargo.crates \
     tokio-stream                        0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
     tokio-util                          0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
     toml                                0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
+    toml                                0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
     toml                      1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    toml_datetime                       0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
     toml_datetime             1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
-    toml_edit               0.25.11+spec-1.1.0  0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
+    toml_edit                          0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
+    toml_edit               0.25.12+spec-1.1.0  d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7 \
     toml_parser               1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_write                           0.1.2  5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801 \
     toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tough                               0.22.0  8031cff0872dd1c6312370515a6be8098f6ea5512f1bad725016046fc725f272 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
@@ -896,7 +899,7 @@ cargo.crates \
     typed-path                           0.9.3  82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607 \
     typed-path                          0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typeid                               1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
-    typenum                             1.20.0  40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
+    typenum                             1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
     ubi                                  0.9.0  eb72e0fb81c47ba1a6adcb248084193109710f482786856ff5e820605ac52546 \
     ucd-trie                             0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uluru                                3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
@@ -907,7 +910,7 @@ cargo.crates \
     unicode-ident                       1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-linebreak                    0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
     unicode-normalization               0.1.25  5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8 \
-    unicode-segmentation                1.13.2  9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c \
+    unicode-segmentation                1.13.3  c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8 \
     unicode-width                       0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                        0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unicode-xid                          0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
@@ -920,11 +923,11 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.4.0  188a4fb4ad9e81729867ebb83ccbc06f850a06362c2467eea0f268fe4f6df609 \
+    usage-lib                            3.5.0  bc055ae0a824bf9e409ee8e175ec224d5e1b79325557f51967eea0f103e5dc03 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                                1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
+    uuid                                1.23.2  d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7 \
     valuable                             0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     value-trait                         0.12.1  8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59 \
     vcpkg                               0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
@@ -938,22 +941,22 @@ cargo.crates \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                    1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
     wasip3      0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                       0.2.122  3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409 \
-    wasm-bindgen-futures                0.4.72  9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f \
-    wasm-bindgen-macro                 0.2.122  916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6 \
-    wasm-bindgen-macro-support         0.2.122  299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e \
-    wasm-bindgen-shared                0.2.122  9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437 \
+    wasm-bindgen                       0.2.123  a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563 \
+    wasm-bindgen-futures                0.4.73  54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf \
+    wasm-bindgen-macro                 0.2.123  24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc \
+    wasm-bindgen-macro-support         0.2.123  908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b \
+    wasm-bindgen-shared                0.2.123  7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92 \
     wasm-encoder                       0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                      0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmparser                         0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                             0.3.99  6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436 \
+    web-sys                            0.3.100  6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69 \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-root-certs                    1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
     webpki-roots                         1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
-    which                                8.0.2  81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459 \
+    which                                8.0.3  c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e \
     widestring                           1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                               0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu           0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -1034,10 +1037,10 @@ cargo.crates \
     xx                                   2.5.4  d61141ccbc979c1421bc450f1a800196abc073e0deccb0adcb100c96238b33e2 \
     xz2                                  0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
-    yoke                                 0.8.2  abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
+    yoke                                 0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                            0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
-    zerocopy-derive                     0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
+    zerocopy                            0.8.50  3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1 \
+    zerocopy-derive                     0.8.50  0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639 \
     zerofrom                             0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                      0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                              1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \


### PR DESCRIPTION
#### Description

mise: Update to 2026.6.5


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
