### PR TITLE
claude-code: update to 2.1.196

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.195
+version             2.1.196
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  ae5a33aec02286e192a8cfbf2faff2681514a7f9 \
-                 sha256  7eb8716e6d6e6a278d13158793529336290837fca457facfec656f1b1a287c60 \
-                 size    234066032
+    checksums    rmd160  466d80a2adc0eb5bb486f87875679b52f551f5d6 \
+                 sha256  32c74d66e27b9ca77aea638fc46cb11c90470bd0d294b2a981065da8896d1ee0 \
+                 size    235139408
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5efb5a9ddc493cfea68918e604101f9d988f2d1e \
-                 sha256  8b45adad93f336ab95f33e714494b19fd3377a494eb05c122c8677bc895876ad \
-                 size    224682640
+    checksums    rmd160  e80f5f03259a3aff6a8f7135b4d4039d7203b41e \
+                 sha256  6fc6e61ab7582c2bf241225ff90d9f79e91d69380cb9589fc9dedd3a30070f5a \
+                 size    225782608
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.196.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?