### PR TITLE
zizmor: Update to 1.26.1

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.25.2 v
+github.setup        zizmorcore zizmor 1.26.1 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 livecheck.regex     {v(\d+\.\d+\.\d+)}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8f1636a47e39eda3823ca603ed81caf2b2402a11 \
-                    sha256  c0e8867d7f32a9a68c62c12611c53c4d915e80adf3608c78b105c2da0bea6e30 \
-                    size    668359
+                    rmd160  0ef6a71e83764c9729153c2767e52bc049604f62 \
+                    sha256  ec5540b3bd6d347df61dcd24ecd2eaffd3181808f4dafc59a9c889e26b075eb8 \
+                    size    693285
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -32,13 +32,12 @@ destroot {
 }
 
 cargo.crates \
-    Inflector                                                              0.11.4  fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3 \
     addr2line                                                              0.25.1  1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b \
     adler2                                                                  2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
     ahash                                                                  0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                                                            1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     allocator-api2                                                         0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
-    annotate-snippets                                                     0.12.15  92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7 \
+    annotate-snippets                                                     0.12.16  f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1 \
     anstream                                                                1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
     anstyle                                                                1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
     anstyle-parse                                                           1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
@@ -46,7 +45,7 @@ cargo.crates \
     anstyle-wincon                                                         3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
     anyhow                                                                1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arrayvec                                                                0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    assert_cmd                                                              2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
+    assert_cmd                                                              2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
     async-lock                                                              3.4.1  5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc \
     async-trait                                                            0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                                                            1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
@@ -59,6 +58,7 @@ cargo.crates \
     bit-set                                                                 0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                                                                 0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
     bitflags                                                               2.10.0  812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3 \
+    bitflip                                                                 0.1.0  7006e6395f41477e1052dfff8381b32c0d740c2ff3d48ffd72d19132293b4578 \
     block-buffer                                                           0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     borrow-or-share                                                         0.2.4  dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c \
     bstr                                                                   1.12.0  234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4 \
@@ -74,7 +74,7 @@ cargo.crates \
     clap                                                                    4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-verbosity-flag                                                     3.0.4  9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394 \
     clap_builder                                                            4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_complete                                                           4.6.3  660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3 \
+    clap_complete                                                           4.6.5  e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772 \
     clap_complete_nushell                                                   4.6.0  fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897 \
     clap_derive                                                             4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                                                                1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
@@ -99,7 +99,6 @@ cargo.crates \
     dashmap                                                                 6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     data-encoding                                                           2.9.0  2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476 \
     deranged                                                                0.5.4  a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071 \
-    diff                                                                   0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     difflib                                                                 0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                                                                 0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     displaydoc                                                              0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
@@ -152,7 +151,7 @@ cargo.crates \
     hashbrown                                                              0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heck                                                                    0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                                                                     0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    http                                                                    1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
+    http                                                                    1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
     http-body                                                               1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                                                          0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     http-cache                                                      1.0.0-alpha.6  d01e0b5d3afe17eadd68dad863adc0715b7ccfa887effbb9ea4de3c7c78c6c44 \
@@ -175,21 +174,21 @@ cargo.crates \
     id-arena                                                                2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     idna                                                                    1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                                                            1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
-    ignore                                                                 0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
+    ignore                                                                 0.4.26  b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d \
     indexmap                                                               2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indicatif                                                              0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
     insta                                                                  1.47.2  7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e \
-    inventory                                                              0.3.21  bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e \
     ipnet                                                                  2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
     iri-string                                                              0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
     is_terminal_polyfill                                                   1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
+    itertools                                                              0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
     itertools                                                              0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                                                                   1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     jni                                                                    0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
     jni-sys                                                                 0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                                                              0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     js-sys                                                                 0.3.85  8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3 \
-    jsonschema                                                             0.46.4  fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f \
+    jsonschema                                                             0.46.5  6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631 \
     lazy_static                                                             1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                                                               0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libc                                                                  0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
@@ -203,18 +202,16 @@ cargo.crates \
     lru-slab                                                                0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     ls-types                                                                0.0.2  7a7deb98ef9daaa7500324351a5bab7c80c644cfb86b4be0c4433b582af93510 \
     matchers                                                                0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
-    memchr                                                                  2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
+    memchr                                                                  2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
     memmap2                                                                0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     micromap                                                                0.3.0  c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74 \
     miette                                                                 5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
     miette-derive                                                          5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
     mime                                                                   0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
-    minimal-lexical                                                         0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                                                             0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                                                                     1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
     moka                                                                  0.12.11  8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077 \
     nohash-hasher                                                           0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
-    nom                                                                     7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     ntapi                                                                   0.4.2  c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081 \
     nu-ansi-term                                                           0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
     num                                                                     0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
@@ -238,10 +235,6 @@ cargo.crates \
     parking_lot                                                            0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                                                       0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     percent-encoding                                                        2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                                                                    2.8.6  e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662 \
-    pest_derive                                                             2.8.6  11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77 \
-    pest_generator                                                          2.8.6  8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f \
-    pest_meta                                                               2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
     pin-project-lite                                                       0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                                                               0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     portable-atomic                                                        1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
@@ -252,7 +245,6 @@ cargo.crates \
     predicates                                                              3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
     predicates-core                                                         1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
     predicates-tree                                                        1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
-    pretty_assertions                                                       1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     prettyplease                                                           0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     proc-macro2                                                           1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     quinn                                                                  0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
@@ -267,13 +259,13 @@ cargo.crates \
     redox_syscall                                                          0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     ref-cast                                                               1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                                                          1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    referencing                                                            0.46.4  cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730 \
+    referencing                                                            0.46.5  69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2 \
     reflink-copy                                                           0.1.28  23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92 \
     regex                                                                  1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
     regex-automata                                                         0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-syntax                                                            0.8.8  7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58 \
-    reqwest                                                                0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
-    reqwest-middleware                                                      0.5.1  199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f \
+    reqwest                                                                0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
+    reqwest-middleware                                                      0.5.2  07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58 \
     ring                                                                  0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rustc-demangle                                                         0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
     rustc-hash                                                              2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
@@ -289,8 +281,6 @@ cargo.crates \
     ryu                                                                    1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     same-file                                                               1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                                                               0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
-    schemafy_core                                                           0.6.0  2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24 \
-    schemafy_lib                                                            0.6.0  af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f \
     schemars                                                                1.2.1  a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc \
     schemars_derive                                                         1.2.1  7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f \
     scopeguard                                                              1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
@@ -299,15 +289,10 @@ cargo.crates \
     self_cell                                                               1.2.2  b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89 \
     semver                                                                 1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
     serde                                                                 1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde-sarif                                                             0.8.0  a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be \
     serde_core                                                            1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                                                          1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
     serde_derive_internals                                                 0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                                                            1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
-    serde_json_path                                                         0.7.2  b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33 \
-    serde_json_path_core                                                    0.2.2  dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc \
-    serde_json_path_macros                                                  0.1.6  517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8 \
-    serde_json_path_macros_internal                                         0.1.2  aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90 \
+    serde_json                                                            1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_spanned                                                           1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                                                        0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha-1                                                                  0.10.1  f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c \
@@ -324,10 +309,7 @@ cargo.crates \
     stable_deref_trait                                                      1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     streaming-iterator                                                      0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strsim                                                                 0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
-    strum                                                                  0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
-    strum_macros                                                           0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     subtle                                                                  2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    syn                                                                   1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                                                                   2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     sync_wrapper                                                            1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                                                           0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
@@ -335,7 +317,7 @@ cargo.crates \
     system-configuration                                                    0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
     system-configuration-sys                                                0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
     tagptr                                                                  0.2.0  7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417 \
-    tar                                                                    0.4.45  22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973 \
+    tar                                                                    0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                                                               3.23.0  2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16 \
     terminal-link                                                           0.1.0  253bcead4f3aa96243b0f8fa46f9010e87ca23bd5d0c723d474ff1d2417bbdf8 \
     termtree                                                                0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
@@ -345,8 +327,8 @@ cargo.crates \
     thiserror-impl                                                         1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                                                         2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
     thread_local                                                            1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    tikv-jemalloc-sys     0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7  cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b \
-    tikv-jemallocator                                                       0.6.1  0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a \
+    tikv-jemalloc-sys     0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8  1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0 \
+    tikv-jemallocator                                                       0.7.0  249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd \
     time                                                                   0.3.47  743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c \
     time-core                                                               0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
     time-macros                                                            0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
@@ -372,16 +354,14 @@ cargo.crates \
     tracing-indicatif                                                      0.3.14  e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e \
     tracing-log                                                             0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                                                     0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
-    tree-sitter                                                            0.26.8  887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538 \
+    tree-sitter                                                            0.26.9  4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3 \
     tree-sitter-bash                                                       0.25.1  9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062 \
     tree-sitter-language                                                    0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
     tree-sitter-powershell                                                 0.26.4  3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022 \
     tree-sitter-yaml                                                        0.7.2  53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97 \
     try-lock                                                                0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    typed-builder                                                          0.21.2  fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d \
-    typed-builder-macro                                                    0.21.2  1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18 \
     typenum                                                                1.19.0  562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb \
-    ucd-trie                                                                0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
+    typomania                                                               0.1.2  38f8c4efb88486b445b83759c6589b97a0fe4cf82bd36be336c164b49af13bef \
     unicode-general-category                                                1.1.0  0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f \
     unicode-ident                                                          1.0.20  462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06 \
     unicode-width                                                          0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
@@ -389,7 +369,6 @@ cargo.crates \
     unicode-xid                                                             0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     unit-prefix                                                             0.5.1  323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817 \
     untrusted                                                               0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    uriparse                                                                0.6.4  0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff \
     url                                                                     2.5.7  08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b \
     utf8_iter                                                               1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                                                               0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -479,7 +458,6 @@ cargo.crates \
     xattr                                                                   1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xxhash-rust                                                            0.8.15  fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3 \
     yaml_serde                                                             0.10.4  08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975 \
-    yansi                                                                   1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                                                    0.8.0  5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc \
     yoke-derive                                                             0.8.0  38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6 \
     zerocopy                                                               0.8.27  0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.26.1

py-segregation: update to 2.5.5


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
