### PR TITLE
micronaut: update to 5.0.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.0.2 v
+github.setup    micronaut-projects micronaut-starter 5.0.3 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  c9ab8d59c0854c2349a34ae141d9a08cd6fffdd4 \
-                 sha256  c9fce15598a2f38afa62f632e92d370d25fed6f22b4f9a64334208b9bfeb36fb \
-                 size    33773853
+    checksums    rmd160  cfa7076fe0d75684185e6c3c4a154b4b4747c89b \
+                 sha256  6304f73116620bcff3c7a6abee1a7c626b18f92c7b33e741b12a25dafdd80790 \
+                 size    33756099
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  0c4992fac04ed896f1ba3b6cc702f76a26b5328e \
-                 sha256  e5b85f3787526145d6a0ef9e58cb3b775288c68678accbd2159d77b207978e11 \
-                 size    38528422
+    checksums    rmd160  ab20a28fc80652664f9cdd9d393bdce7d40a12e8 \
+                 sha256  57091ea0048a0319cb15712ee7fc2389456aae6f4dbcc03d8a0251eacc7df646 \
+                 size    38798080
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.0.3.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?