### PR TITLE
npm11: update to 11.17.0

### DIFF
--- a/devel/npm11/Portfile
+++ b/devel/npm11/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm11
-version             11.13.0
+version             11.17.0
 revision            0
 categories          devel
 platforms           any
@@ -25,9 +25,9 @@ distname            npm-${version}
 
 extract.suffix      .tgz
 
-checksums           rmd160  5188c850b43d99788c7e99e0bc38942f2de3e7ac \
-                    sha256  a4ffa1de3bf1c7f9d5e3dd24fe2921970bdb1589d647f4083eaaaab3be974b7e \
-                    size    3151650
+checksums           rmd160  08b7c9079eceb2a8b7dfbfc51fa7c1114b34ed12 \
+                    sha256  b290bbb35b9e72c3ef84edbe041f28c4479c4d9ee79f555817b8caafe7ce4bba \
+                    size    2966037
 
 worksrcdir          package
 


### PR DESCRIPTION
#### Description

Update to NPM 11.17.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
