### PR TITLE
rust: update to 1.96.1, revbump cargo

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -11,8 +11,8 @@ name                    cargo
 if {${os.platform} eq "darwin" && ${os.major} > 16} {
     # (CURRENT) macOS 10.13 and later
     github.setup        rust-lang ${name} 0.97.2
-    rust_build.version  1.96.0
-    revision            0
+    rust_build.version  1.96.1
+    revision            1
 } else {
     # macOS 10.12 and earlier
     github.setup        rust-lang ${name} 0.79.0

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -36,7 +36,7 @@ name                        rust
 # Keep macOS 10.12 and below frozen to 1.78.0
 if {${os.platform} eq "darwin" && ${os.major} > 16} {
     # (CURRENT) macOS 10.13 and later
-    version                 1.96.0
+    version                 1.96.1
     revision                0
 } else {
     # macOS 10.12 and earlier
@@ -135,9 +135,9 @@ distfiles                   ${distname}${extract.suffix}:apple_vendor
 if {${os.platform} eq "darwin" && ${os.major} > 16} {
     # (CURRENT) macOS 10.13 and later
     checksums-append        rustc-${version}-src${extract.suffix} \
-                            rmd160  9b171ad26300c120f3dd6f953f95d35a5d15f4c1 \
-                            sha256  e90a9eb153b2948afac840dbe9d77b64e376706f2864387ee7717f7450043b44 \
-                            size    528339182
+                            rmd160  4011d6f149d3181ddf0d10480987c53f4f1a098a \
+                            sha256  d0a9b5198c41868538ae12af28064163551d06dcceab11ef0b1bc9aa6e98b7a7 \
+                            size    528742024
 
     patchfiles-append       patch-symlink.diff
 } else {


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
