### PR TITLE
mp3rgain: update to 2.8.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.8.0 v
+github.setup        M-Igashi mp3rgain 2.8.1 v
 github.tarball_from archive
 revision            0
 
 categories          audio
+platforms           {darwin >= 17}
 installs_libs       no
 license             MIT
 maintainers         {@M-Igashi users.noreply.github.com:M-Igashi} \
@@ -25,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b19e163c0dc6ed5d92ba7064ba04a761046f0849 \
-                    sha256  385a39fc99e187e20464793f1690c56972ed14fe4daa19525eec5ea1601698c8 \
-                    size    340865
+                    rmd160  492474c3b1399132fe6dd6c53ccfa8c5d7ec5e2b \
+                    sha256  31001e1d26fbd9b6106ea37ebfdee4d4aa7eb52fb4024ec00febe382885e0513 \
+                    size    493152
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to upstream release 2.8.1.

- `github.setup` version 2.8.0 → 2.8.1, `revision` reset to 0
- Recomputed distfile checksums (rmd160 / sha256 / size) for the v2.8.1 source tarball
- `cargo.crates` unchanged — no dependency changes in this release

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.8.1

###### Type of change
- [x] Update to existing port (version bump)

###### Tested on
macOS (cross-checked against the upstream Cargo.lock; builds `--frozen --offline` with the vendored crates)