### PR TITLE
libheif-devel @1.23.1:  New devel port for testing

### DIFF
--- a/multimedia/libheif-devel/Portfile
+++ b/multimedia/libheif-devel/Portfile
@@ -8,7 +8,7 @@ PortGroup                   legacysupport 1.1
 name                        libheif-devel
 categories                  multimedia
 license                     LGPL-3+
-maintainers                 {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} openmaintainer
+maintainers                 nomaintainer
 description                 a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
 long_description            ${name} is {*}${description}.
 

--- a/multimedia/libheif-devel/Portfile
+++ b/multimedia/libheif-devel/Portfile
@@ -39,7 +39,7 @@ if {${which_version} eq "latest"} {
     compiler.cxx_standard   2020
 } else {
     github.setup            strukturag libheif 1.18.2 v
-    revision                5
+    revision                0
 
     checksums               rmd160  fb41f7c4d109883a214b8db5db1039809a3fb8eb \
                             sha256  c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf \

--- a/multimedia/libheif-devel/Portfile
+++ b/multimedia/libheif-devel/Portfile
@@ -1,0 +1,174 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   cmake 1.1
+PortGroup                   github 1.0
+PortGroup                   legacysupport 1.1
+
+name                        libheif-devel
+categories                  multimedia
+license                     LGPL-3+
+maintainers                 {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} openmaintainer
+description                 a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
+long_description            ${name} is {*}${description}.
+
+conflicts                   libheif
+
+# filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
+
+set which_version latest
+if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
+    if {${os.major} < 11} {
+        # Fall back to last pre-C++20 release.
+        # On 10.6 a failure happens during the linking phase
+        # even with the latest compatible version of ld.
+        set which_version "1.18"
+    }
+}
+
+if {${which_version} eq "latest"} {
+    github.setup            strukturag libheif 1.23.1 v
+    revision                0
+
+    checksums               rmd160  52f1ade573cd8c3137d06e09a0019462d4481193 \
+                            sha256  0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a \
+                            size    2071186
+
+    compiler.cxx_standard   2020
+} else {
+    github.setup            strukturag libheif 1.18.2 v
+    revision                5
+
+    checksums               rmd160  fb41f7c4d109883a214b8db5db1039809a3fb8eb \
+                            sha256  c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf \
+                            size    1525096
+
+    compiler.cxx_standard   2011
+
+    patchfiles-append       patch-1.18.2-svtav1.diff
+}
+
+github.tarball_from         releases
+
+depends_build-append \
+                            path:bin/pkg-config:pkgconfig
+
+depends_lib-append \
+                            port:aom \
+                            port:brotli \
+                            port:dav1d \
+                            path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+                            port:libde265 \
+                            path:include/turbojpeg.h:libjpeg-turbo \
+                            port:libpng \
+                            port:openh264 \
+                            port:openjpeg \
+                            port:svt-av1 \
+                            port:webp \
+                            port:x265 \
+                            port:zlib
+
+# Shared options
+configure.args-append \
+                            -DBUILD_TESTING:BOOL=OFF \
+                            -DWITH_EXAMPLES:BOOL=OFF \
+                            -DWITH_EXAMPLE_HEIF_VIEW:BOOL=OFF
+
+# Codec-specific options
+configure.args-append \
+                            -DWITH_AOM_DECODER:BOOL=ON \
+                            -DWITH_AOM_ENCODER:BOOL=ON \
+                            -DWITH_DAV1D:BOOL=ON \
+                            -DWITH_FFMPEG_DECODER:BOOL=OFF \
+                            -DWITH_JPEG_DECODER:BOOL=ON \
+                            -DWITH_JPEG_ENCODER:BOOL=ON \
+                            -DWITH_KVAZAAR:BOOL=OFF \
+                            -DWITH_LIBDE265:BOOL=ON \
+                            -DWITH_OpenH264_DECODER:BOOL=ON \
+                            -DWITH_OPENJPH_ENCODER:BOOL=OFF \
+                            -DWITH_OpenJPEG_DECODER:BOOL=ON \
+                            -DWITH_OpenJPEG_ENCODER:BOOL=ON \
+                            -DWITH_RAV1E:BOOL=OFF \
+                            -DWITH_SvtEnc:BOOL=ON \
+                            -DWITH_UNCOMPRESSED_CODEC:BOOL=ON \
+                            -DWITH_UVG266:BOOL=OFF \
+                            -DWITH_VVDEC:BOOL=OFF \
+                            -DWITH_VVENC:BOOL=OFF \
+                            -DWITH_X265:BOOL=ON
+
+# Disable dynamic plugin loading, due to upstream issue:
+#   clang: error: invalid argument '-compatibility_version 1.0.0' only allowed with '-dynamiclib'
+# We don't lose any functionality though, as we're building with everything enabled as built-ins.
+configure.args-append \
+                            -DENABLE_PLUGIN_LOADING:BOOL=OFF
+
+# error: unknown warning option '-Werror=potentially-evaluated-expression'
+compiler.blacklist-append   {clang < 700}
+
+platform darwin {
+    if {${os.major} >= 10 && [string match *clang* ${configure.compiler}]} {
+        # Fix for error: non-portable path to file <DAV1D/xxx.h> and <AOM/xxx.h>
+        # https://trac.macports.org/ticket/67404
+        # Flags are Clang-specific, they break build with GCC.
+        configure.cxxflags-append \
+                            -Wno-nonportable-include-path \
+                            -Wno-error=nonportable-include-path \
+                            -Wno-unknown-warning-option \
+                            -Wno-error=unknown-warning-option
+    }
+
+    if {${os.major} < 10 || (${os.major} == 10 && ${configure.build_arch} eq "ppc")} {
+        # TODO: Disable rav1e on <10.6, due to issues with cargo-c; enable if fixed.
+        # Do not enable on PPC until Rust is fixed or it becomes possible to build with gccrs.
+        # See: https://trac.macports.org/ticket/65434
+        if {[variant_isset rav1e]} {
+            error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
+        }
+    }
+}
+
+variant kvazaar description {Use kvazaar for HEIC encoding} {
+    depends_lib-append \
+                            port:kvazaar
+
+    configure.args-replace \
+                            -DWITH_KVAZAAR:BOOL=OFF \
+                            -DWITH_KVAZAAR:BOOL=ON
+}
+
+variant rav1e description {Enable codec rav1e} {
+    depends_lib-append \
+                            port:rav1e
+
+    configure.args-replace \
+                            -DWITH_RAV1E:BOOL=OFF \
+                            -DWITH_RAV1E:BOOL=ON
+}
+
+variant examples description {Enable building examples} {
+    configure.args-replace \
+                            -DWITH_EXAMPLES:BOOL=OFF \
+                            -DWITH_EXAMPLES:BOOL=ON
+}
+
+variant tests description {Enable tests} {
+    configure.args-replace \
+                            -DBUILD_TESTING:BOOL=OFF \
+                            -DBUILD_TESTING:BOOL=ON
+
+    configure.args-append \
+                            -DWITH_REDUCED_VISIBILITY:BOOL=OFF
+
+    test.run                yes
+}
+
+default_variants-append     +examples +kvazaar
+
+if {![variant_isset rav1e]} {
+    notes-append "Support for rav1e now disabled by default; enable via +rav1e"
+}
+
+# Exclude pre-release candidates
+github.livecheck.regex {([0-9.]+)}

--- a/multimedia/libheif-devel/files/patch-1.18.2-svtav1.diff
+++ b/multimedia/libheif-devel/files/patch-1.18.2-svtav1.diff
@@ -1,0 +1,59 @@
+#==================================================================================================
+# From 4bc4cfb66055a997f03d57649bf5456fe09a5a97
+# From: stefantalpalaru
+# Date: Sun, 23 Feb 2025 20:21:44 +0100
+# Subject: [PATCH] support SVT-AV1 3.0.0
+#==================================================================================================
+--- libheif/plugins/encoder_svt.cc
++++ libheif/plugins/encoder_svt.cc
+@@ -678,7 +678,11 @@ struct heif_error svt_encode_image(void* encoder_raw, const struct heif_image* i
+   EbSvtAv1EncConfiguration svt_config;
+   memset(&svt_config, 0, sizeof(EbSvtAv1EncConfiguration));
+ 
++#if SVT_AV1_CHECK_VERSION(3, 0, 0)
++  res = svt_av1_enc_init_handle(&svt_encoder, &svt_config);
++#else
+   res = svt_av1_enc_init_handle(&svt_encoder, nullptr, &svt_config);
++#endif
+   if (res != EB_ErrorNone) {
+     //goto cleanup;
+     return heif_error_codec_library_error;
+@@ -698,7 +702,9 @@ struct heif_error svt_encode_image(void* encoder_raw, const struct heif_image* i
+   auto nclx_deleter = std::unique_ptr<heif_color_profile_nclx, void (*)(heif_color_profile_nclx*)>(nclx, heif_nclx_color_profile_free);
+ 
+   if (nclx) {
++#if !SVT_AV1_CHECK_VERSION(3, 0, 0)
+     svt_config.color_description_present_flag = true;
++#endif
+ #if SVT_AV1_VERSION_MAJOR >= 1
+     svt_config.color_primaries = static_cast<EbColorPrimaries>(nclx->color_primaries);
+     svt_config.transfer_characteristics = static_cast<EbTransferCharacteristics>(nclx->transfer_characteristics);
+@@ -712,20 +718,28 @@ struct heif_error svt_encode_image(void* encoder_raw, const struct heif_image* i
+ #endif
+ 
+ 
++#if !SVT_AV1_CHECK_VERSION(3, 0, 0)
+     // Follow comment in svt header: set if input is HDR10 BT2020 using SMPTE ST2084.
+     svt_config.high_dynamic_range_input = (bitdepth_y == 10 && // TODO: should this be >8 ?
+                                            nclx->color_primaries == heif_color_primaries_ITU_R_BT_2020_2_and_2100_0 &&
+                                            nclx->transfer_characteristics == heif_transfer_characteristic_ITU_R_BT_2100_0_PQ &&
+                                            nclx->matrix_coefficients == heif_matrix_coefficients_ITU_R_BT_2020_2_non_constant_luminance);
++#endif
+   }
+   else {
++#if !SVT_AV1_CHECK_VERSION(3, 0, 0)
+     svt_config.color_description_present_flag = false;
++#endif
+   }
+ 
+ 
+   svt_config.source_width = encoded_width;
+   svt_config.source_height = encoded_height;
++#if SVT_AV1_CHECK_VERSION(3, 0, 0)
++  svt_config.level_of_parallelism = encoder->threads;
++#else
+   svt_config.logical_processors = encoder->threads;
++#endif
+ 
+   // disable 2-pass
+   svt_config.rc_stats_buffer = SvtAv1FixedBuf {nullptr, 0};

--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -12,6 +12,8 @@ maintainers                 {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} o
 description                 a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
 long_description            ${name} is {*}${description}.
 
+conflicts                   libheif-devel
+
 # filesystem
 legacysupport.newest_darwin_requires_legacy 18
 legacysupport.use_mp_libcxx yes


### PR DESCRIPTION
#### Description

* New devel port for testing.
* Update libheif current version:  1.23.0 --> 1.23.1.  (devel port only)
* Remove recently pinned version for 10.7-10.14.  Was mitigated upstream.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

@ryandesign I removed your recent conditional for 10.7-10.4 needing `std::ranges`.  Upstream has downgraded that code in this new release 1.23.1.  `std::ranges` is no longer needed.
https://github.com/strukturag/libheif/issues/1838