### PR TITLE
dillo: fix build on macOS <10.10

### DIFF
--- a/www/dillo/Portfile
+++ b/www/dillo/Portfile
@@ -4,6 +4,9 @@ PortSystem              1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
 name                    dillo
 version                 3.3.0
 revision                0
@@ -35,6 +38,12 @@ post-patch {
 
 # Experimental support for FLTK v1.4+ is currently required.
 configure.args-append   --enable-experimental-fltk
+
+# error: call to implicitly-deleted default constructor of
+# 'const CssPropertyInfo' on macOS <10.10
+compiler.c_standard     1999
+compiler.blacklist-append \
+                        {clang < 700}
 
 livecheck.url           ${homepage}/release/
 livecheck.regex         {>Version ([0-9.]+)<}


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?