### PR TITLE
trufflehog: update to 3.95.7

### DIFF
--- a/security/trufflehog/Portfile
+++ b/security/trufflehog/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/trufflesecurity/trufflehog 3.95.3 v
+go.setup            github.com/trufflesecurity/trufflehog 3.95.7 v
 go.package          github.com/trufflesecurity/trufflehog/v3
 go.offline_build    no
 revision            0
@@ -24,9 +24,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 build.args-append \
     -ldflags \" -X ${go.package}/pkg/version.BuildVersion=${version} \"
 
-checksums           rmd160  3f96cb44957cdbfd2cd956f6f530eb26e80cb5ff \
-                    sha256  99d88bb86e4ad33c5399e057ad091cda771b66f3b2ea60e23784049e7deca442 \
-                    size    4244017
+checksums           rmd160  584db235cd2ad95f4a5cdb4f1a68ef1b9f0c2da4 \
+                    sha256  57f9e798d9d4f281acfb8b7d999f275d5641bbbe5c8a512e42da69a7ec394e9e \
+                    size    6108475
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
## Summary
- Update trufflehog from 3.95.3 to 3.95.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)