### PR TITLE
fastfetch: update to 2.65.2

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -5,7 +5,7 @@ PortGroup           github  1.0
 PortGroup           cmake   1.1
 PortGroup           legacysupport 1.1
 
-github.setup        fastfetch-cli fastfetch 2.64.1
+github.setup        fastfetch-cli fastfetch 2.65.2
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  47fd6167a86752fab0041737725b76517f77e621 \
-                    sha256  a91b736e855847aa8803efdd328c076b0048278368238ea45519bd2164f4fb63 \
-                    size    1513737
+checksums           rmd160  651b49cfea3fe1a34578e986f1455f700ce8cc3c \
+                    sha256  d0b318c33cf6c8bbae1162325f91624762a040a60f748941cbf1b4b99a75fa30 \
+                    size    1555551
 
 set py_branch       3.14
 set py_version      [string map {. ""} ${py_branch}]


### PR DESCRIPTION
## Summary
- Update fastfetch from 2.64.1 to 2.65.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)