### PR TITLE
cppcheck: blacklist clang < 1200

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -45,9 +45,9 @@ post-patch {
 
 compiler.cxx_standard       2011
 compiler.thread_local_storage yes
-# build/valueflow.cpp:10973:124: error: call
-# to deleted function 'toString' on macOS <10.12
-compiler.blacklist-append   {clang < 900}
+# settings.cpp:84:11: error: exception specification of explicitly defaulted
+# move constructor does not match the calculated one on macOS <10.15
+compiler.blacklist-append   {clang < 1200}
 
 use_configure               no
 


### PR DESCRIPTION
https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/263275/steps/install-port/logs/stdio

###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?