### PR TITLE
lhasa: new port

### DIFF
--- a/archivers/lhasa/Portfile
+++ b/archivers/lhasa/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            fragglet lhasa 0.6.0 v
+github.tarball_from     archive
+revision                0
+categories              archivers
+license                 ISC
+maintainers             {@commitmaniac} openmaintainer
+
+description             Parse and extract LHA archives
+long_description        {*}${description}. ${name} is a library for parsing LHA archives \
+                        (.lzh) and a free replacement for the Unix LHA tool.
+
+checksums               rmd160  a5adef4dc7609876e23388a3775adfb8f2e9332f \
+                        sha256  427c47527f11d157380d90e33c86535a3a0e8eb5c7e2cf0278bd6dbfe733fcee \
+                        size    2919820
+
+depends_build-append    path:bin/pkg-config:pkgconfig \
+                        port:autoconf \
+                        port:automake \
+                        port:libtool
+
+configure.cmd           ./autogen.sh
+
+# C23 is optional; intentional error if not C23
+configure.checks.implicit_int   no
+configure.checks.implicit_function_declaration.whitelist-append alignof
+
+test.run                yes
+test.target             check


### PR DESCRIPTION
#### Description

Add lhasa, a tool for extracting and viewing LHA archives, as part of a [port request](https://trac.macports.org/ticket/72213)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
