### PR TITLE
opencv4: Fix linker issue

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           ffmpeg 1.0
 PortGroup           github 1.0
 
 #==============================================================================
@@ -54,7 +55,7 @@ if {${os.major} > 12} {
 if {${opencv_latest}} {
     github.setup    opencv opencv 4.9.0
     github.tarball_from releases
-    revision        9
+    revision        10
     epoch           1
 
     checksums-append \
@@ -85,7 +86,7 @@ dist_subdir         ${my_name}
 # Python build support
 #------------------------------------------------------------------------------
 set default_python_branch \
-                    3.13
+                    3.14
 set default_python_version \
                     [join [lrange [split ${default_python_branch} .] 0 1] ""]
 set default_python_path \
@@ -135,8 +136,7 @@ cmake.set_cxx_standard \
                     yes
                     
 configure.env-append \
-                    PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig"
-
+                    PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg${ffmpeg.version}/lib/pkgconfig"
 
 compiler.blacklist-append \
                     {clang < 900} \
@@ -150,7 +150,6 @@ depends_build-append \
 
 depends_lib-append  \
                     port:ade \
-                    port:ffmpeg4 \
                     port:imath \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
@@ -416,7 +415,7 @@ foreach python_branch ${python_branches} {
     subport py${python_version}-${name} {
         # NOTE: Only rev-bump subports, for major changes/additions
         if {${opencv_latest}} {
-            revision 4
+            revision 5
         } else {
             revision 21
         }
@@ -428,8 +427,6 @@ foreach python_branch ${python_branches} {
 
         depends_build-delete \
                     port:python${default_python_version}
-        depends_lib-delete \
-                    port:ffmpeg4
         depends_lib-append \
                     port:${name} \
                     port:py${python_version}-numpy \
@@ -711,28 +708,16 @@ if {${name} eq ${subport}} {
         configure.args-append  -DOPENCV_WECHAT_QRCODE_URL=file://${distpath}/
     }
 
-    variant ffmpeg6 conflicts ffmpeg7 ffmpeg8 description {Link against ffmpeg 5} {
-        depends_lib-delete port:ffmpeg4
-        depends_lib-append port:ffmpeg6
-        configure.env-replace \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig" \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg6/lib/pkgconfig"
+    variant ffmpeg4 conflicts ffmpeg6 ffmpeg7 description {Link against ffmpeg 4} {
+        ffmpeg.version     4
     }
 
-    variant ffmpeg7 conflicts ffmpeg6 ffmpeg8 description {Link against ffmpeg 7} {
-        depends_lib-delete port:ffmpeg4
-        depends_lib-append port:ffmpeg7
-        configure.env-replace \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig" \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg7/lib/pkgconfig"
+    variant ffmpeg6 conflicts ffmpeg4 ffmpeg7 description {Link against ffmpeg 6} {
+        ffmpeg.version     6
     }
 
-    variant ffmpeg8 conflicts ffmpeg6 ffmpeg7 description {Link against ffmpeg 8} {
-        depends_lib-delete port:ffmpeg4
-        depends_lib-append port:ffmpeg8
-        configure.env-replace \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig" \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg8/lib/pkgconfig"
+    variant ffmpeg7 conflicts ffmpeg4 ffmpeg6 description {Link against ffmpeg 7} {
+        ffmpeg.version     7
     }
 
     variant qt4 conflicts qt5 description {Build with Qt4 Backend support} {


### PR DESCRIPTION
opencv4: Fix linker issue
* Use `ffmpeg8` as default`
* Create `ffmpeg4` variant, remove `ffmpeg8` variant
* Use Python314 as default build tool
* Fixes: https://trac.macports.org/ticket/74107

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
