### PR TITLE
tabiew: update to 0.14.0

### DIFF
--- a/textproc/tabiew/Portfile
+++ b/textproc/tabiew/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        shshemi tabiew 0.13.1 v
+github.setup        shshemi tabiew 0.14.0 v
 github.tarball_from archive
 revision            0
 categories          textproc
@@ -15,9 +15,9 @@ long_description    {*}${description}
 license             MIT
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6a91df0fbc3f32c62fed79f34acb3a0816942481 \
-                    sha256  7f10c6d07ea84e28f2c3b8312ce7f65dc32236a61d9de441817e1a279b5437e7 \
-                    size    3511163
+                    rmd160  6f9b5139fb26f17c1777f6901aea4a0d6d1a9e5f \
+                    sha256  ceae42a8ee138ee8742f173ae127f783c6d28c836f07e7ad2e859033e45224b9 \
+                    size    3520170
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/tw ${destroot}${prefix}/bin/
@@ -109,6 +109,8 @@ cargo.crates \
     crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     csscolorparser                   0.6.2  eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf \
+    cssparser                       0.36.0  dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2 \
+    cssparser-macros                 0.6.1  13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331 \
     darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
     darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
     darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
@@ -120,7 +122,10 @@ cargo.crates \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features               0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
+    dtoa                            1.0.11  4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590 \
+    dtoa-short                       0.3.5  cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87 \
     dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
+    ego-tree                        0.11.0  b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3 \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
@@ -158,6 +163,7 @@ cargo.crates \
     fuzzy-matcher                    0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
     fwf-rs                           0.2.2  4563000434eee25828c12fe5574fc3dea24072e51ccc0367b5c3a3b3771ccdc7 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getopts                         0.2.24  cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
     getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
@@ -173,6 +179,7 @@ cargo.crates \
     hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     home                            0.5.12  cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d \
+    html5ever                       0.39.0  46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8 \
     http                             1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
@@ -227,6 +234,7 @@ cargo.crates \
     lz4                             1.28.1  a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4 \
     lz4-sys                       1.11.1+lz4-1.10.0  6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6 \
     mac_address                      1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
+    markup5ever                     0.39.0  7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de \
     matrixmultiply                  0.3.10  a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08 \
     memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
     memmap2                         0.9.10  714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3 \
@@ -236,6 +244,7 @@ cargo.crates \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
     ndarray                         0.17.2  520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d \
+    new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     now                              0.1.3  6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0 \
@@ -265,11 +274,16 @@ cargo.crates \
     pest_meta                        2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
     phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
     phf                             0.12.1  913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7 \
+    phf                             0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
     phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
+    phf_codegen                     0.13.1  49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1 \
     phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
+    phf_generator                   0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
     phf_macros                      0.11.3  f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216 \
+    phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
     phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
     phf_shared                      0.12.1  06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981 \
+    phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
     pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
     planus                           1.1.1  3daf8e3d4b712abe1d690838f6e29fb76b76ea19589c4afa39ec30e12f62af71 \
@@ -301,10 +315,12 @@ cargo.crates \
     potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
+    precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
     prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     proc-macro-crate                 3.5.0  e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f \
     proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     psm                             0.1.31  645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea \
+    pulldown-cmark                  0.13.3  7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad \
     quick-xml                       0.39.2  958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d \
     quinn                           0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
     quinn-proto                    0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
@@ -363,8 +379,10 @@ cargo.crates \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    scraper                         0.26.0  f0f5297102b8b62b4454ee8561601b2d551b4913148feb4241ca9d1a04bf4526 \
     security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys          2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
+    selectors                       0.36.1  c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c \
     semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
@@ -373,6 +391,7 @@ cargo.crates \
     serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_stacker                   0.1.14  d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    servo_arc                        0.4.3  170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     shell-words                      1.1.1  dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
@@ -399,6 +418,8 @@ cargo.crates \
     streaming-decompression          0.1.2  bf6cc3b19bfb128a8ad11026086e31d3ce9ad23f8ea37354b31383a187c44cf3 \
     streaming-iterator               0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strength_reduce                  0.2.4  fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82 \
+    string_cache                     0.9.0  a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901 \
+    string_cache_codegen             0.6.1  585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
     strum                           0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
@@ -410,6 +431,7 @@ cargo.crates \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
+    tendril                          0.5.0  c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24 \
     terminfo                         0.9.0  d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662 \
     termion                          4.0.6  f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
@@ -446,6 +468,7 @@ cargo.crates \
     typed-path                      0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typenum                         1.20.0  40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
+    unicase                          2.9.0  dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142 \
     unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-normalization           0.1.25  5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8 \
     unicode-reverse                  1.0.9  4b6f4888ebc23094adfb574fdca9fdc891826287a6397d2cd28802ffd6f20c76 \
@@ -455,8 +478,11 @@ cargo.crates \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     unty                             0.0.4  6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae \
-    ureq                            2.12.1  02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d \
+    ureq                             3.3.0  dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0 \
+    ureq-proto                       0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                              2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
+    utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    utf8-zero                        0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                            1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
@@ -481,7 +507,7 @@ cargo.crates \
     wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     web-sys                         0.3.97  2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                   0.26.11  521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9 \
+    web_atoms                        0.2.4  d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538 \
     webpki-roots                     1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
     wezterm-bidi                     0.2.3  0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec \
     wezterm-blob-leases              0.1.1  692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7 \


### PR DESCRIPTION
#### Description
https://github.com/shshemi/tabiew/compare/v0.13.1...v0.14.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
