### PR TITLE
Vulkan SDK ports: update to 1.4.350.1 + new port (vulkan-memory-allocator)

### DIFF
--- a/graphics/spirv-cross/Portfile
+++ b/graphics/spirv-cross/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup SPIRV-Cross 1.1.5 MoltenVK-
+github.setup        KhronosGroup SPIRV-Cross 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 
 name                spirv-cross
 # This version number is taken from the spirv-cross-c library (i.e.
 # the C API), and is obtained by looking in the file
 # ${worksrcpath}/spirv_cross_c.h, as defined by SPVC_C_API_VERSION_*.
-version             0.48.0
+version             0.68.0
 revision            0
 
 categories          graphics
@@ -24,9 +24,11 @@ long_description    ${github.project} is a tool and library for \
                     performing reflection on SPIR-V and disassembling \
                     SPIR-V back to high-level languages.
 
-checksums           rmd160  ac0aab7c3fb854ab95dcee09cb0c0f0b2ef85fd9 \
-                    sha256  e11845d9a4ccb4666923a8b678935cf78acad2b4fc131aba779f5bcc6def5191 \
-                    size    1514658
+checksums           rmd160  42031bd6f7bdd129cdf259307eaefb27072f4a74 \
+                    sha256  21057934ede32fe90a63dc304fdce0f2a6cb4f0ca685a72ed36a73aac6f72ad5 \
+                    size    2001909
+
+cmake.build_type    Release
 
 compiler.cxx_standard   2011
 
@@ -42,7 +44,7 @@ pre-test {
 }
 
 variant tests description {Build unit tests} {
-    set py_ver              3.11
+    set py_ver              3.14
     set py_ver_nodot        [string map {. {}} ${py_ver}]
 
     depends_lib-append      port:glslang \

--- a/graphics/spirv-headers/Portfile
+++ b/graphics/spirv-headers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup SPIRV-Headers 1.4.341.0 vulkan-sdk-
+github.setup        KhronosGroup SPIRV-Headers 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                spirv-headers
 revision            0
@@ -19,6 +19,8 @@ description         SPIR-V Headers
 long_description    {*}${description}
 homepage            https://vulkan.lunarg.com
 
-checksums           rmd160  70ca5bdfb58833b5bd66dd266ac01649107486f3 \
-                    sha256  cab0a654c4917e16367483296b44cdb1d614e3120c721beafcd37e3a8580486c \
-                    size    561287
+checksums           rmd160  afa9c7a603596c091f16fff1667676237207757e \
+                    sha256  9e6d5c78878172d2b810e97f3a74ecbbb14b4ad52b07384ce915fbbeb226d610 \
+                    size    565391
+
+cmake.build_type    Release

--- a/graphics/spirv-tools/Portfile
+++ b/graphics/spirv-tools/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 PortGroup           conflicts_build 1.0
 
-github.setup        KhronosGroup SPIRV-Tools 1.4.341 vulkan-sdk-
+github.setup        KhronosGroup SPIRV-Tools 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                spirv-tools
 revision            0
@@ -31,37 +31,39 @@ post-extract {
 }
 
 checksums           SPIRV-Tools-${version}.tar.gz \
-                    rmd160  1ff7abf34ef2408e3161fa496c2019a8a14214ec \
-                    sha256  dcbbac86eae3f8de59625eb1daece9d8014492ed7307db63293762085523b83f \
-                    size    3455511 \
-                    abseil-cpp-255c84dadd029fd8ad25c5efb5933e47beaa00c7.tar.gz \
-                    rmd160  8606f00142a5830e0be2a1ec4a83af4cb1af21b0 \
-                    sha256  87e91fb785a2d0233f4599317afd576b7736e6732d557bdcdfdc11990bd333ef \
-                    size    2301499 \
-                    effcee-514b52ec61609744d7e587d93a7ef9b60407ab45.tar.gz \
-                    rmd160  8f660fd9db7cba7de45c04fe12165ca56fb347c3 \
-                    sha256  3376aabe01b343753641110e5c3403f3705b6eb98825246f200cc3d9e0b41edd \
-                    size    41155 \
-                    googletest-1b96fa13f549387b7549cc89e1a785cf143a1a50.tar.gz \
-                    rmd160  fa0a0d43eb2994c5892fb7787b1f8bed11cef405 \
-                    sha256  44732cdd185c579c33d7aa70f40c47dcfd9fc3ffac28a3e42cea0e257d7d5c2c \
-                    size    889186 \
+                    rmd160  a8279c334893e1620ef93e30d560025088f5d70c \
+                    sha256  6f7b9b9eed9a7aa485918466ea604b4edc7969d94e96c0c13ae266f4ec120f31 \
+                    size    3472729 \
+                    abseil-cpp-351086314d46e73d430296c9eca1f6d6c0372cd1.tar.gz \
+                    rmd160  58c5d4edb76201e696bb41108713f933c007c243 \
+                    sha256  d52a60908e791075d807dfe8db766a236abfac5c0c6e1e84023d83724948b75d \
+                    size    2357079 \
+                    effcee-ae38e040cbb7e83efa8bfbb4967e5b8c8c89b55a.tar.gz \
+                    rmd160  bdbe73f2480488957c2bc28a8251b02e6ab565f1 \
+                    sha256  cae1288f65c3f71f3a588136483a26482450f787a535c97f05689a4b0c858947 \
+                    size    41184 \
+                    googletest-d72f9c8aea6817cdf1ca0ac10887f328de7f3da2.tar.gz \
+                    rmd160  c1ad84f90d6bde0c2ad1d3c56ceea4f59d0dad5c \
+                    sha256  59d6b38b0daf41b7fa922e3cc1fc54aace4b823d7a51300386336a854fe03a60 \
+                    size    890871 \
                     protobuf-f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c.tar.gz \
                     rmd160  a397c44d602407d85eb6ac6b985f9feb792f76e1 \
                     sha256  d594b561fb41bf243233d8f411c7f2b7d913e5c9c1be4ca439baf7e48384c893 \
                     size    5146983 \
-                    re2-e7aec5985072c1dbe735add802653ef4b36c231a.tar.gz \
-                    rmd160  be95bdfa81cbb7ab41235a3de04f7aac3f9b6f0c \
-                    sha256  f7f9bb4b56012c069d9428f5dd6480309a46a05921412c8150e01eac8a0be6da \
-                    size    397966 \
-                    SPIRV-Headers-04f10f650d514df88b76d25e83db360142c7b174.tar.gz \
-                    rmd160  5183f673e28dc07d61c5043137ca59251346698c \
-                    sha256  1b220e3eec1714f0451b0e3652979bd280edf10893f617837b88e6359a804ded \
-                    size    561661 \
-                    mimalloc-30b2d9d89099bee08e9f67a1ffb3e12e7ba45227.tar.gz \
-                    rmd160  10a999a7c989fc13cff35824f693f7466c957770 \
-                    sha256  7ced84a659a95454ce08b725af56331164e6b8673310e5a9a5c612576145456f \
-                    size    1411187
+                    re2-972a15cedd008d846f1a39b2e88ce48d7f166cbd.tar.gz \
+                    rmd160  dbe18578bbf0b765589da144592985a71f8e713c \
+                    sha256  cd4a75bdc0ec2e2506026ea4ccc9f0c429aceab8b6305b2cd30a1f4cc67644bc \
+                    size    398012 \
+                    SPIRV-Headers-ad9184e76a66b1001c29db9b0a3e87f646c64de0.tar.gz \
+                    rmd160  6c6c7d8c739e59047e7e93f6a23df7a5784cb127 \
+                    sha256  b5b7eba62453eb8c6f6a5fbf7155b71cde693bafe9cd5f03b79ed8c714816afe \
+                    size    565709 \
+                    mimalloc-b1963961a5cdb1996c9ad2e356014089b7a94ea3.tar.gz \
+                    rmd160  0d95089c2b1d3679229b13a5caed190889969324 \
+                    sha256  9ab197701a22fcfaa60f569957925c4d01bf0f8ebc7baa56e55f20f3d00c3644 \
+                    size    1376914
+
+cmake.build_type    Release
 
 compiler.cxx_standard 2017
 # Need to use MacPorts libc++ on macOS 10.14 Mojave and older, because
@@ -74,7 +76,7 @@ compiler.cxx_standard 2017
 legacysupport.newest_darwin_requires_legacy 18
 legacysupport.use_mp_libcxx yes
 
-set py_ver          3.13
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 foreach stage {configure build destroot test} {
     ${stage}.env-append PATH=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin:$env(PATH)
@@ -84,13 +86,13 @@ depends_build-append port:python${py_ver_nodot}
 # See DEPS file in repo
 # Exept abseil changed to lts version.
 set submodules {
-    abseil abseil-cpp 255c84dadd029fd8ad25c5efb5933e47beaa00c7 external/abseil_cpp
-    google effcee 514b52ec61609744d7e587d93a7ef9b60407ab45 external/effcee
-    google googletest 1b96fa13f549387b7549cc89e1a785cf143a1a50 external/googletest
+    abseil abseil-cpp 351086314d46e73d430296c9eca1f6d6c0372cd1 external/abseil_cpp
+    google effcee ae38e040cbb7e83efa8bfbb4967e5b8c8c89b55a external/effcee
+    google googletest d72f9c8aea6817cdf1ca0ac10887f328de7f3da2 external/googletest
     protocolbuffers protobuf f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c external/protobuf
-    google re2 e7aec5985072c1dbe735add802653ef4b36c231a external/re2
-    KhronosGroup SPIRV-Headers 04f10f650d514df88b76d25e83db360142c7b174 external/spirv-headers
-    microsoft mimalloc 30b2d9d89099bee08e9f67a1ffb3e12e7ba45227 external/mimalloc
+    google re2 972a15cedd008d846f1a39b2e88ce48d7f166cbd external/re2
+    KhronosGroup SPIRV-Headers ad9184e76a66b1001c29db9b0a3e87f646c64de0 external/spirv-headers
+    microsoft mimalloc b1963961a5cdb1996c9ad2e356014089b7a94ea3 external/mimalloc
 }
 
 foreach {sub_author sub_project sub_commit sub_dest} ${submodules} {

--- a/graphics/vulkan-headers/Portfile
+++ b/graphics/vulkan-headers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup Vulkan-Headers 1.4.335.0 vulkan-sdk-
+github.setup        KhronosGroup Vulkan-Headers 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                vulkan-headers
 revision            0
@@ -20,11 +20,13 @@ long_description    Development header files for the Vulkan graphics API. See Mo
                     Vulkan-Loader for related ports.
 homepage            https://vulkan.lunarg.com
 
-checksums           sha256  269e95cc5138ea0a0d52fcb0ee19102add2560fedf5a43b1b5c17780c2775764 \
-                    rmd160  8ebfb7f9e669d08802e7b5f44b11e121477b2a5b \
-                    size    2871481
+checksums           rmd160  208743b2d640506aca8865c0696ee62f28f36bb7 \
+                    sha256  6d1bb65e49520344cc0a48af3dc02e993781efff14c7ebdcb8ae9fa23ddf7e83 \
+                    size    3271464
 
-set py_ver          3.13
+cmake.build_type    Release
+
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 foreach stage {configure build destroot test} {
     ${stage}.env-append PATH=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin:$env(PATH)

--- a/graphics/vulkan-loader/Portfile
+++ b/graphics/vulkan-loader/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup Vulkan-Loader 1.4.335.0 vulkan-sdk-
+github.setup        KhronosGroup Vulkan-Loader 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                vulkan-loader
-revision            1
+revision            0
 
 categories          graphics devel
 license             Apache-2
@@ -27,9 +27,11 @@ depends_build-append \
                     port:vulkan-headers \
                     path:bin/pkg-config:pkgconfig
 
-checksums           sha256  e1d7f598d42fa87b38fd7e984968c660e406168db64df8e8e23c5be3a66e9bd8 \
-                    rmd160  2ecca6ba5ae751027d0aaf48b0943659cfb37975 \
-                    size    1793888
+checksums           rmd160  321ce4c477cf783b3920684d44dee9cb4142ca92 \
+                    sha256  602984a71000981e25e4feb419e6cdd70b18ffe2b8004f60f591706027bca468 \
+                    size    1800017
+
+cmake.build_type    Release
 # looked into /opt/local/include instead of the vulkan-headers include paths.
 # Corrected use off file(GLOB_RECURSE ...) .
 patchfiles          vulkan-headers-find.patch

--- a/graphics/vulkan-memory-allocator/Portfile
+++ b/graphics/vulkan-memory-allocator/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github  1.0
+PortGroup           cmake   1.1
+
+github.setup        GPUOpen-LibrariesAndSDKs VulkanMemoryAllocator 3.4.0 v
+github.tarball_from archive
+name                vulkan-memory-allocator
+revision            0
+
+categories          graphics
+license             MIT
+platforms           any
+supported_archs     noarch
+maintainers         {@herby-gillot gmail.com:herby.gillot} openmaintainer
+
+description         Easy to integrate Vulkan memory allocation library
+long_description    {*}${description}. Provides a single header C/C++ library \
+                    that helps with memory allocation for the Vulkan API.
+
+checksums           rmd160  a0a71cfd21ca452421bcd2039c845b81e698b12e \
+                    sha256  822aa850c6ce77346ae96a8a1d351d52e77e85929f35363849a0a4e638e0a2a1 \
+                    size    1002168
+
+cmake.build_type    Release
+
+depends_build-append \
+                    port:vulkan-headers

--- a/graphics/vulkan-tools/Portfile
+++ b/graphics/vulkan-tools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup Vulkan-Tools 1.4.335.0 vulkan-sdk-
+github.setup        KhronosGroup Vulkan-Tools 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                vulkan-tools
 revision            0
@@ -24,11 +24,13 @@ depends_build-append    port:vulkan-headers \
 
 depends_lib-append  port:vulkan-loader
 
-checksums           sha256  85bf51a54271c87925711f7159ea66cc6c5abf6afd5f2bbf452d444fd7deccf3 \
-                    rmd160  88f0b651b85b2a7c2bb42f0c4e492346d6ca41f0 \
-                    size    791395
+checksums           rmd160  b97f933458dbc3922de046969aacc43db17ea7fb \
+                    sha256  502b53a585f49036e45372724f652bacc1fad2c62396e321bc8f5fbc031c14d5 \
+                    size    811196
 
-set py_ver          3.13
+cmake.build_type    Release
+
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 foreach stage {configure build destroot test} {
     ${stage}.env-append PATH=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin:$env(PATH)

--- a/graphics/vulkan-utility-libraries/Portfile
+++ b/graphics/vulkan-utility-libraries/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup Vulkan-Utility-Libraries 1.4.335.0 vulkan-sdk-
+github.setup        KhronosGroup Vulkan-Utility-Libraries 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                vulkan-utility-libraries
 revision            0
@@ -19,13 +19,15 @@ description         Utility libraries for Vulkan developers
 long_description    {*}${description}
 homepage            https://vulkan.lunarg.com
 
-checksums           sha256  df27b66cfabf7d890398274ffda16b89711d41647fc8e0e8bb419994457948f9 \
-                    rmd160  b38a41cc2c3b12647953c155fd4d728bbd17d753 \
-                    size    1505429
+checksums           rmd160  023968373dfcd26c7197aba06bc75d33cd2d5d00 \
+                    sha256  e8eca1be31a658c9d0ca30951f2fc7912e4bb01502da64f8decdc71836241a6c \
+                    size    1319193
+
+cmake.build_type    Release
 
 depends_build-append       port:vulkan-headers
 
-set py_ver          3.13
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 foreach stage {configure build destroot test} {
     ${stage}.env-append PATH=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin:$env(PATH)

--- a/graphics/vulkan-validationlayers/Portfile
+++ b/graphics/vulkan-validationlayers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        KhronosGroup Vulkan-ValidationLayers 1.4.335.0 vulkan-sdk-
+github.setup        KhronosGroup Vulkan-ValidationLayers 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                vulkan-validationlayers
 revision            0
@@ -20,9 +20,11 @@ long_description    \
     use of the Vulkan API
 homepage            https://vulkan.lunarg.com
 
-checksums           sha256  464f754abdebef13c342e18861eab87be0ecc36cb1c257f6b2ddfa10afb8401a \
-                    rmd160  e3cea3a9a77ecb903ad593f0582d618cd20ea358 \
-                    size    7035814
+checksums           rmd160  b7f76a0d2f42a5cd01fa2dcd568dae690b90886d \
+                    sha256  a299313781987946b6b26553d9f3da34126ebaea6e1bf805beb402d510d3b300 \
+                    size    7789524
+
+cmake.build_type    Release
 
 depends_build-append \
                     port:spirv-headers \
@@ -35,7 +37,7 @@ depends_lib-append  \
                     port:vulkan-loader \
                     port:vulkan-utility-libraries
 
-set py_ver          3.13
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 foreach stage {configure build destroot test} {
     ${stage}.env-append PATH=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin:$env(PATH)

--- a/graphics/vulkan-volk/Portfile
+++ b/graphics/vulkan-volk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        zeux volk 1.4.335.0 vulkan-sdk-
+github.setup        zeux volk 1.4.350.1 vulkan-sdk-
 github.tarball_from archive
 name                vulkan-volk
 revision            0
@@ -24,11 +24,13 @@ long_description    \
     Finally, volk enables loading Vulkan entrypoints directly from the driver\
     which can increase performance by skipping loader dispatch overhead.
 
-checksums           sha256  ca2beb1ab9bf272895bc0152ef29b437d178d837bae4a76d0022b7bbafb3c483 \
-                    rmd160  78568ddde99238b324d984da4e50c66602e0eb60 \
-                    size    79441
+checksums           rmd160  e93dde1ba87f36145a6406087ea8c2e994bdad15 \
+                    sha256  078a9411298e4e0f60f5f5398c890783427c25a414619294ca8e69587bbd5eae \
+                    size    84557
 
-set py_ver          3.13
+cmake.build_type    Release
+
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 foreach stage {configure build destroot test} {
     ${stage}.env-append PATH=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin:$env(PATH)


### PR DESCRIPTION
Update + new port, `vulkan-memory-allocator`.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
