### PR TITLE
llvm-devel: update to 20260701-4a11eb33 (LLVM 23)

### DIFF
--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -25,20 +25,19 @@ PortGroup github        1.0
 
 # BEFORE UPDATING to a new upstream commit:
 # Change github.tarball_from (see below)
-set llvm-commit         408a2e7cee3f4bcdcbc4d3dbb13fea3ecd5788d4
-set date                20250908
-revision                2
+set llvm-commit         4a11eb33c70af70bbb5942bf644b6af64386970a
+set date                20260701
+revision                0
 set llvm_version        devel
-set clang_exe_version   22
+set clang_exe_version   23
 github.setup            llvm llvm-project ${llvm-commit}
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from     tarball
+github.tarball_from     archive
 version                 ${date}-[string range ${llvm-commit} 0 7]
 default_variants-append +assertions
 
-checksums               rmd160  e1583512e285b4d0127351ba85500f3cc3bbd04c \
-                        sha256  1df234b4de8fd4b5a4ba277d80989718fc656a08e60e82d0137e306ad3e9a854 \
-                        size    247257333
+checksums               rmd160  fd544309521247ad2f220d8d591830d0648022b0 \
+                        sha256  9bc06d321a95d1170631a95369a03178634c2f5043375e6392cf04fa3ea20d30 \
+                        size    276245914
 
 # For release
 #set llvm_version        14
@@ -50,9 +49,9 @@ checksums               rmd160  e1583512e285b4d0127351ba85500f3cc3bbd04c \
 
 name                    llvm-${llvm_version}
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 2 }
+subport                 clang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version}  { revision 0 }
-subport                 flang-${llvm_version} { revision 1 }
+subport                 flang-${llvm_version} { revision 0 }
 
 dist_subdir             llvm
 set suffix              mp-${llvm_version}
@@ -96,7 +95,8 @@ configure.args-append \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=${prefix}/include \
-    -DFFI_LIBRARY_DIR=${prefix}/lib
+    -DFFI_LIBRARY_DIR=${prefix}/lib \
+    -DLLVM_ENABLE_BINDINGS=OFF
 
 # Disable iOS support
 # To Be reviewed with later versions

--- a/lang/llvm-devel/files/0002-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
+++ b/lang/llvm-devel/files/0002-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
@@ -2,23 +2,24 @@ diff --git a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp b/llvm/lib/CodeGen/AsmPr
 index 2297b27ffdc0..35578040d951 100644
 --- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
 +++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
-@@ -461,13 +461,15 @@ bool AsmPrinter::doInitialization(Module &M) {
+@@ -549,13 +549,15 @@ bool AsmPrinter::doInitialization(Module &M) {
    // alternative is duplicated code in each of the target asm printers that
    // use the directive, where it would need the same conditionalization
    // anyway.
--  const Triple &Target = TM.getTargetTriple();
 -  if (Target.isOSBinFormatMachO() && Target.isOSDarwin()) {
 -    Triple TVT(M.getDarwinTargetVariantTriple());
 -    OutStreamer->emitVersionForTarget(
-+  if (MAI->useIntegratedAssembler()) {
-+    const Triple &Target = TM.getTargetTriple();
+-        Target, M.getSDKVersion(),
+-        M.getDarwinTargetVariantTriple().empty() ? nullptr : &TVT,
+-        M.getDarwinTargetVariantSDKVersion());
++  if (MAI.useIntegratedAssembler()) {
 +    if (Target.isOSBinFormatMachO() && Target.isOSDarwin()) {
 +      Triple TVT(M.getDarwinTargetVariantTriple());
 +      OutStreamer->emitVersionForTarget(
-         Target, M.getSDKVersion(),
-         M.getDarwinTargetVariantTriple().empty() ? nullptr : &TVT,
-         M.getDarwinTargetVariantSDKVersion());
++          Target, M.getSDKVersion(),
++          M.getDarwinTargetVariantTriple().empty() ? nullptr : &TVT,
++          M.getDarwinTargetVariantSDKVersion());
 +    }
    }
- 
+
    // Allow the target to emit any magic that it wants at the start of the file.


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Bumps the trunk snapshot from the 20250908 LLVM 22 commit to a current LLVM 23 trunk commit and sets clang_exe_version to 23. emscripten 6.0.1 hardcodes EXPECTED_LLVM_VERSION = 23, and wasm-ld from the older LLVM 22 toolchain rejected the --no-stack-first flag emcc emits, breaking every wasm link. Switch github.tarball_from to archive and reset subport revisions.

Also set -DLLVM_ENABLE_BINDINGS=OFF to match llvm-19 through llvm-22. Without it, a local build auto-detects an installed ocamlfind and builds the OCaml bindings, installing unversioned META.llvm* files that conflict on activation with any other LLVM port that still ships them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
