### PR TITLE
skaffold: update to 2.23.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.22.1 v
+github.setup        GoogleContainerTools skaffold 2.23.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  24d41960974c3a49b2e9590648b90116def49490 \
-                    sha256  a93466e1593ba4a032771a2c374e8d1d13fb96dbcdd08648633e60fb70c7f480 \
-                    size    75001035
+checksums           rmd160  f467b8183a21e7f8ac50806d25d6cc0f9e67d196 \
+                    sha256  af16760930e9463139f3228858a9308bb5e1eaa1c595c09768a1e058a1ae0baa \
+                    size    74999439
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.23.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?