### PR TITLE
libfmt12, mariadb-{LTS,devel}: update libfmt12 @12.2.0, mariadb-devel @13.1.0 ; add snappy to mariadb-{LTS,devel}

### DIFF
--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -12,11 +12,11 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
-maintainers         {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+maintainers         {@BjarneDMat mathiesen.info:macintosh} openmaintainer
 
 if {$subport eq $name} {
 
@@ -56,7 +56,8 @@ if {$subport eq $name} {
                         port:tcp_wrappers \
                         port:zlib \
                         port:lzo2 \
-                        port:libfmt12
+                        port:libfmt12 \
+                        port:snappy
     depends_run-append  port:mysql_select
 
     select.group        mysql

--- a/databases/mariadb-11.4/Portfile
+++ b/databases/mariadb-11.4/Portfile
@@ -12,11 +12,11 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
-maintainers         {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+maintainers         {@BjarneDMat mathiesen.info:macintosh} openmaintainer
 
 if {$subport eq $name} {
 
@@ -56,7 +56,8 @@ if {$subport eq $name} {
                         port:tcp_wrappers \
                         port:zlib \
                         port:lzo2 \
-                        port:libfmt12
+                        port:libfmt12 \
+                        port:snappy
     depends_run-append  port:mysql_select
 
     select.group        mysql

--- a/databases/mariadb-11.8/Portfile
+++ b/databases/mariadb-11.8/Portfile
@@ -12,11 +12,11 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
-maintainers         {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+maintainers         {@BjarneDMa tmathiesen.info:macintosh} openmaintainer
 
 if {$subport eq $name} {
 
@@ -56,7 +56,8 @@ if {$subport eq $name} {
                         port:tcp_wrappers \
                         port:zlib \
                         port:lzo2 \
-                        port:libfmt12
+                        port:libfmt12 \
+                        port:snappy
     depends_run-append  port:mysql_select
 
     select.group        mysql

--- a/databases/mariadb-12.3/Portfile
+++ b/databases/mariadb-12.3/Portfile
@@ -12,11 +12,11 @@ set version_branch      [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 categories              databases
 homepage                https://mariadb.org/
-maintainers             {BjarneDMat mathiesen.info:macintosh} openmaintainer
+maintainers             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
 
 if {$subport eq $name} {
 
@@ -56,7 +56,8 @@ if {$subport eq $name} {
                         port:tcp_wrappers \
                         port:zlib \
                         port:lzo2 \
-                        port:libfmt12
+                        port:libfmt12 \
+                        port:snappy
     depends_run-append  port:mysql_select
 
     select.group        mysql

--- a/databases/mariadb-devel/Portfile
+++ b/databases/mariadb-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup               legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy     15
 
 name                    mariadb-devel
-version                 13.0.1
+version                 13.1.0
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
 set name_mysql          mariadb-${version_branch}
 # Please set revision_client and revision_server to 0 if you bump
@@ -16,7 +16,7 @@ set revision_client     0
 set revision_server     0
 categories              databases
 homepage                https://mariadb.org/
-maintainers             {BjarneDMat mathiesen.info:macintosh} openmaintainer
+maintainers             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
 
 if {$subport eq $name} {
 
@@ -46,9 +46,9 @@ This will only be updated with compile breaking patches.
 
     master_sites        https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname            mariadb-${version}
-    checksums           rmd160  cb5eeb68e6e1c61291e744692ab1f1f684e3312d \
-                        sha256  cc681a84cc24d2852b93c5bf5fe199084edd553ee72656e10d4b50ec476aa33c \
-                        size    120652616
+    checksums           rmd160  8c1f3dda6b4c665c8162baab67d340c694c722e6 \
+                        sha256  fbeea784cd191b3723862e2c9cf2e155f468ddf7dbd47629f592a2a8fa8acb2f \
+                        size    120984109
 
     cmake.build_type    Release
 
@@ -61,7 +61,8 @@ This will only be updated with compile breaking patches.
                         port:tcp_wrappers \
                         port:zlib \
                         port:lzo2 \
-                        port:libfmt12
+                        port:libfmt12 \
+                        port:snappy
     depends_run-append  port:mysql_select
 
     select.group        mysql

--- a/devel/libfmt12/Portfile
+++ b/devel/libfmt12/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 12
 legacysupport.use_mp_libcxx yes
 
-github.setup        fmtlib fmt 12.1.0
+github.setup        fmtlib fmt 12.2.0
 name                libfmt12
 revision            0
-checksums           rmd160  d238165e20e4f3373d6fbab9409b750d2312e444 \
-                    sha256  ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea \
-                    size    711419
+checksums           rmd160  359bc4b3d3d59ee18866a2ec7ee614d0443a111b \
+                    sha256  8b852bb5aa6e7d8564f9e81394055395dd1d1936d38dfd3a17792a02bebd7af0 \
+                    size    738355
 
 categories          devel
 license             MIT


### PR DESCRIPTION
#### Description
```
libfmt12               : update @12.2.0
mariadb-{LTS}          : add snappy
mariadb-devel          : update @13.1.0; add snappy
```
###### Type(s)
- [x] update
- [x] enhancement
- [ ] security fix
###### Tested on:
```
Model Identifier: MacPro5,1                 Model Identifier: Macmini6,1
macOS 15.7.7 24G720 x86_64                  macOS 10.15.8 19H2036 x86_64
Xcode 26.3 17C529                           Xcode 12.4 12D4e
Command Line Tools 26.3.0.0.1.1771626560    Command Line Tools 12.4.0.0.1.1610135815
```

