### PR TITLE
oasdiff: Update to 1.21.0

### DIFF
--- a/devel/oasdiff/Portfile
+++ b/devel/oasdiff/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Tufin/oasdiff 1.20.0 v
+go.setup            github.com/Tufin/oasdiff 1.21.0 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ffd039e056923e7973c15f1178d18095a579d318 \
-                    sha256  710654aeff1d32dca5e54e494533ffb1210ceee5cbbde4cc10845449cd644c27 \
-                    size    597258
+                    rmd160  1eab7ed321ecf2e134c0978a6b0a0378c2931ece \
+                    sha256  e6cbab12470548920914ae45f900e9b8899ed0b6c692b98b1409f960d79e45f2 \
+                    size    620305
 
 post-build {
     system -W ${worksrcpath} "./${name} completion bash > ${name}.bash"


### PR DESCRIPTION
#### Description

oasdiff: Update to 1.21.0


##### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
