### PR TITLE
llmfit: update to 0.9.33

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.31 v
+github.setup            AlexsJones llmfit 0.9.33 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  5f1201a3b073a5a0715f058d243a35b108d8a3ec \
-                        sha256  8fc87ecd3608b4a007c4ee8300ad129eb5578f4daf31a20ff985b84654be9a31 \
-                        size    3455375
+                        rmd160  ac6500ab4d4b18ef83f1a384c5e70b1bd48bce0d \
+                        sha256  a5416cade59d29c3b4b028e0237d4adf3de0d631736f38e128480fc94765d455 \
+                        size    3600515
 
 categories              llm
 platforms               macosx
@@ -46,7 +46,7 @@ cargo.crates \
     anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arboard                          3.6.1  0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf \
     assert_cmd                       2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
-    async-nats                      0.48.0  31811585c7c5bc2f60f8b80d5a6b0f737115611dac47567d7f7d94562ebb180b \
+    async-nats                      0.49.1  fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a \
     async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atk                             0.18.2  241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b \
     atk-sys                         0.18.2  c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086 \
@@ -221,7 +221,7 @@ cargo.crates \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     html5ever                       0.38.0  1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2 \
-    http                             1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
+    http                             1.4.1  8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0 \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
@@ -273,7 +273,6 @@ cargo.crates \
     libdbus-sys                      0.2.7  328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043 \
     libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
     libredox                        0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    libyml                           0.0.5  3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980 \
     line-clipping                    0.3.7  3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -299,6 +298,7 @@ cargo.crates \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nkeys                            0.4.5  879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    noyalib                          0.0.5  e493c05128df7a83b9676b709d590e0ebc285c7ed3152bc679668e8c1e506af5 \
     ntapi                            0.4.3  c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae \
     nuid                             0.5.0  fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83 \
     num-conv                         0.2.1  c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967 \
@@ -321,6 +321,7 @@ cargo.crates \
     objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
     objc2-io-kit                     0.3.2  33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15 \
     objc2-io-surface                 0.3.2  180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d \
+    objc2-open-directory             0.3.2  bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d \
     objc2-quartz-core                0.3.2  96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f \
     objc2-ui-kit                     0.3.2  d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22 \
     objc2-user-notifications         0.3.2  9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e \
@@ -332,7 +333,7 @@ cargo.crates \
     ordered-float                    4.6.0  7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951 \
     pango                           0.18.3  7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4 \
     pango-sys                       0.18.0  436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5 \
-    papergrid                       0.17.0  6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1 \
+    papergrid                       0.18.0  d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e \
     parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     pastey                           0.2.2  c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a \
@@ -404,8 +405,8 @@ cargo.crates \
     regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
     reqwest                         0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rmcp                             1.6.0  e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad \
-    rmcp-macros                      1.6.0  7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb \
+    rmcp                             1.7.0  0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e \
+    rmcp-macros                      1.7.0  6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d \
     rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
@@ -441,7 +442,7 @@ cargo.crates \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_with                      3.18.0  dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f \
     serde_with_macros               3.18.0  d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65 \
-    serde_yml                       0.0.12  59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd \
+    serde_yml                       0.0.13  909764a65f86829ccdb5eea9ab355843aa02c019a7bfd47465092953565caa05 \
     serialize-to-javascript          0.1.2  04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5 \
     serialize-to-javascript-impl     0.1.2  772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d \
     servo_arc                        0.4.3  170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930 \
@@ -474,9 +475,9 @@ cargo.crates \
     syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
-    sysinfo                         0.38.4  92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f \
+    sysinfo                         0.39.3  21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96 \
     system-deps                      6.2.2  a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349 \
-    tabled                          0.20.0  e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d \
+    tabled                          0.21.0  b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff \
     tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
     tao                             0.35.2  a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4 \
     tao-macros                       0.1.3  f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
