### PR TITLE
npm10: update to 10.9.8

### DIFF
--- a/devel/npm10/Portfile
+++ b/devel/npm10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm10
-version             10.9.3
+version             10.9.8
 revision            0
 categories          devel
 platforms           any
@@ -27,9 +27,9 @@ extract.suffix      .tgz
 
 # Please keep the sha1 - users can use it to validate sha values
 # published on npmjs.org for the package
-checksums           rmd160  f7e7f756b4cccead6eeb92b420c6fbf92605e772 \
-                    sha256  7df781ff358e20e79cd9a51907bc4dacc9238f149a936d997bbb34d4dc0ac002 \
-                    size    2714798
+checksums           rmd160  496b772152b1c8df4c960d871bb2432bd4c5d2fb \
+                    sha256  3e68f9b5fcaf1a94ba0e37e6a565c920b2be6bd98998c50970385d6a692af780 \
+                    size    2973275
 
 worksrcdir          "package"
 
@@ -52,11 +52,11 @@ post-patch {
                    ${worksrcpath}/bin/npx-cli.js \
                    ${worksrcpath}/node_modules/@npmcli/arborist/bin/index.js \
                    ${worksrcpath}/node_modules/@npmcli/installed-package-contents/bin/index.js \
+                   ${worksrcpath}/node_modules/@npmcli/metavuln-calculator/node_modules/pacote/bin/index.js \
                    ${worksrcpath}/node_modules/cross-spawn/node_modules/which/bin/node-which \
                    ${worksrcpath}/node_modules/cssesc/bin/cssesc \
                    ${worksrcpath}/node_modules/glob/dist/esm/bin.d.mts \
                    ${worksrcpath}/node_modules/glob/dist/esm/bin.mjs \
-                   ${worksrcpath}/node_modules/mkdirp/bin/cmd.js \
                    ${worksrcpath}/node_modules/node-gyp/bin/node-gyp.js \
                    ${worksrcpath}/node_modules/nopt/bin/nopt.js \
                    ${worksrcpath}/node_modules/pacote/bin/index.js \


### PR DESCRIPTION
#### Description

Update to NPM 10.9.8.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
