### PR TITLE
cppcheck: update to 2.21.0

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                danmar cppcheck 2.20.0
+github.setup                danmar cppcheck 2.21.0
 revision                    0
 
 categories                  devel
@@ -20,9 +20,9 @@ long_description            Cppcheck is an analysis tool for C and C++ code. Unl
 
 github.tarball_from         archive
 
-checksums                   rmd160  863a2cd4b6ade6ec2a1753d3e8ece606e937bc66 \
-                            sha256  7be7992439339017edb551d8e7d2315f9bb57c402da50c2cee9cd0e2724600a1 \
-                            size    4007393
+checksums                   rmd160  506773381a0aa578c92fc90e5011b9ff43b1d6e4 \
+                            sha256  f028ff75ca5372738f3737c8b3e8611426a6526b6aea2ef01301ab0f5902f044 \
+                            size    4029561
 
 set python_branch   3.14
 set python_version  [string map {"." ""} ${python_branch}]


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?