### PR TITLE
cava: fix build on macOS <10.12

### DIFF
--- a/audio/cava/Portfile
+++ b/audio/cava/Portfile
@@ -2,9 +2,13 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        karlstav cava 1.0.0
-revision            0
+revision            1
 categories          audio
 license             MIT
 maintainers         {makr @mohd-akram} openmaintainer
@@ -27,15 +31,18 @@ depends_lib         port:fftw-3 \
                     port:libsdl2 \
                     port:ncurses
 
-compiler.blacklist-append   *gcc-4.0 *gcc-4.2
+patchfiles-append   patch-ignore-homebrew-iniparser.diff
 
-configure.cppflags-append   -I${prefix}/include/iniparser
+compiler.c_standard 1999
+compiler.blacklist-append   *gcc-4.0 *gcc-4.2
 
 if {${os.platform} eq "darwin" && ${os.major} < 21} {
     configure.cppflags-append   -DkAudioObjectPropertyElementMain=kAudioObjectPropertyElementMaster
 }
 
 configure.args      --disable-input-jack
+
+use_autoreconf      yes
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # https://github.com/karlstav/cava/issues/570

--- a/audio/cava/files/patch-ignore-homebrew-iniparser.diff
+++ b/audio/cava/files/patch-ignore-homebrew-iniparser.diff
@@ -1,0 +1,24 @@
+--- configure.ac
++++ configure.ac
+@@ -490,7 +490,7 @@ dnl ######################
+ dnl checking for iniparser
+ dnl ######################
+ 
+-  PKG_CHECK_MODULES(INIPARSER, libiniparser, have_iniparser_pkg=yes, have_iniparser_pkg=no)
++  PKG_CHECK_MODULES(INIPARSER, iniparser, have_iniparser_pkg=yes, have_iniparser_pkg=no)
+   if [[ $have_iniparser_pkg = "yes" ]] ; then
+     LIBS="$LIBS $INIPARSER_LIBS"
+     CPPFLAGS="$CPPFLAGS $INIPARSER_CFLAGS"
+@@ -500,12 +500,6 @@ dnl ######################
+     AC_CHECK_LIB(iniparser,iniparser_load, have_iniparser=yes, have_iniparser=no)
+     if [[ $have_iniparser = "yes" ]] ; then
+       LIBS="$LIBS -liniparser"
+-      if [[ $build_mac = "yes" ]] ; then
+-        CPPFLAGS="$CPPFLAGS -I/usr/local/include/iniparser/"
+-        CPPFLAGS="$CPPFLAGS -I/opt/homebrew/include/iniparser/"
+-      else
+-        CPPFLAGS="$CPPFLAGS -I/usr/include/iniparser"
+-      fi
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <iniparser.h>]],
+         [[dictionary* ini;
+         const char *keys[3];


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?