### PR TITLE
tdlib: update to 1.8.65

### DIFF
--- a/devel/tdlib/Portfile
+++ b/devel/tdlib/Portfile
@@ -7,9 +7,9 @@ PortGroup           cmake 1.1
 # The tdlib authors do not set tags for minor versions,
 # but we could reuse the versioning from nixpkgs.
 # https://raw.githubusercontent.com/NixOS/nixpkgs/refs/heads/nixos-unstable/pkgs/by-name/td/tdlib/package.nix
-github.setup        tdlib td 5b974c298d4ed551d3ad2c061ad7b8280d137c7e
+github.setup        tdlib td a8f21f5230172634becc1739050ef23ecd6ea291
 name                tdlib
-version             1.8.41
+version             1.8.65
 categories          devel
 license             Boost-1
 maintainers         {l2dy @l2dy} openmaintainer
@@ -22,9 +22,9 @@ description         Cross-platform library for building Telegram clients
 long_description    TDLib (Telegram Database library) is a cross-platform \
                     library for building Telegram clients.
 
-checksums           rmd160  69bcf10deb87ed58d252e0494ec6e05a368edba8 \
-                    sha256  eaa8618a9cade001ea4adf0d9175c01ab5e5ee882fa01800f2adb36366993a06 \
-                    size    5304204
+checksums           rmd160  94e1cbb230d25ec25de2ad41c5f010a5aa32a160 \
+                    sha256  6ce3c64a811391d6d6c6f179cfd11ea8b4c72b701185e838eb8e854bebf7495b \
+                    size    5747439
 
 github.tarball_from archive
 


### PR DESCRIPTION
#### Description

Update TDLib version from 1.8.41 to 1.8.65

###### Tested on

macOS 12.7.6 21H1317 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
