### PR TITLE
harfbuzz: update to 14.2.1

### DIFF
--- a/graphics/harfbuzz/Portfile
+++ b/graphics/harfbuzz/Portfile
@@ -8,10 +8,10 @@ PortGroup           muniversal 1.1
 
 # Please keep the harfbuzz and harfbuzz-devel ports as similar as possible.
 
-github.setup        harfbuzz harfbuzz 14.2.0
-checksums           rmd160  704f3cebb39e523f93ffe9647c2b49f5b2b79607 \
-                    sha256  94017020f96d025bb66ae91574e4cf334bcad23e8175a8a40565b3721bc2eaff \
-                    size    19555096
+github.setup        harfbuzz harfbuzz 14.2.1
+checksums           rmd160  291614dec3db67a0d7da5f5a3c6b0d2690d8c7e4 \
+                    sha256  a54a5d8e9380a41fbb762ce367bcbf7704792dfca0d93f1bbca86c5a57902e0e \
+                    size    19559952
 
 name                harfbuzz
 conflicts           harfbuzz-devel
@@ -78,7 +78,7 @@ configure.cflags-append     -DHB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR
 configure.cxxflags-append   -DHB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR
 
 if {${name} eq ${subport}} {
-    revision        1
+    revision        0
 
     gobject_introspection yes
 
@@ -132,7 +132,7 @@ if {${name} eq ${subport}} {
 }
 
 subport harfbuzz-icu {
-    revision        2
+    revision        0
 
     conflicts       harfbuzz-icu-devel
 


### PR DESCRIPTION
#### Description

harfbuzz-devel is building fine since some time.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
