### PR TITLE
libre-wd-40-git: new port

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -72,7 +72,7 @@ if {${name} eq ${subport}} {
     extract.only    git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
-    conflicts       git-devel
+    conflicts       git-devel libre-wd-40-git
 
     livecheck.type  regexm
     livecheck.regex {<span class="version">.*?(\d+\.\d+\.\d+).*?</span>}
@@ -90,7 +90,7 @@ if {${name} eq ${subport}} {
 
     build.target    all man html
 
-    conflicts       git
+    conflicts       git libre-wd-40-git
 }
 
 perl5.require_variant   false

--- a/devel/libre-wd-40-git/Portfile
+++ b/devel/libre-wd-40-git/Portfile
@@ -1,0 +1,330 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github          1.0
+PortGroup           legacysupport   1.1
+PortGroup           perl5           1.0
+PortGroup           conflicts_build 1.0
+
+legacysupport.newest_darwin_requires_legacy 11
+
+github.setup        Libre-WD-40 git 2.55.0 v -wd40
+github.tarball_from archive
+name                libre-wd-40-git
+revision            0
+
+description         A fork of Git with the Rust dependency removed
+
+long_description    ${name} is a fork of Git, the fast, scalable, distributed \
+                    open source version control system, that strips out \
+                    Git's optional Rust-based components so that it can \
+                    always be built with a C toolchain alone.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+default_variants    +doc +pcre +credential_osxkeychain +diff_highlight
+
+categories          devel
+license             GPL-2 LGPL-2.1+
+installs_libs       no
+
+conflicts           git git-devel
+
+patch.pre_args-replace  -p0 -p1
+
+checksums           rmd160  19f33a34656115befea77f7770ec2d780d5fef3e \
+                    sha256  afa37420e408677cb029d14422d082aeda4beb754923bddae4aee0c42e1500e0 \
+                    size    12188087
+
+depends_build-append \
+                    port:asciidoc \
+                    port:xmlto \
+                    port:gettext
+
+build.target        all man html
+
+perl5.require_variant   false
+perl5.conflict_variants yes
+perl5.branches          5.28 5.30 5.32 5.34
+perl5.default_branch    5.34
+perl5.create_variants   ${perl5.branches}
+
+conflicts_build     libuuid
+
+depends_lib-append  port:curl \
+                    port:zlib \
+                    port:expat \
+                    port:gettext-runtime \
+                    port:libiconv
+
+patchfiles-append   patch-Makefile.diff \
+                    patch-git-subtree.1.diff \
+                    patch-sha1dc-older-apple-gcc-versions.diff
+
+# Old Clang versions (macOS < 10.12) lack __builtin_add_overflow;
+# fall back to the manual overflow check.
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    patchfiles-append   patch-git-compat-util-no-builtin-add-overflow.diff
+}
+
+# Git 2.36.0 implements a new FSEvent listener that uses
+# the API available in Yosemite and newer.
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    patchfiles-append   patch-ignore-fsmonitor-daemon-backend.diff
+}
+
+# Git 2.40.0 fails to build on macOS 10.6 & 10.7 unless
+# USE_ENHANCED_BASIC_REGULAR_EXPRESSIONS is disabled.
+# See: https://trac.macports.org/ticket/67091
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    patchfiles-append   patch-disable-enhanced-basic-regex.diff
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Reverts breakage introduced by 51c15ac1b6ab15d8e29651d0bd364d8f62dc6509
+    # and later commits.
+    # TODO: consider convising upstream to restore fallback code.
+    patchfiles-append   patch-Revert-breaking-osxkeychain.diff
+
+    # Fix an extraction failure with some old versions of tar.
+    # https://superuser.com/questions/1219214/permissions-cannot-be-restored-for-a-tar
+    extract.post_args-append \
+                    -m --touch --no-overwrite-dir
+}
+
+use_configure       no
+
+compiler.c_standard 1999
+
+variant universal   {}
+
+set CFLAGS          "${configure.cflags} -std=gnu99 [get_canonical_archflags cc]"
+set LDFLAGS         "${configure.ldflags} [get_canonical_archflags ld]"
+
+build.args          CFLAGS="${CFLAGS}" \
+                    LDFLAGS="${LDFLAGS}" \
+                    CC=${configure.cc} \
+                    prefix=${prefix} \
+                    CURLDIR=${prefix} \
+                    ICONVDIR=${prefix} \
+                    NO_FINK=1 \
+                    NO_DARWIN_PORTS=1 \
+                    NO_R_TO_GCC_LINKER=1 \
+                    NO_PERL=1 \
+                    V=1
+
+if {[variant_isset ${perl5.variant}]} {
+    depends_lib-delete  port:perl${perl5.major}
+    depends_run-append \
+                    port:perl${perl5.major} \
+                    port:p${perl5.major}-authen-sasl \
+                    port:p${perl5.major}-error \
+                    port:p${perl5.major}-net-smtp-ssl \
+                    port:p${perl5.major}-term-readkey \
+                    port:p${perl5.major}-cgi
+
+    build.args-delete \
+                    NO_PERL=1
+
+    build.args-append \
+                    PERL_PATH="${perl5.bin}" \
+                    NO_PERL_CPAN_FALLBACK=1
+} elseif {[variant_isset svn]} {
+    pre-configure {
+        return -code error "+svn does not work without +perl5_xx"
+    }
+}
+
+test.run            yes
+test.cmd            make
+test.target         test
+test.dir            ${worksrcpath}
+pre-test {
+    test.args  {*}${build.args}
+}
+
+destroot.target     install
+pre-destroot {
+    destroot.args  {*}${build.args}
+    xinstall -m 0644 \
+        ${worksrcpath}/contrib/subtree/git-subtree.1 ${workpath}/man1
+}
+
+set docdestroot         ${destroot}${prefix}/share/doc/git-doc
+set guidir              ${prefix}/share/git-gui/lib/Git\ Gui.app/Contents
+set system_gitconfig    ${prefix}/etc/gitconfig
+
+post-destroot {
+
+    foreach f {1 5 7} {
+        xinstall -d ${destroot}${prefix}/share/man/man${f}
+
+        foreach m [glob -directory ${worksrcpath} Documentation/*.${f}] {
+            xinstall ${m} ${destroot}${prefix}/share/man/man${f}
+        }
+    }
+
+    if {![variant_isset svn]} {
+        system "rm ${destroot}${prefix}/libexec/git-core/git-svn*"
+    }
+
+    xinstall -d ${docdestroot}
+
+    fs-traverse badfile ${destroot} {
+        if {[string last perllocal.pod ${badfile}] != -1} {
+            ui_info "Removing ${badfile}"
+            file delete ${badfile}
+        }
+    }
+
+    set completions_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${completions_path}
+    xinstall -m 0644 ${worksrcpath}/contrib/completion/git-completion.bash \
+        ${completions_path}/git
+
+    set share_path ${destroot}${prefix}/share/${name}
+    xinstall -d ${share_path}
+    xinstall -m 0644 ${worksrcpath}/contrib/completion/git-prompt.sh \
+        ${share_path}/git-prompt.sh
+
+    xinstall -d ${destroot}${prefix}/libexec/git-core
+    xinstall -m 0755 ${worksrcpath}/contrib/subtree/git-subtree.sh \
+        ${destroot}${prefix}/libexec/git-core/git-subtree
+
+    # Tiger doesn't build the GUI, so check for its existence before mucking with it
+    if {[file exists "${destroot}${guidir}"]} {
+        # The executable could be "Wish" or "Wish Shell", depending on the OS version
+        set wish_executable [exec defaults read ${destroot}${guidir}/Info CFBundleExecutable]
+        # The system-provided Tk is now deprecated, so use the MacPorts version if available.
+        system "echo exec wish \"'${guidir}/Resources/Scripts/AppMain.tcl'\" '\"$@\"' > \
+            '${destroot}${guidir}/MacOS/${wish_executable}'"
+    }
+
+    file delete -force ${share_path}/contrib
+    copy ${worksrcpath}/contrib ${share_path}
+}
+
+variant pcre description {Use pcre} {
+    build.args-append       LIBPCREDIR=${prefix} USE_LIBPCRE2=1
+    depends_lib-append      port:pcre2
+}
+
+variant doc description {Install HTML and plaintext documentation} {
+    post-destroot {
+        system -W ${worksrcpath} \
+            "${destroot.cmd} install-html prefix=${destroot}/${prefix}"
+    }
+}
+
+variant gitweb description {Install gitweb.cgi} {
+    depends_run-append  port:lighttpd
+
+    build.target-append gitweb
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/${name}/gitweb
+        xinstall -W ${worksrcpath}/gitweb \
+            gitweb.cgi \
+            ${destroot}${prefix}/share/${name}/gitweb
+        xinstall -m 0444 -W ${worksrcpath}/gitweb/static \
+            gitweb.css \
+            gitweb.js \
+            git-favicon.png \
+            git-logo.png \
+            ${destroot}${prefix}/share/${name}/gitweb
+        xinstall -d ${docdestroot}/gitweb
+        xinstall -m 0444 -W ${worksrcpath}/gitweb README INSTALL \
+            ${docdestroot}/gitweb
+    }
+}
+
+variant svn description {Bi-directional subversion repository support} {
+    depends_run-append  port:subversion \
+                        port:p${perl5.major}-libwww-perl \
+                        port:p${perl5.major}-svn-simple
+}
+
+variant credential_osxkeychain description {Install git credential-osxkeychain utility from contrib} {
+
+    post-build {
+        system -W "${worksrcpath}/contrib/credential/osxkeychain" "make [join ${build.args}]"
+    }
+
+    post-destroot {
+        xinstall -m 0755 \
+            "${worksrcpath}/contrib/credential/osxkeychain/git-credential-osxkeychain" \
+            "${destroot}${prefix}/libexec/git-core/"
+    }
+
+    pre-activate {
+        set osxkc_config        "\[credential]\n\thelper = osxkeychain"
+
+        # Ensure the osxkeychain credential helper is configured in the
+        # system-wide gitconfig.  If the gitconfig file already exists,
+        # then append the configuration to the pre-existing file only
+        # if the file is currently missing the desired config.
+
+        if { ![file exists ${system_gitconfig}] } {
+            set f [open ${system_gitconfig} w 0644]
+            puts ${f} ${osxkc_config}
+            close ${f}
+        } else {
+            if { [catch {exec grep "helper = osxkeychain" ${system_gitconfig}} result] } {
+                set f [open ${system_gitconfig} a]
+                puts ${f} ${osxkc_config}
+                close ${f}
+            }
+        }
+    }
+
+    notes "
+Configuration to enable the osxkeychain credential helper has been added to
+the system-wide gitconfig at ${system_gitconfig}. If you do not wish to use
+this credential helper, you can override this setting in your own personal
+git config file \(\$HOME/.gitconfig\) with e.g.
+
+    \[credential]
+            helper = some_other_credential_helper
+
+For more information, run
+
+    git help credentials
+"
+}
+
+variant diff_highlight description {Install git diff-highlight utility from contrib} {
+
+    post-build {
+        system -W "${worksrcpath}/contrib/diff-highlight" "make [join ${build.args}]"
+    }
+
+    post-destroot {
+        xinstall -m 0755 \
+            "${worksrcpath}/contrib/diff-highlight/diff-highlight" \
+            "${destroot}${prefix}/bin/"
+    }
+}
+
+# Python is only needed to enable certain tools for interacting with other
+# version control systems, such as git-p4 (for interfacing with Perforce).
+# This variant enables git to use MacPorts' Python as it builds these
+# additional tools.
+variant python description {Build with Python support} {
+    depends_lib-append  port:python312
+    build.args-append   PYTHON_PATH="${prefix}/bin/python3.12"
+}
+
+platform darwin 11 {
+    # Add additional headers for open() on 10.7
+    patchfiles-append    patch-osxkeychain-10.7.diff
+}
+
+platform darwin 8 {
+    # https://trac.macports.org/ticket/66480
+    depends_build-append port:gmake-apple
+    build.cmd  ${prefix}/bin/gmake-apple
+
+    build.args-append   NO_APPLE_COMMON_CRYPTO=1
+    build.args-append   CC_LD_DYNPATH=-R
+}

--- a/devel/libre-wd-40-git/files/patch-Makefile.diff
+++ b/devel/libre-wd-40-git/files/patch-Makefile.diff
@@ -1,0 +1,11 @@
+--- a/Makefile.orig
++++ b/Makefile
+@@ -1336,7 +1336,7 @@
+ ifeq ($(COMPUTE_HEADER_DEPENDENCIES),auto)
+ dep_check = $(shell $(CC) $(ALL_CFLAGS) \
+ 	-c -MF /dev/null -MQ /dev/null -MMD -MP \
+-	-x c /dev/null -o /dev/null 2>&1; \
++	-x c /dev/null -o dummy 2>&1; \
+ 	echo $$?)
+ ifeq ($(dep_check),0)
+ override COMPUTE_HEADER_DEPENDENCIES = yes

--- a/devel/libre-wd-40-git/files/patch-Revert-breaking-osxkeychain.diff
+++ b/devel/libre-wd-40-git/files/patch-Revert-breaking-osxkeychain.diff
@@ -1,0 +1,624 @@
+From ac042352b4910134c4c4d74b68f30061bde145b1 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sun, 15 Sep 2024 15:44:12 +0800
+Subject: [PATCH] Revert breaking osxkeychain
+
+This reverts commit e1ab45b2dab51f94db9548666dfd7af626d2aa7e.
+
+This reverts commit fcf5b74e59c1c0d18a8e8e939475007b3b5f83ad.
+
+This reverts commit d5b35bba86e6fdf0484ea71bf5b8ef1167f14015.
+
+This reverts commit e3cef40db89f5a7c91f4e9d6c4959ca1e41f4647.
+
+This reverts commit 9032bcad82f45a403e4a8de86e1fcb4bfd1ab282.
+
+This reverts commit 9abe31f5f161be4d69118bdfae00103cd6efa510.
+
+This reverts commit b201316835bbf2c49c2780f23cfd6146f6b8d1a2.
+
+---
+--- a/contrib/credential/osxkeychain/Makefile
++++ b/contrib/credential/osxkeychain/Makefile
+@@ -1,13 +1,26 @@
+ # The default target of this Makefile is...
+ all:: git-credential-osxkeychain
+ 
+-git-credential-osxkeychain:
+-	$(MAKE) -C ../../.. contrib/credential/osxkeychain/git-credential-osxkeychain
++prefix ?= /usr/local
++gitexecdir ?= $(prefix)/libexec/git-core
+ 
+-install:
+-	$(MAKE) -C ../../.. install-git-credential-osxkeychain
++CC ?= gcc
++CFLAGS ?= -g -O2 -Wall
++INSTALL ?= install
++RM ?= rm -f
+ 
++%.o: %.c
++	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -c $<
++
++git-credential-osxkeychain: git-credential-osxkeychain.o
++	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) \
++		-framework Security -framework CoreFoundation
++
++install: git-credential-osxkeychain
++	$(INSTALL) -d -m 755 $(DESTDIR)$(gitexecdir)
++	$(INSTALL) -m 755 $< $(DESTDIR)$(gitexecdir)
++
+ clean:
+-	$(MAKE) -C ../../.. clean-git-credential-osxkeychain
++	$(RM) git-credential-osxkeychain git-credential-osxkeychain.o
+ 
+-.PHONY: all git-credential-osxkeychain install clean
++.PHONY: all install clean
+--- a/contrib/credential/osxkeychain/git-credential-osxkeychain.c
++++ b/contrib/credential/osxkeychain/git-credential-osxkeychain.c
+@@ -2,390 +2,113 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <Security/Security.h>
+-#include "git-compat-util.h"
+-#include "strbuf.h"
+-#include "wrapper.h"
+ 
+-#define ENCODING kCFStringEncodingUTF8
+-static CFStringRef protocol; /* Stores constant strings - not memory managed */
+-static CFStringRef host;
+-static CFNumberRef port;
+-static CFStringRef path;
+-static CFStringRef username;
+-static CFDataRef password;
+-static CFDataRef password_expiry_utc;
+-static CFDataRef oauth_refresh_token;
+-static char *state_seen;
++static SecProtocolType protocol;
++static char *host;
++static char *path;
++static char *username;
++static char *password;
++static UInt16 port;
+ 
+-static void clear_credential(void)
++__attribute__((format (printf, 1, 2)))
++static void die(const char *err, ...)
+ {
+-	if (host) {
+-		CFRelease(host);
+-		host = NULL;
+-	}
+-	if (port) {
+-		CFRelease(port);
+-		port = NULL;
+-	}
+-	if (path) {
+-		CFRelease(path);
+-		path = NULL;
+-	}
+-	if (username) {
+-		CFRelease(username);
+-		username = NULL;
+-	}
+-	if (password) {
+-		CFRelease(password);
+-		password = NULL;
+-	}
+-	if (password_expiry_utc) {
+-		CFRelease(password_expiry_utc);
+-		password_expiry_utc = NULL;
+-	}
+-	if (oauth_refresh_token) {
+-		CFRelease(oauth_refresh_token);
+-		oauth_refresh_token = NULL;
+-	}
++	char msg[4096];
++	va_list params;
++	va_start(params, err);
++	vsnprintf(msg, sizeof(msg), err, params);
++	fprintf(stderr, "%s\n", msg);
++	va_end(params);
++	exit(1);
+ }
+ 
+-#define STRING_WITH_LENGTH(s) s, sizeof(s) - 1
+-
+-static CFDictionaryRef create_dictionary(CFAllocatorRef allocator, ...)
++static void *xstrdup(const char *s1)
+ {
+-	va_list args;
+-	const void *key;
+-	CFMutableDictionaryRef result;
+-
+-	result = CFDictionaryCreateMutable(allocator,
+-					   0,
+-					   &kCFTypeDictionaryKeyCallBacks,
+-					   &kCFTypeDictionaryValueCallBacks);
+-
+-
+-	va_start(args, allocator);
+-	while ((key = va_arg(args, const void *)) != NULL) {
+-		const void *value;
+-		value = va_arg(args, const void *);
+-		if (value)
+-			CFDictionarySetValue(result, key, value);
+-	}
+-	va_end(args);
+-
+-	return result;
++	void *ret = strdup(s1);
++	if (!ret)
++		die("Out of memory");
++	return ret;
+ }
+ 
+-#define CREATE_SEC_ATTRIBUTES(...) \
+-	create_dictionary(kCFAllocatorDefault, \
+-			  kSecClass, kSecClassInternetPassword, \
+-			  kSecAttrServer, host, \
+-			  kSecAttrAccount, username, \
+-			  kSecAttrPath, path, \
+-			  kSecAttrPort, port, \
+-			  kSecAttrProtocol, protocol, \
+-			  kSecAttrAuthenticationType, \
+-			  kSecAttrAuthenticationTypeDefault, \
+-			  __VA_ARGS__);
++#define KEYCHAIN_ITEM(x) (x ? strlen(x) : 0), x
++#define KEYCHAIN_ARGS \
++	NULL, /* default keychain */ \
++	KEYCHAIN_ITEM(host), \
++	0, NULL, /* account domain */ \
++	KEYCHAIN_ITEM(username), \
++	KEYCHAIN_ITEM(path), \
++	port, \
++	protocol, \
++	kSecAuthenticationTypeDefault
+ 
+-static void write_item(const char *what, const char *buf, size_t len)
++static void write_item(const char *what, const char *buf, int len)
+ {
+ 	printf("%s=", what);
+ 	fwrite(buf, 1, len, stdout);
+ 	putchar('\n');
+ }
+ 
+-static void write_item_strbuf(struct strbuf *sb, const char *what, const char *buf, int n)
++static void find_username_in_item(SecKeychainItemRef item)
+ {
+-	char s[32];
++	SecKeychainAttributeList list;
++	SecKeychainAttribute attr;
+ 
+-	xsnprintf(s, sizeof(s), "__%s=", what);
+-	strbuf_add(sb, s, strlen(s));
+-	strbuf_add(sb, buf, n);
+-}
++	list.count = 1;
++	list.attr = &attr;
++	attr.tag = kSecAccountItemAttr;
+ 
+-static void write_item_strbuf_cfstring(struct strbuf *sb, const char *what, CFStringRef ref)
+-{
+-	char *buf;
+-	int len;
+-
+-	if (!ref)
++	if (SecKeychainItemCopyContent(item, NULL, &list, NULL, NULL))
+ 		return;
+-	len = CFStringGetMaximumSizeForEncoding(CFStringGetLength(ref), ENCODING) + 1;
+-	buf = xmalloc(len);
+-	if (CFStringGetCString(ref, buf, len, ENCODING))
+-		write_item_strbuf(sb, what, buf, strlen(buf));
+-	free(buf);
+-}
+ 
+-static void write_item_strbuf_cfnumber(struct strbuf *sb, const char *what, CFNumberRef ref)
+-{
+-	short n;
+-	char buf[32];
+-
+-	if (!ref)
+-		return;
+-	if (!CFNumberGetValue(ref, kCFNumberShortType, &n))
+-		return;
+-	xsnprintf(buf, sizeof(buf), "%d", n);
+-	write_item_strbuf(sb, what, buf, strlen(buf));
++	write_item("username", attr.data, attr.length);
++	SecKeychainItemFreeContent(&list, NULL);
+ }
+ 
+-static void write_item_strbuf_cfdata(struct strbuf *sb, const char *what, CFDataRef ref)
++static void find_internet_password(void)
+ {
+-	char *buf;
+-	int len;
++	void *buf;
++	UInt32 len;
++	SecKeychainItemRef item;
+ 
+-	if (!ref)
++	if (SecKeychainFindInternetPassword(KEYCHAIN_ARGS, &len, &buf, &item))
+ 		return;
+-	buf = (char *)CFDataGetBytePtr(ref);
+-	if (!buf || strlen(buf) == 0)
+-		return;
+-	len = CFDataGetLength(ref);
+-	write_item_strbuf(sb, what, buf, len);
+-}
+ 
+-static void encode_state_seen(struct strbuf *sb)
+-{
+-	strbuf_add(sb, "osxkeychain:seen=", strlen("osxkeychain:seen="));
+-	write_item_strbuf_cfstring(sb, "host", host);
+-	write_item_strbuf_cfnumber(sb, "port", port);
+-	write_item_strbuf_cfstring(sb, "path", path);
+-	write_item_strbuf_cfstring(sb, "username", username);
+-	write_item_strbuf_cfdata(sb, "password", password);
+-}
+-
+-static void find_username_in_item(CFDictionaryRef item)
+-{
+-	CFStringRef account_ref;
+-	char *username_buf;
+-	CFIndex buffer_len;
+-
+-	account_ref = CFDictionaryGetValue(item, kSecAttrAccount);
+-	if (!account_ref)
+-	{
+-		write_item("username", "", 0);
+-		return;
+-	}
+-	username = CFStringCreateCopy(kCFAllocatorDefault, account_ref);
+-
+-	username_buf = (char *)CFStringGetCStringPtr(account_ref, ENCODING);
+-	if (username_buf)
+-	{
+-		write_item("username", username_buf, strlen(username_buf));
+-		return;
+-	}
+-
+-	/* If we can't get a CString pointer then
+-	 * we need to allocate our own buffer */
+-	buffer_len = CFStringGetMaximumSizeForEncoding(
+-			CFStringGetLength(account_ref), ENCODING) + 1;
+-	username_buf = xmalloc(buffer_len);
+-	if (CFStringGetCString(account_ref,
+-				username_buf,
+-				buffer_len,
+-				ENCODING)) {
+-		write_item("username", username_buf, strlen(username_buf));
+-	}
+-	free(username_buf);
+-}
+-
+-static OSStatus find_internet_password(void)
+-{
+-	CFDictionaryRef attrs;
+-	CFDictionaryRef item;
+-	CFDataRef data;
+-	OSStatus result;
+-
+-	attrs = CREATE_SEC_ATTRIBUTES(kSecMatchLimit, kSecMatchLimitOne,
+-				      kSecReturnAttributes, kCFBooleanTrue,
+-				      kSecReturnData, kCFBooleanTrue,
+-				      NULL);
+-	result = SecItemCopyMatching(attrs, (CFTypeRef *)&item);
+-	if (result) {
+-		goto out;
+-	}
+-
+-	data = CFDictionaryGetValue(item, kSecValueData);
+-	password = CFDataCreateCopy(kCFAllocatorDefault, data);
+-
+-	write_item("password",
+-		   (const char *)CFDataGetBytePtr(data),
+-		   CFDataGetLength(data));
++	write_item("password", buf, len);
+ 	if (!username)
+ 		find_username_in_item(item);
+ 
+-	CFRelease(item);
+-
+-	write_item("capability[]", "state", strlen("state"));
+-	{
+-		struct strbuf sb;
+-
+-		strbuf_init(&sb, 1024);
+-		encode_state_seen(&sb);
+-		write_item("state[]", sb.buf, strlen(sb.buf));
+-		strbuf_release(&sb);
+-	}
+-
+-out:
+-	CFRelease(attrs);
+-
+-	/* We consider not found to not be an error */
+-	if (result == errSecItemNotFound)
+-		result = errSecSuccess;
+-
+-	return result;
++	SecKeychainItemFreeContent(NULL, buf);
+ }
+ 
+-static OSStatus delete_ref(const void *itemRef)
++static void delete_internet_password(void)
+ {
+-	CFArrayRef item_ref_list;
+-	CFDictionaryRef delete_query;
+-	OSStatus result;
++	SecKeychainItemRef item;
+ 
+-	item_ref_list = CFArrayCreate(kCFAllocatorDefault,
+-				      &itemRef,
+-				      1,
+-				      &kCFTypeArrayCallBacks);
+-	delete_query = create_dictionary(kCFAllocatorDefault,
+-					 kSecClass, kSecClassInternetPassword,
+-					 kSecMatchItemList, item_ref_list,
+-					 NULL);
+-
+-	if (password) {
+-		/* We only want to delete items with a matching password */
+-		CFIndex capacity;
+-		CFMutableDictionaryRef query;
+-		CFDataRef data;
+-
+-		capacity = CFDictionaryGetCount(delete_query) + 1;
+-		query = CFDictionaryCreateMutableCopy(kCFAllocatorDefault,
+-						      capacity,
+-						      delete_query);
+-		CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+-		result = SecItemCopyMatching(query, (CFTypeRef *)&data);
+-		if (!result) {
+-			CFDataRef kc_password;
+-			const UInt8 *raw_data;
+-			const UInt8 *line;
+-
+-			/* Don't match appended metadata */
+-			raw_data = CFDataGetBytePtr(data);
+-			line = memchr(raw_data, '\n', CFDataGetLength(data));
+-			if (line)
+-				kc_password = CFDataCreateWithBytesNoCopy(
+-						kCFAllocatorDefault,
+-						raw_data,
+-						line - raw_data,
+-						kCFAllocatorNull);
+-			else
+-				kc_password = data;
+-
+-			if (CFEqual(kc_password, password))
+-				result = SecItemDelete(delete_query);
+-
+-			if (line)
+-				CFRelease(kc_password);
+-			CFRelease(data);
+-		}
+-
+-		CFRelease(query);
+-	} else {
+-		result = SecItemDelete(delete_query);
+-	}
+-
+-	CFRelease(delete_query);
+-	CFRelease(item_ref_list);
+-
+-	return result;
+-}
+-
+-static OSStatus delete_internet_password(void)
+-{
+-	CFDictionaryRef attrs;
+-	CFArrayRef refs;
+-	OSStatus result;
+-
+ 	/*
+ 	 * Require at least a protocol and host for removal, which is what git
+ 	 * will give us; if you want to do something more fancy, use the
+ 	 * Keychain manager.
+ 	 */
+ 	if (!protocol || !host)
+-		return -1;
++		return;
+ 
+-	attrs = CREATE_SEC_ATTRIBUTES(kSecMatchLimit, kSecMatchLimitAll,
+-				      kSecReturnRef, kCFBooleanTrue,
+-				      NULL);
+-	result = SecItemCopyMatching(attrs, (CFTypeRef *)&refs);
+-	CFRelease(attrs);
++	if (SecKeychainFindInternetPassword(KEYCHAIN_ARGS, 0, NULL, &item))
++		return;
+ 
+-	if (!result) {
+-		for (CFIndex i = 0; !result && i < CFArrayGetCount(refs); i++)
+-			result = delete_ref(CFArrayGetValueAtIndex(refs, i));
+-
+-		CFRelease(refs);
+-	}
+-
+-	/* We consider not found to not be an error */
+-	if (result == errSecItemNotFound)
+-		result = errSecSuccess;
+-
+-	return result;
++	SecKeychainItemDelete(item);
+ }
+ 
+-static OSStatus add_internet_password(void)
++static void add_internet_password(void)
+ {
+-	CFMutableDataRef data;
+-	CFDictionaryRef attrs;
+-	OSStatus result;
+-
+ 	/* Only store complete credentials */
+ 	if (!protocol || !host || !username || !password)
+-		return -1;
++		return;
+ 
+-	if (state_seen) {
+-		struct strbuf sb;
+-
+-		strbuf_init(&sb, 1024);
+-		encode_state_seen(&sb);
+-		if (!strcmp(state_seen, sb.buf)) {
+-			strbuf_release(&sb);
+-			return errSecSuccess;
+-		}
+-		strbuf_release(&sb);
+-	}
+-
+-	data = CFDataCreateMutableCopy(kCFAllocatorDefault, 0, password);
+-	if (password_expiry_utc) {
+-		CFDataAppendBytes(data,
+-		    (const UInt8 *)STRING_WITH_LENGTH("\npassword_expiry_utc="));
+-		CFDataAppendBytes(data,
+-				  CFDataGetBytePtr(password_expiry_utc),
+-				  CFDataGetLength(password_expiry_utc));
+-	}
+-	if (oauth_refresh_token) {
+-		CFDataAppendBytes(data,
+-		    (const UInt8 *)STRING_WITH_LENGTH("\noauth_refresh_token="));
+-		CFDataAppendBytes(data,
+-				  CFDataGetBytePtr(oauth_refresh_token),
+-				  CFDataGetLength(oauth_refresh_token));
+-	}
+-
+-	attrs = CREATE_SEC_ATTRIBUTES(kSecValueData, data,
+-				      NULL);
+-
+-	result = SecItemAdd(attrs, NULL);
+-	if (result == errSecDuplicateItem) {
+-		CFDictionaryRef query;
+-		query = CREATE_SEC_ATTRIBUTES(NULL);
+-		result = SecItemUpdate(query, attrs);
+-		CFRelease(query);
+-	}
+-
+-	CFRelease(data);
+-	CFRelease(attrs);
+-
+-	return result;
++	if (SecKeychainAddInternetPassword(
++	      KEYCHAIN_ARGS,
++	      KEYCHAIN_ITEM(password),
++	      NULL))
++		return;
+ }
+ 
+ static void read_credential(void)
+@@ -408,65 +131,36 @@
+ 
+ 		if (!strcmp(buf, "protocol")) {
+ 			if (!strcmp(v, "imap"))
+-				protocol = kSecAttrProtocolIMAP;
++				protocol = kSecProtocolTypeIMAP;
+ 			else if (!strcmp(v, "imaps"))
+-				protocol = kSecAttrProtocolIMAPS;
++				protocol = kSecProtocolTypeIMAPS;
+ 			else if (!strcmp(v, "ftp"))
+-				protocol = kSecAttrProtocolFTP;
++				protocol = kSecProtocolTypeFTP;
+ 			else if (!strcmp(v, "ftps"))
+-				protocol = kSecAttrProtocolFTPS;
++				protocol = kSecProtocolTypeFTPS;
+ 			else if (!strcmp(v, "https"))
+-				protocol = kSecAttrProtocolHTTPS;
++				protocol = kSecProtocolTypeHTTPS;
+ 			else if (!strcmp(v, "http"))
+-				protocol = kSecAttrProtocolHTTP;
++				protocol = kSecProtocolTypeHTTP;
+ 			else if (!strcmp(v, "smtp"))
+-				protocol = kSecAttrProtocolSMTP;
+-			else {
+-				/* we don't yet handle other protocols */
+-				clear_credential();
++				protocol = kSecProtocolTypeSMTP;
++			else /* we don't yet handle other protocols */
+ 				exit(0);
+-			}
+ 		}
+ 		else if (!strcmp(buf, "host")) {
+ 			char *colon = strchr(v, ':');
+ 			if (colon) {
+-				UInt16 port_i;
+ 				*colon++ = '\0';
+-				port_i = atoi(colon);
+-				port = CFNumberCreate(kCFAllocatorDefault,
+-						      kCFNumberShortType,
+-						      &port_i);
++				port = atoi(colon);
+ 			}
+-			host = CFStringCreateWithCString(kCFAllocatorDefault,
+-							 v,
+-							 ENCODING);
++			host = xstrdup(v);
+ 		}
+ 		else if (!strcmp(buf, "path"))
+-			path = CFStringCreateWithCString(kCFAllocatorDefault,
+-							 v,
+-							 ENCODING);
++			path = xstrdup(v);
+ 		else if (!strcmp(buf, "username"))
+-			username = CFStringCreateWithCString(
+-					kCFAllocatorDefault,
+-					v,
+-					ENCODING);
++			username = xstrdup(v);
+ 		else if (!strcmp(buf, "password"))
+-			password = CFDataCreate(kCFAllocatorDefault,
+-						(UInt8 *)v,
+-						strlen(v));
+-		else if (!strcmp(buf, "password_expiry_utc"))
+-			password_expiry_utc = CFDataCreate(kCFAllocatorDefault,
+-							   (UInt8 *)v,
+-							   strlen(v));
+-		else if (!strcmp(buf, "oauth_refresh_token"))
+-			oauth_refresh_token = CFDataCreate(kCFAllocatorDefault,
+-							   (UInt8 *)v,
+-							   strlen(v));
+-		else if (!strcmp(buf, "state[]")) {
+-			int len = strlen("osxkeychain:seen=");
+-			if (!strncmp(v, "osxkeychain:seen=", len))
+-				state_seen = xstrdup(v);
+-		}
++			password = xstrdup(v);
+ 		/*
+ 		 * Ignore other lines; we don't know what they mean, but
+ 		 * this future-proofs us when later versions of git do
+@@ -479,33 +173,21 @@
+ 
+ int main(int argc, const char **argv)
+ {
+-	OSStatus result = 0;
+ 	const char *usage =
+ 		"usage: git credential-osxkeychain <get|store|erase>";
+ 
+ 	if (argc < 2 || !*argv[1])
+ 		die("%s", usage);
+ 
+-	if (open(argv[0], O_RDONLY | O_EXLOCK) == -1)
+-		die("failed to lock %s", argv[0]);
+-
+ 	read_credential();
+ 
+ 	if (!strcmp(argv[1], "get"))
+-		result = find_internet_password();
++		find_internet_password();
+ 	else if (!strcmp(argv[1], "store"))
+-		result = add_internet_password();
++		add_internet_password();
+ 	else if (!strcmp(argv[1], "erase"))
+-		result = delete_internet_password();
++		delete_internet_password();
+ 	/* otherwise, ignore unknown action */
+ 
+-	if (result)
+-		die("failed to %s: %d", argv[1], (int)result);
+-
+-	clear_credential();
+-
+-	if (state_seen)
+-		free(state_seen);
+-
+ 	return 0;
+ }

--- a/devel/libre-wd-40-git/files/patch-disable-enhanced-basic-regex.diff
+++ b/devel/libre-wd-40-git/files/patch-disable-enhanced-basic-regex.diff
@@ -1,0 +1,4 @@
+--- a/config.mak.uname
++++ b/config.mak.uname
+@@ -151 +150,0 @@
+-	USE_ENHANCED_BASIC_REGULAR_EXPRESSIONS = YesPlease

--- a/devel/libre-wd-40-git/files/patch-git-compat-util-no-builtin-add-overflow.diff
+++ b/devel/libre-wd-40-git/files/patch-git-compat-util-no-builtin-add-overflow.diff
@@ -1,0 +1,11 @@
+--- a/git-compat-util.h.orig
++++ b/git-compat-util.h
+@@ -619,7 +619,7 @@
+  * Help Clang; GCC generates the same instructions for both variants on
+  * x64 and aarch64.
+  */
+-#ifdef __clang__
++#if defined(__clang__) && __has_builtin(__builtin_add_overflow)
+ #define st_add_overflow __builtin_add_overflow
+ #else
+ static inline bool st_add_overflow(size_t a, size_t b, size_t *out)

--- a/devel/libre-wd-40-git/files/patch-git-subtree.1.diff
+++ b/devel/libre-wd-40-git/files/patch-git-subtree.1.diff
@@ -1,0 +1,434 @@
+--- /dev/null
++++ b/contrib/subtree/git-subtree.1
+@@ -0,0 +1,431 @@
++'\" t
++.\"     Title: git-subtree
++.\"    Author: [see the "AUTHOR" section]
++.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
++.\"      Date: 06/30/2026
++.\"    Manual: Git Manual
++.\"    Source: Git 2.55.0
++.\"  Language: English
++.\"
++.TH "GIT\-SUBTREE" "1" "06/30/2026" "Git 2\&.55\&.0" "Git Manual"
++.\" -----------------------------------------------------------------
++.\" * Define some portability stuff
++.\" -----------------------------------------------------------------
++.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++.\" http://bugs.debian.org/507673
++.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
++.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++.ie \n(.g .ds Aq \(aq
++.el       .ds Aq '
++.\" -----------------------------------------------------------------
++.\" * set default formatting
++.\" -----------------------------------------------------------------
++.\" disable hyphenation
++.nh
++.\" disable justification (adjust text to left margin only)
++.ad l
++.\" -----------------------------------------------------------------
++.\" * MAIN CONTENT STARTS HERE *
++.\" -----------------------------------------------------------------
++.SH "NAME"
++git-subtree \- Merge subtrees together and split repository into subtrees
++.SH "SYNOPSIS"
++.sp
++.nf
++\fIgit subtree\fR [<options>] \-P <prefix> [\-S[<keyid>]] add <local\-commit>
++\fIgit subtree\fR [<options>] \-P <prefix> [\-S[<keyid>]] add <repository> <remote\-ref>
++\fIgit subtree\fR [<options>] \-P <prefix> [\-S[<keyid>]] merge <local\-commit> [<repository>]
++\fIgit subtree\fR [<options>] \-P <prefix> [\-S[<keyid>]] split [<local\-commit>]
++.fi
++.sp
++
++.sp
++.nf
++\fIgit subtree\fR [<options>] \-P <prefix> [\-S[<keyid>]] pull <repository> <remote\-ref>
++\fIgit subtree\fR [<options>] \-P <prefix> [\-S[<keyid>]] push <repository> <refspec>
++.fi
++.sp
++.SH "DESCRIPTION"
++.sp
++Subtrees allow subprojects to be included within a subdirectory of the main project, optionally including the subproject\(cqs entire history\&.
++.sp
++For example, you could include the source code for a library as a subdirectory of your application\&.
++.sp
++Subtrees are not to be confused with submodules, which are meant for the same task\&. Unlike submodules, subtrees do not need any special constructions (like \fI\&.gitmodules\fR files or gitlinks) be present in your repository, and do not force end\-users of your repository to do anything special or to understand how subtrees work\&. A subtree is just a subdirectory that can be committed to, branched, and merged along with your project in any way you want\&.
++.sp
++They are also not to be confused with using the subtree merge strategy\&. The main difference is that, besides merging the other project as a subdirectory, you can also extract the entire history of a subdirectory from your project and make it into a standalone project\&. Unlike the subtree merge strategy you can alternate back and forth between these two operations\&. If the standalone library gets updated, you can automatically merge the changes into your project; if you update the library inside your project, you can "split" the changes back out again and merge them back into the library project\&.
++.sp
++For example, if a library you made for one application ends up being useful elsewhere, you can extract its entire history and publish that as its own git repository, without accidentally intermingling the history of your application project\&.
++.if n \{\
++.sp
++.\}
++.RS 4
++.it 1 an-trap
++.nr an-no-space-flag 1
++.nr an-break-flag 1
++.br
++.ps +1
++\fBTip\fR
++.ps -1
++.br
++.sp
++In order to keep your commit messages clean, we recommend that people split their commits between the subtrees and the main project as much as possible\&. That is, if you make a change that affects both the library and the main application, commit it in two pieces\&. That way, when you split the library commits out later, their descriptions will still make sense\&. But if this isn\(cqt important to you, it\(cqs not \fBnecessary\fR\&. \fIgit subtree\fR will simply leave out the non\-library\-related parts of the commit when it splits it out into the subproject later\&.
++.sp .5v
++.RE
++.SH "COMMANDS"
++.PP
++add <local\-commit>, add <repository> <remote\-ref>
++.RS 4
++Create the <prefix> subtree by importing its contents from the given <local\-commit> or <repository> and <remote\-ref>\&. A new commit is created automatically, joining the imported project\(cqs history with your own\&. With
++\fI\-\-squash\fR, import only a single commit from the subproject, rather than its entire history\&.
++.RE
++.PP
++merge <local\-commit> [<repository>]
++.RS 4
++Merge recent changes up to <local\-commit> into the <prefix> subtree\&. As with normal
++\fIgit merge\fR, this doesn\(cqt remove your own local changes; it just merges those changes into the latest <local\-commit>\&. With
++\fI\-\-squash\fR, create only one commit that contains all the changes, rather than merging in the entire history\&.
++.sp
++If you use
++\fI\-\-squash\fR, the merge direction doesn\(cqt always have to be forward; you can use this command to go back in time from v2\&.5 to v2\&.4, for example\&. If your merge introduces a conflict, you can resolve it in the usual ways\&.
++.sp
++When using
++\fI\-\-squash\fR, and the previous merge with
++\fI\-\-squash\fR
++merged an annotated tag of the subtree repository, that tag needs to be available locally\&. If <repository> is given, a missing tag will automatically be fetched from that repository\&.
++.RE
++.PP
++split [<local\-commit>] [<repository>]
++.RS 4
++Extract a new, synthetic project history from the history of the <prefix> subtree of <local\-commit>, or of HEAD if no <local\-commit> is given\&. The new history includes only the commits (including merges) that affected <prefix>, and each of those commits now has the contents of <prefix> at the root of the project instead of in a subdirectory\&. Thus, the newly created history is suitable for export as a separate git repository\&.
++.sp
++After splitting successfully, a single commit ID is printed to stdout\&. This corresponds to the HEAD of the newly created tree, which you can manipulate however you want\&.
++.sp
++Repeated splits of exactly the same history are guaranteed to be identical (i\&.e\&. to produce the same commit IDs) as long as the settings passed to
++\fIsplit\fR
++(such as
++\fI\-\-annotate\fR) are the same\&. Because of this, if you add new commits and then re\-split, the new commits will be attached as commits on top of the history you generated last time, so
++\fIgit merge\fR
++and friends will work as expected\&.
++.sp
++When a previous merge with
++\fI\-\-squash\fR
++merged an annotated tag of the subtree repository, that tag needs to be available locally\&. If <repository> is given, a missing tag will automatically be fetched from that repository\&.
++.RE
++.PP
++pull <repository> <remote\-ref>
++.RS 4
++Exactly like
++\fImerge\fR, but parallels
++\fIgit pull\fR
++in that it fetches the given ref from the specified remote repository\&.
++.RE
++.PP
++push <repository> [+][<local\-commit>:]<remote\-ref>
++.RS 4
++Does a
++\fIsplit\fR
++using the <prefix> subtree of <local\-commit> and then does a
++\fIgit push\fR
++to push the result to the <repository> and <remote\-ref>\&. This can be used to push your subtree to different branches of the remote repository\&. Just as with
++\fIsplit\fR, if no <local\-commit> is given, then HEAD is used\&. The optional leading
++\fI+\fR
++is ignored\&.
++.RE
++.SH "OPTIONS FOR ALL COMMANDS"
++.PP
++\-q, \-\-quiet
++.RS 4
++Suppress unnecessary output messages on stderr\&.
++.RE
++.PP
++\-d, \-\-debug
++.RS 4
++Produce even more unnecessary output messages on stderr\&.
++.RE
++.PP
++\-P <prefix>, \-\-prefix=<prefix>
++.RS 4
++Specify the path in the repository to the subtree you want to manipulate\&. This option is mandatory for all commands\&.
++.RE
++.PP
++\-S[<keyid>], \-\-gpg\-sign[=<keyid>], \-\-no\-gpg\-sign
++.RS 4
++GPG\-sign commits\&. The
++keyid
++argument is optional and defaults to the committer identity;
++\-\-no\-gpg\-sign
++is useful to countermand a
++\-\-gpg\-sign
++option given earlier on the command line\&.
++.RE
++.SH "OPTIONS FOR \FIADD\FR AND \FIMERGE\FR (ALSO: \FIPULL\FR, \FISPLIT \-\-REJOIN\FR, AND \FIPUSH \-\-REJOIN\FR)"
++.sp
++These options for \fIadd\fR and \fImerge\fR may also be given to \fIpull\fR (which wraps \fImerge\fR), \fIsplit \-\-rejoin\fR (which wraps either \fIadd\fR or \fImerge\fR as appropriate), and \fIpush \-\-rejoin\fR (which wraps \fIsplit \-\-rejoin\fR)\&.
++.PP
++\-\-squash
++.RS 4
++Instead of merging the entire history from the subtree project, produce only a single commit that contains all the differences you want to merge, and then merge that new commit into your project\&.
++.sp
++Using this option helps to reduce log clutter\&. People rarely want to see every change that happened between v1\&.0 and v1\&.1 of the library they\(cqre using, since none of the interim versions were ever included in their application\&.
++.sp
++Using
++\fI\-\-squash\fR
++also helps avoid problems when the same subproject is included multiple times in the same project, or is removed and then re\-added\&. In such a case, it doesn\(cqt make sense to combine the histories anyway, since it\(cqs unclear which part of the history belongs to which subtree\&.
++.sp
++Furthermore, with
++\fI\-\-squash\fR, you can switch back and forth between different versions of a subtree, rather than strictly forward\&.
++\fIgit subtree merge \-\-squash\fR
++always adjusts the subtree to match the exactly specified commit, even if getting to that commit would require undoing some changes that were added earlier\&.
++.sp
++Whether or not you use
++\fI\-\-squash\fR, changes made in your local repository remain intact and can be later split and send upstream to the subproject\&.
++.RE
++.PP
++\-m <message>, \-\-message=<message>
++.RS 4
++Specify <message> as the commit message for the merge commit\&.
++.RE
++.SH "OPTIONS FOR \FISPLIT\FR (ALSO: \FIPUSH\FR)"
++.sp
++These options for \fIsplit\fR may also be given to \fIpush\fR (which wraps \fIsplit\fR)\&.
++.PP
++\-\-annotate=<annotation>
++.RS 4
++When generating synthetic history, add <annotation> as a prefix to each commit message\&. Since we\(cqre creating new commits with the same commit message, but possibly different content, from the original commits, this can help to differentiate them and avoid confusion\&.
++.sp
++Whenever you split, you need to use the same <annotation>, or else you don\(cqt have a guarantee that the new re\-created history will be identical to the old one\&. That will prevent merging from working correctly\&. git subtree tries to make it work anyway, particularly if you use
++\fI\-\-rejoin\fR, but it may not always be effective\&.
++.RE
++.PP
++\-b <branch>, \-\-branch=<branch>
++.RS 4
++After generating the synthetic history, create a new branch called <branch> that contains the new history\&. This is suitable for immediate pushing upstream\&. <branch> must not already exist\&.
++.RE
++.PP
++\-\-ignore\-joins
++.RS 4
++If you use
++\fI\-\-rejoin\fR, git subtree attempts to optimize its history reconstruction to generate only the new commits since the last
++\fI\-\-rejoin\fR\&.
++\fI\-\-ignore\-joins\fR
++disables this behavior, forcing it to regenerate the entire history\&. In a large project, this can take a long time\&.
++.RE
++.PP
++\-\-onto=<onto>
++.RS 4
++If your subtree was originally imported using something other than git subtree, its history may not match what git subtree is expecting\&. In that case, you can specify the commit ID <onto> that corresponds to the first revision of the subproject\(cqs history that was imported into your project, and git subtree will attempt to build its history from there\&.
++.sp
++If you used
++\fIgit subtree add\fR, you should never need this option\&.
++.RE
++.PP
++\-\-rejoin
++.RS 4
++After splitting, merge the newly created synthetic history back into your main project\&. That way, future splits can search only the part of history that has been added since the most recent
++\fI\-\-rejoin\fR\&.
++.sp
++If your split commits end up merged into the upstream subproject, and then you want to get the latest upstream version, this will allow git\(cqs merge algorithm to more intelligently avoid conflicts (since it knows these synthetic commits are already part of the upstream repository)\&.
++.sp
++Unfortunately, using this option results in
++\fIgit log\fR
++showing an extra copy of every new commit that was created (the original, and the synthetic one)\&.
++.sp
++If you do all your merges with
++\fI\-\-squash\fR, make sure you also use
++\fI\-\-squash\fR
++when you
++\fIsplit \-\-rejoin\fR\&.
++.RE
++.SH "EXAMPLE 1\&. \FIADD\FR COMMAND"
++.sp
++Let\(cqs assume that you have a local repository that you would like to add an external vendor library to\&. In this case we will add the git\-subtree repository as a subdirectory of your already existing git\-extensions repository in ~/git\-extensions/:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree add \-\-prefix=git\-subtree \-\-squash \e
++        git://github\&.com/apenwarr/git\-subtree\&.git master
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++\fImaster\fR needs to be a valid remote ref and can be a different branch name
++.sp
++You can omit the \fI\-\-squash\fR flag, but doing so will increase the number of commits that are included in your local repository\&.
++.sp
++We now have a ~/git\-extensions/git\-subtree directory containing code from the master branch of git://github\&.com/apenwarr/git\-subtree\&.git in our git\-extensions repository\&.
++.SH "EXAMPLE 2\&. EXTRACT A SUBTREE USING \FICOMMIT\FR, \FIMERGE\FR AND \FIPULL\FR"
++.sp
++Let\(cqs use the repository for the git source code as an example\&. First, get your own copy of the git\&.git repository:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git clone git://git\&.kernel\&.org/pub/scm/git/git\&.git test\-git
++$ cd test\-git
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++gitweb (commit 1130ef3) was merged into git as of commit 0a8f4f0, after which it was no longer maintained separately\&. But imagine it had been maintained separately, and we wanted to extract git\(cqs changes to gitweb since that time, to share with the upstream\&. You could do this:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree split \-\-prefix=gitweb \-\-annotate=\*(Aq(split) \*(Aq \e
++        0a8f4f0^\&.\&. \-\-onto=1130ef3 \-\-rejoin \e
++        \-\-branch gitweb\-latest
++$ gitk gitweb\-latest
++$ git push git@github\&.com:whatever/gitweb\&.git gitweb\-latest:master
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++(We use \fI0a8f4f0^\&.\&.\fR because that means "all the changes from 0a8f4f0 to the current version, including 0a8f4f0 itself\&.")
++.sp
++If gitweb had originally been merged using \fIgit subtree add\fR (or a previous split had already been done with \fI\-\-rejoin\fR specified) then you can do all your splits without having to remember any weird commit IDs:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree split \-\-prefix=gitweb \-\-annotate=\*(Aq(split) \*(Aq \-\-rejoin \e
++        \-\-branch gitweb\-latest2
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++And you can merge changes back in from the upstream project just as easily:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree pull \-\-prefix=gitweb \e
++        git@github\&.com:whatever/gitweb\&.git master
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++Or, using \fI\-\-squash\fR, you can actually rewind to an earlier version of gitweb:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree merge \-\-prefix=gitweb \-\-squash gitweb\-latest~10
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++Then make some changes:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ date >gitweb/myfile
++$ git add gitweb/myfile
++$ git commit \-m \*(Aqcreated myfile\*(Aq
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++And fast forward again:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree merge \-\-prefix=gitweb \-\-squash gitweb\-latest
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++And notice that your change is still intact:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ ls \-l gitweb/myfile
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++And you can split it out and look at your changes versus the standard gitweb:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++git log gitweb\-latest\&.\&.$(git subtree split \-\-prefix=gitweb)
++.fi
++.if n \{\
++.RE
++.\}
++.SH "EXAMPLE 3\&. EXTRACT A SUBTREE USING A BRANCH"
++.sp
++Suppose you have a source directory with many files and subdirectories, and you want to extract the lib directory to its own git project\&. Here\(cqs a short way to do it:
++.sp
++First, make the new repository wherever you want:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ <go to the new location>
++$ git init \-\-bare
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++Back in your original directory:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git subtree split \-\-prefix=lib \-\-annotate="(split)" \-b split
++.fi
++.if n \{\
++.RE
++.\}
++.sp
++Then push the new branch onto the new empty repository:
++.sp
++.if n \{\
++.RS 4
++.\}
++.nf
++$ git push <new\-repo> split:master
++.fi
++.if n \{\
++.RE
++.\}
++.SH "AUTHOR"
++.sp
++Written by Avery Pennarun <\m[blue]\fBapenwarr@gmail\&.com\fR\m[]\&\s-2\u[1]\d\s+2>
++.SH "GIT"
++.sp
++Part of the \fBgit\fR(1) suite
++.SH "NOTES"
++.IP " 1." 4
++apenwarr@gmail.com
++.RS 4
++\%mailto:apenwarr@gmail.com
++.RE

--- a/devel/libre-wd-40-git/files/patch-ignore-fsmonitor-daemon-backend.diff
+++ b/devel/libre-wd-40-git/files/patch-ignore-fsmonitor-daemon-backend.diff
@@ -1,0 +1,19 @@
+--- a/Makefile.orig
++++ b/Makefile
+@@ -2371,11 +2371,11 @@
+ 	COMPAT_OBJS += compat/access.o
+ endif
+
+-ifdef FSMONITOR_DAEMON_BACKEND
+-	COMPAT_CFLAGS += -DHAVE_FSMONITOR_DAEMON_BACKEND
+-	COMPAT_OBJS += compat/fsmonitor/fsm-listen-$(FSMONITOR_DAEMON_BACKEND).o
+-	COMPAT_OBJS += compat/fsmonitor/fsm-health-$(FSMONITOR_DAEMON_BACKEND).o
+-endif
++#ifdef FSMONITOR_DAEMON_BACKEND
++#	COMPAT_CFLAGS += -DHAVE_FSMONITOR_DAEMON_BACKEND
++#	COMPAT_OBJS += compat/fsmonitor/fsm-listen-$(FSMONITOR_DAEMON_BACKEND).o
++#	COMPAT_OBJS += compat/fsmonitor/fsm-health-$(FSMONITOR_DAEMON_BACKEND).o
++#endif
+
+ ifdef FSMONITOR_OS_SETTINGS
+ 	COMPAT_CFLAGS += -DHAVE_FSMONITOR_OS_SETTINGS

--- a/devel/libre-wd-40-git/files/patch-osxkeychain-10.7.diff
+++ b/devel/libre-wd-40-git/files/patch-osxkeychain-10.7.diff
@@ -1,0 +1,12 @@
+--- a/contrib/credential/osxkeychain/git-credential-osxkeychain.c	2024-07-29 19:29:45
++++ b/contrib/credential/osxkeychain/git-credential-osxkeychain.c	2024-07-29 19:29:51
+@@ -1,6 +1,9 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <fcntl.h>
+ #include <Security/Security.h>
+ 
+ #define ENCODING kCFStringEncodingUTF8

--- a/devel/libre-wd-40-git/files/patch-sha1dc-older-apple-gcc-versions.diff
+++ b/devel/libre-wd-40-git/files/patch-sha1dc-older-apple-gcc-versions.diff
@@ -1,0 +1,15 @@
+diff --git a/sha1dc/sha1.c b/sha1dc/sha1.c
+index 25eded1..5faf5a5 100644
+--- a/sha1dc/sha1.c
++++ b/sha1dc/sha1.c
+@@ -102,6 +102,10 @@
+  */
+ #define SHA1DC_BIGENDIAN
+ 
++#elif (defined(__APPLE__) && defined(__BIG_ENDIAN__) && !defined(SHA1DC_BIGENDIAN))
++/* older gcc compilers which are the default on Apple PPC do not define __BYTE_ORDER__ */
++#define SHA1DC_BIGENDIAN
++
+ /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> or <os whitelist> */
+ #elif defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
+ /*


### PR DESCRIPTION
#### Description

`git` is adding Rust to its toolchain. As of 2.55.0, you need to pass `NO_RUST=1` to disable the Rust part of the build system, and Rust looks like it will be mandatory with Git 3. This project ( https://github.com/Libre-WD-40/git ) is a fork of `git` removing all Rust.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
