### PR TITLE
ocaml-topkg: update to 1.1.1

### DIFF
--- a/ocaml/ocaml-topkg/Portfile
+++ b/ocaml/ocaml-topkg/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup ocaml     1.1
 
 name                ocaml-topkg
-version             1.0.7
-revision            2
+version             1.1.1
+revision            0
 
 categories          ocaml devel
 maintainers         {landonf @landonf} openmaintainer
@@ -24,10 +24,12 @@ distname            topkg-${version}
 use_bzip2           yes
 extract.suffix      .tbz
 
-checksums           rmd160  c40691219db5e17b37d919b4d45f558843089b67 \
-                    sha256  5fc22ad3f3ad6d127cb1245d18580881478da2d6de50b2315e6dd4586c52be19 \
-                    size    96661
+checksums           rmd160  a2cfbb9e31837b022c6eee24d1944a20141bf4a4 \
+                    sha256  20da062dc9cea21b5c728f22c986ed3e3d57310e643260160a802d559712f6fc \
+                    size    96571
 
 # We use our own build_type to build/install; the ocaml portgroup
 # is smart enough to not create a circular dependency.
 ocaml.build_type    topkg
+
+livecheck.name      topkg


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Also fix livecheck: the default regex was built from livecheck.name, which defaults to ${name} (ocaml-topkg), but distfiles are named topkg-X.Y.Z.tbz. Set livecheck.name explicitly, matching the same fix already in ocaml-astring, ocaml-bos, and ocaml-rresult.

ocaml-topkg is only consumed via depends_build (ocaml.build_type topkg), never depends_lib, so no dependent ports need a revision bump for this update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
