### PR TITLE
libtorrent & rtorrent: update to 0.16.15

### DIFF
--- a/net/libtorrent/Portfile
+++ b/net/libtorrent/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 # Note - releases for libtorrent are provided at https://github.com/rakshasa/rtorrent
 # rather than at the projects own repo, https://github.com/rakshasa/libtorrent
-github.setup        rakshasa rtorrent 0.16.14 v
+github.setup        rakshasa rtorrent 0.16.15 v
 github.tarball_from releases
 name                libtorrent
 distname            libtorrent-${github.version}
@@ -23,9 +23,9 @@ long_description    libTorrent is a BitTorrent library written in C++ for \
                     *nix. It is designed to avoid redundant copying and \
                     storing of data that other clients and libraries suffer from.
 
-checksums           rmd160  7deecc5a2241ddb65757aeaf3fcddea77c11a793 \
-                    sha256  289f1992d8c633f82faa3ed47b2eeb9482c290c0c82b8bf6daa1d3784f68c86a \
-                    size    910536
+checksums           rmd160  7007241762b625e08c374933c931126beac9b3a9 \
+                    sha256  bbb09fb80f50fede504799885d1df054c9edf7e7820f9d5a9c72674dcf60c9cf \
+                    size    911534
 
 use_autoreconf      yes
 

--- a/net/rtorrent/Portfile
+++ b/net/rtorrent/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        rakshasa rtorrent 0.16.14 v
+github.setup        rakshasa rtorrent 0.16.15 v
 github.tarball_from releases
 revision            0
 
@@ -17,9 +17,9 @@ categories          net
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
 
-checksums           rmd160  4b2072c993e875a6a0bcb0bd7b27419da9d3257a \
-                    sha256  d149fd4840065cc69da03caf051119593f10aa8d5b533811bc3bedc3da4a3c00 \
-                    size    868131
+checksums           rmd160  86d7e414dd9f05c20db73bec0906376db3505970 \
+                    sha256  202b56b75916cae86b4db4208cc42279f12d07a06e2ffba8ac8361bcb6dac18d \
+                    size    868541
 
 description         console-based BitTorrent client
 


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?