### PR TITLE
Tcl/Tk updates

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    tkimg
 version                 1.4.17
-revision                0
+revision                1
 checksums               rmd160  cd1a130eb937385862f2f12dba0c82315e1f5e6d \
                         sha256  aeab762f5c11979508974b35c354559a8ffb99404438f38dfd295e70abecc1cf \
                         size    6695711
@@ -69,9 +69,9 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
     && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
     variant quartz conflicts x11 {
-        depends_lib-append  port:tk-quartz
-        configure.args-append   --with-tk=${prefix}/lib/tk-quartz \
-                                --with-tkinclude=${prefix}/include/tk-quartz
+        depends_lib-append  port:tk8-quartz
+        configure.args-append   --with-tk=${prefix}/lib/tk8-quartz \
+                                --with-tkinclude=${prefix}/include/tk8-quartz
     }
     if {![variant_isset x11]} {
         default_variants +quartz
@@ -83,9 +83,9 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
 }
 
 variant x11 conflicts {*}${x11conflicts} {
-    depends_lib-append  port:tk-x11
-    configure.args-append   --with-tk=${prefix}/lib/tk-x11 \
-                            --with-tkinclude=${prefix}/include/tk-x11
+    depends_lib-append  port:tk8-x11
+    configure.args-append   --with-tk=${prefix}/lib/tk8-x11 \
+                            --with-tkinclude=${prefix}/include/tk8-x11
 }
 
 livecheck.type          regex

--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                tcl
-version             8.6.17
+version             8.6.18
 revision            0
 # Tk (x11/tk) port depends on this version
 categories          lang
@@ -19,13 +19,16 @@ long_description    \
     that is truly cross platform, easily deployed and highly extensible.
 
 homepage            https://www.tcl-lang.org/
+configure.cppflags-delete  -I${prefix}/include
+configure.ldflags-delete   -L${prefix}/lib
 
-if {$subport eq $name} {
-    checksums       md5     1ec3444533f54d0f86cd120058e15e48 \
-                    sha1    d9b11a7c4996886e3fb1e5e50fc2f5ca006be270 \
-                    rmd160  7ba0f589c661c8dd94b9733ad2c5436eb91c1919 \
-                    sha256  a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31 \
-                    size    11724552
+subport tcl8 {
+    version         8.6.18
+    revision        0
+    checksums       md5     acfe0c9f7d0c626ecf026e834a888da6 \
+                    sha1    84ba661edc5e615f32944e68039db568328f9a47 \
+                    rmd160  633917b67cb502be919cd5194f6f82ab7c216f44 \
+                    sha256  14f9af32b1767ff718477a8f974ad03c34341097e6b43f4ce54644ee974e268e
 }
 subport tcl9 {
     version         9.0.4
@@ -35,6 +38,9 @@ subport tcl9 {
                     rmd160  41179b681eb73238153889e4ad7920e6646e6a71 \
                     sha256  d0aed49230bc02a65c1e0229e65f34590a4b037ec40d546f32573b467f7551ea
     patchfiles-append   zipfs.patch
+    depends_lib-append  port:libtommath
+    configure.cppflags-append   -I${prefix}/include/libtommath
+    configure.args-append   --with-system-libtommath
 }
 master_sites        sourceforge:project/tcl/Tcl/${version}
 
@@ -42,52 +48,73 @@ distname            ${name}${version}-src
 worksrcdir          ${name}${version}/unix
 patch.dir           ${workpath}/${name}${version}
 
-depends_lib         port:zlib
-
-configure.args      --disable-corefoundation
-
 if {$subport eq $name} {
-    set libdir          ${prefix}/lib
-    configure.args-append   --mandir=${prefix}/share/man
+    # tcl metaport depends on tcl 8 for now - can revisit this when all
+    # dependents switch to depending on a specific subport.
+    set tclmajor 8
+    set tcldepname tcl${tclmajor}
+    depends_lib port:${tcldepname}
+    distfiles
+    # Not noarch so arch checking works transitively
+    test.ignore_archs   yes
+    platforms       any
+    use_configure   no
+    universal_variant   yes
+    build           {}
+    destroot {
+        ln -s tclsh8.6 ${destroot}${prefix}/bin/tclsh
+
+        set incdir ${prefix}/include/${tcldepname}
+        ln -s {*}[glob -directory ${incdir} *] ${destroot}${prefix}/include
+
+        set libdir ${prefix}/lib/${tcldepname}
+        ln -s {*}[glob -directory ${libdir} tcl*Config.sh] ${destroot}${prefix}/lib
+        ln -s libtcl8.6.dylib ${destroot}${prefix}/lib/libtcl.dylib
+        ln -s libtclstub8.6.a ${destroot}${prefix}/lib/libtclstub.a
+        ln -s ${libdir}/pkgconfig/tcl.pc ${destroot}${prefix}/lib/pkgconfig
+
+        set mandir ${prefix}/share/${tcldepname}/man
+        foreach sect {1 3 n} {
+            xinstall -d ${destroot}${prefix}/share/man/man${sect}
+            ln -s {*}[glob -directory ${mandir}/man${sect} *] ${destroot}${prefix}/share/man/man${sect}
+        }
+    }
 } else {
-    depends_lib-append  port:libtommath
+    depends_lib-append  port:zlib
     set libdir          ${prefix}/lib/${subport}
-    configure.cppflags-append   -I${prefix}/include/libtommath
-    configure.args-append   --includedir=${prefix}/include/${subport} \
+    configure.args-append   --disable-corefoundation \
+                            --includedir=${prefix}/include/${subport} \
                             --libdir=${libdir} \
                             --mandir=${prefix}/share/${subport}/man \
-                            --enable-man-symlinks \
-                            --with-system-libtommath
-}
+                            --enable-man-symlinks
 
-configure.cppflags-delete  -I${prefix}/include
-configure.ldflags-delete   -L${prefix}/lib
-
-pre-configure {
-    # sqlite3 package is provided by sqlite3-tcl
-    delete [glob ${worksrcpath}/../pkgs/sqlite*]
-}
-
-post-configure {
-    reinplace -E {s|-arch [^ ]+||g} ${worksrcpath}/tclConfig.sh
-}
-
-# see https://trac.macports.org/ticket/17189
-destroot.target-append \
-                    install-private-headers
-destroot.destdir    INSTALL_ROOT=${destroot}
-post-destroot {
-    if {$subport eq $name} {
-        ln -s tclsh8.6 ${destroot}${prefix}/bin/tclsh
-        ln -s libtcl8.6.dylib ${destroot}${prefix}/lib/libtcl.dylib
+    pre-configure {
+        # sqlite3 package is provided by sqlite3-tcl
+        delete {*}[glob ${worksrcpath}/../pkgs/sqlite*]
     }
 
-    if {${configure.ccache}} {
-        reinplace {/TCL_CC/s/ccache //} ${destroot}${libdir}/tclConfig.sh
+    post-configure {
+        reinplace -E {s|-arch [^ ]+||g} ${worksrcpath}/tclConfig.sh
+    }
+
+    # see https://trac.macports.org/ticket/17189
+    destroot.target-append \
+                        install-private-headers
+    destroot.destdir    INSTALL_ROOT=${destroot}
+    post-destroot {
+        if {${configure.ccache}} {
+            reinplace {/TCL_CC/s/ccache //} ${destroot}${libdir}/tclConfig.sh
+        }
+        if {$subport eq "tcl8"} {
+            foreach lib [glob -directory ${destroot}${libdir} -tails libtcl*.{a,dylib}] {
+                ln -s ${libdir}/${lib} ${destroot}${prefix}/lib
+            }
+        }
+        ln -s ${libdir}/pkgconfig/tcl.pc ${destroot}${prefix}/lib/pkgconfig/${subport}.pc
     }
 }
 
-if {$subport eq $name} {
+if {$subport eq "tcl8"} {
     configure.args-append   --disable-threads
 
     variant threads description {add multithreading support} {
@@ -95,28 +122,12 @@ if {$subport eq $name} {
                                --enable-threads
     }
     default_variants-append +threads
-}
-
-platform macosx {
-    # CF is not fork()-safe and software e.g. using tk and fork() will crash
-    variant corefoundation description {Enable CoreFoundation support (not fork-safe)} {
-        configure.args-replace --disable-corefoundation \
-                               --enable-corefoundation
+    pre-activate {
+        set checkfile ${prefix}/bin/tclsh8.6
+        if {[file exists $checkfile] && [registry_file_registered $checkfile] eq "tcl"} {
+            registry_deactivate_composite tcl {} [dict create ports_nodepcheck 1]
+        }
     }
-    # tk +quartz crashes at launch without CF support
-    default_variants-append +corefoundation
-}
-
-variant memdebug description {enable memory debugging support} {
-    configure.args-append --enable-symbols=mem
-}
-
-variant dtrace description {Enable DTrace static probes} {
-    configure.args-append --enable-dtrace
-}
-
-platform darwin {
-    configure.args-append tcl_cv_type_64bit="long long"
 }
 
 if {$subport eq $name} {
@@ -124,13 +135,35 @@ if {$subport eq $name} {
     The Sqlite3 Tcl package is now being provided by the sqlite3-tcl port:
     sudo port install sqlite3-tcl
     "
-}
-
-test.run            yes
-
-livecheck.type      regex
-if {$subport eq $name} {
-    livecheck.regex     {Tcl/Tk (8(?:\.\d+)*)</a>}
+    livecheck.type      none
 } else {
-    livecheck.regex     {Tcl/Tk (\d+(?:\.\d+)*)</a>}
+    platform macosx {
+        # CF is not fork()-safe and software e.g. using tk and fork() will crash
+        variant corefoundation description {Enable CoreFoundation support (not fork-safe)} {
+            configure.args-replace --disable-corefoundation \
+                                   --enable-corefoundation
+        }
+        # tk +quartz crashes at launch without CF support
+        default_variants-append +corefoundation
+    }
+
+    variant memdebug description {enable memory debugging support} {
+        configure.args-append --enable-symbols=mem
+    }
+
+    variant dtrace description {Enable DTrace static probes} {
+        configure.args-append --enable-dtrace
+    }
+
+    platform darwin {
+        configure.args-append tcl_cv_type_64bit="long long"
+    }
+
+    test.run            yes
+    livecheck.type      regex
+    if {$subport eq "tcl8"} {
+        livecheck.regex     {Tcl/Tk (8(?:\.\d+)*)</a>}
+    } else {
+        livecheck.regex     {Tcl/Tk (\d+(?:\.\d+)*)</a>}
+    }
 }

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -8,7 +8,7 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.6.0
-revision                    0
+revision                    1
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -236,11 +236,11 @@ variant latex description {build with LaTeX support and docs in PDF} {
 variant tcltk description {enable use of tcltk} {
     depends_lib-append      port:tcl
     if {[variant_isset quartz]} {
-        depends_lib-append      port:tk-quartz
-        configure.args-append   --with-tk-config=${prefix}/lib/tk-quartz/tkConfig.sh
+        depends_lib-append      port:tk8-quartz
+        configure.args-append   --with-tk-config=${prefix}/lib/tk8-quartz/tkConfig.sh
     } else {
-        depends_lib-append      port:tk-x11
-        configure.args-append   --with-tk-config=${prefix}/lib/tk-x11/tkConfig.sh
+        depends_lib-append      port:tk8-x11
+        configure.args-append   --with-tk-config=${prefix}/lib/tk8-x11/tkConfig.sh
     }
     configure.args-delete   --without-tcltk
     configure.args-append   --with-tcltk \

--- a/math/netgen/Portfile
+++ b/math/netgen/Portfile
@@ -8,7 +8,7 @@ PortGroup               github    1.0
 PortGroup               legacysupport 1.1
 
 github.setup            NGSolve netgen 6.2.2604 v
-revision                3
+revision                4
 categories              math
 license                 LGPL-2
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -132,17 +132,17 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
     && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
     variant quartz conflicts x11 {
-        depends_lib-append  port:tk-quartz
+        depends_lib-append  port:tk8-quartz
         require_active_variants tkdnd quartz
         require_active_variants Togl  quartz
 
         # OpenGL/gl3.h does not exist prior to 10.7.
         # https://github.com/NGSolve/netgen/issues/173
         patchfiles-append       patch-opengl.diff
-        configure.args-append   -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
-                                -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
-                                -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
-                                -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib \
+        configure.args-append   -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk8-quartz \
+                                -DTK_WISH:PATH=${prefix}/libexec/tk8-quartz/wish \
+                                -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk8-quartz/libtkstub8.6.a \
+                                -DTK_LIBRARY:PATH=${prefix}/lib/tk8-quartz/libtk.dylib \
                                 -DMACPORTS_NO_X11=TRUE
     }
     if {![variant_isset x11]} {
@@ -155,7 +155,7 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
 }
 
 variant x11 conflicts {*}${x11conflicts} {
-    depends_lib-append  port:tk-x11
+    depends_lib-append  port:tk8-x11
     require_active_variants tkdnd x11
     require_active_variants Togl  x11
     depends_lib-append      port:xorg-libX11 \
@@ -167,10 +167,10 @@ variant x11 conflicts {*}${x11conflicts} {
     patchfiles-append       patch-x11-gl.diff
 
     configure.args-append   -DOPENGL_gl_LIBRARY=${prefix}/lib/libGL.dylib \
-                            -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-x11 \
-                            -DTK_WISH:PATH=${prefix}/libexec/tk-x11/wish \
-                            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-x11/libtkstub8.6.a \
-                            -DTK_LIBRARY:PATH=${prefix}/lib/tk-x11/libtk.dylib
+                            -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk8-x11 \
+                            -DTK_WISH:PATH=${prefix}/libexec/tk8-x11/wish \
+                            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk8-x11/libtkstub8.6.a \
+                            -DTK_LIBRARY:PATH=${prefix}/lib/tk8-x11/libtk.dylib
 }
 
 pre-configure {

--- a/science/gvemod-labeler/Portfile
+++ b/science/gvemod-labeler/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 
 name                        gvemod-labeler
 version                     0.4
-revision                    1
+revision                    2
 categories                  science graphics x11
 maintainers                 {raphael @raphael-st} openmaintainer
 description                 An interactive tool for generating \
@@ -34,7 +34,7 @@ checksums                   ${distname}${extract.suffix} \
                                 size    254354
 
 depends_lib                 port:geomview \
-                            port:tk-x11
+                            port:tk8-x11
 
 # Use the Tcl script from version 0.2 and delete the "Labler" binary.
 # Work around case-insensitivity "Labeler" Tcl script <-> "labeler" module
@@ -45,8 +45,8 @@ post-extract {
         ${worksrcpath}/src/Makefile.in
 }
 
-configure.args              --with-tk-lib=${prefix}/lib/tk-x11 \
-                            --with-tk-headers=${prefix}/include/tk-x11
+configure.args              --with-tk-lib=${prefix}/lib/tk8-x11 \
+                            --with-tk-headers=${prefix}/include/tk8-x11
 
 post-destroot {
     move ${destroot}${prefix}/libexec/geomview/tcl/Labeler.tc \

--- a/science/gvemod-labeler/Portfile
+++ b/science/gvemod-labeler/Portfile
@@ -34,6 +34,7 @@ checksums                   ${distname}${extract.suffix} \
                                 size    254354
 
 depends_lib                 port:geomview \
+                            port:tcl8 \
                             port:tk8-x11
 
 # Use the Tcl script from version 0.2 and delete the "Labler" binary.
@@ -45,8 +46,11 @@ post-extract {
         ${worksrcpath}/src/Makefile.in
 }
 
-configure.args              --with-tk-lib=${prefix}/lib/tk8-x11 \
-                            --with-tk-headers=${prefix}/include/tk8-x11
+configure.args              --with-tcl-dir=${prefix}/lib/tcl8 \
+                            --with-tcl-headers=${prefix}/include/tcl8 \
+                            --with-tk-lib=${prefix}/lib/tk8-x11 \
+                            --with-tk-headers=${prefix}/include/tk8-x11 \
+                            --with-tk-dir=${prefix}/lib/tk8-x11
 
 post-destroot {
     move ${destroot}${prefix}/libexec/geomview/tcl/Labeler.tc \

--- a/science/magic/Portfile
+++ b/science/magic/Portfile
@@ -5,7 +5,7 @@ PortGroup           conflicts_build 1.0
 
 name                magic
 version             8.3.508
-revision            1
+revision            2
 checksums           rmd160  f034a75cb02e22b72cf0f5748029bb06e570a259 \
                     sha256  efd23c5b6de4da25868964f1f1e6e4e2229d8ee82f1bfa795e6c2cbfb48e46ab \
                     size    3762537
@@ -34,7 +34,7 @@ depends_lib         port:blt \
                     port:libGLU \
                     port:mesa \
                     port:tcl \
-                    port:tk-x11 \
+                    port:tk8-x11 \
                     port:xorg-libice \
                     port:xorg-libXi \
                     port:xorg-libXmu \
@@ -59,10 +59,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 19} {
 
 configure.args-append \
                     ac_cv_path_PYTHON3=${configure.python} \
-                    --with-tk=${prefix}/lib/tk-x11 \
-                    --with-tkincls=${prefix}/include/tk-x11 \
-                    --with-tklibs=${prefix}/lib/tk-x11 \
-                    --with-wish=${prefix}/libexec/tk-x11/wish
+                    --with-tk=${prefix}/lib/tk8-x11 \
+                    --with-tkincls=${prefix}/include/tk8-x11 \
+                    --with-tklibs=${prefix}/lib/tk8-x11 \
+                    --with-wish=${prefix}/libexec/tk8-x11/wish
 
 use_parallel_build  no
 

--- a/science/xcrysden/Portfile
+++ b/science/xcrysden/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 
 name                xcrysden
 version             1.6.2
-revision            1
+revision            2
 categories          science
 license             GPL-2+
 
@@ -31,7 +31,7 @@ checksums           rmd160  76d689c50dfc2207cf814b2edc4df36b2921e80b \
 compilers.choose    fc
 compilers.setup     require_fortran
 
-depends_lib         port:fftw-3 port:mesa port:libGLU port:tcl port:tk-x11 port:Togl-2.0 \
+depends_lib         port:fftw-3 port:mesa port:libGLU port:tcl port:tk8-x11 port:Togl-2.0 \
                     port:xorg-libXmu port:xorg-libX11 port:xorg-libXext
 depends_run         port:BWidget
 
@@ -82,8 +82,8 @@ COMPILE_FFTW=no
 COMPILE_TOGL=no
 FFTW3_LIB=${prefix}/lib/libfftw3.dylib
 X_LIB=${prefix}/lib/libXmu.dylib ${prefix}/lib/libX11.dylib ${prefix}/lib/libXext.dylib
-TK_INCDIR=-I${prefix}/include/tk-x11
-TK_LIB=${prefix}/lib/tk-x11/libtk.dylib
+TK_INCDIR=-I${prefix}/include/tk8-x11
+TK_LIB=${prefix}/lib/tk8-x11/libtk.dylib
 TCL_LIB=${prefix}/lib/libtcl.dylib
 GL_LIB=${prefix}/lib/libGL.dylib
 GLU_LIB=${prefix}/lib/libGLU.dylib

--- a/x11/Togl/Portfile
+++ b/x11/Togl/Portfile
@@ -10,7 +10,7 @@ name                            Togl
 # See https://github.com/NGSolve/netgen/tree/master/ng.
 github.setup                    NGSolve netgen 6.2.2307 v
 version                         2.1
-revision                        6
+revision                        7
 categories                      x11
 license                         permissive
 maintainers                     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -43,10 +43,10 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
     && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
     variant quartz conflicts x11 {
-        depends_lib-append  port:tk-quartz
-        configure.args-append       --with-tk=${prefix}/lib/tk-quartz \
-                                    --with-tkinclude=${prefix}/include/tk-quartz
-        configure.cppflags-prepend  -I${prefix}/include/tk-quartz
+        depends_lib-append  port:tk8-quartz
+        configure.args-append       --with-tk=${prefix}/lib/tk8-quartz \
+                                    --with-tkinclude=${prefix}/include/tk8-quartz
+        configure.cppflags-prepend  -I${prefix}/include/tk8-quartz
         # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L250
         configure.cppflags-append   -DTOGL_NSOPENGL
         # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L221
@@ -62,14 +62,14 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
 }
 
 variant x11 conflicts {*}${x11conflicts} {
-    depends_lib-append          port:tk-x11 \
+    depends_lib-append          port:tk8-x11 \
                                 port:xorg-libX11 \
                                 port:xorg-libXmu \
                                 port:mesa
-    configure.args-append       --with-tk=${prefix}/lib/tk-x11 \
-                                --with-tkinclude=${prefix}/include/tk-x11 \
+    configure.args-append       --with-tk=${prefix}/lib/tk8-x11 \
+                                --with-tkinclude=${prefix}/include/tk8-x11 \
                                 --with-Xmu
-    configure.cppflags-prepend  -I${prefix}/include/tk-x11
+    configure.cppflags-prepend  -I${prefix}/include/tk8-x11
     # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L252
     configure.cppflags-append   -DTOGL_X11
 }

--- a/x11/blt/Portfile
+++ b/x11/blt/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    blt
 version                 2.5.3
-revision                1
+revision                2
 categories              x11
 license                 MIT
 maintainers             nomaintainer
@@ -25,15 +25,15 @@ checksums               rmd160  a0e0882e19003bbdb8a89d7c3d410bd32b12b685 \
                         size    2724036
 
 depends_build           port:tcl \
-                        port:tk-x11 \
+                        port:tk8-x11 \
                         port:xorg-libX11
 
 use_parallel_build      no
 
 configure.args-append   --with-tcl=${prefix}/lib \
-                        --with-tk=${prefix}/lib/tk-x11 \
-                        --with-tkincls=${prefix}/include/tk-x11 \
-                        --with-tklibs=${prefix}/lib/tk-x11
+                        --with-tk=${prefix}/lib/tk8-x11 \
+                        --with-tkincls=${prefix}/include/tk8-x11 \
+                        --with-tklibs=${prefix}/lib/tk8-x11
 
 # prevent having to modify all of Debian patches
 patch.pre_args-replace  -p0 -p1

--- a/x11/tix/Portfile
+++ b/x11/tix/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tix
 version             8.4.3
-revision            6
+revision            7
 categories          x11
 license             BSD
 maintainers         {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -47,10 +47,10 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
     && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
     variant quartz conflicts x11 {
-        depends_lib-append  port:tk-quartz
+        depends_lib-append  port:tk8-quartz
         configure.args-append \
-                        --with-tk=${prefix}/lib/tk-quartz
-        configure.cppflags-prepend  -I${prefix}/include/tk-quartz
+                        --with-tk=${prefix}/lib/tk8-quartz
+        configure.cppflags-prepend  -I${prefix}/include/tk8-quartz
     }
     if {![variant_isset x11]} {
         default_variants +quartz
@@ -62,14 +62,14 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
 }
 
 variant x11 conflicts {*}${x11conflicts} {
-    depends_lib-append  port:tk-x11
+    depends_lib-append  port:tk8-x11
 
     configure.args-append \
                     --with-x \
                     --x-includes=${prefix}/include \
                     --x-libraries=${prefix}/lib \
-                    --with-tk=${prefix}/lib/tk-x11
-    configure.cppflags-prepend  -I${prefix}/include/tk-x11
+                    --with-tk=${prefix}/lib/tk8-x11
+    configure.cppflags-prepend  -I${prefix}/include/tk8-x11
 }
 
 test.run            yes

--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.1
 
 name                tk
-version             8.6.17
+version             8.6.18
 revision            0
 categories          x11
 license             Tcl/Tk
@@ -15,16 +14,37 @@ long_description    This is Tk version ${version}, a GUI toolkit for Tcl. The be
                     started with Tcl is to read ``Tcl and the Tk Toolkit'' by John K.         \
                     Ousterhout, Addison-Wesley, ISBN 0-201-63337-X.
 
+subport tk8-quartz  {revision 0}
+subport tk8-x11     {revision 0}
+subport tk9-quartz  {revision 0}
+subport tk9-x11     {revision 0}
+subport tk-quartz  {
+    replaced_by     tk8-quartz
+}
+subport tk-x11  {
+    replaced_by     tk8-x11
+}
+
+if {$subport in {tk8-quartz tk8-x11}} {
+    checksums   md5     63a13111a136118ec72faee1228143e6 \
+                sha1    a7593f9f62e41eb0edab0deb0e0b92a62ec219b9 \
+                rmd160  9e2248f4f97bd939bada96cf8ddf16f8b8c44fc6 \
+                sha256  95cd528a80f5e4bdb557af9b14a7197d6860793a3894e25e7c9fad2ed05d4c3c
+
+    livecheck.regex     {Tcl/Tk (8(?:\.\d+)*)</a>}
+} elseif {$subport in {tk9-quartz tk9-x11}} {
+    version     9.0.4
+    checksums   md5     1b133d4ddf3dec2c01340cdc68c87096 \
+                sha1    ca517d325695cdd1d5fe71ae5bb1ae724d51d00b \
+                rmd160  ef0356645a77429ecf7da590f9cf2eeaa89d498d \
+                sha256  d7a146d2917eb8b5cc95276dbf0e3d03c7464d2b19c1675357857c989301dbb4
+
+    livecheck.regex     {Tcl/Tk (\d+(?:\.\d+)*)</a>}
+}
 master_sites        sourceforge:project/tcl/Tcl/${version}
 dist_subdir         tcltk
 distname            ${name}${version}-src
 worksrcdir          ${name}${version}
-
-checksums           md5     44af36d6421cf1b2080aa991be26becd \
-                    sha1    1127e2a8b758fbc173c18223996eb924d4730396 \
-                    rmd160  63ca8e82735e147822b558848232f3426f899017 \
-                    sha256  e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946 \
-                    size    4593109
 
 if {$subport eq $name} {
     distfiles
@@ -36,9 +56,9 @@ if {$subport eq $name} {
     build           {}
     destroot {
         if {[variant_exists quartz] && [variant_isset quartz]} {
-            set tkdepname tk-quartz
+            set tkdepname tk${tkmajor}-quartz
         } else {
-            set tkdepname tk-x11
+            set tkdepname tk${tkmajor}-x11
         }
 
         set bindir ${prefix}/libexec/${tkdepname}
@@ -58,30 +78,38 @@ if {$subport eq $name} {
             ln -s {*}[glob -directory ${mandir}/man${sect} *] ${destroot}${prefix}/share/man/man${sect}
         }
     }
+
+    # tk metaport depends on tk 8 for now - can revisit this when all
+    # dependents switch to depending on a specific subport.
+    set tkmajor 8
+
     if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
         && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
         variant quartz conflicts x11 {}
         # The buildbot uses default variants, so binaries for ports
         # that don't depend on a specific tk subport will be linked
         # with tk-quartz, which is thus always needed.
-        depends_lib port:tk-quartz
+        depends_lib port:tk${tkmajor}-quartz
 
         variant x11 conflicts quartz {
-            depends_lib-append port:tk-x11
+            depends_lib-append port:tk${tkmajor}-x11
         }
 
         if {![variant_isset x11]} {
-            default_variants +quartz
+            default_variants-append +quartz
         }
     } else {
-        depends_lib port:tk-x11
+        depends_lib port:tk${tkmajor}-x11
     }
-    livecheck.type      regex
-    # Only check for 8.x versions - 9 will need to be a separate port.
-    livecheck.regex     {Tcl/Tk (8(?:\.\d+)*)</a>}
+    livecheck.type      none
 } else {
     depends_build       path:bin/pkg-config:pkgconfig
-    depends_lib         port:tcl
+    if {$subport in {tk8-quartz tk8-x11}} {
+        set tclport tcl8
+    } else {
+        set tclport tcl9
+    }
+    depends_lib         port:${tclport}
 
     configure.dir       ${worksrcpath}/unix
     build.dir           ${configure.dir}
@@ -91,30 +119,29 @@ if {$subport eq $name} {
     set libdir          ${prefix}/lib/${subport}
     set mandir          ${prefix}/share/${subport}/man
 
-    configure.args      --bindir=${bindir} \
+    configure.args      --with-tcl=${prefix}/lib/${tclport} \
+                        --bindir=${bindir} \
                         --includedir=${incdir} \
                         --libdir=${libdir} \
                         --mandir=${mandir} \
-                        --with-tcl=${prefix}/lib
+                        --enable-man-symlinks
     configure.env       {TK_LIBRARY=$(libdir)/tk$(VERSION)}
     platform darwin {
         configure.args-append \
                         tcl_cv_type_64bit="long long"
     }
     # see https://trac.macports.org/ticket/58447
-    configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
-    configure.ldflags   -L${worksrcpath} -L${prefix}/lib
-
-    configure.args.arm64-append     --enable-64bit
-    configure.args.x86_64-append    --enable-64bit
-    configure.args.ppc64-append     --enable-64bit
+    configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include/${tclport}
+    configure.ldflags   -L${worksrcpath} -L${prefix}/lib/${tclport}
 
     # see https://trac.macports.org/ticket/17189
     destroot.target-append \
                         install-private-headers
     post-destroot {
-        ln -s wish8.6 ${destroot}${bindir}/wish
-        ln -s libtk8.6.dylib ${destroot}${libdir}/libtk.dylib
+        if {$subport in {tk8-quartz tk8-x11}} {
+            ln -s libtk8.6.dylib ${destroot}${libdir}/libtk.dylib
+            ln -s wish8.6 ${destroot}${bindir}/wish
+        }
     
         foreach fl {tk3d.h tkFont.h} {
             xinstall -m 0644 ${workpath}/tk${version}/generic/${fl} ${destroot}${incdir}
@@ -126,8 +153,7 @@ if {$subport eq $name} {
     livecheck.type      none
 }
 
-subport tk-quartz {
-    revision        0
+if {$subport in {tk8-quartz tk9-quartz}} {
     platforms       {macosx >= 10}
     supported_archs arm64 i386 x86_64
     configure.args-append \
@@ -145,8 +171,7 @@ subport tk-quartz {
     }
 }
 
-subport tk-x11 {
-    revision        0
+if {$subport in {tk8-x11 tk9-x11}} {
     depends_lib-append \
                     port:fontconfig \
                     port:Xft2 \

--- a/x11/tkdnd/Portfile
+++ b/x11/tkdnd/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        petasis tkdnd 2.9.4 tkdnd-release-test-v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            1
+revision            2
 categories          x11
 license             BSD
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -36,12 +36,12 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
     && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
     variant quartz conflicts x11 {
-        depends_lib-append  port:tk-quartz
+        depends_lib-append  port:tk8-quartz
         configure.args-append \
-            -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
-            -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
-            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
-            -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
+            -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk8-quartz \
+            -DTK_WISH:PATH=${prefix}/libexec/tk8-quartz/wish \
+            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk8-quartz/libtkstub8.6.a \
+            -DTK_LIBRARY:PATH=${prefix}/lib/tk8-quartz/libtk.dylib
         # garbage collection is still available for ${os.major} < 16
         # ARC is available for ${os.major} > 10
         # in Xcode < 10, ARC forbids Objective-C objects in struct
@@ -74,17 +74,17 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
 
 variant x11 conflicts {*}${x11conflicts} {
     depends_lib-append \
-        port:tk-x11 \
+        port:tk8-x11 \
         port:xorg-libX11 \
         port:xorg-libXext \
         port:xorg-libice \
         port:xorg-libsm
 
     configure.args-append \
-        -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-x11 \
-        -DTK_WISH:PATH=${prefix}/libexec/tk-x11/wish \
-        -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-x11/libtkstub8.6.a \
-        -DTK_LIBRARY:PATH=${prefix}/lib/tk-x11/libtk.dylib
+        -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk8-x11 \
+        -DTK_WISH:PATH=${prefix}/libexec/tk8-x11/wish \
+        -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk8-x11/libtkstub8.6.a \
+        -DTK_LIBRARY:PATH=${prefix}/lib/tk8-x11/libtk.dylib
 }
 
 pre-configure {

--- a/x11/tktable/Portfile
+++ b/x11/tktable/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tktable
 version             2.11
-revision            3
+revision            4
 categories          x11
 license             Tcl/Tk
 maintainers         {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -47,9 +47,9 @@ if {${os.platform} eq "moof" && ${os.subplatform} eq "macosx"
     && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
     variant quartz conflicts x11 {
-        depends_build-append    port:tk-quartz
-        configure.args-append   --with-tk=${prefix}/lib/tk-quartz \
-                                --with-tkinclude=${prefix}/include/tk-quartz
+        depends_build-append    port:tk8-quartz
+        configure.args-append   --with-tk=${prefix}/lib/tk8-quartz \
+                                --with-tkinclude=${prefix}/include/tk8-quartz
     }
     if {![variant_isset x11]} {
         default_variants +quartz
@@ -61,9 +61,9 @@ if {${os.platform} eq "moof" && ${os.subplatform} eq "macosx"
 }
 
 variant x11 conflicts {*}${x11conflicts} {
-    depends_build-append    port:tk-x11
-    configure.args-append   --with-tk=${prefix}/lib/tk-x11 \
-                            --with-tkinclude=${prefix}/include/tk-x11
+    depends_build-append    port:tk8-x11
+    configure.args-append   --with-tk=${prefix}/lib/tk8-x11 \
+                            --with-tkinclude=${prefix}/include/tk8-x11
 }
 
 test.run            yes

--- a/x11/xcircuit/Portfile
+++ b/x11/xcircuit/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                xcircuit
 version             3.10.30
-revision            3
+revision            4
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          x11 cad
 maintainers         {khindenburg @kurthindenburg} openmaintainer
@@ -39,7 +39,7 @@ depends_build       port:autoconf \
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:ghostscript \
-                    port:tk-x11 \
+                    port:tk8-x11 \
                     port:xpm
 
 # Currently, xcircuit crashes upon start if tk is built without x11
@@ -55,7 +55,7 @@ patchfiles-append   patch-xcircuit-implicit-udrawxat.diff
 configure.cflags-append -Wno-return-type
 
 configure.args      --with-tcl=${prefix}/lib \
-                    --with-tk=${prefix}/lib/tk-x11 \
+                    --with-tk=${prefix}/lib/tk8-x11 \
                     --with-gs=${prefix}/bin/gs \
                     --x-includes=${prefix}/include \
                     --x-libraries=${prefix}/lib


### PR DESCRIPTION
- Add tk 9 subports and rename existing tk subports to tk8-*.
- Don't use muniversal in tk.
- Update dependencies on the above in other ports and rev bump.
- Make tcl a shim port that depends on tcl8.
- Update tcl8 and tk8 to 8.6.18.

Closes: https://trac.macports.org/ticket/71415

###### Type(s)

- [x] enhancement

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?
