### PR TITLE
jaq: Update to 3.1.0

### DIFF
--- a/textproc/jaq/Portfile
+++ b/textproc/jaq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        01mf02 jaq 3.0.0 v
+github.setup        01mf02 jaq 3.1.0 v
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 depends_lib-append  port:jq
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2a6c37eebd644fd0c0397566cdd9ad01670e10aa \
-                    sha256  c56948c90d0c3566c8b33eedd9fa61587ffbb2feef7d78172955876d6e10a315 \
-                    size    226365
+                    rmd160  4a09e12df2f911f6277a25f63c979d80dbdd9f35 \
+                    sha256  8ad074d7e90e07ad7e77048dcf0d0e7ad434b8e3e38044260b9457d4551e644d \
+                    size    227819
 
 github.livecheck.regex \
                     {([0-9.]+)}


### PR DESCRIPTION
#### Description

jaq: Update to 3.1.0


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
