### PR TITLE
charls: Update to 2.4.4

### DIFF
--- a/graphics/charls/Portfile
+++ b/graphics/charls/Portfile
@@ -4,20 +4,20 @@ PortSystem          1.0
 PortGroup           cmake   1.1
 PortGroup           github  1.0
 
-github.setup        team-charls charls 2.4.2 
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        team-charls charls 2.4.4
+github.tarball_from archive
 revision            0
 categories          graphics
-maintainers         {vince @Veence}
+maintainers         {vince @Veence} \
+                    openmaintainer
 description         CharLS is an implementation of JPEG-LS
 long_description    CharLS implements JPEG-LS, a lossless JPEG codec.
 
 license             BSD
 
-checksums           rmd160  a0bba10cb3125795cf77fa95d8fd023fd336b713 \
-                    sha256  17dd4d441c44d1d42e6785f2cfa7016de15a2d35f5cc1a2dcac85a121f927cbb \
-                    size    9492542
+checksums           rmd160  76e46d5f58ae2f2a0537fb3f6d0a35230a98995c \
+                    sha256  fbd712903d61306ad00d5fa5029a9882630c7311ca487f48d2d76000956e8ff9 \
+                    size    9495457
 
 compiler.cxx_standard 2014
 configure.args-append -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
#### Description

* Update charls 2.4.2 --> 2.4.4.
* Contains security fix.
* Add openmaintainer.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?