### PR TITLE
glab: update to 1.103.0

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/cli 1.92.1 v
+go.setup            gitlab.com/gitlab-org/cli 1.103.0 v
 name                glab
 revision            0
 categories          devel
@@ -16,9 +16,9 @@ long_description    ${name} is an open source GitLab CLI tool \
                     you are already working with git and your code.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  05bc51a6d19074fa11bb9a7849230f7a7d6df094 \
-                    sha256  b85999ac0ee7c76044b44d1a7e6294533ca0607bc3828f8dda1e52a9e453561b \
-                    size    17120184
+                    rmd160  c2a9db5053c6478ce4ade62e23cba77d88b611f0 \
+                    sha256  b6f1c0477491ba506ca7d01d301c8a4efaf514d63f4a997e27af03508a5527e5 \
+                    size    17695993
 
 # If not set, it states that it's a developer build
 # Suppress build date for reproducible builds


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
