### PR TITLE
ocaml-pcre: update to 8.0.5

### DIFF
--- a/ocaml/ocaml-pcre/Portfile
+++ b/ocaml/ocaml-pcre/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-pcre
-github.setup        mmottl pcre-ocaml 7.5.0
-revision            3
+github.setup        mmottl pcre-ocaml 8.0.5
+revision            0
 categories          ocaml devel
 maintainers         nomaintainer
 license             LGPL-2.1
@@ -18,9 +18,9 @@ long_description    This OCaml-library interfaces the PCRE (Perl-compatibility r
 
 homepage            https://mmottl.github.io/pcre-ocaml/
 
-checksums           rmd160  c822f1bbed673c134609e34b467fca6b41525f1c \
-                    sha256  4f047eff30b7715c58c2ca3c98c0c741884f28d8ee99847688be66703661ebe4 \
-                    size    47652
+checksums           rmd160  718c771d16ca2cbfe1f68ccb6b929f9c18996d37 \
+                    sha256  2c6fdb3d134d977862bb50b840af7ce52c1f1fb94d53aacbf6e9a6758f781d2e \
+                    size    51846
 github.tarball_from archive
 
 depends_lib-append  port:pcre
@@ -36,10 +36,7 @@ oasis.configure.args-append "--override docdir ${prefix}/share/doc/${name}"
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} CHANGES.md README.md pre-v7.3.0-CHANGES.txt \
+    xinstall -m 644 -W ${worksrcpath} CHANGELOG.md README.md \
          ${destroot}${prefix}/share/doc/${name}
     file copy ${worksrcpath}/examples ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.type      regex
-livecheck.regex     {>pcre-ocaml-release-(.*)\.tar\.bz2}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The public pcre.mli interface is unchanged between 7.5.0 and 8.0.5, so no revision bumps are needed for dependents.

Also fix the post-destroot doc install list (CHANGES.md was renamed to CHANGELOG.md, pre-v7.3.0-CHANGES.txt no longer exists upstream) and drop the stale livecheck.regex left over from before the port switched to the github PortGroup; the default github livecheck now works.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
