### PR TITLE
mole-cleaner: fix fish completions path

### DIFF
--- a/sysutils/mole-cleaner/Portfile
+++ b/sysutils/mole-cleaner/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/tw93/Mole 1.40.0 V
 name                [string tolower ${github.project}]-cleaner
-revision            0
+revision            1
 categories          sysutils
 platforms           macosx
 license             MIT
@@ -42,7 +42,7 @@ destroot {
     copy ${worksrcpath}/bin ${worksrcpath}/lib ${destroot}${script_dir}
     # All supported shells: bash, fish, zsh
     set comp_path(bash) ${destroot}${prefix}/share/bash-completion/completions/
-    set comp_path(fish) ${destroot}${prefix}/share/fish/completions/
+    set comp_path(fish) ${destroot}${prefix}/share/fish/vendor_completions.d/
     set comp_path(zsh)  ${destroot}${prefix}/share/zsh/site-functions/
     set comp_file(bash) [string tolower ${github.project}]
     set comp_file(fish) [string tolower ${github.project}].fish


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Third-party packages should put their completions in ${prefix}/share/fish/vendor_completions.d , see #33189

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.7.8 22H730 x86_64
Command Line Tools 15.1.0.0.1.1700200546


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
