### PR TITLE
apfel: Update to 1.6.0

### DIFF
--- a/llm/apfel/Portfile
+++ b/llm/apfel/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Arthur-Ficial apfel 1.5.5 v
-revision            1
+github.setup        Arthur-Ficial apfel 1.6.0 v
+revision 0
 github.tarball_from archive
 
 homepage            https://apfel.franzai.com
@@ -23,9 +23,9 @@ license             MIT
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  f9cde544cb1ec866dfc57565db38970a52816053 \
-                    sha256  d00c0d99eb7b5bd3f6aafccfb937c12519ded88abc239d6237c540894d1b9e90 \
-                    size    1300378
+checksums           rmd160  9345e01b21ffa13a015d8194926b3f02af9c6624 \
+                    sha256  d10be2811bbbfaeeca35ccda967c7750d78b0f66c2b3e6b23502e5129d463fd0 \
+                    size    1326820
 
 platforms           {darwin >= 26}
 supported_archs     arm64


### PR DESCRIPTION
#### Description

apfel: Update to 1.6.0


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
