### PR TITLE
ctags: restore +regex (on newer compilers?)

### DIFF
--- a/devel/ctags/Portfile
+++ b/devel/ctags/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ctags
 version             5.8
-revision            4
+revision            5
 checksums           rmd160  191495869fbfa2f77a9619a4920eba26d02eface \
                     sha256  0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7 \
                     size    479927

--- a/devel/ctags/files/implicit.patch
+++ b/devel/ctags/files/implicit.patch
@@ -1,9 +1,10 @@
 Fix:
 
-error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
---- configure.orig	2009-07-09 17:03:57.000000000 -0500
-+++ configure	2021-01-23 01:47:41.000000000 -0600
-@@ -4337,6 +4337,7 @@
+error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
+error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+--- configure
++++ configure
+@@ -4337,6 +4337,7 @@ _ACEOF
  cat confdefs.h >>conftest.$ac_ext
  cat >>conftest.$ac_ext <<_ACEOF
  /* end confdefs.h.  */
@@ -11,11 +12,16 @@ error: implicitly declaring library function 'exit' with type 'void (int) __attr
  #include <sys/stat.h>
  int
  main ()
-@@ -6275,6 +6276,7 @@
+@@ -6275,9 +6276,10 @@ cat confdefs.h >>conftest.$ac_ext
  cat >>conftest.$ac_ext <<_ACEOF
  /* end confdefs.h.  */
  
 +#include <stdlib.h>
  #include <sys/types.h>
  #include <regex.h>
- main() {
+-main() {
++int main() {
+ 	regex_t patbuf;
+ 	exit (regcomp (&patbuf, "/hello/", 0) != 0);
+ }
+


### PR DESCRIPTION
Please see commit message.

before:

```
% /opt/local/bin/ctags --version
Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
  Compiled: Jun 10 2021, 14:06:31
  Addresses: <dhiebert@users.sourceforge.net>, http://ctags.sourceforge.net
  Optional compiled features: +wildcards
```

after:

```
% /opt/local/bin/ctags --version
Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
  Compiled: Jul  2 2026, 05:26:29
  Addresses: <dhiebert@users.sourceforge.net>, http://ctags.sourceforge.net
  Optional compiled features: +wildcards, +regex
```

(note `+regex`)

I have also tested that REs now work as expected with `--langdef`.

---

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.7 24G720 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
  (tracing is busted)
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
  (no variants)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
