### PR TITLE
gstreamer1: blacklist clang < 700 for stdatomic.h

### DIFF
--- a/gnome/gstreamer1/Portfile
+++ b/gnome/gstreamer1/Portfile
@@ -71,8 +71,10 @@ gobject_introspection   yes
 
 # Match blacklist used in gstreamer1-gst-plugins-base
 # error: redefinition of typedef ‘GstHarness’
+# fatal error: 'stdatomic.h' file not found
+compiler.c_standard 2011
 compiler.blacklist-append \
-                    *gcc-3.* *gcc-4.* {clang < 212}
+                    *gcc-3.* *gcc-4.* {clang < 700}
 
 configure.args-append \
                     -Dexamples=disabled \


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?