### PR TITLE
ocaml-menhir, ocaml-ounit2: fix noarch misclassification

### DIFF
--- a/ocaml/ocaml-menhir/Portfile
+++ b/ocaml/ocaml-menhir/Portfile
@@ -46,8 +46,7 @@ subport ocaml-menhirCST {
 }
 
 subport ocaml-coq-menhirlib {
-    platforms       any
-    supported_archs noarch
+    revision        1
 
     livecheck.type      regex
     livecheck.url       https://gitlab.inria.fr/fpottier/menhir/-/tags?format=atom

--- a/ocaml/ocaml-ounit2/Portfile
+++ b/ocaml/ocaml-ounit2/Portfile
@@ -18,7 +18,7 @@ long_description    OUnit is a unit test framework for OCaml. \
                     It allows one to easily create unit-tests for OCaml code. \
                     It is based on HUnit, a unit testing framework for \
                     Haskell. It is similar to JUnit, and other XUnit \
-                    testing frameworks. 
+                    testing frameworks.
 
 checksums           rmd160  6a5b098d95e539e41b400bb2fb2a1ab5d7d3233d \
                     sha256  6e5fecfd47e8f17a8f311dbb8f9fa5c0289104f3fed6e8166b79afc32eaca815 \
@@ -36,8 +36,7 @@ subport ocaml-ounit {
     description         Compatibility shim for ocaml-ounit2
     long_description    Provides legacy 'oUnit' ocamlfind package name for ocaml-ounit2
 
-    platforms           any
-    supported_archs     noarch
+    revision            2
 
     depends_run-append  port:ocaml-ounit2
     depends_build-append \


### PR DESCRIPTION
ocaml-coq-menhirlib and ocaml-ounit install architecture-specific OCaml native compiled files and must not be declared noarch.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
