### PR TITLE
hurl: update to 8.0.1

### DIFF
--- a/www/hurl/Portfile
+++ b/www/hurl/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 PortGroup           openssl 1.0
 
-github.setup        Orange-OpenSource hurl 8.0.0
+github.setup        Orange-OpenSource hurl 8.0.1
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    \
     used for both fetching data and testing HTTP sessions.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  54140b066d15a006f58732b31bad7fb55bc343e2 \
-                    sha256  07cd840fed40a79487813eeb05201d5f99a969c3b0c80010230afd33e4ff69bf \
-                    size    11902342
+                    rmd160  8452d23a0b8c3c48ae84199ac8aa8f6ef42d5a76 \
+                    sha256  d5ea72ed489b9de319d0306d7b23728c4d284ac505adeb06c297ff5da1cf0de8 \
+                    size    13083794
 
 dist_subdir         ${name}/${version}_0
 
@@ -68,7 +68,7 @@ cargo.crates \
     brotli-decompressor              5.0.0  874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03 \
     bstr                            1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
     bumpalo                         3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
-    cc                              1.2.60  43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20 \
+    cc                              1.2.61  d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d \
     cexpr                            0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     chacha20                        0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
@@ -85,7 +85,7 @@ cargo.crates \
     crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crypto-common                    0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
     curl                            0.4.49  79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc \
-    curl-sys            0.4.87+curl-8.19.0  61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327 \
+    curl-sys                      0.4.87+curl-8.19.0  61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327 \
     dary_heap                        0.3.9  8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe \
     digest                          0.11.2  4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
@@ -97,13 +97,16 @@ cargo.crates \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
+    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
+    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
+    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
     getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
     glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
     hashbrown                       0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
-    hybrid-array                    0.4.10  3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214 \
+    hybrid-array                    0.4.11  08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5 \
     iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     icu_collections                  2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
@@ -115,18 +118,18 @@ cargo.crates \
     icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
     id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
-    idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
+    idna_adapter                     1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
     indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    js-sys                          0.3.95  2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca \
+    js-sys                          0.3.97  a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf \
     leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
-    libc                           0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
+    libc                           0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libflate                         2.3.0  cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df \
     libflate_lz77                    2.3.0  ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd \
     libloading                       0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
-    libxml                           0.3.8  74a5e46b8bcd6b70cb485ca086e43aa020af841e29fb0aba88ce02cd1cb52cc7 \
+    libxml                           0.3.9  92e66b69764e678a92f78f56a70b394dc9f01ea2155a06d07b54424cc9f4deaf \
     libz-sys                        1.1.28  fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -140,9 +143,10 @@ cargo.crates \
     once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
-    openssl-src              300.6.0+3.6.2  a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4 \
+    openssl-src                   300.6.0+3.6.2  a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4 \
     openssl-sys                    0.9.114  13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6 \
     percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
     potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
@@ -167,6 +171,7 @@ cargo.crates \
     sha2                            0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     similar                          3.1.0  04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f \
+    slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     socket2                          0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
@@ -184,12 +189,12 @@ cargo.crates \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                            1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    wasip2                1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
-    wasip3  0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                   0.2.118  0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89 \
-    wasm-bindgen-macro             0.2.118  eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed \
-    wasm-bindgen-macro-support     0.2.118  9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904 \
-    wasm-bindgen-shared            0.2.118  5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129 \
+    wasip2                        1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
+    wasip3                        0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
+    wasm-bindgen                   0.2.120  df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1 \
+    wasm-bindgen-macro             0.2.120  78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103 \
+    wasm-bindgen-macro-support     0.2.120  9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41 \
+    wasm-bindgen-shared            0.2.120  49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea \
     wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
@@ -228,3 +233,4 @@ cargo.crates \
     zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
     zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
     zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa
+


### PR DESCRIPTION
## Summary
- Update hurl from 8.0.0 to 8.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)