### PR TITLE
GPXSee: update to 16.10

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -2,15 +2,15 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           qmake5 1.0
+PortGroup           qmake6 1.0
 
-github.setup        tumic0 GPXSee 16.7
+github.setup        tumic0 GPXSee 16.10
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  2d6d40ee9353f05466221377430de07477cc805e \
-                    sha256  9b75b392464d4a00b69a7c7633893ed1a77e7cdb2075b693957ba939235d371a \
-                    size    6580001
+checksums           rmd160  f72027bdd0d7cce14d929f9285147ab9b2297285 \
+                    sha256  a99740cfab36d60a944b9938aa71eae0a0427407f75d617709df88179d1d06d8 \
+                    size    6481438
 
 categories          gis graphics
 license             GPL-3
@@ -24,16 +24,16 @@ homepage            https://www.gpxsee.org/
 
 patchfiles          patch-src_GUI_app_cpp.diff
 
-qt5.depends_component           qtlocation qtmultimedia
-qt5.depends_build_component     qttools
-qt5.depends_runtime_component   qtimageformats qttranslations
+qt6.depends_lib    qtlocation qtmultimedia qt5compat
+qt6.depends_build  qttools
+qt6.depends_run    qtimageformats qttranslations
 
 compiler.cxx_standard 2011
 
 depends_lib-append  port:zlib
 
 post-configure {
-    system -W ${worksrcpath} "${qt_lrelease_cmd} gpxsee.pro"
+    system -W ${worksrcpath} "${prefix}/libexec/qt6/bin/lrelease gpxsee.pro"
 }
 
 destroot {

--- a/gis/GPXSee/files/patch-src_GUI_app_cpp.diff
+++ b/gis/GPXSee/files/patch-src_GUI_app_cpp.diff
@@ -1,11 +1,11 @@
---- src/GUI/app.cpp.orig	2026-03-14 19:48:32.000000000 +0400
-+++ src/GUI/app.cpp	2026-03-14 22:10:19.000000000 +0400
-@@ -42,7 +42,7 @@
+--- src/GUI/app.cpp.orig
++++ src/GUI/app.cpp
+@@ -43,7 +43,7 @@ App::App(int &argc, char **argv) : QApplication(argc, argv)
  			installTranslator(app);
  
  	QTranslator *qt = new QTranslator(this);
--#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
+-#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
 +#if defined(Q_OS_WIN32)
  	if (qt->load(QLocale::system(), "qt", "_", ProgramPaths::translationsDir()))
- #else // Q_OS_WIN32 || Q_OS_MAC
+ #else // Q_OS_WIN32 || Q_OS_MACOS
  #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
