### PR TITLE
mirrors_sites.tcl: Remove invalid mirror

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -215,7 +215,6 @@ set sites(gentoo) {
     http://gentoo.aditsu.net:8000/distfiles/:nosubdir
     http://gentoo.c3sl.ufpr.br/distfiles/:nosubdir
     http://gentoo.cs.utah.edu/distfiles/:nosubdir
-    http://gentoo.gossamerhost.com/distfiles/:nosubdir
     http://gentoo.mirror.web4u.cz/distfiles/:nosubdir
     http://gentoo.mirrors.ovh.net/gentoo-distfiles/distfiles/:nosubdir
     http://gentoo.mirrors.tera-byte.com/distfiles/:nosubdir


### PR DESCRIPTION
#### Description

Remove invalid mirror from Gentoo mirror list. This mirror is no longer listed in the [Gentoo source mirror](https://www.gentoo.org/downloads/mirrors/) list and redirects to carbon60[dot]com, thus it's no longer valid.

Required by [#33133](https://github.com/macports/macports-ports/pull/33133).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
