### PR TITLE
fish: Add documentation

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
 github.setup            fish-shell fish-shell 4.8.0
-revision                0
+revision                1
 
 checksums               rmd160  60c03b296d71d88770a46865a16df69f9109143c \
                         sha256  33af62c7df2fa553e0e84fa81f6ea48acf98c2bfc50036eaacc70ac8ba63e707 \
@@ -40,6 +40,13 @@ configure.args-append   -DFISH_USE_SYSTEM_PCRE2=ON \
                         -DMAC_CODESIGN_ID=OFF \
                         -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
                         -DCMAKE_BUILD_TYPE=Release
+
+variant docs description {Installs fish man pages and documentation} {
+    depends_build-append    port:py314-sphinx
+    configure.args-append   -DSPHINX_EXECUTABLE=${prefix}/bin/sphinx-build-3.14
+}
+
+default_variants +docs
 
 notes "
 To set MacPorts' ${name} as default login shell, run:


### PR DESCRIPTION
#### Description

With the upgrade to Fish 4, `help string` and `string -h` stopped working because the documentation was no longer built as it requires py-sphinx.

This makes it the `+docs` variant which is a default, making it easier for people to opt out of this.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 26.5.2 25F84 arm64\
Xcode 26.6 17F113

###### Verification 

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?