### PR TITLE
dia: Python select, fix build for Catalina

### DIFF
--- a/gnome/dia/Portfile
+++ b/gnome/dia/Portfile
@@ -54,7 +54,7 @@ depends_lib         port:desktop-file-utils \
 
 patchfiles          meson.build.patch
 
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
     set py_vers         3.14
     configure.python    ${prefix}/bin/python${py_vers}
     depends_run-append  port:python[string map {. {}} ${py_vers}]


### PR DESCRIPTION
#### Description

* Select newer python for Catalina, fix build for Catalina only.
* Catalina provides only python 3.7 built in.  Dia apparently needs 3.8 or greater.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.
* Waiting for merge to test on Catalina builder.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?