### PR TITLE
mp3rgain: update to 2.9.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.0 v
+github.setup        M-Igashi mp3rgain 2.9.1 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  74350c5431112d1765d6a7361ff68911d6f1c3f3 \
-                    sha256  2ecdecf7cf633edce7fd97030144b7a0a30ee2b4e6ec76d133a4a42b831d6b90 \
-                    size    502943
+                    rmd160  142150ff09394e441f1dfcede2d1b64209ed8f13 \
+                    sha256  1345bfc3dc7f918cef48474329f0525415901be0c7f502da01aa09c46b2d0b74 \
+                    size    503488
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update audio/mp3rgain to 2.9.1.

- Bumped `github.setup` to 2.9.1 and refreshed the source-tarball checksums (rmd160 / sha256 / size).
- `cargo.crates` unchanged — no new dependencies (only the crate's own version changed in Cargo.lock).
- `revision` reset to 0 for the new upstream version.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.1

##### Description
2.9.1 is a metadata-only patch over 2.9.0: it writes the album-wide `MP3GAIN_ALBUM_MINMAX` tag from the GUI as well as the CLI (mp3gain album-mode parity). No CLI behaviour change.

##### Verification
- [x] Have you followed the [guidelines for contributing](https://guide.macports.org/#project.contributing)?
- [x] Does `port lint --nitpick` pass?
- [ ] Does it build (verified by maintainer infra)?