### PR TITLE
opkssh: new port

### DIFF
--- a/net/opkssh/Portfile
+++ b/net/opkssh/Portfile
@@ -1,0 +1,539 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/openpubkey/opkssh 0.15.0 v
+revision            0
+categories          net security
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             Apache-2
+
+description         Enables SSH to be used with OpenID Connect
+long_description    {*}${description}
+
+build.args-append   -ldflags \" -X main.Version=${version} \"
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  1867df7021016dcd7362888cf5b77d828c1e938e \
+                        sha256  036287cf27ce2baa3715fe917e2d6b300a499ee8766c1895bfb708690162502c \
+                        size    3129209
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    golang.org/x/text \
+                        lock    v0.38.0 \
+                        rmd160  d94b5751c77f0ca4cf0da06728cdb8f65b22d1b2 \
+                        sha256  4f095c2604d031dc7f95cd9e72154af1df1e917d3336aa96d00cdca2385c5332 \
+                        size    6772338 \
+                    golang.org/x/term \
+                        lock    v0.44.0 \
+                        rmd160  29457e71c83193e5cce45f004d6541e63da24bf9 \
+                        sha256  2dca7703280ae655bd2229d1e26f69c5af9e655d6f9f831ed60ce7ab18bace6b \
+                        size    16446 \
+                    golang.org/x/sys \
+                        lock    v0.46.0 \
+                        rmd160  4fb5f50fe64f25e9345f8d2fe6f523e5e3efaafa \
+                        sha256  a407db45a6dbc5409b82ca6a20a6bf6c3c7b7cf98e1559c41374390b55e75246 \
+                        size    1550340 \
+                    golang.org/x/oauth2 \
+                        lock    v0.30.0 \
+                        rmd160  63353a82f136c21da2c2613e3393b724d52b6f92 \
+                        sha256  259d504972689aef6ba45f2ca479d462524e0803a0104735262c94a5ad3b1da2 \
+                        size    100393 \
+                    golang.org/x/net \
+                        lock    v0.55.0 \
+                        rmd160  7b32b0fb3631970b8bb5d9d66bcf25e6eec0eea8 \
+                        sha256  4bf0a1ec5fdc50e6a2f14735130909cfafe09e28525bdaeaf7232c6e33a1e55f \
+                        size    1342150 \
+                    golang.org/x/mod \
+                        lock    v0.36.0 \
+                        rmd160  95d8398b6397ab4f7c43e4b9cd6c7ea027fc909e \
+                        sha256  71f03abd2eb8d1ecd7f637ce9d846513b71b197a63760a3e3890c6d75501a4e9 \
+                        size    127886 \
+                    golang.org/x/exp \
+                        lock    542afb5b7346 \
+                        rmd160  32bc32f7e13e0924553d41af9e5c7ab826bfcfab \
+                        sha256  3830d727d743f9cc622eee6cb0af49ce0d34c949b48aece21e75ec3cb4d65cef \
+                        size    1749144 \
+                    golang.org/x/crypto \
+                        lock    v0.53.0 \
+                        rmd160  a6125d2a0268cbc606b0acdc2ab7a43fdb2dfc46 \
+                        sha256  cace2121a385c8aed7f5493453c00541df543231bf810244942c9dc4c642e242 \
+                        size    2165577 \
+                    go.opentelemetry.io/proto/otlp \
+                        repo    github.com/open-telemetry/opentelemetry-proto-go \
+                        lock    otlp/v1.0.0 \
+                        rmd160  658c0c057237a8bdb1daec98a7a626067471c36d \
+                        sha256  e2d4121ad0298570c79576bcf6bab3e605d8ed8c2256861239e0932a9b58a6bf \
+                        size    177234 \
+                    go.opentelemetry.io/otel/trace \
+                        repo    github.com/open-telemetry/opentelemetry-go \
+                        lock    trace/v1.35.0 \
+                        rmd160  616a1099045c08db55c17744919f5e59b0279e69 \
+                        sha256  52868597a598fd97a8f7bb20668361272a722c68849917ec58763dacc4783fca \
+                        size    2077168 \
+                    go.opentelemetry.io/otel/metric \
+                        repo    github.com/open-telemetry/opentelemetry-go \
+                        lock    metric/v1.35.0 \
+                        rmd160  27c7097cc556d337904ebcb672a53019a30873a7 \
+                        sha256  412421effe365a146e155c1babc229972c184e3a79471a061afbd8c391b9f510 \
+                        size    2077142 \
+                    go.opentelemetry.io/otel/exporters/otlp/otlptrace \
+                        repo    github.com/open-telemetry/opentelemetry-go \
+                        lock    exporters/otlp/otlptrace/v1.19.0 \
+                        rmd160  b7e42b993aa165087b0465128c5dce10fbc9f59f \
+                        sha256  d49209f4c3f0e976e4ec72788cf14a5f0557fcd4aeff1cc6a24e7d95cc39bdd7 \
+                        size    1255273 \
+                    go.opentelemetry.io/otel \
+                        repo    github.com/open-telemetry/opentelemetry-go \
+                        lock    v1.35.0 \
+                        rmd160  884adaedb43f338a678d58be97e37516ac857b9a \
+                        sha256  efc31f28b2ec363b8aca698fca734d61720336ac29f4c7fde0b142c1ee83bb43 \
+                        size    2077161 \
+                    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp \
+                        repo    github.com/open-telemetry/opentelemetry-go-contrib \
+                        lock    instrumentation/net/http/otelhttp/v0.54.0 \
+                        rmd160  35e4b36f43583e4e75bdea93599aa8dd0b85b89f \
+                        sha256  47f2f9cee4feaa18422d99e097d9e37d0b1bbb0a60065d18410b059ddadf14a3 \
+                        size    641461 \
+                    go.opentelemetry.io/auto/sdk \
+                        repo    github.com/open-telemetry/opentelemetry-go-instrumentation \
+                        lock    sdk/v1.1.0 \
+                        rmd160  509151d1ba28ec1db50b5f53d28f43f010dadf2e \
+                        sha256  585f46697b804ce49f3d3e4ab95cb534ec3dcaf51d4d468df23128c43be3907a \
+                        size    1114827 \
+                    github.com/zitadel/schema \
+                        lock    v1.3.1 \
+                        rmd160  174a14e933703ec7220959d22c6726816835871d \
+                        sha256  25f858a8532b116ab7f4bcd336ec44a23454bc01e0984be6679ccde1735c659f \
+                        size    25758 \
+                    github.com/zitadel/oidc/v3 \
+                        lock    v3.41.0 \
+                        rmd160  8b3cf299857f2005c338a3f8d61e787e2274eef9 \
+                        sha256  d78b3cfb45480b4f28395510577aea3a6cb6e333b9c440e03ac0654ce7c1ddfb \
+                        size    196408 \
+                    github.com/zitadel/logging \
+                        lock    v0.6.2 \
+                        rmd160  314326e6314c6cac81d340ca7d707f9ef238a248 \
+                        sha256  3b4cbd17861768bfa73d87627ea3fd000fc5eee3338621d58acffc4313719d94 \
+                        size    14873 \
+                    github.com/yusufpapurcu/wmi \
+                        lock    v1.2.4 \
+                        rmd160  23599ad98727cca3e1678e909a1014e212d41fc7 \
+                        sha256  05d3cee4c74f456174ea5538ee95fba675aeb520fd7bdd3872860a3c7dcafa11 \
+                        size    12672 \
+                    github.com/yeqown/reedsolomon \
+                        lock    v1.0.0 \
+                        rmd160  e5aeaad82ec6415b9ac8ab0dcbef25fabec2232f \
+                        sha256  61955c5866a14412c2eec60d15d1106fb1bace076009efa423965282868defe2 \
+                        size    6785 \
+                    github.com/yeqown/go-qrcode/v2 \
+                        lock    v2.2.5 \
+                        rmd160  d6f361fa573b4ce4a60d5ae06abf6fee79ba689e \
+                        sha256  d1b099747d40333da2c3de8d90b51855e14779cc073e6213aff467c67fca6b6e \
+                        size    509650 \
+                    github.com/valyala/fastjson \
+                        lock    v1.6.4 \
+                        rmd160  03cb09174487ae03b028ad424bec4d0453236f59 \
+                        sha256  238ed69deb26c46f6fa230138fc074fe97d0725b64a569d2690c1e196c67d586 \
+                        size    731454 \
+                    github.com/tklauser/numcpus \
+                        lock    v0.6.1 \
+                        rmd160  db67212c0ad3f243bc1a1322f0b13209b839ce58 \
+                        sha256  79d9983e092006b0f95b5f64cf64d8d056c53844040f405f78820af9927f2d0c \
+                        size    9403 \
+                    github.com/tklauser/go-sysconf \
+                        lock    v0.3.12 \
+                        rmd160  ae582febe943a7b3c002b805a1c08cec97b5b852 \
+                        sha256  61ca9fa5482fc7f4419da9bf5cdfb10642ce3be1ea45a56ea4a0674c756a9b03 \
+                        size    30414 \
+                    github.com/thediveo/enumflag/v2 \
+                        lock    v2.0.7 \
+                        rmd160  291527fa5df18211d0f31834a4cfd2dfa60b621f \
+                        sha256  40489f843c4bdb0fc42c6cdbeca9f7b4278d36ecd22161e99d5df0b7bc640136 \
+                        size    25941 \
+                    github.com/testcontainers/testcontainers-go \
+                        lock    v0.38.0 \
+                        rmd160  80a68b6a48c172cc552b4182b5f57bfaa5fa2ffa \
+                        sha256  00e6e3cf765ab65f8782554f3b2204e7ee67517db5ce02498692ff5dcc44c944 \
+                        size    20888973 \
+                    github.com/stretchr/testify \
+                        lock    v1.11.1 \
+                        rmd160  d6dec631a506398b8b731a0476b9e44c206243ac \
+                        sha256  759279b90772bfc79db1620874f45eb008aceab35b14f007cb4ab8316a2398db \
+                        size    116867 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.6 \
+                        rmd160  71c96f5c72e1ec15157e4dd6438e69f717bd7b99 \
+                        sha256  296b98eebe4fd4b6435afbb05a93ffd4e4cb20a54ab128f633b21cfac9f136e1 \
+                        size    52859 \
+                    github.com/spf13/cobra \
+                        lock    v1.9.1 \
+                        rmd160  95925251f62ff042108f882129779eae809a9a8c \
+                        sha256  33dec62c9ce9622184102f590c5c97e4b6aaa6341510b3defc21c1266b31f057 \
+                        size    197845 \
+                    github.com/spf13/afero \
+                        lock    v1.14.0 \
+                        rmd160  95180c509220d8ffdd6cfd9f9ca708ae3be7b1a5 \
+                        sha256  880c030de2ca2e4652a6d6cb3e17b14fe9a096077c8f0b5858bad0bfdca279f5 \
+                        size    93470 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.9.3 \
+                        rmd160  db211aeb52d4a85a7dc8acf83f7475b5f4fa9092 \
+                        sha256  36a05391b8c6cef99e9a9c78b598f3a8da8feed318b385eadcdede08ae5cc229 \
+                        size    50327 \
+                    github.com/shirou/gopsutil/v4 \
+                        lock    v4.25.5 \
+                        rmd160  9fa5190dc7ca0068baa288684d2787676787bdd2 \
+                        sha256  a60c3d08755076c9ed1166bdffdc5f5b229bcd1e63d2768aa3af53e8dcc98f90 \
+                        size    189969 \
+                    github.com/segmentio/asm \
+                        lock    v1.2.1 \
+                        rmd160  8eab5907df1af45d21a3a4c1e9a909deaf9a5b8c \
+                        sha256  45b3477f02582f24dfe1c79871e9e6f024fdfc7f807d68e610d18b49f70d304f \
+                        size    92716 \
+                    github.com/russross/blackfriday/v2 \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/rs/cors \
+                        lock    v1.11.1 \
+                        rmd160  1bdbc0039910474b46defc9476cbcadfe148cbe8 \
+                        sha256  b57dab6b175a5b9693565fc19d31633e01d59f256982bf77b3f3db8229baa0b9 \
+                        size    35082 \
+                    github.com/power-devops/perfstat \
+                        lock    5aafc221ea8c \
+                        rmd160  1c4f659015f1a59d261a493397534436ccb6a608 \
+                        sha256  617a974b1f9c38ac9fd958a8cc80c14aaf083906691dda43d642c0ef12611047 \
+                        size    36009 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/sftp \
+                        lock    v1.13.7 \
+                        rmd160  d7ae23c1f268a3ba874385b697bfdde1c4e77ad9 \
+                        sha256  58e1689c520f2cf1aaea947320c4f4a745bfff592c7fd12ff37496ae6694eee1 \
+                        size    125646 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/openpubkey/openpubkey \
+                        lock    v0.23.0 \
+                        rmd160  fb01f3ae3f0738539083f9f662c854803267f4d8 \
+                        sha256  46f82e7e6c1bfb6b59bf1468c016f845312733c20a6fc5bb14cfaed5cb21be80 \
+                        size    194804 \
+                    github.com/opencontainers/image-spec \
+                        lock    v1.1.1 \
+                        rmd160  9d1f2f7143d6e5d700f21c083ec5b82171bf4e48 \
+                        sha256  2d4dea08d5289b98efa67a0c54c206273f114b0c47c0efdba35196fd252a481c \
+                        size    160376 \
+                    github.com/opencontainers/go-digest \
+                        lock    v1.0.0 \
+                        rmd160  8a4108c4ab0b11d2bb6e82021f5a7bb0fdee2e6f \
+                        sha256  7c93509fe4e49a67f5e9147534927d5efa662c852e593ab08ab50fc7228ce734 \
+                        size    24469 \
+                    github.com/muhlemmer/httpforwarded \
+                        lock    v0.1.0 \
+                        rmd160  b6d6f5209ce5dda0ade62bdf78e2d4bfe182f022 \
+                        sha256  7b3e317f856ca775ad8166a4eb7e94ce9e4fe4597198930b3a2f1cb8beb5996a \
+                        size    6914 \
+                    github.com/muhlemmer/gu \
+                        lock    v0.3.1 \
+                        rmd160  e65df31b5f7c8ce2ec847460e8ed1e6789ad1531 \
+                        sha256  cbede4fcd13f3e989129a2fc95dec4d7fd07f50540a497b5e01e58e18e6dc22b \
+                        size    6906 \
+                    github.com/morikuni/aec \
+                        lock    v1.0.0 \
+                        rmd160  7e49b739cc71aae5ec1ef99a569b297bf189efa0 \
+                        sha256  2eeca6007564eca34d51a01af9a41efb7953ff671cf98be679b13607e6edfe5a \
+                        size    55433 \
+                    github.com/moby/term \
+                        lock    v0.5.0 \
+                        rmd160  dfddb6d33a65b53173bb75c063c965e95830a933 \
+                        sha256  8018fe550ce9b45a849171c0b367604b3dd6ee9148acaaa798190df8d8ccb518 \
+                        size    14677 \
+                    github.com/moby/sys/userns \
+                        lock    userns/v0.1.0 \
+                        rmd160  424bb3d0c6621a50a83706c37d16e4ae8023747f \
+                        sha256  56bc844cc5d75210e46e0ac9762487efab259597d5e71e9391aed39f59926ade \
+                        size    70562 \
+                    github.com/moby/sys/user \
+                        lock    user/v0.4.0 \
+                        rmd160  d7e964586b289254554bef8e2e3fca3b0b9b9b7a \
+                        sha256  9d322f7596a0b1dca6daee9acc880ec8b8db4aadd392a870891e0d5dc3707979 \
+                        size    93164 \
+                    github.com/moby/sys/sequential \
+                        lock    sequential/v0.6.0 \
+                        rmd160  7f81968b62f9374a3c29e92eaf4b75e02a849e1e \
+                        sha256  f90a4659cbe60ac23dd7602b36174ef1ebdd14e063e416ee62a26360797a05ec \
+                        size    69146 \
+                    github.com/moby/patternmatcher \
+                        lock    v0.6.0 \
+                        rmd160  2ef1460504082dca2e6eb7505580ab2a019eee72 \
+                        sha256  1233580e6b685022f66ff90fc8059d07b16ade4f66d3db33caf9c2544afcb0dc \
+                        size    12270 \
+                    github.com/moby/go-archive \
+                        lock    v0.1.0 \
+                        rmd160  39876e6f69e171caced193294ced2a1f05e24d90 \
+                        sha256  8a4100e30da8ecd82b616415793fb7f65b9826867b589b246b47a5a8d1f34831 \
+                        size    82164 \
+                    github.com/moby/docker-image-spec \
+                        lock    v1.3.1 \
+                        rmd160  fde7870f4674c820f37d9050140a931e0cda8a5a \
+                        sha256  9bda6b22c834c44cda332eb7ec97fa509d82a0017c682008ce5c1c51b7e188f3 \
+                        size    14101 \
+                    github.com/melbahja/goph \
+                        lock    v1.4.0 \
+                        rmd160  13d60559cef1fc81bf832263f6afc59c5ef0dff2 \
+                        sha256  7341a606436d814640d76e4f64e553812521f940ccd0058ed2a0a3a3c5c7beca \
+                        size    16108 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.10 \
+                        rmd160  cdb665b9319d0f484fdfe95a27359ca6d9811a09 \
+                        sha256  4ebc836d1fdfb99ba654063208387558639e62a8d7406ffa7c36e0c44a7bda38 \
+                        size    29078 \
+                    github.com/lufia/plan9stats \
+                        lock    39d0f177ccd0 \
+                        rmd160  f51617c89f9004fbc70199874ce8f290f59c309e \
+                        sha256  4a3903621bc835f693af93062001f8deaadf692e37becf9ee772930eab155d20 \
+                        size    10243 \
+                    github.com/lestrrat-go/option/v2 \
+                        lock    v2.0.0 \
+                        rmd160  ea2395df6f18482b38a505026071b19ed5af313e \
+                        sha256  028d72d380b51f78c549365e96af4469623f056f36e2bdbf703512ef7646ed0f \
+                        size    11942 \
+                    github.com/lestrrat-go/option \
+                        lock    v1.0.1 \
+                        rmd160  f84ffe208692adca250c3ef0fb37465056444e31 \
+                        sha256  505f1d34da918691b42ae2df022a1242a1bf6239565be99cf31ea280796ce226 \
+                        size    10587 \
+                    github.com/lestrrat-go/jwx/v3 \
+                        lock    v3.0.12 \
+                        rmd160  45087b7c7dc71ca6e6a49f848cf3183342248f37 \
+                        sha256  2d5fc1a945315dfb2b5aa79f580c651acbcbe189ac59918ac94f9784eacf6696 \
+                        size    544545 \
+                    github.com/lestrrat-go/httprc/v3 \
+                        lock    v3.0.1 \
+                        rmd160  6f99e28230ba75aaf8766d98b63c660831109cf0 \
+                        sha256  b615ce1313c5bc6ba82fc78c891c7bf41a476efba020182aea1b5f293e214044 \
+                        size    35470 \
+                    github.com/lestrrat-go/httpcc \
+                        lock    v1.0.1 \
+                        rmd160  3a45f15d9458f6186e213d47c0fb2a4c08b8c7a3 \
+                        sha256  90bbf577f7c2fa15a854039152e6fb44a65e92f45371b482aa819197aa154ca8 \
+                        size    6156 \
+                    github.com/lestrrat-go/dsig-secp256k1 \
+                        lock    v1.0.0 \
+                        rmd160  369d45a0e3246673b517125663852150e8de439f \
+                        sha256  04c55eff000e02516ccf8b6b4e727083f653ac24a23bd6af46e7eb9be60e218d \
+                        size    3157 \
+                    github.com/lestrrat-go/dsig \
+                        lock    v1.0.0 \
+                        rmd160  ae2cf758235a8502e2a03d1c2c8ff7edf6480011 \
+                        sha256  5493f887edf5ccf8d4066dd3aae2f1dddcba301f6d9e771dccdbd4d9a9f87519 \
+                        size    16783 \
+                    github.com/lestrrat-go/blackmagic \
+                        lock    v1.0.4 \
+                        rmd160  446e2628d52e851e3216266a50cbb6b40eb1530e \
+                        sha256  3e9d3fce1b68d276e22ee5717feb69ee70a5f5aa97b17e5d6a97743fd02782f0 \
+                        size    4726 \
+                    github.com/kr/fs \
+                        lock    v0.1.0 \
+                        rmd160  8abd3fd492702ff682f7eecce8af4f40f36a4b27 \
+                        sha256  815510d12f36bbb2a45cd45021c65d1eaf7b035942c6694629a188ceb3ef43bf \
+                        size    4410 \
+                    github.com/klauspost/compress \
+                        lock    v1.18.0 \
+                        rmd160  641294afaa0766e028b582ef93f027997e6b795a \
+                        sha256  9953494099d6853773afd56ccbcc8d4928b537ad30e475983524a7a0fc87e180 \
+                        size    39079077 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jeremija/gosubmit \
+                        lock    v0.2.8 \
+                        rmd160  42c1650e05691779ced21dccab33a0864dc5c012 \
+                        sha256  1182f424c501a421fdca7ed7135fca96eac44ba0e3b5ffbb307f86578718f4d3 \
+                        size    13933 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
+                    github.com/gorilla/securecookie \
+                        lock    v1.1.2 \
+                        rmd160  04c5f7f0e669abf64482e61ba98ec5600a746ddd \
+                        sha256  9d648d93237a8b967beddd79916073d14c6e752fc4a5d9dadac38f1576a25f91 \
+                        size    12174 \
+                    github.com/google/uuid \
+                        lock    v1.6.0 \
+                        rmd160  3d4f6f95018c6313f7258805845eb2a7e717850c \
+                        sha256  72700459e75cad2b36586e8a13aa12c2d6248c45db24d1eebf41e18b1ec1c811 \
+                        size    20895 \
+                    github.com/gogo/protobuf \
+                        lock    v1.3.2 \
+                        rmd160  c16e6e6fb8f26d3d1ceef9e99fa4dfb5899878fd \
+                        sha256  d24f8e0b99dbc6ffaa0731490bf80d3ab4cb0b332bcf4b57e3fd830c60e0960b \
+                        size    2040306 \
+                    github.com/goccy/go-json \
+                        lock    v0.10.5 \
+                        rmd160  45f43805f73da9bdb84ee6e8190ac444b025e340 \
+                        sha256  61acf13f9a2968ed3f5134d48556232a2b3f678c544e75d24b7ae66cbdc569a8 \
+                        size    399162 \
+                    github.com/go-ole/go-ole \
+                        lock    v1.2.6 \
+                        rmd160  70350a72faa92597facb55379e481ea049bb57da \
+                        sha256  d818d3dab064c4f8f2be9460353318207f58d562f874d06c0bff91cd423dc2af \
+                        size    52614 \
+                    github.com/go-logr/stdr \
+                        lock    v1.2.2 \
+                        rmd160  2f24ba9c61d88475841e65ea6109c189fcb6de3c \
+                        sha256  694ed0928bb3e77d98e90d48e970dd2750b8fee1170a85897a5f256c3f459a1c \
+                        size    9105 \
+                    github.com/go-logr/logr \
+                        lock    v1.4.2 \
+                        rmd160  fc3b3bfb8b3c969154b1f6a934a0361351be5b8d \
+                        sha256  71c00041c33e2cb2361ef4d4ac2a50e6f8f8da5c2e50a7a5938f2e6a2fa1b227 \
+                        size    57472 \
+                    github.com/go-jose/go-jose/v4 \
+                        lock    v4.0.5 \
+                        rmd160  2a6ecc7134a1bfa9e78e7690a3644eabd30aaef4 \
+                        sha256  0c556ed030776c6dbe37c82f30b14a5950a1f68d2c829d98d38e103d47555c3f \
+                        size    319081 \
+                    github.com/go-chi/chi/v5 \
+                        lock    v5.2.2 \
+                        rmd160  f38088a31a9baa4085a848e085ce05a5fbbfea2c \
+                        sha256  0e046b7c10eabb6ec5a3314c6e362526616086681f0bcaf94d3fcab3a1b2dd5e \
+                        size    86884 \
+                    github.com/felixge/httpsnoop \
+                        lock    v1.0.4 \
+                        rmd160  1d362d3a3cbafe1cfb75642a476e46ca8249231f \
+                        sha256  f31b40d924ae6cbf00d9835b2b5b9270ddf6adf034ceb664bdc9bd065beececc \
+                        size    11955 \
+                    github.com/ebitengine/purego \
+                        lock    v0.8.4 \
+                        rmd160  3f78666210cc60fe8fdd1e89a8ccf379ef156300 \
+                        sha256  a13e42ddb6f57c9ecb6f5ffe839c0a8ce5112f1f6e15ead2563479c46975985e \
+                        size    66966 \
+                    github.com/docker/go-units \
+                        lock    v0.5.0 \
+                        rmd160  43b8579cfcb0af5377e0af531d203c16c99f7bc1 \
+                        sha256  6fb6c155c6d1a61059a3ec82e790dc6bfe87bff4d72cfa7c23f5c76303240bc0 \
+                        size    12244 \
+                    github.com/docker/go-connections \
+                        lock    v0.5.0 \
+                        rmd160  0c544936a4c6ce90fdbde0249414d66bdd4e2788 \
+                        sha256  3005e08540e05e3301172e2f563d5edd5db707871dd6dd9d00935c3d60cb3dec \
+                        size    33221 \
+                    github.com/docker/docker \
+                        lock    v28.3.3 \
+                        rmd160  3e511ac6939cf58a345b147864cb2f2ead0b09fd \
+                        sha256  02b97ca1526b9d0bcb6548f3a541ed9defcfba0df3065a08c081c211a89f9c9f \
+                        size    18052054 \
+                    github.com/distribution/reference \
+                        lock    v0.6.0 \
+                        rmd160  01dca1792d6ad60c9afff4ca92a1ffb8a553b49c \
+                        sha256  a29ba6c7dcff1fb53a7620b2959958813fdd841f373d18635843444027207f02 \
+                        size    34135 \
+                    github.com/decred/dcrd/dcrec/secp256k1/v4 \
+                        lock    dcrec/secp256k1/v4.4.0 \
+                        rmd160  0ec8c1f3ba55ed370f03250a14106ccc0f5b1451 \
+                        sha256  bf247c9e1d4c2da0339c053111b10006e65c30767b6fddbaa8d35463774d459f \
+                        size    7060774 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cpuguy83/go-md2man/v2 \
+                        lock    v2.0.6 \
+                        rmd160  f1a0f3ea4b3327a78aa1e69feb4fe31360b05ae8 \
+                        sha256  e13c0173838f14f1105d738546ec16269aea36953411d4ff2c53e3b644e58f29 \
+                        size    11075 \
+                    github.com/cpuguy83/dockercfg \
+                        lock    v0.3.2 \
+                        rmd160  af8d610729b9c6aab1ded25a10854dd18a9a8d5d \
+                        sha256  1ce542225ff5d36658f4347fb00fa47f2c5fb329fb04ea46f4dd62058f702e26 \
+                        size    6981 \
+                    github.com/containerd/platforms \
+                        lock    v0.2.1 \
+                        rmd160  645112af6d29813c1e62bac2ab87abc9b2c33d58 \
+                        sha256  a222a199282b8e1bf928f6072259f2fbaec130180b0e831a36dd2e80369efe9a \
+                        size    20903 \
+                    github.com/containerd/log \
+                        lock    v0.1.0 \
+                        rmd160  17434cd86f700ebb74b8bce9136a83a822ed8e5f \
+                        sha256  851ebb388f19772338736f664156b629e38196ce273c31ce9a5ec214639cc52b \
+                        size    9668 \
+                    github.com/containerd/errdefs/pkg \
+                        lock    pkg/v0.3.0 \
+                        rmd160  5d8031d182a57bd13fc6fc823534a327ab39ea68 \
+                        sha256  c9be4c4d167ac29abd3691c961e94b798793bd5c894020eb5ddb3fa9af81ce8d \
+                        size    20432 \
+                    github.com/containerd/errdefs \
+                        lock    v1.0.0 \
+                        rmd160  5d8031d182a57bd13fc6fc823534a327ab39ea68 \
+                        sha256  c9be4c4d167ac29abd3691c961e94b798793bd5c894020eb5ddb3fa9af81ce8d \
+                        size    20432 \
+                    github.com/cenkalti/backoff/v4 \
+                        lock    v4.2.1 \
+                        rmd160  e4ac343410906a6a1ab0acd578ce034783b5ab42 \
+                        sha256  f30a8b3e79935ada4f425a1e19ba42863bc00e42a981d5b936f7555bd326651d \
+                        size    10399 \
+                    github.com/bmatcuk/doublestar/v4 \
+                        lock    v4.9.0 \
+                        rmd160  d87bd5a69e1c6912dfc51ede7083bd713831d402 \
+                        sha256  a9d39f352f7a4d03292b8c0806b2e632e455dfd3706e6c5ba73520d9a474a0cc \
+                        size    28442 \
+                    github.com/bits-and-blooms/bitset \
+                        lock    v1.24.1 \
+                        rmd160  8bcf701cb191171521c9f2c08bfa4af5f1eef2c3 \
+                        sha256  d7dedbef46487a72e466514a50126c947fb607ff6484896ca6565ee0d5abfcae \
+                        size    94916 \
+                    github.com/awnumar/memguard \
+                        lock    v0.22.3 \
+                        rmd160  eb3bcde76bed9d9d78b279eb731aa0497d1c5c72 \
+                        sha256  61102ca5b1b2a1b12a7c0dfac277fdb8e8fe369bf1d2669c6133982b3fcf5203 \
+                        size    74801 \
+                    github.com/awnumar/memcall \
+                        lock    v0.1.2 \
+                        rmd160  3337e42703050fe6062f8e848f40a57e31923f5a \
+                        sha256  e347ee4493ae8a950201901b78d896d009a5cb09e7d7b34a4346438250d45f8e \
+                        size    7429 \
+                    github.com/Microsoft/go-winio \
+                        lock    v0.6.2 \
+                        rmd160  8b2c7d4932878e0fdc4e6ed44cd701e6f8a1520d \
+                        sha256  c0014a760e6484f39611354dd095eee4a166b3313d1a7bbb9c85465374243870 \
+                        size    114161 \
+                    github.com/Azure/go-ansiterm \
+                        lock    d185dfc1b5a1 \
+                        rmd160  0bee49b1521e3ab51740780b4104007fff3f7e5f \
+                        sha256  c75bfc5488590b609906ec8126dbe18b7e28afeabe66017dbe96a7c15bb74add \
+                        size    21649 \
+                    filippo.io/bigmod \
+                        repo    github.com/FiloSottile/bigmod \
+                        lock    v0.1.0 \
+                        rmd160  343000f10620fe1a3b1f16bee390d0c47a043ee4 \
+                        sha256  cf7a1a55aee6c650aa9dc09154620929eaa07f6fb0c6dfa79a3a74393e2d589f \
+                        size    27359 \
+                    dario.cat/mergo \
+                        repo    github.com/imdario/mergo \
+                        lock    v1.0.1 \
+                        rmd160  38c83c7cca3cd366db516728a42f0d6d9a10dce8 \
+                        sha256  e26148e113cdf2668987d100488d7af1a889e73d088caecfe483f7ff3c7fdca1 \
+                        size    29249
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
opkssh (OpenPubkey SSH) - https://github.com/openpubkey/opkssh

[![Packaging status](https://repology.org/badge/tiny-repos/opkssh.svg)](https://repology.org/project/opkssh/versions)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
