### PR TITLE
qdmr: Update to 0.15.1

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           app 1.1
 PortGroup           qt6 1.0
 
-github.setup        hmatuschek qdmr 0.14.1 v
+github.setup        hmatuschek qdmr 0.15.1 v
 github.tarball_from archive
 maintainers         @hmatuschek \
                     {ra1nb0w @ra1nb0w} \
@@ -27,13 +27,14 @@ long_description    {*}${description}: \
 
 homepage            https://dm3mat.darc.de/qdmr/
 
-checksums           rmd160  d755d2352b61d240bac082efe3ab092ae9c2c562 \
-                    sha256  cb584c500f98897a959d7242292261ae7d8deafc7d0f709fc53d811e40d27f11 \
-                    size    7266522
+checksums           rmd160  5dd14fa928c7d6397c921ee4c0821d3f2ff39d77 \
+                    sha256  209b41d38ee228760ebe50fce0ecaab42aabbdd22872e0437c32799736eab2b2 \
+                    size    7676014
 
 qt6.depends_lib \
     qtserialport \
     qtlocation \
+    qtmultimedia \
     qttools
  
 depends_lib \
@@ -45,6 +46,12 @@ configure.args-append \
     -DBUILD_TESTS=OFF \
     -DBUILD_DOCS=OFF \
     -DBUILD_MAN=OFF
+
+notes "
+       The first time you try to edit a channel the dialog box may be too small.\
+       Just resize the box and it should snap to the correct size.  This will be\
+       saved and used in the future.
+      "
 
 app.create yes
 app.name qDMR


### PR DESCRIPTION
#### Description

qdmr: Update to 0.15.1
Upstream release: https://github.com/hmatuschek/qdmr/releases/tag/v0.15.1

This supersedes https://github.com/macports/macports-ports/pull/33059

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
