### PR TITLE
ocaml-cudf: bump revision to rebuild against current OCaml

### DIFF
--- a/devel/libCUDF/Portfile
+++ b/devel/libCUDF/Portfile
@@ -38,6 +38,8 @@ post-patch {
 subport ocaml-cudf {
     PortGroup           ocaml 1.1
 
+    revision            1
+
     ocaml.build_type    dune
 
     depends_lib-append  port:ocaml-extlib


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The ocaml-cudf subport was missed by both the OCaml 5.4.1 and 5.5.0 cascade revbumps (4c8893022ea, a776172ef66), unlike its sibling subport libCUDF which was bumped in both. Its published archive is therefore still built against a pre-5.x OCaml, so libCUDF's build now fails linking against its stale .cmi files:

    Error: /opt/local/lib/ocaml/site-lib/cudf/cudf_parser.cmi
           is not a compiled interface for this version of OCaml.

Fixes: https://trac.macports.org/ticket/74170

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
