### PR TITLE
arm-binutils, m68k-binutils, mips-binutils, powerpc-binutils: Update …

### DIFF
--- a/cross/arm-binutils/Portfile
+++ b/cross/arm-binutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                arm-binutils
-version             2.46.0
+version             2.46.1
 revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer

--- a/cross/m68k-binutils/Portfile
+++ b/cross/m68k-binutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                m68k-binutils
-version             2.46.0
+version             2.46.1
 revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer

--- a/cross/mips-binutils/Portfile
+++ b/cross/mips-binutils/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                mips-binutils
-version             2.46.0
+version             2.46.1
+revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer
 

--- a/cross/powerpc-binutils/Portfile
+++ b/cross/powerpc-binutils/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                powerpc-binutils
-version             2.46.0
-revision            1
+version             2.46.1
+revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer
 


### PR DESCRIPTION
#### Description

arm-binutils, m68k-binutils, mips-binutils, powerpc-binutils: Update to 2.46.1


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
