### PR TITLE
py-altair: update to 6.2.2

### DIFF
--- a/python/py-altair/Portfile
+++ b/python/py-altair/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-altair
-version             6.2.1
+version             6.2.2
 revision            0
 
 categories-append   devel graphics
@@ -22,9 +22,9 @@ long_description    {*}${description}
 
 homepage            https://altair-viz.github.io/
 
-checksums           rmd160  4503dad8b51ee761bca00772d72395d76198e76b \
-                    sha256  ca0298fa20b1a4fae22eff8847b95f74912bd90544013ad36af192119883ea64 \
-                    size    766468
+checksums           rmd160  809949bf99360549ad66664180d46c78cb54f60a \
+                    sha256  a1ff9d9cfe81c75414641826312b9471780e19d39293ba0b012933f6b6cba0fe \
+                    size    766606
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-versioningit


### PR DESCRIPTION
Update `py-altair` from 6.2.1 to 6.2.2.

Upstream release: https://github.com/vega/altair/releases/tag/v6.2.2

Verified locally:
- `port lint --nitpick` passes
- `port test` passes