### PR TITLE
ralphex: update to 1.5.1

### DIFF
--- a/llm/ralphex/Portfile
+++ b/llm/ralphex/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/umputun/ralphex 1.5.0 v
+go.setup            github.com/umputun/ralphex 1.5.1 v
 revision            0
 categories          llm
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -19,9 +19,9 @@ build.pre_args-append \
                     TAG=v${version}
 build.args          build
 
-checksums           rmd160  1464bb8ff71a0146f92c45e2381f05c455b9e0a6 \
-                    sha256  4e1549f13c0192f1f56e4f5e4a2a181a46b89a5c58921cca6f63a782c3d8080b \
-                    size    8211318
+checksums           rmd160  a3edd14816088db0016539bff3e54fd425ae1884 \
+                    sha256  f6750a671853ec7bc7a45e04f50a0f5b5969e7d6d8f24dcae6d7508bb39c18c3 \
+                    size    8210031
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/.bin/ralphex.v${version} ${destroot}${prefix}/bin/ralphex


### PR DESCRIPTION
#### Description
https://github.com/umputun/ralphex/blob/v1.5.1/CHANGELOG.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
