### PR TITLE
claude-code: update to 2.1.197

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.196
+version             2.1.197
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  466d80a2adc0eb5bb486f87875679b52f551f5d6 \
-                 sha256  32c74d66e27b9ca77aea638fc46cb11c90470bd0d294b2a981065da8896d1ee0 \
-                 size    235139408
+    checksums    rmd160  549bf9724e59399ec0f24da45ec5671c38217fcd \
+                 sha256  5e8a57cc7a92377f0744fa4c79191cf93d4b26c79cb919b07a407511fed1be26 \
+                 size    235288016
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e80f5f03259a3aff6a8f7135b4d4039d7203b41e \
-                 sha256  6fc6e61ab7582c2bf241225ff90d9f79e91d69380cb9589fc9dedd3a30070f5a \
-                 size    225782608
+    checksums    rmd160  21e6bf543bb22a4c872354b8ee5744bd44e9a4b6 \
+                 sha256  8cc0c4d1e4eb1dca3b0cc92ab02ee3505de764e023f8c901761c167b72041fb8 \
+                 size    227251472
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.197.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?