### PR TITLE
wasm-tools: new port (1.252.0)

### DIFF
--- a/devel/wasm-tools/Portfile
+++ b/devel/wasm-tools/Portfile
@@ -1,0 +1,355 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           cargo   1.0
+
+github.setup        bytecodealliance wasm-tools 1.252.0 v
+github.tarball_from archive
+revision            0
+
+categories          devel lang
+installs_libs       no
+license             Apache-2 MIT
+maintainers         nomaintainer
+
+description         \
+    CLI and Rust libraries for low-level manipulation of WebAssembly modules
+
+long_description    {*}${description}
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  5ab896635bbac5ed06ae0e56d82c758c4fb1414f \
+                    sha256  1589a4379632b5b44d7b5fca2a3bfcb4c6e39be5de722229cc28328342da6b48 \
+                    size    5636497
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    # Shell completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    system "${destroot}${prefix}/bin/${name} completion bash > ${destroot}${prefix}/share/bash-completion/completions/${name}"
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    system "${destroot}${prefix}/bin/${name} completion zsh > ${destroot}${prefix}/share/zsh/site-functions/_${name}"
+
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    system "${destroot}${prefix}/bin/${name} completion fish > ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish"
+}
+
+cargo.crates \
+    addr2line                                     0.25.1  1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b \
+    adler2                                         2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    ahash                                         0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
+    aho-corasick                                   1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    allocator-api2                                0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
+    anes                                           0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    anstream                                      0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
+    anstyle                                       1.0.11  862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd \
+    anstyle-parse                                  0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
+    anstyle-query                                  1.1.3  6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9 \
+    anstyle-wincon                                 3.0.9  403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882 \
+    anyhow                                       1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    arbitrary                                      1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
+    arbtest                                        0.3.2  2a3be567977128c0f71ad1462d9624ccda712193d124e944252f0c5789a06d46 \
+    arraydeque                                     0.5.1  7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236 \
+    arrayref                                       0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
+    arrayvec                                       0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
+    auditable-serde                                0.9.0  d026218ae25ba5c72834245412dd1338f6d270d2c5109ee03a4badec288d4056 \
+    autocfg                                        1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    beef                                           0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
+    bitflags                                      2.11.0  843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
+    blake3                                         1.8.2  3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0 \
+    bumpalo                                       3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    bytesize                                       2.0.1  a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba \
+    camino                                        1.1.12  dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5 \
+    cargo-platform                                 0.3.2  87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082 \
+    cargo_metadata                                0.23.1  ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9 \
+    cast                                           0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cc                                            1.2.59  b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283 \
+    cfg-if                                         1.0.1  9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268 \
+    chacha20                                      0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
+    ciborium                                       0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
+    ciborium-io                                    0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
+    ciborium-ll                                    0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
+    clap                                          4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
+    clap_builder                                  4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
+    clap_complete                                 4.5.54  aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677 \
+    clap_derive                                   4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
+    clap_lex                                       0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
+    cobs                                           0.3.0  0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1 \
+    colorchoice                                    1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
+    comfy-table                                    7.1.4  4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a \
+    constant_time_eq                               0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
+    cpp_demangle                                   0.4.4  96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d \
+    cpp_demangle                                   0.5.1  0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def \
+    cpufeatures                                    0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
+    cranelift-assembler-x64                      0.123.7  c8056d63fef9a6f88a1e7aae52bb08fcf48de8866d514c0dc52feb15975f5db5 \
+    cranelift-assembler-x64-meta                 0.123.7  57d063b40884a0d733223a45c5de1155395af4393cf7f900d5be8e2cbc094015 \
+    cranelift-bforest                            0.123.7  3c3add2881bae2d55cd7162906988dd70053cb7ece865ad793a6754b04d47df6 \
+    cranelift-bitset                             0.123.7  dd73e32bc1ea4bddc4c770760c66fa24b2890991b0561af554219e603fcd7c34 \
+    cranelift-codegen                            0.123.7  3e1da85f2636fe28244848861d1ed0f8dccdc6e98fc5db31aa5eb8878e7ff617 \
+    cranelift-codegen-meta                       0.123.7  ee3c8aba9d89832df27364b2e79dc2fe288daf4bd6c7347829e7f3f258ea5650 \
+    cranelift-codegen-shared                     0.123.7  ac9a9b09fe107fef6377caed20614586124184cffccb73611312ceb922a917e6 \
+    cranelift-control                            0.123.7  50aef001c7ad250d5fdda2c7481cbfcabe6435c66106adf5760dcb9fb9a8ede4 \
+    cranelift-entity                             0.123.7  cf3c84656a010df2b5afaedcbbbd94f1efe175b55e29864df7b99e64bfa40d56 \
+    cranelift-frontend                           0.123.7  6aa1d2006915cddb63705db46dcfb8637fe08f91d26fbe59680d7257ec39d609 \
+    cranelift-isle                               0.123.7  6e4fecbcbb81273f9aff4559e26fc341f42663da420cca5ac84b34e74e9267e0 \
+    cranelift-native                             0.123.7  976a3d85f197a56ae34ee4d5a5e469855ac52804a09a513d0562d425da0ff56e \
+    cranelift-srcgen                             0.123.7  37fbd4aefce642145491ff862d2054a71b63d2d97b8dd1e280c9fdaf399598b7 \
+    crc32fast                                      1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    criterion                                      0.7.0  e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928 \
+    criterion-plot                                 0.6.0  9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338 \
+    crossbeam-deque                                0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
+    crossbeam-epoch                               0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                               0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    crunchy                                        0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
+    derive_arbitrary                               1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
+    diff                                          0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+    displaydoc                                     0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
+    egg                                            0.6.0  05a6c0bbc92278f84e742f08c0ab9cb16a987376cd2bc39d228ef9c74d98d6f7 \
+    either                                        1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    embedded-io                                    0.4.0  ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced \
+    embedded-io                                    0.6.1  edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d \
+    encoding_rs                                   0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
+    env_filter                                     0.1.3  186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0 \
+    env_logger                                    0.11.8  13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f \
+    equivalent                                     1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
+    errno                                         0.3.13  778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad \
+    escape8259                                     0.5.3  5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6 \
+    fallible-iterator                              0.3.0  2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649 \
+    fastrand                                       2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
+    find-msvc-tools                                0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    fixedbitset                                    0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
+    flagset                                        0.4.7  b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe \
+    flate2                                         1.1.2  4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d \
+    fnv                                            1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                                       0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    foldhash                                       0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
+    form_urlencoded                                1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    futures                                       0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
+    futures-channel                               0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
+    futures-core                                  0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
+    futures-executor                              0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
+    futures-io                                    0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
+    futures-macro                                 0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
+    futures-sink                                  0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
+    futures-task                                  0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
+    futures-util                                  0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    getrandom                                      0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
+    getrandom                                      0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
+    gimli                                         0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
+    glob                                           0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
+    half                                           2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
+    hashbrown                                     0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                                     0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashbrown                                     0.15.4  5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5 \
+    hashbrown                                     0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
+    hashlink                                       0.8.4  e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
+    heck                                           0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    hermit-abi                                     0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
+    icu_collections                                1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
+    icu_locid                                      1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
+    icu_locid_transform                            1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
+    icu_locid_transform_data                       1.5.1  7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d \
+    icu_normalizer                                 1.5.0  19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f \
+    icu_normalizer_data                            1.5.1  c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7 \
+    icu_properties                                 1.5.1  93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5 \
+    icu_properties_data                            1.5.1  85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2 \
+    icu_provider                                   1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
+    icu_provider_macros                            1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    id-arena                                       2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
+    idna                                           1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
+    idna_adapter                                   1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
+    indexmap                                       1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    indexmap                                      2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    indoc                                          2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
+    instant                                       0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
+    is_executable                                  1.0.4  d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2 \
+    is_terminal_polyfill                          1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
+    itertools                                     0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itertools                                     0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itoa                                          1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
+    jiff                                          0.2.15  be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49 \
+    jiff-static                                   0.2.15  03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4 \
+    jobserver                                     0.1.33  38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a \
+    lazy_static                                    1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    leb128                                         0.2.5  884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67 \
+    leb128fmt                                      0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
+    libc                                         0.2.184  48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af \
+    libfuzzer-sys                                 0.4.10  5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404 \
+    libm                                          0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
+    libtest-mimic                                  0.8.1  5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33 \
+    linux-raw-sys                                 0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
+    litemap                                        0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
+    log                                           0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    logos                                         0.14.4  7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458 \
+    logos-codegen                                 0.14.4  59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f \
+    logos-derive                                  0.14.4  24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d \
+    mach2                                          0.4.3  d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44 \
+    memchr                                         2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
+    memfd                                          0.6.5  ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227 \
+    memmap2                                        0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
+    miniz_oxide                                    0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    num-traits                                    0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    num_cpus                                      1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
+    object                                        0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
+    once_cell                                     1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    once_cell_polyfill                            1.70.1  a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad \
+    oorandom                                      11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
+    percent-encoding                               2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    petgraph                                       0.6.5  b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db \
+    pin-project-lite                              0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
+    pin-utils                                      0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    portable-atomic                               1.11.1  f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
+    portable-atomic-util                           0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
+    postcard                                       1.1.3  6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24 \
+    pretty_assertions                              1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
+    prettyplease                                  0.2.36  ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2 \
+    proc-macro2                                  1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    pulley-interpreter                            36.0.7  a078b4bdfd275fadeefc4f9ae3675ee5af302e69497da439956dd05257858970 \
+    pulley-macros                                 36.0.7  9dac91999883fd00b900eb5377be403c5cb8b93e10efcb571bf66454c2d9f231 \
+    quote                                         1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    r-efi                                          5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
+    r-efi                                          6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
+    rand                                          0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
+    rand_core                                     0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    rayon                                         1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
+    rayon-core                                    1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
+    regalloc2                                     0.12.2  5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734 \
+    regex                                         1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
+    regex-automata                                 0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
+    regex-syntax                                   0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    rustc-demangle                                0.1.25  989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f \
+    rustc-hash                                     2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
+    rustix                                         1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
+    ruzstd                                         0.8.1  3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c \
+    same-file                                      1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    semver                                        1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
+    serde                                        1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_core                                   1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                                 1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                                   1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_yaml2                                    0.1.3  63a7808e70b0b09116f01a4730d8976bcab457ea4a5e2e638e9b12ed3e01f27c \
+    shlex                                          1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    slab                                          0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
+    smallvec                                      1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    spdx                                          0.10.8  58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193 \
+    spdx                                          0.13.4  a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7 \
+    stable_deref_trait                             1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    strsim                                        0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    symbolic_expressions                           5.0.3  7c68d531d83ec6c531150584c42a4290911964d5f0d79132b193b67252a23b71 \
+    syn                                          2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    synstructure                                  0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
+    target-lexicon                                0.13.2  e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a \
+    tempfile                                      3.20.0  e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1 \
+    termcolor                                      1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
+    terminal_size                                  0.4.2  45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed \
+    thiserror                                     1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
+    thiserror                                     2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror-impl                                1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
+    thiserror-impl                                2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    tinystr                                        0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
+    tinytemplate                                   1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
+    topological-sort                               0.2.2  ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d \
+    twox-hash                                      2.1.2  9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c \
+    typed-arena                                    2.0.2  6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a \
+    unicode-ident                                 1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
+    unicode-segmentation                          1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
+    unicode-width                                  0.2.1  4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
+    unicode-xid                                    0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
+    url                                            2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
+    utf16_iter                                     1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
+    utf8_iter                                      1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
+    utf8parse                                      0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
+    version_check                                  0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    walkdir                                        2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
+    wasi                               0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
+    wasi-preview1-component-adapter-provider      36.0.2  4da2ec25ddcaf86d98cd2e1928af72963bc24318cf22fee36c61953bc5fd9f28 \
+    wasip2                              1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
+    wasip3                0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
+    wasm-encoder                                 0.214.0  ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041 \
+    wasm-encoder                                 0.236.1  724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7 \
+    wasm-encoder                                 0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
+    wasm-encoder                                 0.247.0  30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204 \
+    wasm-metadata                                0.214.0  865c5bff5f7a3781b5f92ea4cfa99bb38267da097441cdb09080de1568ef3075 \
+    wasm-metadata                                0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
+    wasm-metadata                                0.247.0  665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10 \
+    wasmparser                                   0.214.0  5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6 \
+    wasmparser                                   0.236.1  a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7 \
+    wasmparser                                   0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
+    wasmparser                                   0.247.0  8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80 \
+    wasmprinter                                  0.236.1  2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1 \
+    wasmtime                                      36.0.7  b80d5ba38b9b00f60a0665e07dde38e91d884d4a78cd61d777c8cf081a1267c1 \
+    wasmtime-environ                              36.0.7  44a45d60dea98308decb71a9f7bb35a629696d1fbf7127dbfde42cbc64b8fa33 \
+    wasmtime-internal-asm-macros                  36.0.7  dd014b4001b6da03d79062d9ad5ec98fa62e34d50e30e46298545282cc2957e4 \
+    wasmtime-internal-component-macro             36.0.7  0f2942aa5d44b02061e0c6ab71b23090cf3b300b4519e3b80776ac38edde2e65 \
+    wasmtime-internal-component-util              36.0.7  bcb6f974fe739e98034b7e6ec6feb2ab399f4cde7207675f26138bd9a1d65720 \
+    wasmtime-internal-cranelift                   36.0.7  4047020866a80aa943e41133e607020e17562126cf81533362275272098a22b1 \
+    wasmtime-internal-fiber                       36.0.7  7cd172b622993bb8f834f6ca3b7683dfdba72b12db0527824850fdec17c89e5a \
+    wasmtime-internal-jit-debug                   36.0.7  1287e310fef4c8759a6b5caa0d44eff9a03ebcd6c273729cc39ce3e321a9e26a \
+    wasmtime-internal-jit-icache-coherence        36.0.7  c02bca30ef670a31496d742d9facdbd0228debe766b1e9541655c0530ff5c953 \
+    wasmtime-internal-math                        36.0.7  fd3a1f51a037ae2c048f0d76d36e27f0d22276295496c44f16a251f24690e003 \
+    wasmtime-internal-slab                        36.0.7  ba6171aac3d66e4d69e50080bb6bc5205de2283513984a4118a93cb66dc02994 \
+    wasmtime-internal-unwinder                    36.0.7  3fd1bc1783391a02176fb687159b1779fc10b71d5350adf09c1f3aa8442a02cc \
+    wasmtime-internal-versioned-export-macros     36.0.7  8097e2c8ca02ed65d31dda111faa0888ffbf28dc3ee74355e283118a8d293eb0 \
+    wasmtime-internal-winch                       36.0.7  6a8cb36b61fbcff2c8bcd14f9f2651a6e52b019d0d329324620d7bc971b2b235 \
+    wasmtime-internal-wit-bindgen                 36.0.7  ff555cfb71577028616d65c00221c7fe6eef45a9ebb96fc6d34d4a41fa1de191 \
+    winapi                                         0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu                     0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                                    0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
+    winapi-x86_64-pc-windows-gnu                   0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winch-codegen                                 36.0.7  0989126b21d12c9923aa2de7ddbcf87db03037b24b7365041d9dd0095b69d8cb \
+    windows-link                                   0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-sys                                   0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-sys                                   0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
+    windows-sys                                   0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
+    windows-targets                               0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                               0.53.2  c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef \
+    windows_aarch64_gnullvm                       0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm                       0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
+    windows_aarch64_msvc                          0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc                          0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
+    windows_i686_gnu                              0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                              0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
+    windows_i686_gnullvm                          0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm                          0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
+    windows_i686_msvc                             0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc                             0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
+    windows_x86_64_gnu                            0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu                            0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
+    windows_x86_64_gnullvm                        0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm                        0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
+    windows_x86_64_msvc                           0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc                           0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
+    wit-bindgen                                   0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
+    wit-bindgen                                   0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
+    wit-bindgen-core                              0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
+    wit-bindgen-core                              0.57.1  02dee27a2dc20d1008016c742ec9fc6ea498492994ba3750be7454cbc97ff04c \
+    wit-bindgen-rt                                0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
+    wit-bindgen-rust                              0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
+    wit-bindgen-rust                              0.57.1  b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484 \
+    wit-bindgen-rust-macro                        0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
+    wit-bindgen-rust-macro                        0.57.1  af9237d678e3513ad24e96fe98beacdc0db6405284ba2a2400418cf0d42caa89 \
+    wit-component                                0.214.0  fd9fd46f0e783bf80f1ab7291f9d442fa5553ff0e96cdb71964bd8859b734b55 \
+    wit-component                                0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
+    wit-component                                0.247.0  9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8 \
+    wit-parser                                   0.214.0  681d526d6ea42e28f9afe9eae2b50e0b0a627aef8822c75eb04078db84d03e57 \
+    wit-parser                                   0.236.1  16e4833a20cd6e85d6abfea0e63a399472d6f88c6262957c17f546879a80ba15 \
+    wit-parser                                   0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
+    wit-parser                                   0.247.0  8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc \
+    write16                                        1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
+    writeable                                      0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
+    yaml-rust2                                     0.8.1  8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8 \
+    yansi                                          1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
+    yoke                                           0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
+    yoke-derive                                    0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
+    zerocopy                                      0.8.26  1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f \
+    zerocopy-derive                               0.8.26  9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181 \
+    zerofrom                                       0.1.5  cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e \
+    zerofrom-derive                                0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
+    zerovec                                       0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
+    zerovec-derive                                0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
+    zmij                                          1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa


### PR DESCRIPTION
#### Description

[wasm-tools](https://github.com/bytecodealliance/wasm-tools) are CLI and Rust libraries for low-level manipulation of WebAssembly modules.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.3 (25D125) ASi
Xcode 26.1.1 (17B100)

macOS 15.7.4 (24G517) x86-64
Xcode 16.0 (16A242d)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
