### PR TITLE
expat: update to 2.8.2

### DIFF
--- a/textproc/expat/Portfile
+++ b/textproc/expat/Portfile
@@ -6,11 +6,11 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                expat
-version             2.8.1
+version             2.8.2
 revision            0
-checksums           rmd160  d96d2b5701954eed8cd6c6bbc24264c457dc08ad \
-                    sha256  f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb \
-                    size    655697
+checksums           rmd160  60d9b52208da31a3aff01c63bbc7f04cc2a75b76 \
+                    sha256  69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b \
+                    size    660292
 
 categories          textproc devel
 platforms           darwin freebsd


### PR DESCRIPTION
## Summary
- Update expat from 2.8.1 to 2.8.2
- Existing `O_CLOEXEC.patch` still applies cleanly

## Test plan
- [ ] Verify checksums match upstream tarball
- [ ] Build and test on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)