### PR TITLE
go-devel: update to 1.27rc1

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -73,9 +73,9 @@ subport ${name}-devel {
 
     # macOS 12 and up - latest version
     } else {
-        version         1.26.4
+        version         1.27rc1
         revision        0
-        epoch           2
+        epoch           3
     }
 }
 
@@ -131,17 +131,17 @@ if {$subport eq "${name}-devel"} {
     # Go (DEVEL / UNSTABLE) - LATEST
      } else {
          checksums  ${go_src_dist} \
-                    rmd160  72e8b56676705af84b5d4dcdce086a157c19e4df \
-                    sha256  4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d \
-                    size    34118246 \
+                    rmd160  68316fdb8737fd4682107d4735f2668255dda432 \
+                    sha256  338f51f557c6db1235a3eeb89a0936af6f4e0d4116291ef3b8e41186bc655334 \
+                    size    35025205 \
                     ${go_armbin_dist} \
-                    rmd160  298f9644d433c7cd5e280729a616a1b4e44d6475 \
-                    sha256  b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53 \
-                    size    64723756 \
+                    rmd160  c8e7c54c4b634c6ff64045f9f7dd1ba736e9b0e1 \
+                    sha256  7b7b4d66fc0a7bc8e57b3602340dfef46d4f5f95fc5d30e5c5af6a671830de54 \
+                    size    68247319 \
                     ${go_amdbin_dist} \
-                    rmd160  dbdbe667fc3970bba220b733befecbe134d8fb2c \
-                    sha256  05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d \
-                    size    67816160
+                    rmd160  1e0acf10073bfa1944c33a1c3fc948c3d59614cf \
+                    sha256  ec2abfa675a1882a13fd72035bdc50635b5b4a2b424c1f692a5737b0a333a322 \
+                    size    71647298
      }
 
     livecheck.regex {go([0-9.A-z]+)\.src\.tar\.gz}


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
