### PR TITLE
lima: Update to 2.1.3

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 2.1.2 v
+go.setup            github.com/lima-vm/lima 2.1.3 v
 go.offline_build    no
 revision            0
 
@@ -28,9 +28,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  c2d52c4d949919fa5f9e6055c525dd94420b7c15 \
-                    sha256  23fa5f4621e355236a10200c4e4f61eae9f69c805c57a107247847b51522ab8a \
-                    size    7810777
+checksums           rmd160  cf12fd36957d6b293abe183ad43fcc7710d122d6 \
+                    sha256  3f6dd39922eb42ff6aa497c28b7573775864a38554002719fdbf64a05033f87e \
+                    size    7812914
 
 build.cmd           make
 build.args-append   native


### PR DESCRIPTION
#### Description

lima: Update to 2.1.3


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
