### PR TITLE
pi-coding-agent: update to 0.80.3

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.80.2
+version             0.80.3
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  d9cf2f5f2b882628062ef9f310c946bc4f8f2526 \
-                    sha256  9cab186615345f3cc2ab1d35f7d6f139306a3122a030a45f7c245489f7349085 \
-                    size    4803981
+checksums           rmd160  9b4ad1c14e5553f90d2f28253c0ecf9ab9d52149 \
+                    sha256  155c5800134cb8df6c47adb3eab56415e8fa7746e0b1cba6687134137c451d90 \
+                    size    4818396
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
