### PR TITLE
mp3rgain: update to 2.9.3

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.2 v
+github.setup        M-Igashi mp3rgain 2.9.3 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  44723a8c7925b7b7c60f6d2cacdc0830e371c3b8 \
-                    sha256  f62a455b7477158c27c41dcf316c613c984f43a0f8514f2c9535e8c9e7804a95 \
-                    size    516563
+                    rmd160  5469b07f17723c882f17018eef1b9c3dd91439b3 \
+                    sha256  7b1df9a15541ecedca9bf27e7b7cc4f02706a22b577817c80d9a9b9e0c08f3db \
+                    size    517322
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update mp3rgain to 2.9.3.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.3

- Bumped `github.setup` to 2.9.3 (revision reset to 0)
- Updated rmd160 / sha256 / size for the new source tarball
- `cargo.crates` unchanged (no dependency changes since 2.9.2)