### PR TITLE
vale: update to 3.15.1

### DIFF
--- a/textproc/vale/Portfile
+++ b/textproc/vale/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/errata-ai/vale 3.14.1 v
+go.setup            github.com/errata-ai/vale 3.15.1 v
 github.tarball_from archive
 checksums           ${distname}${extract.suffix} \
-                      rmd160  971f8dc30285b168bd187be79b62d6f207282954 \
-                      sha256  2b56cb18274a881c8d18d4751cd8c05283529ca8e4934fc0ff8f059113131c86 \
-                      size    9737478
+                    rmd160  91be0b726a18b5d174b74afc3d108ce18508e6fc \
+                    sha256  f2dc8fd38deb4789a780f5e2f1fbb8489c45333ccd6e923999e528d78efe297a \
+                    size    9750315
 
 categories          textproc
 maintainers         nomaintainer
@@ -82,21 +82,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  03f45e9801b38da949e34fec0c1881c96d6fa37d \
                         sha256  c8f968af54b9283119a9132ff6748f081afdd6b52deef111f6ac680c00a01f19 \
                         size    35179 \
+                    github.com/tomwright/dasel/v3 \
+                        lock    v3.10.1 \
+                        rmd160  42c6c4065010e84991599dfcf2f4500627bef463 \
+                        sha256  f7431371fa2b32e6f803c21deb4ba132543bfaf7e939037c0f939713216f82ba \
+                        size    3177198 \
                     github.com/tomwright/dasel/v2 \
                         lock    v2.8.1 \
                         rmd160  aab7df3c3c1d6d892b041f8897608740a0872850 \
                         sha256  e5240bd280c9fe1be15b350b91b1b088771d2d844cc89ccc5430ed3ba6983392 \
                         size    2794438 \
-                    github.com/tomwright/dasel \
-                        lock    v3.3.1 \
-                        rmd160  c49ecf35c4c51bcc70797296cc2f2a4d1c2100a1 \
-                        sha256  ee09b15af24f9bc26f15afd0aa5af077724a7bfa53adcc52ee919b8fac6a9d42 \
-                        size    3113877 \
-                    github.com/stretchr/testify \
-                        lock    v1.11.1 \
-                        rmd160  d6dec631a506398b8b731a0476b9e44c206243ac \
-                        sha256  759279b90772bfc79db1620874f45eb008aceab35b14f007cb4ab8316a2398db \
-                        size    116867 \
                     github.com/spf13/pflag \
                         lock    v1.0.5 \
                         rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
@@ -117,16 +112,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  f5d4faeaee2a7c3dbde037dbfb223f22e6d270a0 \
                         sha256  0cb83ee13420134951fdc8e07092061467bdcbd5574f1ee7c71c32c112cd2613 \
                         size    53702 \
-                    github.com/sergi/go-diff \
-                        lock    v1.2.0 \
-                        rmd160  0ee3ab8df694f8b9d8aeea2309da3512aa6ade66 \
-                        sha256  c01c182c57692b98bc38d787e7428c63a11338a8f1a1931427ab184bbdf59df0 \
-                        size    1333604 \
-                    github.com/rogpeppe/go-internal \
-                        lock    v1.9.0 \
-                        rmd160  acb8f644e5634bdae632cdb61ea736422aeb88f0 \
-                        sha256  65b0852e5c78fa920fef2176fa17180bf1f7f32a1163baacb44c2aa480845a16 \
-                        size    133682 \
                     github.com/remeh/sizedwaitgroup \
                         lock    v1.0.0 \
                         rmd160  284f09ac7768fda039f764409c1540f57d47b1d0 \
@@ -137,41 +122,41 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  0b404c978593496d7cd8cc556e9d064e55db9732 \
                         sha256  aa24a7030263ed321610312a16942d5174f972b21d280316ef7bc3429c2d8aa6 \
                         size    198673 \
-                    github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
-                    github.com/pelletier/go-toml \
+                    github.com/pelletier/go-toml/v2 \
                         lock    a0e846496753 \
                         rmd160  aec534d8209dbba5c0c86a4f421a0275860e5be0 \
                         sha256  d0db5e87864ba29559b85c20848a5af999270abaf637e04ad934c146ca5b9ebf \
                         size    917671 \
-                    github.com/otiai10/mint \
-                        lock    v1.5.1 \
-                        rmd160  8aaf21bd738c31bc0f17384f037099424535e070 \
-                        sha256  bae652a615d562b8e749454dbacf845d9afbbf06d188ee97ac10d26d2fcfc221 \
-                        size    7869 \
                     github.com/otiai10/copy \
                         lock    v1.14.0 \
                         rmd160  2dd5e9499c52d770586396cbce4612e5acd8d168 \
                         sha256  8a4ee1cb4e58abc259dc171a7db51d84c2c1776baeebc79db67cc1a77e3d2e8d \
                         size    20327 \
                     github.com/olekukonko/tablewriter \
-                        lock    v0.0.5 \
-                        rmd160  aa952a560c3aa5102bfb3e55f12facf048379adf \
-                        sha256  830bdee7f05aa76353c113075a864359762a502c6d6a1f72bfb7055247c0539b \
-                        size    19579 \
+                        lock    v1.1.4 \
+                        rmd160  ec80775a3b916809da09618e728892c8ad8960cf \
+                        sha256  357fd62a3526ad2d12608405316009e771ff7b59acdb56c9f482084632463464 \
+                        size    419811 \
+                    github.com/olekukonko/ll \
+                        lock    v0.1.6 \
+                        rmd160  3780a939722b970712cf788d17f589d725fafbfc \
+                        sha256  71a91988c1f134bc9fc5f2997ffa0c0da8138cdd2697ecc5a66bdb2c47bd77f8 \
+                        size    305821 \
+                    github.com/olekukonko/errors \
+                        lock    v1.2.0 \
+                        rmd160  fc715c294fe383e2a171f38d8b0cb540504b499c \
+                        sha256  95d071c82e2dfa71b180dbd67801f0bd9e630975fdf38898f1c3f977cda7ee88 \
+                        size    79251 \
+                    github.com/olekukonko/cat \
+                        lock    50322a0618f6 \
+                        rmd160  84cab2cb154c2eeca9defa29d169bb83b352ad38 \
+                        sha256  add453f3b0fe4a68ff7067041986f268820c82a1991b95ff5b178f69689a63e6 \
+                        size    18587 \
                     github.com/niklasfasching/go-org \
                         lock    v1.7.0 \
                         rmd160  4a36aac160516ea3592d7ffcfd157f916794c1ff \
                         sha256  b7aeaf8fb6cf88a423235ddc69087baa37629850d7515516692fab5ac93b7720 \
                         size    241270 \
-                    github.com/neurosnap/sentences \
-                        lock    v1.1.2 \
-                        rmd160  743d4e2caf0bc9e06de827694b5dfcfd92fea31f \
-                        sha256  a139a8c7fb22fc2934312cdd9eeeadc25f053634d392fd3ff091ed8b88d1303a \
-                        size    5198729 \
                     github.com/montanaflynn/stats \
                         lock    v0.7.1 \
                         rmd160  02861be5d0622683a277ca0cb9443a24a54d1f30 \
@@ -197,21 +182,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  b0f62e2f1c2086189f2ed14ad635733c4e5ced56 \
                         sha256  6f5a00cdfbf4d88d05406a07bb95c34dc0abc2f65f15e9c5ca35814f4008b82f \
                         size    20550 \
-                    github.com/kr/text \
-                        lock    v0.2.0 \
-                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
-                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
-                        size    8702 \
-                    github.com/kr/pretty \
-                        lock    v0.3.1 \
-                        rmd160  8c08579b4c56cdc958794e77afe3413e80aa67c3 \
-                        sha256  7fcea475d6280976cf4a838e75d2b3a4105827316e588a80e49e8063d950c999 \
-                        size    10232 \
-                    github.com/klauspost/cpuid \
-                        lock    v2.0.12 \
-                        rmd160  e4fc07a2cfad3b9da39ebd0c41fd779938ec8924 \
-                        sha256  88ebd59c61cad2d99148d8deecc758ddb70358fd6ce964e4edd70fabc0aad76f \
-                        size    343280 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.14 \
+                        rmd160  5b6117d2728f6478faf0be5b8790425fed6c4ad8 \
+                        sha256  6661917405b168f0c8b92a2be524e668ee1c29b393353639453cb8f9c2f7eff8 \
+                        size    9806 \
                     github.com/jdkato/twine \
                         lock    v0.10.2 \
                         rmd160  1cd3dcdf73fb7f60a399273de76664564596f3df \
@@ -237,26 +217,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  3d4f6f95018c6313f7258805845eb2a7e717850c \
                         sha256  72700459e75cad2b36586e8a13aa12c2d6248c45db24d1eebf41e18b1ec1c811 \
                         size    20895 \
-                    github.com/google/go-cmp \
-                        lock    v0.7.0 \
-                        rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \
-                        sha256  b621b304b529134076c9ebe09343aea7add039cd98e68be7e5a616245b0c3d03 \
-                        size    105180 \
-                    github.com/goccy/go-json \
-                        lock    v0.10.5 \
-                        rmd160  45f43805f73da9bdb84ee6e8190ac444b025e340 \
-                        sha256  61acf13f9a2968ed3f5134d48556232a2b3f678c544e75d24b7ae66cbdc569a8 \
-                        size    399162 \
                     github.com/gobwas/glob \
                         lock    v0.2.3 \
                         rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
                         sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
                         size    25971 \
-                    github.com/frankban/quicktest \
-                        lock    v1.14.6 \
-                        rmd160  d517a6cb2f6acc7f969c9ed49f464014a717bf98 \
-                        sha256  0142a3dd40b949b4d7e86768020e5f3c08fe026447458fd975b1b4c1f18b0745 \
-                        size    40112 \
+                    github.com/fatih/color \
+                        lock    v1.18.0 \
+                        rmd160  cea38fd7fdad5b4b20f519ebd1301bc2c277f54b \
+                        sha256  e085d36aabb91de9adfa7ff605a06a342b6bc583e3bbb8ce49605590f4e0bd71 \
+                        size    12711 \
                     github.com/expr-lang/expr \
                         lock    v1.17.7 \
                         rmd160  1e82d735e0347db673b108bc4471a5f61ff49531 \
@@ -272,27 +242,27 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  6db9d7c842d78eb3877fed489bf2b29cc85654e4 \
                         sha256  77d0eda3c25f479fceb5c90e621437043d0a8786b6388fb750de927b5286202c \
                         size    30662 \
-                    github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171 \
-                    github.com/d5/tengo \
+                    github.com/d5/tengo/v2 \
                         lock    v2.17.0 \
                         rmd160  266bcefd922ecd627a8bc5597716fdea7dbe7480 \
                         sha256  5f63f2ee2d6cb9ca369279a07564830060359eef16e630be8308a780d9ab390c \
                         size    173107 \
-                    github.com/clipperhouse/uax29 \
-                        lock    v2.5.0 \
-                        rmd160  125722e2638157946407f0be25e3e46f69a777b7 \
-                        sha256  64652c06538cf011435bdc7be18693b4f646607c329f16f243bf5d11d5ab4eb9 \
-                        size    315597 \
-                    github.com/clipperhouse/stringish \
-                        lock    v0.1.1 \
-                        rmd160  83e859a426d4041c5fc3d756c082786bd4d8132c \
-                        sha256  8ff258affd8bbada149f5ef799bf99391494faa86a9fa88f04c26c51db63db12 \
-                        size    2316908 \
-                    github.com/bmatcuk/doublestar \
+                    github.com/clipperhouse/uax29/v2 \
+                        lock    v2.6.0 \
+                        rmd160  af1e479a77993e1d3dfaeb3b09b38037780bffdb \
+                        sha256  7e4795b71d2ffe90c054fdb15a5683d1252a94a9a31e4ca2f8d44f9b1031f1f0 \
+                        size    316119 \
+                    github.com/clipperhouse/displaywidth \
+                        lock    v0.10.0 \
+                        rmd160  ef2e531d99f5ddc737dfa51e9527ef2656fc00d8 \
+                        sha256  f70e21d79ab6daecf0ce035fce9d7535baef73167d1078d3b2fc9eb0bdf0de0b \
+                        size    246331 \
+                    github.com/cespare/xxhash/v2 \
+                        lock    v2.3.0 \
+                        rmd160  dfed275969e04769f613bd08336420dc9009794a \
+                        sha256  79cc788ad30f0d7987fb1f259f21477a74178e30f4a2b2803af2b43c3ebcfa91 \
+                        size    12704 \
+                    github.com/bmatcuk/doublestar/v4 \
                         lock    v4.7.1 \
                         rmd160  d743f293d5f7ee27bffda5bf25bd20be9b7eb38c \
                         sha256  b614d25a46b586edf0139619c759ba6a000409824c73337d9f9f8074f9d93300 \
@@ -317,12 +287,12 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  63c38d59e391efd2f301b0deb386ce3bc0a6c6b3 \
                         sha256  067f2aebf5ac6fa16c775ffd568816149260371714512135d0373bea2de65289 \
                         size    10107 \
-                    github.com/Masterminds/sprig \
+                    github.com/Masterminds/sprig/v3 \
                         lock    v3.3.0 \
                         rmd160  69b6f7483e18f8cf9c5ea026651dbf288e41ff49 \
                         sha256  7b7ce30fb6e40d50ba754a741fea77b65a7fe9576bdd780d87517fd3a44e13f7 \
                         size    56073 \
-                    github.com/Masterminds/semver \
+                    github.com/Masterminds/semver/v3 \
                         lock    v3.3.1 \
                         rmd160  c43013f94e9b042bcbf319e5cb7268f514b01458 \
                         sha256  c377a81e270bb33f2be86f8f3759b5320df91306f36d2ad444578e9ea7b63fb9 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
