### PR TITLE
google-cloud-sdk: update to 573.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             572.0.0
+version             573.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  69334c00d00e5aa6df9677480bbc92dd7dae21e2 \
-                    sha256  c473154462eb14d403baa48958b25bc5305615ef9a16eff0ef68cfbc67c764fa \
-                    size    59158053
+    checksums       rmd160  dba518aafe788d1924d086ade941834867bfdfdb \
+                    sha256  1728731d5531376036f2d79c73ec0795acedee533862457bebb7657c7df3132c \
+                    size    59298706
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  f4977b28604d570e3a8b2940893c55317f0b22ac \
-                    sha256  8b90de8ce97380d1daf9da19e7a1832989114a4fa86ad499a9348fe6b4e04360 \
-                    size    60816896
+    checksums       rmd160  e2b6e4c65819758c633c662408a9b1ee5fdf06ba \
+                    sha256  652b7ed9556ec7dc00cb1e6bdb21343e57571701456230c35850cc6e212a5cfa \
+                    size    60954028
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  448870a13850b0ec318794b44e2f5185c17ac8ff \
-                    sha256  33b7a1fa93c433b78e3050cc464ed0a0851af9ed721feee60054960ff3e43340 \
-                    size    60720240
+    checksums       rmd160  e275199aae55b84183b1e83ed39c78259bd583e6 \
+                    sha256  180984c10f424253858b0bfc8b491da0bee9541d554ad2922b71cbdb92bfa643 \
+                    size    60858679
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 573.0.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?