### PR TITLE
Remove obsolete option from legacysupport PG

### DIFF
--- a/_resources/port1.0/group/legacysupport-1.1.tcl
+++ b/_resources/port1.0/group/legacysupport-1.1.tcl
@@ -38,9 +38,6 @@ default legacysupport.redirect_bins     {}
 options legacysupport.use_mp_libcxx
 default legacysupport.use_mp_libcxx     no
 
-options legacysupport.disable_function_wrap
-default legacysupport.disable_function_wrap no
-
 if {[exists makefile.override]} {
     pre-configure {
         ui_error "The legacysupport PG must be included *before* the makefile PG"
@@ -61,11 +58,7 @@ proc legacysupport::get_library_name {} {
 proc legacysupport::get_cpp_flags {} {
     global os.platform os.major prefix
     if {${os.platform} eq "darwin" && ${os.major} <= [option legacysupport.newest_darwin_requires_legacy]} {
-        if { [option legacysupport.disable_function_wrap] } {
-            return "-isystem${prefix}/include/LegacySupport -D__DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__=1 -D__DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__=1"
-        } else {
-            return  -isystem${prefix}/include/LegacySupport
-        }
+        return  -isystem${prefix}/include/LegacySupport
     } else {
         return ""
     }

--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -11,8 +11,6 @@ cmake.set_cxx_standard   no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 license                 NCSA

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -11,8 +11,6 @@ cmake.set_cxx_standard   no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 license                 NCSA

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -11,8 +11,6 @@ cmake.set_cxx_standard   no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 license                 NCSA

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -11,8 +11,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 license                 NCSA

--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin > 10}

--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin >= 11}

--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin >= 11}

--- a/lang/llvm-20/Portfile
+++ b/lang/llvm-20/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin >= 11}

--- a/lang/llvm-21/Portfile
+++ b/lang/llvm-21/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin >= 11}

--- a/lang/llvm-22/Portfile
+++ b/lang/llvm-22/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin >= 16}

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -12,8 +12,6 @@ cmake.set_cxx_standard                no
 
 # link legacysupport statically for compilers
 legacysupport.use_static              yes
-# Sysconf wrapping causes issues so disable
-legacysupport.disable_function_wrap   yes
 
 categories              lang
 platforms               {darwin >= 11}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] cleanup

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9
Xcode 6.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
