### PR TITLE
libmed: fix missing HDF5_INCLUDE_DIRS

### DIFF
--- a/science/libmed/Portfile
+++ b/science/libmed/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                    libmed
 version                 4.1.1
-revision                5
+revision                6
 categories              science devel
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 license                 GPL-3+ LGPL-3+
@@ -29,7 +29,8 @@ checksums               rmd160  2e0a189cb4b5d72ae88c8e8fb26a61821e4e60be \
                         size    50506725
 
 patchfiles              patch-hdf5-1.12.diff \
-                        patch-test10.diff
+                        patch-test10.diff \
+                        patch-medMacros-hdf5-include.diff
 
 # error: cinttypes: No such file or directory
 compiler.c_standard     2011

--- a/science/libmed/files/patch-medMacros-hdf5-include.diff
+++ b/science/libmed/files/patch-medMacros-hdf5-include.diff
@@ -1,0 +1,14 @@
+--- config/cmake_files/medMacros.cmake.orig	2026-06-16 13:56:51
++++ config/cmake_files/medMacros.cmake	2026-06-16 13:57:39
+@@ -444,6 +444,11 @@
+     
+     FIND_PACKAGE(MedfileHDF5 REQUIRED)
+ 
++    # Patch for when h5cc doesn't include include directory
++    IF(NOT HDF5_INCLUDE_DIRS)
++        FIND_PATH(HDF5_INCLUDE_DIRS H5public.h REQUIRED)
++    ENDIF()
++
+     ##
+     ## Requires 1.10.x version
+     ##


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/74096

#### Description

`libmed` presently fails to compile owing to a missing `HDF5_INCLUDE_DIR` CMake variable. This appears to be because `h5cc` doesn't provide an include directory in its command line arguments. This patch uses `FIND_PATH` to find the directory if it is not set by `h5cc`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
