### PR TITLE
ocaml: revbump library ports missed in the 5.4.1 cascade

### DIFF
--- a/lang/ocaml-lua/Portfile
+++ b/lang/ocaml-lua/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 github.setup        pdonadeo ocaml-lua 1.8 v
-revision            0
+revision            1
 categories          lang devel ocaml
 license             MIT
 maintainers         nomaintainer

--- a/net/unison/Portfile
+++ b/net/unison/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        bcpierce00 unison 2.54.0 v
-revision            0
+revision            1
 categories          net
 maintainers         nomaintainer
 license             GPL-3

--- a/ocaml/ocaml-camlidl/Portfile
+++ b/ocaml/ocaml-camlidl/Portfile
@@ -8,7 +8,7 @@ github.setup        xavierleroy camlidl 113 camlidl
 github.tarball_from archive
 name                ocaml-camlidl
 version             1.13
-revision            0
+revision            1
 categories          ocaml devel
 license             {QPL LGPL}
 maintainers         {takeshi @tenomoto} openmaintainer

--- a/ocaml/ocaml-camlp5-buildscripts/Portfile
+++ b/ocaml/ocaml-camlp5-buildscripts/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        camlp5 camlp5-buildscripts 0.07
 github.tarball_from archive
 name                ocaml-camlp5-buildscripts
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {pguyot @pguyot} openmaintainer
 license             BSD

--- a/ocaml/ocaml-lambda-term/Portfile
+++ b/ocaml/ocaml-lambda-term/Portfile
@@ -7,7 +7,7 @@ PortGroup           ocaml 1.1
 name                ocaml-lambda-term
 github.setup        ocaml-community lambda-term 3.4.0
 github.tarball_from archive
-revision            0
+revision            1
 categories          ocaml devel editors
 maintainers         nomaintainer
 license             BSD

--- a/ocaml/ocaml-utop/Portfile
+++ b/ocaml/ocaml-utop/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-utop
 github.setup        ocaml-community utop 2.17.0
-revision            1
+revision            2
 categories          ocaml devel editors
 maintainers         nomaintainer
 license             BSD

--- a/ocaml/ocaml-zip/Portfile
+++ b/ocaml/ocaml-zip/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        xavierleroy camlzip 1.14 v
-revision            0
+revision            1
 name                ocaml-zip
 categories          ocaml devel
 maintainers         nomaintainer

--- a/x11/lablgtk3/Portfile
+++ b/x11/lablgtk3/Portfile
@@ -7,7 +7,7 @@ PortGroup           ocaml 1.1
 github.setup        garrigue lablgtk 3.1.5
 github.tarball_from archive
 name                lablgtk3
-revision            0
+revision            1
 
 categories          x11 ocaml
 license             {LGPL-2.1+ Restrictive/Distributable}


### PR DESCRIPTION
#### Description

The OCaml 5.4.1 update (4c8893022ea) rebuilt the ecosystem but left these ports at their old revision. Their dependencies were revbumped while they were not, so they need a rebuild against OCaml 5.4.1:

  lablgtk3
  ocaml-camlidl
  ocaml-camlp5-buildscripts
  ocaml-lambda-term
  ocaml-lua
  ocaml-zip

The following two are cascade dependents:
  ocaml-utop
  unison

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
