### PR TITLE
google-cloud-sdk: update to 574.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             573.0.0
+version             574.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  dba518aafe788d1924d086ade941834867bfdfdb \
-                    sha256  1728731d5531376036f2d79c73ec0795acedee533862457bebb7657c7df3132c \
-                    size    59298706
+    checksums       rmd160  830e497376b34f1b0e7077d0d4b6a609fbe6ce90 \
+                    sha256  8dfab9208ef9ffe1078e5fda19aa341442a1b7e1df6fb3ca4cd5f0aeef46d97e \
+                    size    59487131
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  e2b6e4c65819758c633c662408a9b1ee5fdf06ba \
-                    sha256  652b7ed9556ec7dc00cb1e6bdb21343e57571701456230c35850cc6e212a5cfa \
-                    size    60954028
+    checksums       rmd160  32aebada9e7793821179790c16c991388c3f1132 \
+                    sha256  d59125d65f01f8eefcfcb2290dbc52aceb1d77585178370074636c0ff8bbb3cd \
+                    size    61143204
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  e275199aae55b84183b1e83ed39c78259bd583e6 \
-                    sha256  180984c10f424253858b0bfc8b491da0bee9541d554ad2922b71cbdb92bfa643 \
-                    size    60858679
+    checksums       rmd160  bac2dac7fac8b5f6281b3981e2d80af3cf2013bd \
+                    sha256  1dd2b9ae759cf1a64377c4e4e152303c0b42d38a8d3adabc3954cd2e9c3a62a3 \
+                    size    61048540
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 574.0.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?