### PR TITLE
nrsc5: update to 3.2.0

### DIFF
--- a/audio/nrsc5/Portfile
+++ b/audio/nrsc5/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # _strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        theori-io nrsc5 3.1.0 v
+github.setup        theori-io nrsc5 3.2.0 v
 github.tarball_from archive
 
 categories          audio
@@ -20,9 +20,9 @@ description         This program receives NRSC-5 digital radio stations using an
 long_description    {*}${description}. It offers a command-line interface \
                     as well as an API upon which other applications can be built.
 
-checksums           rmd160  ef40c59245ff62c8c1d8c5d545b415ad7e030fbe \
-                    sha256  66a1d199e92fd7b9464d55ece633757cb9d1daf37d4d80e0f4f8f63da089295e \
-                    size    23184491
+checksums           rmd160  177689bcb6b594f3e732ceb96eb1f2f13cfa4c8b \
+                    sha256  8e3bc5ca66256da7c16b617cbd0271a62096411c08e973893191b83c02ecae21 \
+                    size    23191012
                                         
 patchfiles          CMakeLists.txt.diff
 


### PR DESCRIPTION
#### Description

Update nrsc5 to 3.2.0.

###### Tested on

macOS 26.5.1 25F80 arm64 / Command Line Tools 26.5.0.0.1777544298
macOS 27.0 26A5368g arm64 / Command Line Tools 27.0.0.0.1781811268

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?