### PR TITLE
libpsl: Remove python dependency, no longer needed

### DIFF
--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -43,19 +43,14 @@ checksums           ${main_distfile} \
                     size    302617
 
 # Please note this port is (indirectly, via cmake) a dependency of the
-# various clang-X ports. When updating the port versions (e.g. python)
+# various clang-X ports. When updating the port versions
 # used here make sure to ensure that the new port being used uses the
 # clang_dependency PortGroup to avoid circular dependencies whilst building.
 # See e.g. https://trac.macports.org/ticket/60419
 
-# DO NOT change this unless you have understood and acted on the above comment!
-set py_ver          3.10
-set py_ver_nodot    [string map {. {}} ${py_ver}]
-
 depends_build-append \
                     port:gettext \
-                    path:bin/pkg-config:pkgconfig \
-                    port:python${py_ver_nodot}
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  \
                     port:gettext-runtime \
@@ -63,20 +58,11 @@ depends_lib-append  \
                     port:libidn2 \
                     port:libunistring
 
-license_noconflict  python${py_ver_nodot}
-
 post-extract {
     # Replace older bundled publicsuffix list.
     delete ${worksrcpath}/list
     move ${workpath}/${psl_data_worksrcdir} ${worksrcpath}/list
 }
-
-post-patch {
-    reinplace "s|^#!.*|#!${prefix}/bin/python${py_ver}|" \
-        ${worksrcpath}/src/psl-make-dafsa
-}
-
-configure.python    ${prefix}/bin/python${py_ver}
 
 configure.args      --enable-builtin \
                     --enable-runtime=libidn2 \


### PR DESCRIPTION
#### Description

* Remove python dependency and related python controls.  No longer needed.
* Build dependency on python was removed upstream in [current release 0.22.0](https://github.com/rockdaboot/libpsl/releases/tag/0.22.0):
"Allow building from tarball without Python"
* Closes: https://trac.macports.org/ticket/70998
* Will mitigate python version-related problems.

Using **port rdeps libpsl**, the total number of recursive dependencies drops from 32 to 16 on macos 15.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?