### PR TITLE
jsoncpp: Add thread-local-storage, fix builds 10.8 - 10.10

### DIFF
--- a/devel/jsoncpp/Portfile
+++ b/devel/jsoncpp/Portfile
@@ -24,6 +24,7 @@ patchfiles-append   patch-fix-build.diff
 patch.pre_args-replace  -p0 -p1
 
 compiler.cxx_standard 2011
+compiler.thread_local_storage yes
 
 configure.args-append \
     -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
#### Description

* Add `compiler.thread_local_storage yes`.
* Fix builds, 10.8 - 10.10.
* Fixes: error: thread-local storage is not supported for the current target

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.
* Waiting for merge to test the legacy builds.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?