### PR TITLE
google-cloud-sdk: update to 575.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             574.0.0
+version             575.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  830e497376b34f1b0e7077d0d4b6a609fbe6ce90 \
-                    sha256  8dfab9208ef9ffe1078e5fda19aa341442a1b7e1df6fb3ca4cd5f0aeef46d97e \
-                    size    59487131
+    checksums       rmd160  c17637713c546293e090b778dfda94670bda2029 \
+                    sha256  e39d0afa34d1f661932ed3b990e586d47c39d29f9d25f3cbb379da4fb61a8b9e \
+                    size    59528822
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  32aebada9e7793821179790c16c991388c3f1132 \
-                    sha256  d59125d65f01f8eefcfcb2290dbc52aceb1d77585178370074636c0ff8bbb3cd \
-                    size    61143204
+    checksums       rmd160  64933e711025d03046cef270427c31eaadfba1e3 \
+                    sha256  1ecd73028d093885ffdb51759f0580d2c2e50ba38512e8eb02e3ff5578b44f22 \
+                    size    61185607
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  bac2dac7fac8b5f6281b3981e2d80af3cf2013bd \
-                    sha256  1dd2b9ae759cf1a64377c4e4e152303c0b42d38a8d3adabc3954cd2e9c3a62a3 \
-                    size    61048540
+    checksums       rmd160  917483910a801e46cdeb0c30f11490818b60ca6c \
+                    sha256  eb9e8aab8f86ef485e3392473bb460cd6dd00384509ce33546ad38635682ea48 \
+                    size    61093541
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 575.0.0.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?