### PR TITLE
opencode: update to 1.17.9

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.17.7
+version             1.17.9
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  76b97e3db52aba93437e084e1c4747573bc90a9f \
-                    sha256  1642eca13464b2616a786c5a860edfc7daf1c40dc9cfb880d27a37a5d1c04e1a \
-                    size    3041
+checksums           rmd160  e9717c44df483454387e36dc1e873ba82c7373b1 \
+                    sha256  c943d8f0bde6192f0b8744a0cf9388b4d3d417bec010707da45d50dac960a369 \
+                    size    3043


### PR DESCRIPTION
#### Description

Update to OpenCode 1.17.9.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?