### PR TITLE
claude-code: update to 2.1.190

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.187
+version             2.1.190
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  83173d974cc19e4075129f61eedd9c855b8a3958 \
-                 sha256  7f57b6935b4246d03cb7acee90dc22153083483a267da589c5c920dd04744c36 \
+    checksums    rmd160  6ae72ca3fd4b5219c07585bbcd85bb0cc57feb67 \
+                 sha256  4eca48431a43c5540c53657964be604f301d38c02b244ca7c05da18f84bb5c85 \
                  size    224795776
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e4f1d811500e44cbb1d13f9eaabcc35490206efe \
-                 sha256  a59a16ba4922adab7a145728f215d042184d349f5f7e72cddb7fc114250a4ce3 \
-                 size    215994048
+    checksums    rmd160  893efdec1013c175e7868c1289ca81f5a27566b5 \
+                 sha256  1fa59529c233914fdd9d42816a74ecf300eefa14c3d118d4ecba2f0f16fc5741 \
+                 size    217273568
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.190.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?