### PR TITLE
claude-code: update to 2.1.178

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.177
+version             2.1.178
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  4df06e20b1f9ff2b5ab97ac208220e78e7ffb163 \
-                 sha256  fcdc6c6679d4e1e3a0a3812f24e8b08ab73156732072c2ca5ee6248bee8313bd \
-                 size    227642800
+    checksums    rmd160  335bcee25888d3edf404e9c14956f13482f01e04 \
+                 sha256  e6c5f5eec2b4d18f6234c3ba500e285f07a2e5ffb4c67d4ba0494c28c70dfe79 \
+                 size    228550960
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  84ff8351ec13f5b4385a99951493258f67a7fb2b \
-                 sha256  eb0730351be2f02b482b1855870f5877489085aac86b0c4c1db4e458d9e40ed9 \
-                 size    225124512
+    checksums    rmd160  450fef3a13441acd23d15a5b94453a8db7fc1dc8 \
+                 sha256  473495d0c15d6616cd0870480db5eb8aa0402fe4f8ead3277a1b521e94110309 \
+                 size    226032672
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.178.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?