### PR TITLE
file: Update to 5.48

### DIFF
--- a/sysutils/file/Portfile
+++ b/sysutils/file/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 
 name                file
-version             5.47
-checksums           rmd160  88cdab68eb3f07e97a5377a408e02846e9bf4b24 \
-                    sha256  45672fec165cb4cc1358a2d76b5d57d22876dcb97ab169427ac385cbe1d5597a \
-                    size    2676776
+version             5.48
+checksums           rmd160  86faf8eeb05e9a1853c059aca41ea1600a1c158e \
+                    sha256  ed14656883b23a364b4057c05595d93252da9bc473d30106519519d0da141283 \
+                    size    2693209
 
 categories          sysutils
 license             BSD
@@ -26,7 +26,8 @@ master_sites        freebsd \
                     gentoo \
                     ftp://ftp.fu-berlin.de/unix/tools/${name}/ \
                     ftp://ftp.astron.com/pub/${name}/ \
-                    ftp://ftp.gw.com/mirrors/pub/unix/${name}/
+                    ftp://ftp.gw.com/mirrors/pub/unix/${name}/ \
+                    https://astron.com/pub/${name}/
 
 patchfiles          patch-magic-Makefile.am.diff
 
@@ -49,7 +50,9 @@ depends_lib         port:bzip2 \
 # We patch Makefile.am files.
 use_autoreconf      yes
 autoreconf.args     -fvi
-configure.checks.implicit_function_declaration.whitelist-append strchr
+# alignof is C23, not necessary to build
+configure.checks.implicit_function_declaration.whitelist-append strchr alignof
+configure.checks.implicit_int   no
 
 if {${name} eq ${subport}} {
     revision            0


### PR DESCRIPTION
#### Description

Update file to 5.48. The `master_sites` field was re-ordered since a Gentoo mirror is no longer valid. It might be worth updating them at a later date.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
