### PR TITLE
fish: specify DCMAKE_INSTALL_SYSCONFDIR

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
 github.setup            fish-shell fish-shell 4.7.1
-revision                0
+revision                1
 
 checksums               rmd160  20a3a6735bda09a74795771f8540dd7b72e34bb2 \
                         sha256  6f4d5b438a6338e3f5dcda19a28261e2ece7a9b7ff97686685e6abdc31dbb7df \
@@ -38,6 +38,7 @@ depends_lib-append      port:gettext-runtime \
 
 configure.args-append   -DFISH_USE_SYSTEM_PCRE2=ON \
                         -DMAC_CODESIGN_ID=OFF \
+                        -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
                         -DCMAKE_BUILD_TYPE=Release
 
 notes "


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

By default

`$__fish_sysconf_dir` is `/etc/opt/local/fish`,

`/etc/opt/local/fish/completions` is in `$fish_complete_path` and

`/etc/opt/local/fish/functions` in `$fish_function_path`, which I believe a bug?

After the modification they will be `/opt/local/etc/fish`, `/opt/local/etc/fish/completions` and `/opt/local/etc/fish/functions`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.7.8 22H730 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
