### PR TITLE
osxphotos: update to 0.76.1

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.76.0
+version                 0.76.1
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  07535df7f1023f6453e36b1c9e2397746b00bee0 \
-                        sha256  32a6d4c6bb223e90c0a22954001252ef977cef9a68d71a861923d01bf1d73eea \
-                        size    2405439
+checksums               rmd160  98a9339822a3bd8b0792ddb0213b999d0679ab1a \
+                        sha256  f493a4674f2c5981ac7c5f33dea1c5fd42db365cb4e7ec6004e5cd29ff8d667f \
+                        size    2406359
 
 # Latest Python version supported by osxphotos
 python.default_version  314


### PR DESCRIPTION
#### Description

Update to osxphotos 0.76.1.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?