### PR TITLE
riscv-linux-kernel-headers-5.10: update to 5.10.259

### DIFF
--- a/cross/riscv-linux-kernel-headers-5.10/Portfile
+++ b/cross/riscv-linux-kernel-headers-5.10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                riscv-linux-kernel-headers-5.10
-version             5.10.258
+version             5.10.259
 categories          cross devel
 license             GPL-2
 maintainers         {pguyot @pguyot} openmaintainer
@@ -21,9 +21,9 @@ master_sites        https://cdn.kernel.org/pub/linux/kernel/v5.x/
 distname            linux-${version}
 use_xz              yes
 
-checksums           rmd160  719dbabce59062b4b0fb93ee90d44f5d83d86f56 \
-                    sha256  9e7ccb1efc5796e6f8398b778a8b25f7e227e7c54ef5caf6377b8c37d66fb4e5 \
-                    size    120878440
+checksums           rmd160  0ace87db4baf1aeaf8a19e9df7fd33c8c734ab86 \
+                    sha256  aa5e8e580a555e55176658b78fb6759f9c84654462b735119d4e819b5c46b609 \
+                    size    120920220
 
 depends_build       port:gmake \
                     port:gsed


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

and

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
