### PR TITLE
libiconv: update to 1.19

### DIFF
--- a/textproc/libiconv/Portfile
+++ b/textproc/libiconv/Portfile
@@ -5,11 +5,11 @@ PortGroup               muniversal 1.1
 PortGroup               clang_dependency 1.0
 
 name                    libiconv
-version                 1.18
+version                 1.19
 revision                0
-checksums               rmd160  7daf36870dc6258ef8570a727b9b75af2ab65d7f \
-                        sha256  3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8 \
-                        size    5822590
+checksums               rmd160  05debe548a671ddf6f023389d5b20eb85bc17203 \
+                        sha256  88dd96a8c0464eca144fc791ae60cd31cd8ee78321e67397e25fc095c4a19aa6 \
+                        size    5921103
 
 categories              textproc
 license                 {LGPL-2+ GPL-3+}

--- a/textproc/libiconv/files/patch-Makefile.devel
+++ b/textproc/libiconv/files/patch-Makefile.devel
@@ -1,11 +1,10 @@
---- Makefile.devel.orig	2019-04-26 14:00:57.000000000 -0500
-+++ Makefile.devel	2019-06-24 06:10:29.000000000 -0500
-@@ -118,7 +118,7 @@
- 	$(CC) $(CFLAGS) lib/genaliases.c -o genaliases
+--- Makefile.devel.orig	2024-11-26 05:56:55.000000000 +0000
++++ Makefile.devel	2024-11-26 05:56:55.000000000 +0000
+@@ -146,7 +146,7 @@
  	./genaliases lib/aliases.gperf canonical.sh canonical_local.sh
  	$(RM) genaliases
 -	$(GPERF) -m 10 lib/aliases.gperf > tmp.h
 +	$(GPERF) lib/aliases.gperf > tmp.h
- 	$(CP) tmp.h lib/aliases.h
+ 	sed -e 's/^\(const struct alias \)/static \1/' < tmp.h > lib/aliases.h
  	sh canonical.sh > lib/canonical.h
  	sh canonical_local.sh > lib/canonical_local.h


### PR DESCRIPTION
## Summary
- Update libiconv from 1.18 to 1.19
- Updated `patch-Makefile.devel` (FreeBSD-only) for changed surrounding context
- `patch-src-Makefile.in-darwin.diff` and `patch-utf8mac.diff` apply cleanly without changes
- Builds successfully to destroot

## Test plan
- [x] Verified all patches apply cleanly against 1.19 source
- [x] Built to destroot successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)