### PR TITLE
djvulibre: Update to 3.5.30

### DIFF
--- a/graphics/djvulibre/Portfile
+++ b/graphics/djvulibre/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                djvulibre
-version             3.5.29
+version             3.5.30
 revision            0
 
 categories          graphics www
@@ -21,16 +21,16 @@ long_description    DjVu can advantageously replace PDF, PS, TIFF, JPEG, and GIF
 homepage            http://djvu.sourceforge.net/
 master_sites        sourceforge:project/djvu/DjVuLibre/${version}
 
-checksums           rmd160  c4538e4a6e27baa9cbd4905bafc88cc41a78710b \
-                    sha256  d3b4b03ae2bdca8516a36ef6eb27b777f0528c9eda26745d9962824a3fdfeccf \
-                    size    3716911
+checksums           rmd160  3214e6f1695cd64902880d29fbba432f53382e04 \
+                    sha256  ee5e457d4cfebe566f94b99e5e3d3cc7f5c79ddb741c2ac2ba2e456f00329644 \
+                    size    3721274
 
 depends_lib         port:libiconv \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:tiff
 
 patchfiles          patch-noconvert.diff
- 
+
 # Teach glibtool about -stdlib=libc++
 use_autoreconf      yes
 autoreconf.args     -fvi
@@ -41,5 +41,8 @@ configure.args      --mandir=${prefix}/share/man \
                     --enable-xmltools \
                     --disable-desktopfiles \
                     --disable-silent-rules
+
+configure.cxxflags-append \
+                    -Wno-register
 
 livecheck.regex      /${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

* Update djvulibre 3.5.29 --> 3.5.30.
* Fixes: https://trac.macports.org/ticket/72471

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?