### PR TITLE
llama.cpp: update to 9741

### DIFF
--- a/llm/llama.cpp/Portfile
+++ b/llm/llama.cpp/Portfile
@@ -5,9 +5,9 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 
-github.setup            ggerganov llama.cpp 9515 b
+github.setup            ggerganov llama.cpp 9741 b
 github.tarball_from     archive
-set git-commit          e7bcf1c
+set git-commit          84de01a
 # This line is for displaying commit in CLI only
 revision                0
 categories              llm
@@ -19,9 +19,9 @@ long_description        The main goal of ${name} is to enable LLM inference with
                         setup and state-of-the-art performance on a wide variety of hardware\
                          - locally and in the cloud.
 
-checksums               rmd160  9fa6ed343109fc1ec7b38ca500c696cb728f6fbd \
-                        sha256  63243d0bc0fb3f8644a35c8d6654fc47f875522e3f73d1744ae998d3f21b5965 \
-                        size    34052887
+checksums               rmd160  1fdc0ec898840c862a1f89006fa701a04e865ffc \
+                        sha256  0f4998fc3ed8ead130c053f9f1331f4e09ae688e19221d1d602cbae557841309 \
+                        size    34960991
 
 # error: 'filesystem' file not found on 10.14
 legacysupport.newest_darwin_requires_legacy \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
