### PR TITLE
mise: Update to 2026.6.14

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.6.11 v
+github.setup        jdx mise 2026.6.14 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  cfe63a93bc687579e1d85fd31ea129de402dc416 \
-                    sha256  b4189990c7cfd2e40ff322e9ad51b972dd8edfeda9bdedd239cf8a16384e0c59 \
-                    size    7311593
+                    rmd160  dbaba3ff9849876a4a30d0def109a650bd4bae67 \
+                    sha256  2480b1bd8ed693300551113b4dd7771828dcc65651e46edef8ec38e0e37a0fba \
+                    size    12331607
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -108,7 +108,7 @@ cargo.crates \
     arc-swap                             1.9.1  6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207 \
     archspec                             0.2.0  3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33 \
     arrayref                             0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
-    arrayvec                             0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
+    arrayvec                             0.7.7  f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     astral-reqwest-middleware            0.5.1  98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9 \
     astral-tokio-tar                     0.6.2  cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277 \
@@ -164,8 +164,9 @@ cargo.crates \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
+    bitflags                             1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                            2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
-    bitvec                               1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
+    bitvec                               1.1.1  ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837 \
     blake2                         0.11.0-rc.6  061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690 \
     blake3                               1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
@@ -180,7 +181,7 @@ cargo.crates \
     bytecheck_derive                     0.8.2  89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9 \
     bytecount                            0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                               1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
+    bytes                               1.12.0  8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593 \
     bytes-utils                          0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
     bytesize                             2.4.0  49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d \
     bzip2                                0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
@@ -190,7 +191,7 @@ cargo.crates \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.64  dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f \
+    cc                                  1.2.65  e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96 \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                          0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
@@ -273,6 +274,9 @@ cargo.crates \
     deadpool                            0.12.3  0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b \
     deadpool-runtime                     0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
     deflate64                           0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
+    defmt                                1.1.0  a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f \
+    defmt-macros                         1.1.0  f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b \
+    defmt-parser                         1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
     demand                               2.0.2  9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
@@ -358,69 +362,69 @@ cargo.crates \
     generic-array                       0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                           0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                            0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
-    getrandom                            0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
+    getrandom                            0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     ghash                                0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                               0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
-    gix                                 0.84.0  ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce \
+    gix                                 0.85.0  fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6 \
     gix-actor                           0.41.1  8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f \
-    gix-archive                         0.33.0  16909cacc78936ab96f6c3be08379d0a2e88bfa3a7527972d2ed75c7517ef31e \
-    gix-attributes                      0.33.1  8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02 \
+    gix-archive                         0.34.0  1303ed647e048d2bbecb9fd3a627d753e73f883a20ad5c039b30c7cbc85e217f \
+    gix-attributes                      0.33.2  39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4 \
     gix-bitmap                           0.3.2  52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283 \
-    gix-blame                           0.14.0  4d39a0c14af94c2edaa5eefe06d5ef2cdea55316ae9a9321314288e3f55fa4c0 \
+    gix-blame                           0.15.0  cf49c828ad8a8a674d52caaf0b61fdee1f20cc46c15439ca3d875ef3b6f64bdc \
     gix-chunk                            0.7.2  9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb \
     gix-command                          0.9.1  00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6 \
     gix-commitgraph                     0.37.1  7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb \
-    gix-config                          0.57.0  4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de \
+    gix-config                          0.58.0  a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583 \
     gix-config-value                    0.18.1  ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab \
     gix-credentials                     0.38.1  f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d \
-    gix-date                            0.15.4  a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c \
-    gix-diff                            0.64.0  3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b \
-    gix-dir                             0.26.0  21bb2a53a6fd917ec499ed0bfb5b6887de7a15bd79197dcea7c987938749a9f1 \
-    gix-discover                        0.52.0  77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7 \
+    gix-date                            0.15.5  3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0 \
+    gix-diff                            0.65.0  92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3 \
+    gix-dir                             0.27.0  20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f \
+    gix-discover                        0.53.0  d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722 \
     gix-error                            0.2.4  e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b \
     gix-features                        0.48.1  1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc \
-    gix-filter                          0.31.0  ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa \
+    gix-filter                          0.32.0  6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c \
     gix-fs                              0.21.2  6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe \
     gix-glob                            0.26.1  d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756 \
     gix-hash                            0.25.1  cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce \
-    gix-hashtable                       0.15.1  b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563 \
+    gix-hashtable                       0.15.2  7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e \
     gix-ignore                          0.21.1  d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d \
-    gix-imara-diff                       0.2.2  19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19 \
-    gix-index                           0.52.0  4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d \
+    gix-imara-diff                       0.2.3  b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b \
+    gix-index                           0.53.0  36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681 \
     gix-lock                            23.0.1  65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c \
     gix-mailmap                         0.33.1  195fd20808055824531be2fd0d34136d900e5fbca3ffb0a3c07e8beeefb9c828 \
-    gix-negotiate                       0.32.0  890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55 \
-    gix-object                          0.61.0  d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525 \
-    gix-odb                             0.81.0  7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d \
-    gix-pack                            0.71.0  e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174 \
-    gix-packetline                      0.21.4  bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126 \
+    gix-negotiate                       0.33.0  63d6081882a5f575ace9f53924a7c85f69bbd0f96071b982df12f258ab338cc9 \
+    gix-object                          0.62.0  019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e \
+    gix-odb                             0.82.0  7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a \
+    gix-pack                            0.72.0  ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b \
+    gix-packetline                      0.21.5  b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7 \
     gix-path                            0.12.1  afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6 \
     gix-pathspec                        0.18.1  3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f \
     gix-prompt                          0.15.1  3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8 \
-    gix-protocol                        0.62.0  51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee \
+    gix-protocol                        0.63.0  978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2 \
     gix-quote                            0.7.2  a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef \
-    gix-ref                             0.64.0  4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b \
-    gix-refspec                         0.42.0  b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3 \
-    gix-revision                        0.46.0  0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f \
-    gix-revwalk                         0.32.0  85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6 \
+    gix-ref                             0.65.0  9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e \
+    gix-refspec                         0.43.0  7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f \
+    gix-revision                        0.47.0  885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f \
+    gix-revwalk                         0.33.0  8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455 \
     gix-sec                             0.14.1  ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3 \
     gix-shallow                         0.12.1  a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97 \
-    gix-status                          0.31.0  22042e385d28a34275e029d98f4970285045be14b9073658ca897923f2ed8700 \
-    gix-submodule                       0.31.0  3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781 \
-    gix-tempfile                        23.0.1  27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22 \
+    gix-status                          0.32.0  aec3293f75db1212f99217832cbc70c30faeb95cefc97c7f1a17fd3bcf13a72e \
+    gix-submodule                       0.32.0  a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8 \
+    gix-tempfile                        23.0.2  6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f \
     gix-trace                           0.1.20  44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678 \
-    gix-transport                       0.57.1  7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff \
-    gix-traverse                        0.58.0  e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed \
+    gix-transport                       0.57.2  186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3 \
+    gix-traverse                        0.59.0  5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1 \
     gix-url                             0.36.1  65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2 \
     gix-utils                            0.3.3  66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771 \
     gix-validate                        0.11.2  7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3 \
-    gix-worktree                        0.53.0  cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1 \
-    gix-worktree-state                  0.31.0  4bffae8b3ca258fdd50370cd51f06deb4c76a3b43db3868bc28dde45ffa77d69 \
-    gix-worktree-stream                 0.33.0  d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557 \
+    gix-worktree                        0.54.0  92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036 \
+    gix-worktree-state                  0.32.0  c0f926b6a249bdb0086b307c704b7abd9d643e08f98040efe6467f00bb6d2ef5 \
+    gix-worktree-stream                 0.34.0  55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f \
     glob                                 0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     globset                             0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
-    h2                                  0.4.14  171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733 \
+    h2                                  0.4.15  6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155 \
     halfbrown                            0.4.0  0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09 \
     hash32                               0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
     hashbrown                           0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
@@ -467,7 +471,6 @@ cargo.crates \
     icu_properties                       2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
     icu_properties_data                  2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
     icu_provider                         2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
-    id-arena                             2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                         1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
@@ -493,8 +496,8 @@ cargo.crates \
     itertools                           0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jiff                                0.2.28  4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102 \
-    jiff-static                         0.2.28  782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47 \
+    jiff                                0.2.29  34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46 \
+    jiff-static                         0.2.29  0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f \
     jiff-tzdb                            0.1.6  c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076 \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
@@ -513,7 +516,6 @@ cargo.crates \
     lazy-regex                           3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
     lazy-regex-proc_macros               3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    leb128fmt                            0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libbz2-rs-sys                        0.2.5  34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c \
     libc                               0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
@@ -527,7 +529,7 @@ cargo.crates \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     litrs                                1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                            0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                                 0.4.32  953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a \
+    log                                 0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
@@ -651,10 +653,10 @@ cargo.crates \
     quick-xml                           0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quick-xml                           0.38.4  b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c \
     quick-xml                           0.39.4  cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e \
-    quinn                               0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
-    quinn-proto                        0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
+    quinn                              0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
+    quinn-proto                        0.11.15  4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e \
     quinn-udp                           0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
-    quote                               1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    quote                               1.0.46  dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
     r-efi                                5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
@@ -688,7 +690,7 @@ cargo.crates \
     redox_users                          0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                            1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                       1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    reflink-copy                        0.1.29  13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27 \
+    reflink-copy                        0.1.30  d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b \
     regex                               1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
     regex-automata                      0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-lite                           0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
@@ -719,7 +721,7 @@ cargo.crates \
     rustc_version                        0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                             0.23.40  ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
+    rustls                             0.23.41  6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f \
     rustls-native-certs                  0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
     rustls-pki-types                    1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
@@ -825,7 +827,7 @@ cargo.crates \
     supports-hyperlinks                  3.2.0  e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91 \
     supports-unicode                     3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
     syn                                1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                                2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    syn                                2.0.118  1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
     sync_wrapper                         1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                        0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     sysctl                               0.5.5  ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea \
@@ -851,9 +853,9 @@ cargo.crates \
     thiserror-impl                      1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                      2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
     thread_local                         1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    time                                0.3.49  711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469 \
+    time                                0.3.51  85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327 \
     time-core                            0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
-    time-macros                         0.2.29  71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d \
+    time-macros                         0.2.30  dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935 \
     tinystr                              0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
     tinyvec                             1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
@@ -915,7 +917,7 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.5.0  bc055ae0a824bf9e409ee8e175ec224d5e1b79325557f51967eea0f103e5dc03 \
+    usage-lib                            3.5.2  fd4e84470f848f8cea3efba8d1245cf6c2051d0fe2fe9ddd29b5977d0e906844 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -932,23 +934,19 @@ cargo.crates \
     want                                 0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                   1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
-    wasip3      0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
     wasm-bindgen                       0.2.125  8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a \
     wasm-bindgen-futures                0.4.75  503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280 \
     wasm-bindgen-macro                 0.2.125  4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d \
     wasm-bindgen-macro-support         0.2.125  fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd \
     wasm-bindgen-shared                0.2.125  23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f \
-    wasm-encoder                       0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
-    wasm-metadata                      0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
-    wasmparser                         0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
     web-sys                            0.3.102  a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-root-certs                    1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
-    webpki-roots                         1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
-    which                                8.0.3  c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e \
+    webpki-root-certs                    1.0.8  0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267 \
+    webpki-roots                         1.0.8  bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf \
+    which                                8.0.4  48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248 \
     widestring                           1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                               0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu           0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -1012,13 +1010,7 @@ cargo.crates \
     winnow                               1.0.3  0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
     winver                               1.0.0  9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33 \
     wiremock                             0.6.5  08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031 \
-    wit-bindgen                         0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
     wit-bindgen                         0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    wit-bindgen-core                    0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
-    wit-bindgen-rust                    0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
-    wit-bindgen-rust-macro              0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
-    wit-component                      0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
-    wit-parser                         0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
     writeable                            0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
     wyz                                  0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     x25519-dalek                         2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
@@ -1046,7 +1038,7 @@ cargo.crates \
     zip                                  8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zipsign-api                          0.2.1  32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99 \
-    zlib-rs                              0.6.3  3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513 \
+    zlib-rs                              0.6.4  977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3 \
     zmij                                1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
     zopfli                               0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249 \
     zstd                                0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \


### PR DESCRIPTION
#### Description

mise: Update to 2026.6.14


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
