### PR TITLE
quickjs, quickjs-devel: update to latest version

### DIFF
--- a/devel/quickjs/Portfile
+++ b/devel/quickjs/Portfile
@@ -40,18 +40,18 @@ if {${subport} eq ${name}} {
 } else {
     # quickjs-devel
     conflicts       ${name}
-    github.setup    bellard ${name} f1139494d18a2053630c5ed3384a42bb70db3c53
+    github.setup    bellard ${name} 04be246001599f5995fa2f2d8c91a0f198d3f34c
     github.tarball_from archive
-    version         20251222
+    version         20260616
     revision        0
-    checksums       rmd160 25b2853365f4d3c2fdb597a8d12774dac439d18a \
-                    sha256 0364fd5136857117c8204c2f0c203b71b25b9f025dc1a0605ea51f0fd7f92511 \
-                    size   618177
+    checksums       rmd160 076b7eb2d019627aa810bb1cb35e77c9f11b0713 \
+                    sha256 2a87ffcca6c870f764ce70a7736351bd7cff3dc1fb95a8fb059c260979f1e01a \
+                    size   636419
 
     # this is the -devel port, there is no point to print a stable version
     set fixed-version [regsub {^(\d{4})(\d{2})(\d{2})$} $version {\1-\2-\3}]
     post-patch {
-        reinplace "s|2025-09-13|${fixed-version}|g" ${worksrcpath}/VERSION
+        reinplace "s|2026-06-04|${fixed-version}|g" ${worksrcpath}/VERSION
     }
 }
 

--- a/devel/quickjs/Portfile
+++ b/devel/quickjs/Portfile
@@ -23,13 +23,13 @@ subport          ${name}-devel {}
 
 if {${subport} eq ${name}} {
     conflicts       ${name}-devel
-    github.setup    bellard ${name} fa628f8c523ecac8ce560c081411e91fcaba2d20
+    github.setup    bellard ${name} 3d5e064e9dd67c70f7962836505a7fa067bf0a4e
     github.tarball_from archive
-    version         20250913
+    version         20260604
     revision        0
-    checksums       rmd160  39e947aced6544a85fad6ab91594181615710281 \
-                    sha256  2623e6336b1b8d82a9e509899f5c934bdfeda0e6f518fe5b7ad4fdaa01cafb7e \
-                    size    594843
+    checksums       rmd160  219bddcd2835fbcb7de6e01b18f4a6582a5f8fd2 \
+                    sha256  afccd11533e21a4e49af43e6909fc7236ed0b92f25e01e1061ceb0b47e15e05d \
+                    size    635373
 
     # use the changelog link to check stable releases
     livecheck.type  regex


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?