### PR TITLE
trivy: update to 0.71.2

### DIFF
--- a/security/trivy/Portfile
+++ b/security/trivy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/aquasecurity/trivy 0.71.1 v
+go.setup            github.com/aquasecurity/trivy 0.71.2 v
 go.offline_build    no
 revision            0
 


### PR DESCRIPTION
## Summary
- Update trivy from 0.71.1 to 0.71.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)