### PR TITLE
openjdk25-graalvm: update to 25.1.3

### DIFF
--- a/java/openjdk25-graalvm/Portfile
+++ b/java/openjdk25-graalvm/Portfile
@@ -18,38 +18,27 @@ license          GPL-2 NoMirror
 universal_variant no
 
 # https://github.com/graalvm/graalvm-ce-builds/releases
-supported_archs  x86_64 arm64
+supported_archs  arm64
 
-version          ${feature}.0.2
-set build        10
+version          ${feature}.1.3
+set build        9
 revision         0
+
+set jdk_version  ${feature}.0.3
 
 description GraalVM Community Edition based on OpenJDK ${feature} (Long Term Support)
 long_description {*}${description} \
 \n\nGraalVM is an advanced JDK with ahead-of-time Native Image compilation
 
-master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${version}/
 
-if {${configure.build_arch} eq "x86_64"} {
-    # 25.0.1 was the last version with support for macOS/x64: https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.1
-    version ${feature}.0.1
-    set build        8
-    set graalvm_arch x64
-    checksums    rmd160  f22f3693a6a0aa5a6519ca1af12f8ba6c828716d \
-                 sha256  a3d895b4cd1c783badbd277ec70409806bd4102fca0d2a60dbaeb0bab41aec30 \
-                 size    309820209
-} elseif {${configure.build_arch} eq "arm64"} {
-    set graalvm_arch aarch64
-    checksums    rmd160  50da97da02c8c291e883314bd653e40d03319215 \
-                 sha256  50201fb8e8e653e7a253d955877a6b6ad634b42e60c84f45df7e1bb51361635f \
-                 size    325426892
-} else {
-    set graalvm_arch unsupported_arch
-}
+checksums    rmd160  ab24742c988bf12f126c32aedda38b8d769fd382 \
+             sha256  b41cdde27691a0e04a1f2b0660624bc37e59c738e536888860c4c9f65a4a9a3b \
+             size    336020050
 
-distname     graalvm-community-jdk-${version}_macos-${graalvm_arch}_bin
+distname     graalvm-community-jdk-${feature}i1-${jdk_version}_macos-aarch64_bin
 
-worksrcdir   graalvm-community-openjdk-${version}+${build}.1
+worksrcdir   graalvm-community-${version}+${build}.1
 
 homepage     https://www.graalvm.org
 


### PR DESCRIPTION
#### Description

Update to GraalVM Community 25 Innovation 1 (graal 25.1.3, jdk 25.0.3).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?