### PR TITLE
mp3rgain: update to 2.9.4

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.3 v
+github.setup        M-Igashi mp3rgain 2.9.4 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5469b07f17723c882f17018eef1b9c3dd91439b3 \
-                    sha256  7b1df9a15541ecedca9bf27e7b7cc4f02706a22b577817c80d9a9b9e0c08f3db \
-                    size    517322
+                    rmd160  a705479e41be426bf7977e235a4603591e5aabd0 \
+                    sha256  586a30a3b656e575124a892008099cd9433add57a86a92a4c6362a6043f62a0b \
+                    size    517746
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -40,7 +40,7 @@ cargo.crates \
     byteorder                    1.5.0            1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cfg-if                       1.0.4            9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     colored                      3.1.1            faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
-    console                      0.16.3           d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
+    console                      0.16.4           4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     crc32fast                    1.5.0            9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-deque              0.8.6            9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch              0.9.18           5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
@@ -49,7 +49,7 @@ cargo.crates \
     encode_unicode               1.0.0            34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     flate2                       1.1.9            843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
     id3                          1.17.0           70d6d9f23a28c6feab60d7b4a339e004809019ec9d5fd964b3f4c655ff9bc141 \
-    indicatif                    0.18.4           25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
+    indicatif                    0.18.6           9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
     itoa                         1.0.18           8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     js-sys                       0.3.94           2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9 \
     lazy_static                  1.5.0            bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \


### PR DESCRIPTION
Update audio/mp3rgain to 2.9.4.

- Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.4
- Bumped `github.setup` to 2.9.4, reset revision to 0
- Recomputed rmd160 / sha256 / size for the source tarball
- Regenerated `cargo.crates` from the new Cargo.lock (console 0.16.4, indicatif 0.18.6)

Maintainer: @M-Igashi