### PR TITLE
mp3rgain: update to 2.9.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.8.1 v
+github.setup        M-Igashi mp3rgain 2.9.0 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  492474c3b1399132fe6dd6c53ccfa8c5d7ec5e2b \
-                    sha256  31001e1d26fbd9b6106ea37ebfdee4d4aa7eb52fb4024ec00febe382885e0513 \
-                    size    493152
+                    rmd160  74350c5431112d1765d6a7361ff68911d6f1c3f3 \
+                    sha256  2ecdecf7cf633edce7fd97030144b7a0a30ee2b4e6ec76d133a4a42b831d6b90 \
+                    size    502943
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update audio/mp3rgain to 2.9.0.

- Bumped `github.setup` to 2.9.0 and refreshed the source-tarball checksums (rmd160 / sha256 / size).
- `cargo.crates` is unchanged — the release added no new dependencies (only the crate's own version changed in Cargo.lock).
- `revision` reset to 0 for the new upstream version.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.0

##### Description
2.9.0 brings mp3rgain's APEv2 tag conventions into parity with the original mp3gain (REPLAYGAIN_* in default APE mode, post-apply residual values, MP3GAIN_UNDO sign so cross-tool undo works, and MP3GAIN_ALBUM_MINMAX).

##### Note
`port lint --nitpick` was **not** run for this PR — MacPorts is not available in the environment used to prepare it. The change is a mechanical `version` + checksum bump with an unchanged `cargo.crates` block (verified identical to the new Cargo.lock), so it should lint and build cleanly; please run CI/lint on merge.