### PR TITLE
ruff: update to 0.15.20

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.15.9
+github.setup        astral-sh ruff 0.15.20
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e8d351390306705abda63176d80432f0d7cb7bbb \
-                    sha256  c3ae08e55f6822909f590e733bfd912c489027139c5f083e35d67afc197a15f3 \
-                    size    11389702
+                    rmd160  a8333597e1ed2be84a7ee3ec442ff341ae4510b5 \
+                    sha256  3d2d9283f8221d04f1debf1ac32ec900bba08aec5609266ac93b8b8464073d16 \
+                    size    12157944
 
 cargo.offline_cmd
 
@@ -88,10 +88,11 @@ cargo.crates \
     anstyle-wincon                  3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
     anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
-    arc-swap                         1.9.0  a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6 \
+    arc-swap                         1.9.1  6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207 \
     argfile                          1.0.0  99489a733dea0d2930bfa59c243146a8513ce7b0991b9d006647687cc61f53e7 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    assert_fs                        1.1.3  a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9 \
+    assert_fs                        1.1.4  6ecf5c70ca07b7f80220bce936f0556a960ca6fb00fc2bd4125b5e581b218137 \
+    async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     attribute-derive                0.10.3  0053e96dd3bec5b4879c23a138d6ef26f2cb936c9cdc96274ac2b9ed44b5bb54 \
     attribute-derive-macro          0.10.3  463b53ad0fd5b460af4b1915fe045ff4d946d025fb6c4dc3337752eaa980f71b \
     autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
@@ -100,47 +101,45 @@ cargo.crates \
     bit-set                          0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                          0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                        2.11.0  843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
+    bitflags                        2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
     bitvec                           1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
     boxcar                          0.2.14  36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e \
     bstr                            1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
     bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
-    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
     camino                           1.2.2  e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
     cc                              1.2.38  80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9 \
-    cfg-if                           1.0.3  2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9 \
+    cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                        0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
     chrono                          0.4.44  c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0 \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.6.0  b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351 \
+    clap                             4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap_builder                     4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
     clap_complete                   4.5.58  75bf0b32ad2e152de789bb635ea4d3078f6b838ad7974143e99b99f45a04af4a \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.8  0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce \
-    clap_derive                      4.6.0  1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a \
+    clap_derive                      4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                         1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
     clearscreen                      4.0.6  d669bb552908e336ad5681789752033b45566b7e591aeaac7a614e58e5d6d8f2 \
     codspeed                         4.4.1  b684e94583e85a5ca7e1a6454a89d76a5121240f2fb67eb564129d9bafdb9db0 \
     codspeed-criterion-compat        4.4.1  2e65444156eb73ad7f57618188f8d4a281726d133ef55b96d1dcff89528609ab \
-    codspeed-criterion-compat-walltime 4.4.1 96389aaa4bbb872ea4924dc0335b2bb181bcf28d6eedbe8fea29afcc5bde36a6 \
+    codspeed-criterion-compat-walltime     4.4.1  96389aaa4bbb872ea4924dc0335b2bb181bcf28d6eedbe8fea29afcc5bde36a6 \
     codspeed-divan-compat            4.4.1  89e4bf8c7793c170fd0fcf3be97b9032b2ae39c2b9e8818aba3cc10ca0f0c6c0 \
     codspeed-divan-compat-macros     4.4.1  78aae02f2a278588e16e8ca62ea1915b8ab30f8230a09926671bba19ede801a4 \
-    codspeed-divan-compat-walltime   4.4.1  59ffd32c0c59ab8b674b15be65ba7c59aebac047036cfa7fa1e11bc2c178b81f \
+    codspeed-divan-compat-walltime     4.4.1  59ffd32c0c59ab8b674b15be65ba7c59aebac047036cfa7fa1e11bc2c178b81f \
     collection_literals              1.0.2  26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8 \
     colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     colored                          3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
-    compact_str                      0.9.0  3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a \
+    compact_str                      0.9.1  9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab \
     condtype                         1.3.0  baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af \
-    console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     console                         0.16.1  b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4 \
     console_error_panic_hook         0.1.7  a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc \
     console_log                      1.0.0  be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f \
@@ -163,10 +162,7 @@ cargo.crates \
     csv                              1.4.0  52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938 \
     csv-core                        0.1.12  7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d \
     ctrlc                            3.5.2  e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162 \
-    darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
-    darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
-    darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
-    dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
+    dashmap                          6.2.1  e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c \
     datatest-stable                  0.3.3  a867d7322eb69cf3a68a5426387a25b45cb3b9c5ee41023ee6cea92e2afadd82 \
     derive-where                     1.6.0  ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
@@ -177,7 +173,6 @@ cargo.crates \
     dispatch2                        0.3.0  89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     divan-macros                    0.1.17  8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c \
-    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     drop_bomb                        0.1.5  9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
@@ -191,18 +186,23 @@ cargo.crates \
     fancy-regex                     0.14.0  6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298 \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fern                             0.7.1  4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29 \
-    filetime                        0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
+    filetime                        0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     find-msvc-tools                  0.1.2  1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959 \
     flate2                           1.1.2  4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     fs-err                           3.3.0  73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0 \
     fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
     funty                            2.0.0  e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c \
+    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
+    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
+    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    gen-lsp-types                    0.9.0  946cd448051e8061e4e17d88ecaceea8d84c33da52b93a9391b4a657def1b8bd \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    get-size-derive2                 0.7.4  f2b6d1e2f75c16bfbcd0f95d84f99858a6e2f885c2287d1f5c3a96e8444a34b4 \
-    get-size2                        0.7.4  49cf31a6d70300cf81461098f7797571362387ef4bf85d32ac47eaa59b3a5a1a \
+    get-size-derive2                0.10.1  1da24fbda09ec01bca7cfa1797c0e520e75123bccb01dcdf9041f8aa65183bc2 \
+    get-size2                       0.10.1  823645bc6404ae2915707777061a47d3a031a9ee0bff51b34ec973df3d8d2990 \
     getopts                         0.2.24  cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df \
     getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
@@ -213,8 +213,8 @@ cargo.crates \
     half                             2.6.0  459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
-    hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
-    hashlink                        0.10.0  7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1 \
+    hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
+    hashlink                        0.12.0  a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
@@ -228,67 +228,69 @@ cargo.crates \
     icu_properties_data              2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
     icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
     id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
-    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
-    ignore                          0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
+    ignore                          0.4.26  b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d \
     imara-diff                       0.2.0  2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c \
     imperative                       1.0.7  35e1d0bd9c575c52e59aad8e122a11786e852a154678d0c86e9e243d55273970 \
-    indexmap                        2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
+    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indicatif                       0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
     indoc                            2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inotify                         0.11.0  f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3 \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
-    insta                           1.46.3  e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4 \
-    insta-cmd                        0.6.0  ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6 \
+    insta                           1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
+    insta-cmd                        0.7.0  bffdf4af1db390cf0401535d7c1303cd079a074d28d8473b026fdb6559c41403 \
     interpolator                     0.5.0  71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8 \
-    intrusive-collections            0.9.7  189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86 \
-    inventory                       0.3.21  bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e \
+    intrusive-collections           0.10.1  80e165935eba36cb526af8389effd2005a741adcbb6ed32106cc68e3f7b92960 \
+    inventory                       0.3.24  a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b \
     is-macro                         0.3.7  1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4 \
     is-terminal                     0.4.16  e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itertools                       0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-    jiff                            0.2.23  1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359 \
-    jiff-static                     0.2.23  2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4 \
+    jiff                            0.2.28  4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102 \
+    jiff-static                     0.2.28  782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47 \
     jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     jod-thread                       1.0.0  a037eddb7d28de1d0fc42411f501b53b75838d313908078d6698d064f3029b24 \
-    js-sys                          0.3.82  b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65 \
+    js-sys                         0.3.100  f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162 \
     kqueue                           1.1.1  eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
-    libc                           0.2.180  bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc \
+    libc                           0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libcst                           1.8.6  6aea7143e4a0ed59b87a1ee71e198500889f8b005311136be15e84c97a6fcd8d \
     libcst_derive                    1.8.6  0903173ea316c34a44d0497161e04d9210af44f5f5e89bf2f55d9a254c9a0e8d \
-    libmimalloc-sys                 0.1.44  667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870 \
+    libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
+    libmimalloc-sys                 0.1.49  6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9 \
     libredox                        0.1.10  416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb \
     libtest-mimic                    0.7.3  cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58 \
     libtest-mimic                    0.8.1  5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33 \
-    linux-raw-sys                   0.11.0  df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039 \
+    libz-rs-sys                      0.5.5  c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415 \
+    linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                          0.8.0  241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956 \
     lock_api                        0.4.13  96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765 \
-    log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    log                             0.4.32  953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a \
     lsp-server                       0.7.9  7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e \
     manyhow                         0.11.4  b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587 \
     manyhow-macros                  0.11.4  46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495 \
     markdown                         1.0.0  a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb \
     matchers                         0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
-    matchit                          0.9.1  b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b \
-    memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
+    matchit                          0.9.2  8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608 \
+    memchr                           2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
-    mimalloc                        0.1.48  e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8 \
-    minicov                          0.3.7  f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b \
+    mimalloc                        0.1.52  2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862 \
+    minicov                          0.3.8  4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
     natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
     newtype-uuid                     1.3.2  5c012d14ef788ab066a347d19e3dda699916c92293b05b85ba2c76b8c82d2830 \
-    nix                             0.31.1  225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66 \
+    nix                             0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
     notify                           8.2.0  4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3 \
@@ -298,11 +300,11 @@ cargo.crates \
     num_cpus                        1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     objc2                            0.6.3  b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05 \
     objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
-    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.1  a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad \
     oorandom                        11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
-    ordermap                         1.1.0  cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715 \
+    ordermap                         1.2.0  7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1 \
     os_pipe                          1.2.2  db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224 \
     os_str_bytes                     7.1.1  63eceb7b5d757011a87d08eb2123db15d87fb0c281f65d101ce30a1e96c3ad5c \
     page_size                        0.6.0  30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da \
@@ -335,9 +337,9 @@ cargo.crates \
     portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
     potential_utf                    0.1.3  84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
-    predicates                       3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
-    predicates-core                  1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
-    predicates-tree                 1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
+    predicates                       3.1.4  ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
+    predicates-core                 1.0.10  cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144 \
+    predicates-tree                 1.0.13  d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     proc-macro-crate                 3.4.0  219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983 \
@@ -355,27 +357,30 @@ cargo.crates \
     r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                           0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
-    rand                            0.10.0  bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8 \
+    rand                            0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                       0.10.0  0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba \
-    rayon                           1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
+    rayon                           1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                   0.5.17  5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77 \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                        1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                   1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex                           1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
     regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-lite                       0.1.7  943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30 \
-    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     ron                             0.12.0  fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32 \
     rust-stemmers                    1.2.0  e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54 \
-    rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
+    rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustc-stable-hash                0.1.2  781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08 \
-    rustix                           1.1.3  146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34 \
+    rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
+    salsa                           0.27.2  ffbaab832e2ea754afda4a738f987dd1e8bd30c9e5d8c981ee6a3934386095e2 \
+    salsa-macro-rules               0.27.2  de6872462ac73d39969a836273c24163e6a26a4e08f5114fcd80e25af30ea9c6 \
+    salsa-macros                    0.27.2  76bc78ffaf65b1a9175818592c5130aa10b1bb245a905722fd4db87cea8a8457 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schemars                         1.2.1  a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc \
     schemars_derive                  1.2.1  7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f \
@@ -387,19 +392,18 @@ cargo.crates \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
-    serde_repr                      0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
-    serde_spanned                    1.0.4  f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776 \
+    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_test                     1.0.177  7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed \
-    serde_with                      3.18.0  dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f \
-    serde_with_macros               3.18.0  d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shellexpand                      3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
+    similar                          3.1.1  e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16 \
     siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
-    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
+    smallvec                        1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
     snapbox                          1.0.0  71d70a71b68054cbe88708f77abfc4bd2daf75028f8f55f4f1cff63565df89ea \
     snapbox-macros                   1.0.0  d248cef42e1456ab2f7149c0376985351b7d849ea9ad2a957bf15ddfebf1fdf9 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
@@ -410,10 +414,10 @@ cargo.crates \
     strum                           0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                    0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     supports-hyperlinks              3.2.0  e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91 \
-    syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    syn                            2.0.118  1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
-    tempfile                        3.25.0  0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1 \
+    tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.4.3  60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0 \
     terminfo                         0.9.0  d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662 \
@@ -421,26 +425,26 @@ cargo.crates \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
-    thin-vec                        0.2.14  144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d \
+    thin-vec                        0.2.18  b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                       2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
     thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
     threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
-    tikv-jemalloc-sys 0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b \
+    tikv-jemalloc-sys             0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7  cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b \
     tikv-jemallocator                0.6.1  0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a \
     tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                         1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    toml                 0.9.12+spec-1.1.0  cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863 \
-    toml                  1.0.7+spec-1.1.0  dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96 \
-    toml_datetime         0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
-    toml_datetime         1.1.0+spec-1.1.0  97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f \
+    toml                          0.9.12+spec-1.1.0  cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863 \
+    toml                          1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    toml_datetime                 0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
+    toml_datetime                 1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
     toml_edit                       0.23.6  f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b \
-    toml_parser           1.1.0+spec-1.1.0  2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011 \
-    toml_writer           1.1.0+spec-1.1.0  d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed \
+    toml_parser                   1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_writer                   1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
     tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
@@ -450,6 +454,7 @@ cargo.crates \
     tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
     tryfn                            1.0.0  f68b00518dd6c69ee2289900b140e55dad068cb925678603bfa8d539f61ef6c1 \
     typed-arena                      2.0.2  6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a \
+    typed-path                      0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
@@ -468,7 +473,7 @@ cargo.crates \
     utf8-width                       0.1.7  86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.22.0  a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37 \
+    uuid                            1.23.3  144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7 \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     version-ranges                   0.1.1  f8d079415ceb2be83fc355adbadafe401307d5c309c7e6ade6638e6f9f42f42d \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
@@ -478,22 +483,23 @@ cargo.crates \
     vte                             0.15.0  a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd \
     wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
-    wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasip2                1.0.1+wasi-0.2.4  0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7 \
-    wasip3  0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                   0.2.105  da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60 \
-    wasm-bindgen-futures            0.4.55  551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0 \
-    wasm-bindgen-macro             0.2.105  04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2 \
-    wasm-bindgen-macro-support     0.2.105  420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc \
-    wasm-bindgen-shared            0.2.105  76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76 \
-    wasm-bindgen-test               0.3.55  bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373 \
-    wasm-bindgen-test-macro         0.3.55  085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1 \
+    wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
+    wasip2                        1.0.1+wasi-0.2.4  0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7 \
+    wasip3                        0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
+    wasm-bindgen                   0.2.123  a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563 \
+    wasm-bindgen-futures            0.4.73  54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf \
+    wasm-bindgen-macro             0.2.123  24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc \
+    wasm-bindgen-macro-support     0.2.123  908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b \
+    wasm-bindgen-shared            0.2.123  7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92 \
+    wasm-bindgen-test               0.3.73  e28a0782b173cf2e98f62aacb487c5c021b7c5925df46098675f28e1fa85e159 \
+    wasm-bindgen-test-macro         0.3.73  ee997551ce1ad5adda03f7ce37ec34b4140fe9f547fd07b46d55901d1ba1a06b \
+    wasm-bindgen-test-shared       0.2.123  ae0f005eb61f765eff31a79ef71df7e21819731268a868df41192c1e41d6d3e5 \
     wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
-    web-sys                         0.3.82  3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1 \
+    web-sys                        0.3.100  6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    which                            8.0.2  81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459 \
+    which                            8.0.4  48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248 \
     wild                             2.2.1  a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -503,7 +509,7 @@ cargo.crates \
     windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
     windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
     windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
-    windows-link                     0.2.0  45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65 \
+    windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
     windows-result                   0.4.0  7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f \
     windows-strings                  0.5.0  7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
@@ -549,8 +555,10 @@ cargo.crates \
     zerotrie                         0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
     zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
     zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
-    zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
+    zip                              8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
+    zlib-rs                          0.5.5  40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3 \
     zmij                            1.0.10  30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868 \
-    zstd                 0.11.2+zstd.1.5.2  20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4 \
-    zstd-safe             5.0.2+zstd.1.5.2  1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db \
-    zstd-sys             2.0.16+zstd.1.5.7  91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748
+    zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
+    zstd-safe                        7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \
+    zstd-sys                      2.0.16+zstd.1.5.7  91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748
+


### PR DESCRIPTION
## Summary
- Update ruff from 0.15.9 to 0.15.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)