### PR TITLE
claude-code: update to 2.1.195

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.191
+version             2.1.195
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  e3f5e305ac92fbef0051c89adec8cbdb5017523c \
-                 sha256  6e83aad5fc4fd459fd74539cda06d2279105eac2befc603d2fba6494974cb2a4 \
-                 size    229178416
+    checksums    rmd160  ae5a33aec02286e192a8cfbf2faff2681514a7f9 \
+                 sha256  7eb8716e6d6e6a278d13158793529336290837fca457facfec656f1b1a287c60 \
+                 size    234066032
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  75bfd289b6feb4154ad6d59c9ca5c8cfcd7f93c1 \
-                 sha256  99fdfb552a5260e649aedd06c024d0a4105b09cefec0bf67d558e017ee66c400 \
-                 size    219856224
+    checksums    rmd160  5efb5a9ddc493cfea68918e604101f9d988f2d1e \
+                 sha256  8b45adad93f336ab95f33e714494b19fd3377a494eb05c122c8677bc895876ad \
+                 size    224682640
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.195.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?