### PR TITLE
wsddn: new port

### DIFF
--- a/net/wsddn/Portfile
+++ b/net/wsddn/Portfile
@@ -1,0 +1,121 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+name                    wsddn
+github.setup            gershnik wsdd-native 1.25 v
+revision                0
+categories              net
+maintainers             @gershnik openmaintainer
+description             WS-Discovery Host Daemon
+long_description        Allows your Mac to be discovered by systems running Windows 10 \
+                        or later and to appear in their Explorer \"Network\" view.
+license                 BSD
+installs_libs           no
+
+github.tarball_from     releases
+distname                wsddn-src-prefetch-${github.version}
+extract.suffix          .tar.bz2
+extract.cmd             bzip2
+checksums               rmd160  87317647f1031543a4a5ebead17b5f3d19de2e5c \
+                        sha256  37e3881ae5b7ae6179610ebf86ff43849fd15fd9f667b70f9b08c79ed725a54f \
+                        size    5230737
+worksrcdir              wsdd-native-${github.version}
+compiler.cxx_standard   2020
+compiler.c_standard     2011
+
+set bundle_identifier   "org.macports.wsddn"
+
+cmake.generator         Ninja
+configure.args-append   -DWSDDN_VERSION="${github.version}" \
+                        -C "${worksrcpath}/external/external.cmake" \
+                        -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+                        -DWSDDN_BUNDLE_IDENTIFIER=${bundle_identifier} \
+                        -DWSDDN_MACOS_SUPPRESS_WRAPPER=ON
+
+startupitem.autostart   yes
+startupitem.create      yes
+startupitem.install     yes
+startupitem.location    LaunchDaemons
+startupitem.custom_file ${build.dir}/${bundle_identifier}.plist
+
+pre-extract {
+    set status [catch {exec pkgutil --pkgs=io.github.gershnik.wsddn} output]
+    if {$status == 0 || $::errorCode eq "NONE"} {
+        ui_error "It appears that a non-MacPorts version of ${name} is installed on your machine."
+        ui_error ""
+        ui_error "Having two versions of this software at the same time may result in unpredictable behavior."
+        ui_error "You can uninstall the non-MacPorts version via '/usr/local/bin/wsddn-uninstall'"
+        ui_error ""
+        return -code error "non-MacPorts version present"
+    }
+}
+
+post-patch {
+    reinplace "s|{SAMPLE_IFACE_NAME}|en0|g" ${worksrcpath}/installers/wsddn.conf
+    set reloadinst "# sudo launchctl kill HUP system/${bundle_identifier}\\n"
+    reinplace "s|{RELOAD_INSTRUCTIONS}|${reloadinst}|g" ${worksrcpath}/installers/wsddn.conf
+    reinplace {/^set(CMAKE_OSX_DEPLOYMENT_TARGET/d} ${worksrcpath}/CMakeLists.txt
+    file copy ${worksrcpath}/installers/wsddn.conf ${worksrcpath}/installers/wsddn.conf.sample
+}
+
+post-build {
+    set plist [open "${build.dir}/${bundle_identifier}.plist" w 0755]
+    puts ${plist} "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+    <key>Label</key>
+    <string>${bundle_identifier}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${prefix}/bin/wsddn</string>
+        <string>--launchd</string>
+        <string>--config=${prefix}/etc/wsddn.conf</string>
+        <string>--log-os-log</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/var/empty</string>
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+"
+    close ${plist}
+}
+
+post-destroot {
+    xinstall -m 0644 ${worksrcpath}/installers/wsddn.conf.sample ${destroot}${prefix}/etc/
+    xinstall -d -m 0755 ${destroot}${prefix}/share/doc/wsddn/
+    xinstall -m 0644 -W ${worksrcpath} LICENSE Acknowledgements.md ${destroot}${prefix}/share/doc/wsddn/
+}
+
+post-activate {
+    if {![file exists ${prefix}/etc/wsddn.conf]} {
+        file copy ${prefix}/etc/wsddn.conf.sample ${prefix}/etc/wsddn.conf
+    }
+}
+
+pre-deactivate {
+    system "if /bin/launchctl list \"${bundle_identifier}\" &> /dev/null; then /bin/launchctl bootout system/${bundle_identifier}; fi"
+    system "if dscl . -read /Users/_wsddn > /dev/null 2>&1; then dscl . -delete /Users/_wsddn; fi"
+    system "if dscl . -read /Groups/_wsddn > /dev/null 2>&1; then dscl . -delete /Groups/_wsddn; fi"
+}
+
+notes-append "
+To customize ${name}, you can edit ${prefix}/etc/wsddn.conf.
+An up-to-date sample is provided in ${prefix}/etc/wsddn.conf.sample
+
+Daemon and related logs can be viewed in the system log by searching for subsystem or
+process names containing the string \"wsddn\". For example:
+
+    log show --last 15m --debug --info --predicate 'subsystem CONTAINS \"wsddn\" OR process CONTAINS \"wsddn\"'
+"


### PR DESCRIPTION
#### Description

Add new port for https://github.com/gershnik/wsdd-native


###### Tested on
macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
It fails with the following which seems like https://trac.macports.org/ticket/66358 to me:
```
Executing:  cd "/opt/local/var/macports/build/wsddn-e57299a6/work/destroot" && /usr/bin/tar -cvf - . | /usr/bin/bsdtar -C /opt/local/var/macports/software/wsddn/wsddn-1.25_1.darwin_25.arm64 -xvp --hfsCompression -f - 
dyld[73266]: terminating because inserted dylib '/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' could not be loaded: tried: '/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' (no such file), '/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e'))
dyld[73266]: tried: '/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' (no such file), '/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e'))
Command failed:  cd "/opt/local/var/macports/build/wsddn-e57299a6/work/destroot" && /usr/bin/tar -cvf - . | /usr/bin/bsdtar -C /opt/local/var/macports/software/wsddn/wsddn-1.25_1.darwin_25.arm64 -xvp --hfsCompression -f - 
Killed by signal: 6
```

- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
