### PR TITLE
kubetail: update to 0.18.0

### DIFF
--- a/devel/kubetail/Portfile
+++ b/devel/kubetail/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubetail-org/kubetail 0.17.0 cli/v
+go.setup            github.com/kubetail-org/kubetail 0.18.0 cli/v
 github.tarball_from releases
 revision            0
 
@@ -23,9 +23,9 @@ long_description    Kubetail is a general-purpose logging tool for Kubernetes, o
                     terminal.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  71993feb0c97b3c2f88ce5c4da08a1dddfb2ffd3 \
-                    sha256  9e4e1dbc7a13ddbd71bc03473c572a10e464a28b5e3ed8a3163eedd188037312 \
-                    size    21084536
+                    rmd160  cc3f268d315646c067349f63bb5d1938ed4dc2e1 \
+                    sha256  d75eb044f98b8a3f507d7b08eda109f07346662e7e9f6dfa77a71aa39d4513b5 \
+                    size    21369238
 
 build.env-append GO111MODULE=on \
                  GOWORK=off


### PR DESCRIPTION
#### Description

This PR upgrades `kubetail` to 0.18.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.4 25E246 arm64
Xcode 26.5 17F42

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
