### PR TITLE
aqua/Quicksilver: update to 2.6.0

### DIFF
--- a/aqua/Quicksilver/Portfile
+++ b/aqua/Quicksilver/Portfile
@@ -5,13 +5,13 @@ PortGroup               github 1.0
 PortGroup               xcode 1.0
 PortGroup               xcodeversion 1.0
 
-github.setup            quicksilver Quicksilver 1.3.1 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from     tarball
+github.setup            quicksilver Quicksilver 2.6.0 v
+revision                0
 maintainers             {ryandesign @ryandesign} openmaintainer
 categories              aqua sysutils
+platforms               {darwin >= 18}
 license                 Apache-2
-supported_archs         x86_64
+supported_archs         x86_64 arm64
 
 description             OS X launcher utility app
 
@@ -42,16 +42,7 @@ post-patch {
     reinplace -E "s|/tmp/QS|${workpath}${config_root}|" ${build.dir}/Configuration/Common.xcconfig
 }
 
-# Quicksilver uses new Objective-C features which require the MacOSX10.8 SDK when compiling on 10.7.
-minimum_xcodeversions {11 4.4}
-platform darwin 11 {
-    configure.sdkroot ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
-}
-
-# Blacklist compilers that don't support new Objective-C features.
-# Blacklisting does not work because xcode portgroup doesn't recognize MacPorts compilers.
-# https://trac.macports.org/ticket/40762
-compiler.blacklist      *gcc* {clang < 421}
+minimum_xcodeversions {18 10.0}
 
 build.dir               ${worksrcpath}/${name}
 
@@ -68,15 +59,6 @@ post-build {
 destroot {
     move ${workpath}${config_root} ${destroot}${config_root}
     move {*}[glob ${build.dir}/build/${xcode.configuration}/*.app] ${destroot}${applications_dir}
-}
-
-if {${os.major} < 11} {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} @${version} requires Mac OS X 10.7 or greater."
-        ui_error "You can download an older version of ${name} for your OS from ${homepage}download.php"
-        return -code error "incompatible Mac OS X version"
-    }
 }
 
 livecheck.type          regex


### PR DESCRIPTION
## Description

Update Quicksilver from 1.3.1 to 2.6.0.

cc @ryandesign (maintainer)

## Changes

- Version bump 1.3.1 → 2.6.0; revision reset to 0
- Remove `github.tarball_from tarball` and its stale comment (port uses `fetch.type git`; this directive had no effect but was confusing)
- Add `platforms {darwin >= 18}`: upstream `Common.xcconfig` sets `MACOSX_DEPLOYMENT_TARGET = 10.14` (darwin 18), superseding the old 10.7 minimum
- Expand `supported_archs` to `x86_64 arm64`: upstream xcconfig uses `ARCHS = $(ARCHS_STANDARD_64_BIT)`, which produces native builds on both architectures
- Update `minimum_xcodeversions {18 10.0}` (from `{11 4.4}`)
- Remove darwin 11 `configure.sdkroot` block and `compiler.blacklist` — no longer relevant with the 10.14 minimum

## Testing

Not build-tested (GUI app; build requires a full Xcode install). The submodule list and xcconfig paths are confirmed unchanged from 1.3.1. Portfile parses cleanly.

Please verify `xcode.target {Quicksilver Distribution}` and the `post-build`/`destroot` output paths are still valid for 2.6.0 before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)