### PR TITLE
ipsw: Update to 3.1.700

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -7,7 +7,7 @@ PortGroup               golang 1.0
 # maintains a release schedule. Update every 5th release, unless
 # a hotfix is necessary, only.
 
-go.setup                github.com/blacktop/ipsw 3.1.680 v
+go.setup                github.com/blacktop/ipsw 3.1.700 v
 revision                0
 categories              security devel
 license                 MIT
@@ -21,9 +21,9 @@ long_description        {*}${description}. Everything you need to start \
 
 homepage                https://blacktop.github.io/ipsw
 
-checksums               rmd160  cd1dfe1d7eef6d0f543498de0c8e2bbb65780831 \
-                        sha256  ae797d794f1441afe8ab088e50301a92c96e5caf5d3bd1818a7f6e74a4bb5a4d \
-                        size    12572120
+checksums               rmd160  14cce6afda6d318f383d6ebc5f72448f89addb70 \
+                        sha256  4a2f85f5b1efcc9e857ebacb935bf12ff98b5e9377779d90563c47954c90c99b \
+                        size    12854528
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.700

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
