### PR TITLE
cdo: update to 2.6.2

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,8 +5,8 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.1
 
 name                        cdo
-version                     2.6.1
-revision                    1
+version                     2.6.2
+revision                    0
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
                             openmaintainer
@@ -14,11 +14,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/30210
+master_sites                https://code.mpimet.mpg.de/attachments/download/30213
 
-checksums           rmd160  3921412c349ff7271c577dda7f2be2b2adec8b7b \
-                    sha256  ccf5f3bd5800f703c031bb5b10ae0cd3feac34d8eba7956661ff1ba6deb5985f \
-                    size    13661502
+checksums           rmd160  66e30330c2d3d3dc6d2be257c903cdaa6f9a5bf3 \
+                    sha256  d59f57a3b33a063023b2b0ef8f38165e0bcf426d3b843031c5078e76832e957b \
+                    size    13267490
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.6.2, containing only bug fixes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.7 24G720 x86_64
Command Line Tools 26.3.0.0.1.1771626560

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
