### PR TITLE
gdcm: Update to 3.2.8

### DIFF
--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -8,8 +8,8 @@ PortGroup               legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup            malaterre GDCM 3.2.5 v
-revision                1
+github.setup            malaterre GDCM 3.2.8 v
+revision                0
 
 name                    gdcm
 categories              science graphics
@@ -22,10 +22,9 @@ long_description        Grassroots DiCoM is a C++ library for DICOM medical file
 homepage                https://sourceforge.net/projects/gdcm/
 
 github.tarball_from     archive
-
-checksums               rmd160  5b84f55a53af869cb29e6a7ae863f44f1140d038 \
-                        sha256  1763d94228ef31babe68a2b5f3b0d4fc66bc0afae641d9a4c38ea5269e06ba5d \
-                        size    4092525
+checksums               rmd160  35be4e0d6afed61bf7ed82f58abcccc7c20ddc76 \
+                        sha256  bf9f75af2607adb8a4ee0e30dd3d61f61e8dc4e5229c748bdcc72c1c546fd232 \
+                        size    4111429
 
 compiler.cxx_standard   2014
 
@@ -36,6 +35,11 @@ compiler.blacklist-append \
 
 # fix error with newer Poppler
 patchfiles-append       patch-poppler.diff
+
+# Fix build dependency on "proj" version.
+# Use only needed VTK components, not all possible ones.
+# https://discourse.vtk.org/t/could-not-find-libproj/15779
+patchfiles-append       patch-vtk_components.diff
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -69,11 +73,6 @@ configure.args-append   -DCMAKE_CXX_STANDARD=14 \
                         -DGDCM_WRAP_CSHARP=OFF \
                         -DGDCM_WRAP_JAVA=OFF \
                         -DGDCM_WRAP_PYTHON=OFF
-
-#  PROJ version should be in sync with VTK
-set proj_version        proj9
-configure.args-append   -DLibPROJ_INCLUDE_DIR=${prefix}/lib/${proj_version}/include
-configure.env-append    CMAKE_LIBRARY_PATH=${prefix}/lib/${proj_version}/lib
 
 variant applications description {build Application} {
     PortGroup               qt5 1.0

--- a/science/gdcm/files/patch-vtk_components.diff
+++ b/science/gdcm/files/patch-vtk_components.diff
@@ -1,0 +1,36 @@
+# Use only needed VTK components, not all possible ones.  Reduce dependencies.
+# https://discourse.vtk.org/t/could-not-find-libproj/15779
+
+--- CMakeLists.txt.orig	2026-06-18 10:24:52
++++ CMakeLists.txt	2026-06-21 15:55:45
+@@ -717,7 +717,29 @@
+   if(GDCM_USE_VTK)
+     option(GDCM_USE_PARAVIEW "paraview plugin ?" OFF)
+     # needed here so that we have VTK_WRAP_PYTHON and al. available
+-    find_package(VTK REQUIRED)
++
++    if("${VTK_MAJOR_VERSION}" LESS 9)
++      find_package(VTK REQUIRED)
++    else()
++      # VTK components list was extracted from Utilities/VTK/vtkgdcm.module.
++      # Classifications were ignored.  For future, some modules may be optional.
++      # Outer signature copied from openEMS/CMakeLists.txt.
++      find_package(VTK REQUIRED COMPONENTS
++          CommonCore
++          CommonDataModel
++          CommonExecutionModel
++          IOImage
++          IOLegacy
++          ImagingSources
++          CommonMisc
++          ImagingCore
++          IOCore
++          InteractionStyle
++          RenderingCore
++          TestingCore
++        NO_MODULE REQUIRED)
++    endif()
++
+     mark_as_advanced(VTK_DIR)
+     set(GDCM_VTK_DIR ${VTK_DIR})
+     mark_as_advanced(GDCM_USE_PARAVIEW)


### PR DESCRIPTION
#### Description

* Update gdcm 3.2.5 --> 3.2.8.
* Fix cmake problem, remove invalid proj9 build dependency.

###### Type(s)

###### Tested on

macOS 15.7.7
Xcode 26.0.1
Command Line Tools 26.0.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -s install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?