### PR TITLE
ruby34: update to 3.4.10

### DIFF
--- a/lang/ruby34/Portfile
+++ b/lang/ruby34/Portfile
@@ -16,7 +16,7 @@ legacysupport.newest_darwin_requires_legacy 15
 # This property should be preserved.
 
 set ruby_ver        3.4
-set ruby_patch      9
+set ruby_patch      10
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
@@ -41,9 +41,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  ad1c871806975db852d95549be1b151649201b86 \
-                    sha256  7bb4d4f5e807cc27251d14d9d6086d182c5b25875191e44ab15b709cd7a7dd9c \
-                    size    22456968
+checksums           rmd160  fe10fc2ca86a0d5700573f7e92829c3e7d4c1cea \
+                    sha256  ecee2d072a14f2d14347dd56dfd8fe5c3130abf5117bfaacbda0f4ef9cc429ec \
+                    size    22476870
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.

--- a/lang/ruby34/files/patch-generated.diff
+++ b/lang/ruby34/files/patch-generated.diff
@@ -1,5 +1,5 @@
---- configure.orig	2026-03-11 02:51:49.000000000 -0700
-+++ configure	2026-03-14 16:14:52.000000000 -0700
+--- configure.orig	2026-06-30 03:54:37.000000000 -0700
++++ configure	2026-06-30 14:56:09.000000000 -0700
 @@ -8505,7 +8505,8 @@ printf %s "checking for $CC linker warni
  	   >/dev/null
  then :

--- a/lang/ruby34/files/patch-sources.diff
+++ b/lang/ruby34/files/patch-sources.diff
@@ -1,5 +1,5 @@
---- configure.ac.orig	2026-03-11 02:51:47.000000000 -0700
-+++ configure.ac	2026-03-14 16:14:52.000000000 -0700
+--- configure.ac.orig	2026-06-30 03:54:35.000000000 -0700
++++ configure.ac	2026-06-30 14:56:08.000000000 -0700
 @@ -446,7 +446,8 @@ AS_CASE(["$build_os"],
  	      -e '^ld: warning: text-based stub file' \
  	      -e '^ld: warning: -multiply_defined is obsolete' \
@@ -10,8 +10,8 @@
      ])
      rm -fr conftest*
      test $suppress_ld_waring = yes && warnflags="${warnflags:+${warnflags} }-Wl,-w"
---- file.c.orig	2026-03-11 02:51:47.000000000 -0700
-+++ file.c	2026-03-14 16:14:52.000000000 -0700
+--- file.c.orig	2026-06-30 03:54:35.000000000 -0700
++++ file.c	2026-06-30 14:56:08.000000000 -0700
 @@ -275,9 +275,27 @@ static CFMutableStringRef
  mutable_CFString_new(CFStringRef *s, const char *ptr, long len)
  {
@@ -40,8 +40,8 @@
      return CFStringCreateMutableCopy(alloc, len, *s);
  }
  
---- lib/bundler/gem_helper.rb.orig	2026-03-11 02:51:47.000000000 -0700
-+++ lib/bundler/gem_helper.rb	2026-03-14 16:14:52.000000000 -0700
+--- lib/bundler/gem_helper.rb.orig	2026-06-30 03:54:35.000000000 -0700
++++ lib/bundler/gem_helper.rb	2026-06-30 14:56:08.000000000 -0700
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -51,8 +51,8 @@
      end
    end
  end
---- thread_pthread.c.orig	2026-03-11 02:51:47.000000000 -0700
-+++ thread_pthread.c	2026-03-14 16:14:52.000000000 -0700
+--- thread_pthread.c.orig	2026-06-30 03:54:35.000000000 -0700
++++ thread_pthread.c	2026-06-30 14:56:08.000000000 -0700
 @@ -43,6 +43,22 @@
  
  #if defined __APPLE__


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2026/06/30/ruby-3-4-10-released/

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-26.x arm64.  Included all variants compatible with available dependencies on the respective platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.7 23J520, arm64, Xcode 16.2 16C5032a
macOS 15.7.7 24G720, arm64, Xcode 26.3 17C529
macOS 26.5.1 25F80, arm64, Xcode 26.5 17F42
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
