### PR TITLE
ocaml-alcotest: update to 1.9.1

### DIFF
--- a/ocaml/ocaml-alcotest/Portfile
+++ b/ocaml/ocaml-alcotest/Portfile
@@ -5,17 +5,17 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-alcotest
-github.setup        mirage alcotest 1.7.0
-revision            2
+github.setup        mirage alcotest 1.9.1
+revision            0
 categories          ocaml devel
 maintainers         nomaintainer
 license             ISC
 description         Lightweight and colorful test framework
 long_description    Alcotest exposes simple interface to perform unit tests.
 
-checksums           rmd160  951497c990bd6ce0b122a0f197c916a475ad8c5b \
-                    sha256  ce9be08ebce6ce557360ca78729caf5adcbbf56ff18585ff63ad068b71ecba48 \
-                    size    293433
+checksums           rmd160  cbf969404bd0e0c6f49ffd918c37d566a6da65fb \
+                    sha256  9659376cc5434220bcbc8fe8649588208eeb32126f6b9cc7d649c35f653627fa \
+                    size    297323
 github.tarball_from archive
 
 depends_lib-append  port:ocaml-astring \

--- a/ocaml/ocaml-ppx_blob/Portfile
+++ b/ocaml/ocaml-ppx_blob/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 name                ocaml-ppx_blob
 version             0.9.0
-revision            3
+revision            4
 categories          ocaml devel
 maintainers         {pguyot @pguyot} openmaintainer
 license             Unlicense


### PR DESCRIPTION
Bump revision of ocaml-ppx_blob for updated OCaml module interfaces.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
