### PR TITLE
gemini-cli: update to 0.49.0

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                gemini-cli
-version             0.47.0
+version             0.49.0
 revision            0
 
 categories          llm
@@ -21,9 +21,9 @@ homepage            https://geminicli.com
 npm.rootname        @google/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  4987c3c66ecdd1b9b42f91dfb9fbd5bb7d447d32 \
-                    sha256  c97121a2f89f538e6bd594be94d7562f648cd63ff0257c02ae7e4d988a483267 \
-                    size    19940841
+checksums           rmd160  348c06a706a380c416b12220b3def5fea4299471 \
+                    sha256  ce07c3ab62de761efa92c0cd16b5efcb869a16ce0cb04befed8f1f22b1d1379a \
+                    size    20708228
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules
@@ -31,15 +31,12 @@ post-destroot {
     # Remove binaries for other operating systems
     if {${os.platform} ne "darwin"} {
         delete {*}[glob ${node_modules_dir}/@lydell/node-pty-darwin*]
-        delete {*}[glob ${node_modules_dir}/node-pty/prebuilds/darwin*]
     }
     if {${os.platform} ne "linux"} {
         delete ${node_modules_dir}/clipboardy/fallbacks/linux
     }
     if {${os.platform} ne "windows"} {
         delete ${node_modules_dir}/clipboardy/fallbacks/windows
-        delete {*}[glob ${node_modules_dir}/node-pty/prebuilds/win*]
-        delete {*}[glob ${node_modules_dir}/node-pty/third_party/conpty/*/win*]
     }
 
     # Remove binaries for other CPU architectures


### PR DESCRIPTION
#### Description

Update to Gemini CLI 0.49.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?