### PR TITLE
ocaml-cgi: bump revision for ocaml5, fix build on macos-11

### DIFF
--- a/www/ocaml-cgi/Portfile
+++ b/www/ocaml-cgi/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 github.setup        rixed ocaml-cgi 0.14 v
 github.tarball_from archive
-revision            0
+revision            1
 categories          www devel ocaml
 maintainers         nomaintainer
 license             LGPL-2
@@ -16,5 +16,7 @@ long_description    ${description}
 checksums           rmd160  03064e401e62c951910c0e6e947e2efe03162ecd \
                     sha256  0e3002b452d84dfd6e2b0031d29e3cfdef9c39f8bfe63af9048a1b4eb7b1c267 \
                     size    44323
+
+patchfiles          patch-Makefile.in.diff
 
 ocaml.use_findlib   yes

--- a/www/ocaml-cgi/files/patch-Makefile.in.diff
+++ b/www/ocaml-cgi/files/patch-Makefile.in.diff
@@ -1,27 +1,15 @@
---- Makefile.in	2006-05-24 08:29:46.000000000 +0200
-+++ Makefile.in	2011-02-20 19:38:13.000000000 +0100
-@@ -3,7 +3,7 @@
- # Configuration part
+--- Makefile.in
++++ Makefile.in
+@@ -19,10 +19,10 @@
+ all: @OCAMLBEST@
+ 
+ byte: $(CMO) runcgi.byte
+-	cp -l -f runcgi.byte runcgi
++	cp -f runcgi.byte runcgi
+ 
+ opt: $(CMO) $(CMX) runcgi.opt
+-	cp -l -f runcgi.opt runcgi
++	cp -f runcgi.opt runcgi
+ 
  ###################################################################
- 
--TARGETDIR = @OCAMLLIB@
-+TARGETDIR = $(DESTDIR)@OCAMLLIB@
- 
- CAMLC   = @OCAMLC@ -g
- CAMLOPT = @OCAMLOPT@
-@@ -35,12 +35,15 @@
- install: install-@OCAMLBEST@
- 
- install-common:
-+	mkdir -p $(TARGETDIR)
- 	cp $(COMMFILES) $(TARGETDIR)
- 
- install-byte: install-common
-+	mkdir -p $(TARGETDIR)
- 	cp $(BYTEFILES) $(TARGETDIR)
- 
- install-opt: install-common install-byte
-+	mkdir -p $(TARGETDIR)
- 	cp $(OPTFILES) $(TARGETDIR)
- 
- MAJORVN=0
+ # Installation and export


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
