### PR TITLE
claude-code: update to 2.1.199

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.198
+version             2.1.199
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  f0621ad0025fe7508bcb121304d767a5772b1e6f \
-                 sha256  280b6cfc60dacc4caed31af1249e53c259c01759556e60633944c02405c82dd0 \
-                 size    238706000
+    checksums    rmd160  4169257b74b7f63b0fedc1cc38bffa7b5912f45e \
+                 sha256  e64853ff3bc2ae6ed8115581c851e1176762d445d0b8b9e0dd37d0d560224a88 \
+                 size    240192080
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  d5b0c3dd184af9d46d55137f4c9f5764155379c3 \
-                 sha256  ab6f7ee109816ede414f7c285446633f805b623aa609f425609a64266451d61e \
-                 size    229328464
+    checksums    rmd160  32433a636c6554c9fe7e1af65572237822acdf1c \
+                 sha256  e3cb61abc8a2ec7b98976cee1ffdde5a3fa755c9990bc8d688cd89290e0dcec0 \
+                 size    232155536
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.199.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?