### PR TITLE
opencode: update to 1.17.13

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.17.11
+version             1.17.13
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  e91d6371fbf00e9221128f30b0bc282c3cd7fa32 \
-                    sha256  e3951c7f35f4b8c8f27a3185690be5244a5012b6f15a538b5d600e5b946bb6f1 \
-                    size    3046
+checksums           rmd160  cd7908d802c588e2638525fc3b3e5d7a235a3ad7 \
+                    sha256  f9601b73edf9418886daab0682fd6f84743dfb85bd27aa1007cd765fa687bc6a \
+                    size    3045


### PR DESCRIPTION
#### Description

Update to OpenCode 1.17.13.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?