### PR TITLE
btop: Fix build for macOS 11+

### DIFF
--- a/sysutils/btop/Portfile
+++ b/sysutils/btop/Portfile
@@ -23,6 +23,8 @@ long_description    Resource monitor that shows usage and stats for processor, m
 depends_build       path:libexec/coreutils/libstdbuf.so:coreutils \
                     port:gmake
 
+patchfiles          patch-no-literal-type.patch
+
 makefile.override-append \
                     PREFIX
 compiler.cxx_standard   2020

--- a/sysutils/btop/files/patch-no-literal-type.patch
+++ b/sysutils/btop/files/patch-no-literal-type.patch
@@ -1,0 +1,14 @@
+Fix
+
+error: constexpr function's return type 'std::optional<fs::path>' is not a literal type
+--- src/btop_config.cpp.orig	2026-05-01 12:05:43.000000000 -0400
++++ src/btop_config.cpp	2026-06-17 20:19:30.028240527 -0400
+@@ -816,7 +816,7 @@
+ 		}
+ 	}
+ 
+-	static constexpr auto get_xdg_state_dir() -> std::optional<fs::path> {
++	static auto get_xdg_state_dir() -> std::optional<fs::path> {
+ 		std::optional<fs::path> xdg_state_home;
+ 
+ 		{


### PR DESCRIPTION
#### Description

Fix btop building on macOS 11+, reported broken through a [Trac ticket](https://trac.macports.org/ticket/73988)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd nstall`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
