### PR TITLE
qt6-qtcreator: update to 20.0.0

### DIFF
--- a/devel/qt6-qtcreator/Portfile
+++ b/devel/qt6-qtcreator/Portfile
@@ -18,31 +18,23 @@ long_description    Qt Creator is a cross-platform integrated development enviro
 compiler.cxx_standard \
                     2020
 
-if {([vercmp ${xcodeversion} 15] >= 0)} {
+if {${os.major} >= 23} {
+    # qtcreator since version 20.0.0 requires qt 6.8.3
+    version                 20.0.0
+    revision                0
+
+    checksums               rmd160  3d6ed4841ed20967bfcacbceb77c0140c0476e89 \
+                            sha256  079969711f64adb34293e0096480d4ff02e280cef825a66e8c2db567c91833a1 \
+                            size    52229731
+} elseif {[vercmp ${xcodeversion} 15] >= 0} {
     # qtcreator since version 19.0.0 requires xcode version 15
+    # last version for qt 6.5.3
     version                 19.0.2
     revision                1
 
     checksums               rmd160  f61c3808880e480c8804dcfcea80326d2e15056b \
                             sha256  92711b85a5642af5970dd3100982f724f4ce2af2181aea5fe0e335a30060dfc0 \
                             size    51833111
-
-    # Do not update all versions to clang 18+ until https://trac.macports.org/ticket/72064 is resolved
-    if {${os.major} >= 24} {
-        set llvm_version    20
-    } else {
-        set llvm_version    17
-    }
-
-    depends_build-append    port:python314
-    configure.args-append   -DPython3_EXECUTABLE=${prefix}/bin/python3.14
-
-    # qtcreator since version 18.0.0 requires go
-    depends_build-append    port:go
-
-    # add qt6 to rpath (for external extensions)
-    cmake.install_rpath-append \
-                            ${prefix}/libexec/qt6/lib
 } else {
     if {${os.major} >= 21} {
         # qtcreator since version 16.0.0 requires qt 6.5.3
@@ -54,10 +46,6 @@ if {([vercmp ${xcodeversion} 15] >= 0)} {
         checksums           rmd160  a07ece48ad3035d08489825aa70bde917df45fd3 \
                             sha256  e73799b526dbf041487dc5023dd80840d3e722ad476d6995f98cf9a894f6698f \
                             size    68461824
-
-        # qtcreator since version 18.0.0 requires go
-        depends_build-append \
-                            port:go
     } else {
         # last version for qt 6.4
         version             15.0.1
@@ -68,11 +56,6 @@ if {([vercmp ${xcodeversion} 15] >= 0)} {
                             size    64570173
     }
 
-    set llvm_version        17
-
-    depends_build-append    port:python314
-    configure.args-append   -DPython3_EXECUTABLE=${prefix}/bin/python3.14
-
     # remove -no_warn_duplicated_libraries linker option (for xcode up to 15)
     post-configure {
         foreach f [exec find "${worksrcpath}/../build/" -name link.txt] {
@@ -81,21 +64,43 @@ if {([vercmp ${xcodeversion} 15] >= 0)} {
     }
 }
 
-set llvm_dir            ${prefix}/libexec/llvm-${llvm_version}
+if {[vercmp ${version} >= "18.0.0"]} {
+    # qtcreator since version 18.0.0 requires go
+    depends_build-append    port:go
+}
 
-depends_build-append    port:llvm-${llvm_version}
-depends_lib-append      port:clang-${llvm_version}
+if {[vercmp ${version} >= "19.0.2"]} {
+    # add qt6 to rpath (for external extensions)
+    cmake.install_rpath-append \
+                            ${prefix}/libexec/qt6/lib
+    # this can also be done manually:
+    #    sudo install_name_tool -add_rpath /opt/local/libexec/qt6/lib "/Applications/MacPorts/Qt6/Qt Creator.app/Contents/MacOS/Qt Creator"
+}
 
-cmake.install_rpath-append \
-                        ${llvm_dir}/lib
+depends_build-append        port:python314
+configure.args-append       -DPython3_EXECUTABLE=${prefix}/bin/python3.14
 
-configure.compiler      macports-clang-${llvm_version}
-configure.args-append   -DLLVM_DIR=${llvm_dir}/lib/cmake/llvm \
-                        -DClang_DIR=${llvm_dir}/lib/cmake/clang
+# Do not update all versions to clang 18+ until https://trac.macports.org/ticket/72064 is resolved
+if {${os.major} >= 24} {
+    set llvm_version        21
+} else {
+    set llvm_version        17
+}
 
-homepage                http://qt-project.org/wiki/Category:Tools::QtCreator
-distname                qt-creator-opensource-src-${version}
-master_sites            https://download.qt.io/official_releases/qtcreator/[join [lrange [split ${version} .] 0 1] .]/${version}/
+set llvm_dir                ${prefix}/libexec/llvm-${llvm_version}
+
+depends_build-append        port:llvm-${llvm_version}
+depends_lib-append          port:clang-${llvm_version}
+
+cmake.install_rpath-append  ${llvm_dir}/lib
+
+configure.compiler          macports-clang-${llvm_version}
+configure.args-append       -DLLVM_DIR=${llvm_dir}/lib/cmake/llvm \
+                            -DClang_DIR=${llvm_dir}/lib/cmake/clang
+
+homepage                    http://qt-project.org/wiki/Category:Tools::QtCreator
+distname                    qt-creator-opensource-src-${version}
+master_sites                https://download.qt.io/official_releases/qtcreator/[join [lrange [split ${version} .] 0 1] .]/${version}/
 
 if { ${subport} eq ${name} } {
     # xcode-select: error: tool 'actool' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance


### PR DESCRIPTION
#### Description

The Qt requirements have been increased to version 6.8.3. LLVM version 21 is used.
Portfile has also been slightly rewritten, preserving the logical structure and data for previous versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
