### PR TITLE
mp3rgain: update to 2.9.2

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.1 v
+github.setup        M-Igashi mp3rgain 2.9.2 v
 github.tarball_from archive
 revision            0
 
@@ -26,13 +26,13 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  142150ff09394e441f1dfcede2d1b64209ed8f13 \
-                    sha256  1345bfc3dc7f918cef48474329f0525415901be0c7f502da01aa09c46b2d0b74 \
-                    size    503488
+                    rmd160  44723a8c7925b7b7c60f6d2cacdc0830e371c3b8 \
+                    sha256  f62a455b7477158c27c41dcf316c613c984f43a0f8514f2c9535e8c9e7804a95 \
+                    size    516563
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
-    anyhow                       1.0.102          7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    anyhow                       1.0.103          2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
     autocfg                      1.5.0            c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     bitflags                     2.11.0           843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
     bumpalo                      3.20.2           5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \


### PR DESCRIPTION
Update audio/mp3rgain to 2.9.2.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.2

- Bumped version; reset revision to 0.
- Recomputed rmd160/sha256/size for the v2.9.2 source tarball.
- Updated the anyhow crate (1.0.102 -> 1.0.103) in cargo.crates.

The release fixes a ReplayGain analysis bug (silent windows were dropped from the loudness histogram, causing sparse material like acapellas to read too loud).