### PR TITLE
mise: Update to 2026.6.11

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.6.5 v
+github.setup        jdx mise 2026.6.11 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  969adb607ee0a61b5cfbc00669eb7e288c2eac3f \
-                    sha256  81d9b27a067cf6f91d071b9520a78598524747df1e894f9fcd4d03ae339d7748 \
-                    size    7139880
+                    rmd160  cfe63a93bc687579e1d85fd31ea129de402dc416 \
+                    sha256  b4189990c7cfd2e40ff322e9ad51b972dd8edfeda9bdedd239cf8a16384e0c59 \
+                    size    7311593
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -162,16 +162,14 @@ cargo.crates \
     beef                                 0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                             0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
-    bit-set                              0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
-    bit-vec                              0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
     bitflags                            2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
     bitvec                               1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     blake2                         0.11.0-rc.6  061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690 \
     blake3                               1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    block-buffer                        0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
+    block-buffer                        0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     block-padding                        0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     blowfish                             0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     bs58                                 0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
@@ -184,7 +182,7 @@ cargo.crates \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                               1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
     bytes-utils                          0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
-    bytesize                             2.3.1  6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3 \
+    bytesize                             2.4.0  49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d \
     bzip2                                0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2                                0.6.1  f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c \
     bzip2-sys                     0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
@@ -192,7 +190,7 @@ cargo.crates \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.63  556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f \
+    cc                                  1.2.64  dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                          0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
@@ -323,7 +321,6 @@ cargo.crates \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     file_url                             0.3.1  f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747 \
     filetime                            0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
-    filetime_creation                    0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
     find-msvc-tools                      0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
     fixedbitset                          0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
@@ -484,7 +481,7 @@ cargo.crates \
     indoc                                2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inout                                0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
     inout                                0.2.2  4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7 \
-    insta                               1.47.2  7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e \
+    insta                               1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
     intl-memoizer                        0.5.3  310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f \
     intl_pluralrules                     7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
     io-close                             0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
@@ -505,7 +502,7 @@ cargo.crates \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                             0.3.100  f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162 \
+    js-sys                             0.3.102  03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31 \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
@@ -539,14 +536,13 @@ cargo.crates \
     lua-src                            550.0.0  e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb \
     luajit-src                 210.6.6+707c12b  a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295 \
     lzma-rs                              0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
-    lzma-rust                            0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
     lzma-rust2                          0.16.4  ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02 \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
-    memchr                               2.8.1  6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8 \
+    memchr                               2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
     memmap2                             0.9.10  714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3 \
     memoffset                            0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                               7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
@@ -571,8 +567,8 @@ cargo.crates \
     nom                                  8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
     nom-language                         0.1.0  2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29 \
     nonempty                            0.12.0  9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6 \
-    nt-time                              0.8.1  2de419e64947cd8830e66beb584acc3fb42ed411d103e3c794dda355d1b374b5 \
     nu-ansi-term                        0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
+    nucleo-matcher                       0.3.1  bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85 \
     num                                  0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
     num-bigint                           0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
     num-bigint-dig                       0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
@@ -583,19 +579,17 @@ cargo.crates \
     num-rational                         0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                            1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
-    number_prefix                        0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                              0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
     olpc-cjson                           0.1.4  696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083 \
     once_cell                           1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    openssl                            0.10.80  a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967 \
+    openssl                            0.10.81  77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45 \
     openssl-macros                       0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                        0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
-    openssl-sys                        0.9.116  f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4 \
+    openssl-sys                        0.9.117  b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695 \
     option-ext                           0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                       2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
-    os-release                           0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
     os_pipe                              1.2.3  7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967 \
     outref                               0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     owo-colors                           4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
@@ -674,20 +668,20 @@ cargo.crates \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.44.3  95d047508f114f4a0b9d215f309042799f117c66c08fb381113e5e0ed20640e9 \
-    rattler_cache                        0.9.1  7bca0097ce72d097d4381802a4107fb7ee45fc59025feeb2a893cfbeb44ef4b1 \
-    rattler_conda_types                 0.47.0  883f32f7a7729524bf7724e5c7077cc13f8913a28cdf320c83a93d2e2029dcf2 \
+    rattler                             0.44.4  611ee9a35405e2c18b0c580e0c865632eee10164c258d9aa02a93aea31759d32 \
+    rattler_cache                        0.9.2  32c96ef6f35bffb3fb1ba9879de944a0d3477fa0c6c642f29b83100822c9f82f \
+    rattler_conda_types                 0.47.1  7647a414fef338ed377096a263f23728ff8a8a0d33416a2d32e8cb4ab0355cb6 \
     rattler_digest                       1.3.1  2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69 \
     rattler_macros                       1.1.1  ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff \
-    rattler_menuinst                    0.2.65  5ea4f082855a8e0df75d0073b9f78e8fb13e8ee9205cb88eec1b3f8b1a030741 \
-    rattler_networking                  0.28.0  5cbe3eb2914bd715ca7dde169979bce15a8e3c6f0850a039d3ab67110180f73a \
-    rattler_package_streaming           0.26.3  411276a9c5c5a1735be82b201e25287df6c7af312fbd7d66ef0b64d4bb170df0 \
+    rattler_menuinst                    0.2.66  26cb8c41131de072608b789c2069ca9c1293b309c278ff95f39a4fe1949d283e \
+    rattler_networking                  0.28.1  9528ad148dd32f978e355a07b7b5f7a557091b34d6846aff0084afa8c4bd0c64 \
+    rattler_package_streaming           0.26.4  fefd549117f3f0e6f4679aae4f0f3c26514bc6d5e7734994915a173c16cb0052 \
     rattler_pty                         0.2.13  ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a \
     rattler_redaction                    0.2.1  2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b \
-    rattler_repodata_gateway            0.29.4  a2d5aa7ec70dca63533386ebb55cf8f4a38a5f94e0a496978fd986cdb3b6b00e \
-    rattler_shell                       0.27.5  8e492bf2653b421279f245f135ca694ee4b8ea2f470443f5c6fc60b02ea0b1c5 \
-    rattler_solve                        7.1.2  af99e94a11cac58a5d70efbca4b71f5ba4a2f833d2e343f470ab2f29dc1a15b9 \
-    rattler_virtual_packages             3.0.0  ef425f0790fd4bb3b3121b4a14e9f2b5a0a261f8345c9d1a189353b40136fda5 \
+    rattler_repodata_gateway            0.29.5  f5f156179615c31cc410933d5dfcfc2c15b3578c1accf5be1439eb8ef430a323 \
+    rattler_shell                       0.27.6  7e7d8d4fa67349c86006241e3863ebd8c144d790c6e2f0cc55f0074ff7842d1c \
+    rattler_solve                        7.1.3  7317fb3ff057a7aa151ea34a0f0eae4b09560e51e3961f262cca9d2d03b46646 \
+    rattler_virtual_packages             3.0.1  5a447bfff51679f9662c3bc48811942acff7bb27efd3ce6bb0d19b6c26045f86 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
@@ -695,11 +689,11 @@ cargo.crates \
     ref-cast                            1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                       1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
     reflink-copy                        0.1.29  13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27 \
-    regex                               1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex                               1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
     regex-automata                      0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-lite                           0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     regex-syntax                        0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
-    regex-syntax                        0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    regex-syntax                        0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     rend                                 0.5.3  cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
@@ -774,7 +768,6 @@ cargo.crates \
     serde_yaml               0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     serial_test                          3.5.0  699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
     serial_test_derive                   3.5.0  94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
-    sevenz-rust                          0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sevenz-rust2                        0.20.2  29225600349ef74beda5a9fffb36ac660a24613c0bde9315d0c49be1d51e9c24 \
     sha1                                0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha1                                0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
@@ -786,7 +779,6 @@ cargo.crates \
     shared_thread                        0.2.0  52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0 \
     shell-escape                         0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
     shell-words                          1.1.1  dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77 \
-    shellexpand                          3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                                1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     shlex                                2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
     sigchld                              0.2.4  47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1 \
@@ -811,7 +803,7 @@ cargo.crates \
     siphasher                            1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     slab                                0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slug                                 0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
-    smallvec                            1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    smallvec                            1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
     snafu                                0.8.9  6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2 \
     snafu-derive                         0.8.9  c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451 \
     snap                                 1.1.1  1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b \
@@ -821,6 +813,7 @@ cargo.crates \
     spki                                 0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait                   1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                    1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    strip-ansi-escapes                   0.2.1  2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025 \
     strsim                              0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                               0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
     strum                               0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
@@ -835,7 +828,6 @@ cargo.crates \
     syn                                2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     sync_wrapper                         1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                        0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
-    sys-info                             0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     sysctl                               0.5.5  ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea \
     system-configuration                 0.7.0  a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
     system-configuration-sys             0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
@@ -859,9 +851,9 @@ cargo.crates \
     thiserror-impl                      1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                      2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
     thread_local                         1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    time                                0.3.47  743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c \
-    time-core                            0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
-    time-macros                         0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
+    time                                0.3.49  711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469 \
+    time-core                            0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
+    time-macros                         0.2.29  71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d \
     tinystr                              0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
     tinyvec                             1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
@@ -927,7 +919,7 @@ cargo.crates \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                                1.23.2  d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7 \
+    uuid                                1.23.3  144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7 \
     valuable                             0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     value-trait                         0.12.1  8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59 \
     vcpkg                               0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
@@ -939,20 +931,20 @@ cargo.crates \
     walkdir                              2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                                 0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasip2                    1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
+    wasip2                   1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
     wasip3      0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                       0.2.123  a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563 \
-    wasm-bindgen-futures                0.4.73  54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf \
-    wasm-bindgen-macro                 0.2.123  24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc \
-    wasm-bindgen-macro-support         0.2.123  908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b \
-    wasm-bindgen-shared                0.2.123  7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92 \
+    wasm-bindgen                       0.2.125  8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a \
+    wasm-bindgen-futures                0.4.75  503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280 \
+    wasm-bindgen-macro                 0.2.125  4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d \
+    wasm-bindgen-macro-support         0.2.125  fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd \
+    wasm-bindgen-shared                0.2.125  23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f \
     wasm-encoder                       0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                      0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmparser                         0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                            0.3.100  6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69 \
+    web-sys                            0.3.102  a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-root-certs                    1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
     webpki-roots                         1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
@@ -1034,17 +1026,17 @@ cargo.crates \
     x509-tsp                             0.1.0  f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1 \
     xattr                                1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xmlparser                           0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
-    xx                                   2.5.4  d61141ccbc979c1421bc450f1a800196abc073e0deccb0adcb100c96238b33e2 \
+    xx                                   2.6.1  f8aff208388ac09afbb2bd20c3db8f7d253c9fbed7076e3618d598bb3deef2c5 \
     xz2                                  0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                 0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                            0.8.50  3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1 \
-    zerocopy-derive                     0.8.50  0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639 \
+    zerocopy                            0.8.52  ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f \
+    zerocopy-derive                     0.8.52  1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930 \
     zerofrom                             0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                      0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
-    zeroize                              1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
-    zeroize_derive                       1.4.3  85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e \
+    zeroize                              1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
+    zeroize_derive                       1.5.0  3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328 \
     zerotrie                             0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
     zerovec                             0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
     zerovec-derive                      0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \


### PR DESCRIPTION
#### Description

mise: Update to 2026.6.11


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
