### PR TITLE
ocaml-gsl: realign discover.ml patch so it applies on older macOS

### DIFF
--- a/math/ocaml-gsl/files/patch-discover-gsl-include.diff
+++ b/math/ocaml-gsl/files/patch-discover-gsl-include.diff
@@ -1,8 +1,6 @@
 --- src/config/discover.ml.orig
 +++ src/config/discover.ml
-@@ -18,7 +18,8 @@
-       let conf =
-         let default =
+@@ -26,7 +26,8 @@
            { libs = [ "-lgsl"; "-lgslcblas"; "-lm" ]; cflags = [] }
          in
          let write_gsl_include = C.Flags.write_lines "gsl_include.sexp" in
@@ -10,3 +8,5 @@
 +        let default_gsl_include =
 +          [ (try Sys.getenv "GSL_INCLUDE_DIR" with Not_found -> "/usr/include") ] in
          match C.Pkg_config.get c with
+         | None ->
+             write_gsl_include default_gsl_include;


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
