### PR TITLE
libtorrent & rtorrent: update to 0.16.14

### DIFF
--- a/net/libtorrent/Portfile
+++ b/net/libtorrent/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 # Note - releases for libtorrent are provided at https://github.com/rakshasa/rtorrent
 # rather than at the projects own repo, https://github.com/rakshasa/libtorrent
-github.setup        rakshasa rtorrent 0.16.12 v
+github.setup        rakshasa rtorrent 0.16.14 v
 github.tarball_from releases
 name                libtorrent
 distname            libtorrent-${github.version}
@@ -23,9 +23,9 @@ long_description    libTorrent is a BitTorrent library written in C++ for \
                     *nix. It is designed to avoid redundant copying and \
                     storing of data that other clients and libraries suffer from.
 
-checksums           rmd160  a5892d006443076a266c2c09c90800e8c392dc88 \
-                    sha256  4e47701aebc37d6a700a77e759baeb3dc2be12e265d3e5e36716d9803e16e5d5 \
-                    size    907273
+checksums           rmd160  7deecc5a2241ddb65757aeaf3fcddea77c11a793 \
+                    sha256  289f1992d8c633f82faa3ed47b2eeb9482c290c0c82b8bf6daa1d3784f68c86a \
+                    size    910536
 
 use_autoreconf      yes
 
@@ -40,6 +40,15 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     depends_build-append port:cctools
 }
 
+# system/thread.cc:155:7: error: 'notify_all' is
+# unavailable: introduced in macOS 11.0
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cxxflags-append \
+                    -D_LIBCPP_DISABLE_AVAILABILITY
+    }
+}
+
 # http_stack.cc:17:13: error: aligned allocation function of type 'void
 # *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
 if {${os.platform} eq "darwin" && ${os.major} < 17} {
@@ -49,7 +58,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 17} {
     }
 }
 
-compiler.cxx_standard   2017
+# Starting with version 0.16.13, a compiler that supports C++20 is mandatory
+compiler.cxx_standard   2020
 
 configure.args      --disable-debug \
                     --with-kqueue \

--- a/net/rtorrent/Portfile
+++ b/net/rtorrent/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        rakshasa rtorrent 0.16.12 v
+github.setup        rakshasa rtorrent 0.16.14 v
 github.tarball_from releases
 revision            0
 
@@ -17,9 +17,9 @@ categories          net
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
 
-checksums           rmd160  a1dde64f8377c8365664cc4a779017cfea12c061 \
-                    sha256  46e8b5e9b6daadaf5d3002a3bc5cbde25d6bdc0eb2f17177641cf47ce2d3ef86 \
-                    size    859606
+checksums           rmd160  4b2072c993e875a6a0bcb0bd7b27419da9d3257a \
+                    sha256  d149fd4840065cc69da03caf051119593f10aa8d5b533811bc3bedc3da4a3c00 \
+                    size    868131
 
 description         console-based BitTorrent client
 
@@ -37,8 +37,17 @@ depends_lib-append  port:libtorrent \
                     path:lib/libssl.dylib:openssl \
                     port:zlib
 
-# error: *** A compiler with support for C++17 language features is required.
-compiler.cxx_standard   2017
+# control.cc:34:15: error: aligned allocation function of type 'void
+# *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cxxflags-append \
+                    -fno-aligned-allocation
+    }
+}
+
+# Starting with version 0.16.13, a compiler that supports C++20 is mandatory
+compiler.cxx_standard   2020
 
 configure.args      --mandir=${prefix}/share/man \
                     --disable-debug \


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?