### PR TITLE
camlp5: update to 8.05.01

### DIFF
--- a/genealogy/geneweb/Portfile
+++ b/genealogy/geneweb/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        geneweb geneweb 7.1.0-beta2 v
-revision            3
+revision            4
 categories          genealogy
 maintainers         {pguyot @pguyot} openmaintainer
 license             GPL-2

--- a/lang/camlp5/Portfile
+++ b/lang/camlp5/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        camlp5 camlp5 8.04.00
+github.setup        camlp5 camlp5 8.05.01
 github.tarball_from archive
-revision            1
+revision            0
 categories          lang ocaml
 license             BSD
 maintainers         {pmetzger @pmetzger} openmaintainer
@@ -24,9 +24,9 @@ long_description    Camlp5 is a preprocessor and pretty-printer for \
 
 homepage            https://camlp5.github.io/
 
-checksums           rmd160  961bdd0ff8cbbfcd4df05f57e7cbf25c4dc8eeeb \
-                    sha256  eb8c5bc0f47ce4b9518d37bcbf8be05ee80243c38e7019f8c3808456be8f15a8 \
-                    size    1438379
+checksums           rmd160  69c8ee14343af0c0d2f381a88b28d29462dcf82c \
+                    sha256  7aa71c393cf4f24860051a5aa78da8925d73cb79ba045df442dff2343b1283d7 \
+                    size    1506086
 
 depends_build       bin:perl:perl5
 depends_lib         port:ocaml \
@@ -54,8 +54,14 @@ use_parallel_build  no
 universal_variant   no
 
 post-destroot {
-    # Install META file not installed by the Makefile
+    # Install META file not installed by the Makefile, with directory field
+    # so ocamlfind can locate the compiled modules in ${prefix}/lib/${name}
     xinstall -m 755 -d ${destroot}${prefix}/lib/ocaml/site-lib/${name}
-    xinstall -m 644 ${worksrcpath}/etc/META \
-        ${destroot}${prefix}/lib/ocaml/site-lib/${name}
+    set meta_fd [open ${worksrcpath}/etc/META r]
+    set meta_content [read $meta_fd]
+    close $meta_fd
+    set out_fd [open ${destroot}${prefix}/lib/ocaml/site-lib/${name}/META w]
+    puts $out_fd "directory = \"${prefix}/lib/${name}\""
+    puts -nonewline $out_fd $meta_content
+    close $out_fd
 }

--- a/ocaml/ocaml-ulex/Portfile
+++ b/ocaml/ocaml-ulex/Portfile
@@ -7,7 +7,7 @@ PortGroup           ocaml 1.1
 name                ocaml-ulex
 github.setup        whitequark ulex 1.3 v
 github.tarball_from archive
-revision            1
+revision            2
 categories          ocaml devel textproc
 license             BSD
 maintainers         {landonf @landonf} openmaintainer


### PR DESCRIPTION
Bump revision of ocaml-ulex and geneweb for updated OCaml module interfaces (mLast.mli, ast2pt.mli, asttools.mli changed).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
