### PR TITLE
fcron: Update to 3.4.1

### DIFF
--- a/sysutils/fcron/Portfile
+++ b/sysutils/fcron/Portfile
@@ -2,14 +2,14 @@
 
 PortSystem          1.0
 PortGroup           legacysupport 1.0
+
 # for strndup
 legacysupport.newest_darwin_requires_legacy 10
 
 name                fcron
-version             3.2.1
-revision            3
+version             3.4.1
+revision            0
 categories          sysutils
-platforms           darwin
 license             GPL-2
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 description         fcron is an alternative scheduler aka cron daemon
@@ -20,14 +20,14 @@ long_description    fcron is a scheduler. It aims at replacing Vixie Cron, so \
     systems which are not running neither all the time nor \
     regularly (contrary to anacrontab).
 
-homepage            https://web.archive.org/web/20190804123648/http://fcron.free.fr/
-# This archives still works
+homepage            http://fcron.free.fr/
 master_sites        http://fcron.free.fr/archives
-# The official git repo is now https://github.com/yo8192/fcron; nothing there ATM
+# The official git repo is now https://github.com/yo8192/fcron
 extract.suffix      .src.tar.gz
 
-checksums           rmd160  a3c17af13e2b6fd9e30e9365822e6609c3d79464 \
-                    sha256  6114d0a39a32853669c0c0ba0f96d92920e7cabca3ff1edf37d25750403e5f6a
+checksums           rmd160  119ca00c096c93b4d46ae0e8eeb030fe8bf89992 \
+                    sha256  75717e3916cbcefbcde58e7bfd515150d75f7632385b2db6bdd2fbc24289ecd5 \
+                    size    624543
 
 depends_build-append    port:perl5
 depends_lib-append      port:readline
@@ -79,4 +79,5 @@ Try 'EDITOR=/usr/bin/vi fcrontab -e', if that works, set EDITOR in your
 shells config.
 "
 
-livecheck.type      none
+livecheck.type      regex
+livecheck.regex     "${name} (\\d+(?:\\.\\d+)+)"


### PR DESCRIPTION
#### Description

Update fcron to 3.4.1. Add livecheck to check for later updates

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
