### PR TITLE
jsoncons: update to 1.8.1

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            danielaparker jsoncons 1.5.0 v
+github.setup            danielaparker jsoncons 1.8.1 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -15,11 +15,13 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             A C++, header-only library for constructing JSON and JSON-like data formats
 long_description        {*}${description}
 
-checksums               rmd160  34687d245ac6872c210950bce2204d39ae4e2aed \
-                        sha256  956021e44e50639be766a4ad71aff9a95168da188005fc6bfa23ee5d6a53eb32 \
-                        size    1554707
+checksums               rmd160  42831b640194a79d6ea8150dee8d8a13b04b8c19 \
+                        sha256  05657792d92f55be3e6494036c414e9d94237e3959fa46b073fdc712f4a9e56d \
+                        size    1664123
 
-compiler.cxx_standard   2011
+compiler.cxx_standard   2017
+configure.args-append   -DCMAKE_CXX_STANDARD=17 \
+                        -DCMAKE_CXX_STANDARD_REQUIRED=ON
 
 # https://github.com/danielaparker/jsoncons/issues/488
 if {${configure.cxx_stdlib} ne "libc++"} {


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons/blob/v1.8.1/CHANGELOG.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
