### PR TITLE
docker: update to 29.6.1

### DIFF
--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 29.6.0 v
+go.setup            github.com/docker/cli 29.6.1 v
 revision            0
 name                docker
 categories          devel
@@ -16,9 +16,9 @@ long_description    Docker is an open source project to pack, ship \
                     This port contains command line utilities for interacting \
                     with Docker, but not the core daemon.
 
-checksums           rmd160  fa26eb991573d3c9b186b9a0f0fe12c242bd12bd \
-                    sha256  f95b9594a671a8650eea0c47c267fbe15516a7c5f01fbf777715881497eb58a5 \
-                    size    6871111
+checksums           rmd160  b15d5b83592f1c51f6f9a82e02346475a4dbeb6e \
+                    sha256  74d14dd212b07cd3328989dc6a029dde2ebbe6a878199eaaafad54916f456194 \
+                    size    6869604
 
 build.target        github.com/docker/cli/cmd/docker
 


### PR DESCRIPTION
#### Description

Update to Docker CLI 29.6.1.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?