### PR TITLE
lagrange: update to 1.20.7

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           codeberg 1.0
 
-codeberg.setup      skyjake lagrange 1.20.6 v
+codeberg.setup      skyjake lagrange 1.20.7 v
 revision            0
 categories          net gemini
 license             BSD
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  d0c3ada243a18591f0d645b17e6e4694bb4b79ff \
-                    sha256  41bb1257ed7c6aa1b6b4b1a36187f2509276d2dbc6829be5262f19dc1ccacef1 \
-                    size    9801943
+checksums           rmd160  e7b534236d27adf7ce975b4fe255945a5097bff9 \
+                    sha256  18e04f66a4e09616a70fc79e6a683bbf4ac7341394da9dfb99211ac08a8ae1ba \
+                    size    9802310
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://codeberg.org/skyjake/lagrange/releases/tag/v1.20.7

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
