### PR TITLE
ocaml-re: update to 1.14.0

### DIFF
--- a/devel/everparse/Portfile
+++ b/devel/everparse/Portfile
@@ -7,7 +7,7 @@ name                everparse
 github.setup        project-everest everparse 2026.03.21 v
 github.tarball_from archive
 epoch               1
-revision            0
+revision            1
 
 categories          devel
 maintainers         {landonf @landonf} openmaintainer

--- a/lang/camlp5/Portfile
+++ b/lang/camlp5/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        camlp5 camlp5 8.05.02
 github.tarball_from archive
-revision            0
+revision            1
 categories          lang ocaml
 license             BSD
 maintainers         {pmetzger @pmetzger} openmaintainer

--- a/math/abella/Portfile
+++ b/math/abella/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        abella-prover abella 2.0.8.3 v
 
-revision            3
+revision            4
 categories          math ocaml
 maintainers         nomaintainer
 license             GPL-3

--- a/math/stanc3/Portfile
+++ b/math/stanc3/Portfile
@@ -6,7 +6,7 @@ PortGroup               ocaml 1.1
 
 github.setup            stan-dev stanc3 2.35.0 v
 epoch                   1
-revision                4
+revision                5
 categories              math lang ocaml
 maintainers             nomaintainer
 license                 BSD

--- a/ocaml/ocaml-alcotest/Portfile
+++ b/ocaml/ocaml-alcotest/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-alcotest
 github.setup        mirage alcotest 1.9.1
-revision            1
+revision            2
 categories          ocaml devel
 maintainers         nomaintainer
 license             ISC

--- a/ocaml/ocaml-camlp5-buildscripts/Portfile
+++ b/ocaml/ocaml-camlp5-buildscripts/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        camlp5 camlp5-buildscripts 0.07
 github.tarball_from archive
 name                ocaml-camlp5-buildscripts
-revision            2
+revision            3
 categories          ocaml devel
 maintainers         {pguyot @pguyot} openmaintainer
 license             BSD

--- a/ocaml/ocaml-core_extended/Portfile
+++ b/ocaml/ocaml-core_extended/Portfile
@@ -6,11 +6,11 @@ PortGroup           ocaml 1.1
 
 name                ocaml-core_extended
 github.setup        janestreet core_extended 0.17.0 v
-revision            2
+revision            3
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT
-description         Jane Street Capitalʼs standard library overlay
+description         Jane Street Capital's standard library overlay
 long_description    ${description}
 
 checksums           rmd160  9097bec4c96cad2609a5685c4f4efb95ba95dff1 \

--- a/ocaml/ocaml-expect_test_helpers_core/Portfile
+++ b/ocaml/ocaml-expect_test_helpers_core/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-expect_test_helpers_core
 github.setup        janestreet expect_test_helpers_core 0.17.0 v
-revision            2
+revision            3
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-expect_test_helpers_kernel/Portfile
+++ b/ocaml/ocaml-expect_test_helpers_kernel/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-expect_test_helpers_kernel
 github.setup        janestreet expect_test_helpers_kernel 0.13.0 v
-revision            4
+revision            5
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-jingoo/Portfile
+++ b/ocaml/ocaml-jingoo/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 name                ocaml-jingoo
 version             1.5.2
-revision            3
+revision            4
 categories          ocaml devel
 maintainers         {pguyot @pguyot} openmaintainer
 license             BSD

--- a/ocaml/ocaml-ocamlformat/Portfile
+++ b/ocaml/ocaml-ocamlformat/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ocamlformat
 github.setup        ocaml-ppx ocamlformat 0.29.0
-revision            4
+revision            5
 categories          ocaml devel
 maintainers         nomaintainer
 license             {LGPL-2.1 MIT}

--- a/ocaml/ocaml-patdiff/Portfile
+++ b/ocaml/ocaml-patdiff/Portfile
@@ -6,12 +6,12 @@ PortGroup           ocaml 1.1
 
 name                ocaml-patdiff
 github.setup        janestreet patdiff 0.17.0 v
-revision            2
+revision            3
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT
 description         Colored patience diffs with word-level refinement
-long_description    Patdiff is an OCaml implementation of Bram Cohenʼs patience diff algorithm, \
+long_description    Patdiff is an OCaml implementation of Bram Cohen's patience diff algorithm, \
                     with a few extra conveniences for comparing code and config files.
 
 checksums           rmd160  bbb18aa37e6445515ba977f82cb430f2ec70369b \

--- a/ocaml/ocaml-re/Portfile
+++ b/ocaml/ocaml-re/Portfile
@@ -5,8 +5,8 @@ PortGroup github    1.0
 PortGroup ocaml     1.1
 
 name                ocaml-re
-github.setup        ocaml ocaml-re 1.11.0
-revision            2
+github.setup        ocaml ocaml-re 1.14.0
+revision            0
 
 categories          ocaml devel
 maintainers         {landonf @landonf} openmaintainer
@@ -16,13 +16,11 @@ long_description    A pure OCaml regular expression library with support for \
                     Perl, POSIX extended, and Emacs-style regular expressions \
                     as well as shell-style file globbing.
 
-checksums           rmd160  a6875b049935de7f08dc98b6806d22ca7839e7cf \
-                    sha256  e32660b6068b78a8588ca065a6a2b01ae7339584d8261356beac0e26dbc5f854 \
-                    size    93319
+checksums           rmd160  909d28e74af264785691c584403c2c25a3a9b712 \
+                    sha256  e32eb4c6f319ff74241da9e1b00032f990241347271baf3adb468faaaa616147 \
+                    size    110936
 
 github.tarball_from archive
-
-depends_lib-append  port:ocaml-seq
 
 depends_test-append port:ocaml-ounit
 

--- a/ocaml/ocaml-sexp_pretty/Portfile
+++ b/ocaml/ocaml-sexp_pretty/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-sexp_pretty
 github.setup        janestreet sexp_pretty 0.17.0 v
-revision            2
+revision            3
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/textproc/ocaml-xtmpl/Portfile
+++ b/textproc/ocaml-xtmpl/Portfile
@@ -5,7 +5,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-xtmpl
 version             1.2.0
-revision            2
+revision            3
 categories          textproc devel ocaml
 maintainers         nomaintainer
 license             GPL-3


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Drop the depends_lib on ocaml-seq: upstream no longer requires the seq compatibility package (minimum OCaml is now 4.12.0, and the stdlib's built-in Seq module is used directly). Fixes the build failure where dune could not find library "seq".

The public re.mli/Re module interface gained new functions and modules between 1.11.0 and 1.14.0 (Re.split_delim, character classes in Re.Posix, non-raising Re.Group variants, hex/octal escapes, \Q...\E quoting, Re.Pcre.get_named_substring_opt, the experimental Re.Stream API), so dependents linking against ocaml-re need a clean rebuild. Bump revision for all direct depends_lib dependents:

  ocaml-expect_test_helpers_kernel, ocaml-ocamlformat (main subport
  only; ocaml-ocamlformat-lib does not depend on ocaml-re),
  ocaml-sexp_pretty, ocaml-patdiff, ocaml-core_extended, ocaml-jingoo,
  ocaml-alcotest, ocaml-camlp5-buildscripts,
  ocaml-expect_test_helpers_core, everparse, stanc3, abella, camlp5,
  ocaml-xtmpl

Of these, only ocaml-core_extended re-exports Re types in its own public interface (lib/selector.mli), but nothing in the ports tree depends on it, so the cascade stops there.

Also fix two pre-existing non-ASCII characters (curly apostrophes) in ocaml-patdiff and ocaml-core_extended descriptions while touching those files.

Closes: https://trac.macports.org/ticket/67356

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
