### PR TITLE
opencv4: expose ffmpeg6/7/8 variants on Python subports; default +ffmpeg8

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -54,7 +54,7 @@ if {${os.major} > 12} {
 if {${opencv_latest}} {
     github.setup    opencv opencv 4.9.0
     github.tarball_from releases
-    revision        9
+    revision        10
     epoch           1
 
     checksums-append \
@@ -126,6 +126,21 @@ platform darwin {
 
 #worksrcdir          ${parent_subport_name}-${version}
 
+# FFmpeg variant selection — declared in common scope so Python subports inherit them
+variant ffmpeg6 conflicts ffmpeg7 ffmpeg8 description {Link against ffmpeg 6} {}
+variant ffmpeg7 conflicts ffmpeg6 ffmpeg8 description {Link against ffmpeg 7} {}
+variant ffmpeg8 conflicts ffmpeg6 ffmpeg7 description {Link against ffmpeg 8} {}
+
+default_variants    +ffmpeg8
+
+if {[variant_isset ffmpeg6]} {
+    set ffmpeg_version 6
+} elseif {[variant_isset ffmpeg7]} {
+    set ffmpeg_version 7
+} else {
+    set ffmpeg_version 8
+}
+
 # Claims to only need c++11 but actually uses c++14 features
 # core/cvstd_wrapper.hpp:45:40: warning: variable templates are a C++14 extension [-Wc++14-extensions]
 set cxx_standard    2014
@@ -135,7 +150,7 @@ cmake.set_cxx_standard \
                     yes
                     
 configure.env-append \
-                    PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig"
+                    PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg${ffmpeg_version}/lib/pkgconfig"
 
 
 compiler.blacklist-append \
@@ -150,7 +165,6 @@ depends_build-append \
 
 depends_lib-append  \
                     port:ade \
-                    port:ffmpeg4 \
                     port:imath \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
@@ -160,6 +174,12 @@ depends_lib-append  \
                     port:tiff \
                     port:webp \
                     port:zlib
+
+# ffmpeg dep scoped to main port; Python subports pull it transitively via port:opencv4
+if {${name} eq ${subport}} {
+    depends_lib-append \
+                    port:ffmpeg${ffmpeg_version}
+}
 
 #------------------------------------------------------------------------------
 # CMake Variables
@@ -416,9 +436,9 @@ foreach python_branch ${python_branches} {
     subport py${python_version}-${name} {
         # NOTE: Only rev-bump subports, for major changes/additions
         if {${opencv_latest}} {
-            revision 4
+            revision 5
         } else {
-            revision 21
+            revision 22
         }
 
         conflicts-append \
@@ -711,30 +731,6 @@ if {${name} eq ${subport}} {
         configure.args-append  -DOPENCV_WECHAT_QRCODE_URL=file://${distpath}/
     }
 
-    variant ffmpeg6 conflicts ffmpeg7 ffmpeg8 description {Link against ffmpeg 5} {
-        depends_lib-delete port:ffmpeg4
-        depends_lib-append port:ffmpeg6
-        configure.env-replace \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig" \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg6/lib/pkgconfig"
-    }
-
-    variant ffmpeg7 conflicts ffmpeg6 ffmpeg8 description {Link against ffmpeg 7} {
-        depends_lib-delete port:ffmpeg4
-        depends_lib-append port:ffmpeg7
-        configure.env-replace \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig" \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg7/lib/pkgconfig"
-    }
-
-    variant ffmpeg8 conflicts ffmpeg6 ffmpeg7 description {Link against ffmpeg 8} {
-        depends_lib-delete port:ffmpeg4
-        depends_lib-append port:ffmpeg8
-        configure.env-replace \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg4/lib/pkgconfig" \
-            PKG_CONFIG_PATH="${prefix}/libexec/ffmpeg8/lib/pkgconfig"
-    }
-
     variant qt4 conflicts qt5 description {Build with Qt4 Backend support} {
         PortGroup   qt4 1.0
 
@@ -819,7 +815,7 @@ if {${name} eq ${subport}} {
     }
 }
 
-# NOTE: Variant 'debug' is the only one that should be shared with Python subports
+# NOTE: Variants 'debug' and 'ffmpeg{6,7,8}' are shared with Python subports
 variant debug description {Build with debugging info} {
     configure.args-replace \
                     -DBUILD_WITH_DEBUG_INFO:BOOL=OFF \


### PR DESCRIPTION
## Problem

`py${v}-opencv4` fails to build on any host where the main `ffmpeg` (8.x) port
is also installed. The root cause is a mismatch in what the build system _detects_
vs. what it _links_:

1. `patch-ffmpeg8.diff` is applied unconditionally and uses `LIBAVCODEC_BUILD` to
   decide whether to call `av_packet_side_data_get`.
2. When `ffmpeg` 8.x is installed it places its headers in `${prefix}/include`,
   which the compiler finds before the ffmpeg4 isolated headers.
3. `LIBAVCODEC_BUILD` therefore resolves to the ffmpeg 8 value (≥ 62.11), the
   patch emits a call to `av_packet_side_data_get` — but the `PKG_CONFIG_PATH`
   still points to `…/ffmpeg4/lib/pkgconfig`, so the binary links against ffmpeg4
   which does _not_ export that symbol.
4. Result: `Undefined symbols … "_av_packet_side_data_get"` on `libopencv_videoio`.

The C++ `opencv4` port has `ffmpeg6/7/8` variants as an escape hatch (+ffmpeg8
works), but those variants are defined inside `if {${name} eq ${subport}}` —
making them **silently unavailable to `py${v}-opencv4`**. Running
`port install py314-opencv4 +ffmpeg8` produces an identical build hash to the
no-variant build; `port info --variants py314-opencv4` shows only `debug`.

This is tracked upstream in [Trac #74070](https://trac.macports.org/ticket/74070),
which previously only addressed the C++ port. This PR also covers the subport gap
flagged in [comment:5](https://trac.macports.org/ticket/74070#comment:5).

## Fix

- Move the `ffmpeg6/7/8` variant declarations to **common scope** (above the
  `if {${name} eq ${subport}}` guard) with empty bodies.
- Add `default_variants +ffmpeg8` so both the C++ port and all Python subports
  build against ffmpeg 8 by default (consistent with what the unconditional
  `patch-ffmpeg8.diff` already implies).
- Derive a `ffmpeg_version` variable at top-level eval time and use it for
  both `configure.env-append PKG_CONFIG_PATH` and the (main-port-only) ffmpeg
  dep in `depends_lib-append`.
- Python subports get ffmpeg transitively via `port:opencv4`; the common
  `PKG_CONFIG_PATH` ensures they compile and link against the same version.

Also fixes the `ffmpeg6` variant description typo ("Link against ffmpeg 5").

## Tested

macOS 26 (darwin 25) arm64 with `ffmpeg @8.1` installed:

| Port | Variant | Result |
|------|---------|--------|
| `opencv4` | `+ffmpeg8` (now default) | ✅ builds clean |
| `py314-opencv4` | `+ffmpeg8` (now default) | ✅ builds clean, `av_packet_side_data_get` resolves |

Both previously failed with `Undefined symbols … "_av_packet_side_data_get"`.

## Revisions

- `opencv4`: `revision 9 → 10`
- `py${v}-opencv4 (latest)`: `revision 4 → 5`
- `py${v}-opencv4 (legacy 4.5.0)`: `revision 21 → 22`