### PR TITLE
claude-code: update to 2.1.187

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.186
+version             2.1.187
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  29c308302656a2505d76edf23e17243b2d6154f7 \
-                 sha256  9e17e23d451cbbc64cf4b9536c1d25efd86808512617c855091fa608f77c9899 \
-                 size    224349952
+    checksums    rmd160  83173d974cc19e4075129f61eedd9c855b8a3958 \
+                 sha256  7f57b6935b4246d03cb7acee90dc22153083483a267da589c5c920dd04744c36 \
+                 size    224795776
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  c9b7f6e89ef9d4927f92f75432330ab699e25d8d \
-                 sha256  463a79cc34a9787cff1b3361b4ec9e2dff928c18b077f41f0bb412e4cda78637 \
-                 size    216811232
+    checksums    rmd160  e4f1d811500e44cbb1d13f9eaabcc35490206efe \
+                 sha256  a59a16ba4922adab7a145728f215d042184d349f5f7e72cddb7fc114250a4ce3 \
+                 size    215994048
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.187.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?