### PR TITLE
lazygit: update to 0.62.2

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.62.0 v
+go.setup            github.com/jesseduffield/lazygit 0.62.2 v
 revision            0
 
 description         A simple terminal UI for git commands, written in Go
@@ -15,9 +15,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c0cce9dae356a7256479a871cbc42c30e074a43a \
-                    sha256  15f20b97c98a799998bc2d32a9a68674a7ddee8b73735d6d4758fafc854a00cb \
-                    size    4476133
+checksums           rmd160  a736425ee25fa75cd3d7351fba5dbe806c4e31fb \
+                    sha256  0bd1cdbaf1a584d2eb2fd14f068a8eaaeaeb80d3e2713c72005de9e4feaf6844 \
+                    size    4480071
 
 # lazygit's dependencies are already vendored in the source code
 # Allow Go modules so that we can build vendored dependencies


### PR DESCRIPTION
## Summary
- Update lazygit from 0.62.0 to 0.62.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)