### PR TITLE
camlp5: update to 8.05.02

### DIFF
--- a/editors/ledit/Portfile
+++ b/editors/ledit/Portfile
@@ -23,9 +23,9 @@ checksums           rmd160  a9c31a53816dae63b356a5b2a5c289f894b2f403 \
                     size    25419
 github.tarball_from archive
 
-depends_build       port:ocaml
-depends_lib         bin:camlp5:camlp5 \
-                    port:ocaml-camlp-streams \
+depends_build       port:ocaml \
+                    port:camlp5
+depends_lib         port:ocaml-camlp-streams \
                     port:ncurses
 
 use_parallel_build  no

--- a/genealogy/geneweb/Portfile
+++ b/genealogy/geneweb/Portfile
@@ -22,10 +22,10 @@ checksums           rmd160  97f060aec92e757499eb8adb3979178c7feefa59 \
                     sha256  5599ed26d69e65ac59a55c73efd806c6cebf8e0aeb4bd1173123621084d4aae8 \
                     size    8920128
 
-depends_build       port:ocaml-dune
+depends_build       port:ocaml-dune \
+                    port:camlp5
 
 depends_lib         port:ocaml \
-                    port:camlp5 \
                     port:ocaml-calendars \
                     port:ocaml-camlp-streams \
                     port:ocaml-cppo \

--- a/lang/camlp5/Portfile
+++ b/lang/camlp5/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        camlp5 camlp5 8.05.01
+github.setup        camlp5 camlp5 8.05.02
 github.tarball_from archive
-revision            2
+revision            0
 categories          lang ocaml
 license             BSD
 maintainers         {pmetzger @pmetzger} openmaintainer
@@ -24,9 +24,9 @@ long_description    Camlp5 is a preprocessor and pretty-printer for \
 
 homepage            https://camlp5.github.io/
 
-checksums           rmd160  69c8ee14343af0c0d2f381a88b28d29462dcf82c \
-                    sha256  7aa71c393cf4f24860051a5aa78da8925d73cb79ba045df442dff2343b1283d7 \
-                    size    1506086
+checksums           rmd160  53af269ac6f8bdb7f001bfbc8acd8627035ece7b \
+                    sha256  ceceb2377563f5483738090b614447536daa4cea119dc768a0659543727b4497 \
+                    size    1506228
 
 depends_build       bin:perl:perl5
 depends_lib         port:ocaml \

--- a/ocaml/ocaml-ulex/Portfile
+++ b/ocaml/ocaml-ulex/Portfile
@@ -7,7 +7,7 @@ PortGroup           ocaml 1.1
 name                ocaml-ulex
 github.setup        whitequark ulex 1.3 v
 github.tarball_from archive
-revision            4
+revision            5
 categories          ocaml devel textproc
 license             BSD
 maintainers         {landonf @landonf} openmaintainer


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Bump revision of ocaml-ulex for updated camlp5.
Move camlp5 to depends_build in geneweb and ledit, where it is only used as a preprocessor at build time and not needed at runtime.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
