### PR TITLE
pbhush: new port

### DIFF
--- a/sysutils/pbhush/Portfile
+++ b/sysutils/pbhush/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           codeberg 1.0
+PortGroup           makefile 1.0
+
+codeberg.setup      midnightrocket pbhush 1.0.0 v
+revision            0
+
+categories          sysutils
+maintainers         {@midnightrocket} \
+                    openmaintainer
+
+platforms           {darwin >= 26}
+
+description         pbhush is an alternative to pbcopy which marks the copied content as secret.
+long_description    {*}${description} \nThis is a small cli utility which copies text from STDIN to the clipboard, \
+                    whilst marking the content as secret. This means conforming clipboard managers, \
+                    knows that they should not save the content in their history. \
+                    This includes the new clipboard history feature in MacOS Tahoe.
+
+license             MIT
+
+checksums           rmd160  98e96e9d6f58337bd31845842dcca456ae0dab78 \
+                    sha256  3ad85acebdd9ea629f323a749586e6e08a304d3a5baf3653ea739ae19b438849 \
+                    size    10867
+
+use_configure       no
+use_xcode           yes
+
+build.env           VERSION=${version} \
+                    ARGS=--disable-sandbox
+
+destroot.env        SKIP_BUILD=1


### PR DESCRIPTION
#### Description
Add new port `pbhush`


This is a small cli utility which copies text from STDIN to the clipboard, whilst marking the content as secret. This means conforming clipboard managers, knows that they should not save the content in their history. This includes the new clipboard history feature in [MacOS Tahoe](https://support.apple.com/guide/mac-help/search-your-clipboard-history-mchl40d5b86b/mac).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
