### PR TITLE
gh: update to 2.95.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             2.93.0
+version             2.95.0
 revision            0
 
 # Github CLI is failing to build on 10.12 and below.
@@ -54,9 +54,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  30208fe44abf94b838d77f3b8cce9b357f049dc7 \
-                        sha256  8f3369ade41fe7a04ff93ec6029d5b0a8a94ccb4bb59f338d5c445aa695f0753 \
-                        size    14621130
+    checksums           rmd160  ed76869195434f71546e5e56a5c3baabe872988b \
+                        sha256  b6a1c88cbd15f49f60a68d210a117a60b349bcb0d028a0dca0ef2d9dc92bd028 \
+                        size    14790571
 
     dist_subdir         ${name}
 
@@ -74,9 +74,9 @@ if ${source_build} {
 
     distname        gh_${version}_macOS_amd64
 
-    checksums       rmd160  805ed90c2b3b5ecc6182f659bac841522a6e9272 \
-                    sha256  009425b9d175c482037fe25181817fd6b1ea3ae1f51cfae0e18f29f33d3152ac \
-                    size    14960426
+    checksums       rmd160  250bbff325ad6ce22a919bdd465b7338df30bc04 \
+                    sha256  985707e9ac60c95ed51cddd808c338b481abe69fffa77e9d6547c3750045f77e \
+                    size    15285963
 
     use_configure   no
     use_zip         yes


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
