### PR TITLE
librsvg-devel, librsvg: skip .9X (beta) versions on livecheck

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -173,5 +173,7 @@ post-deactivate {
     system "${prefix}/bin/gdk-pixbuf-query-loaders --update-cache"
 }
 
+#we use regex to avoid catching '.90' (beta) releases
 livecheck.type      gnome
 livecheck.name      ${my_name}
+livecheck.regex     {"(\d+\.\d*[02468]\.(?!9\d)\d+(?:\.\d+)*)"}

--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gobject_introspection 1.0
 
 name                librsvg
 set my_name         librsvg
@@ -64,8 +65,6 @@ if {[info exists librsvg.override.fallback]} {
 
 if {${librsvg_fallback}} {
     # revert to latest pre-cargo version
-    PortGroup       gobject_introspection 1.0
-
     version         2.40.21
     revision        1
     epoch           1
@@ -99,7 +98,6 @@ if {${librsvg_fallback}} {
     # gobject_introspection uses `configure.ldflags` in callback function
     # therefore, rust PG must precede gobject_introspection PG
     PortGroup       rust 1.0
-    PortGroup       gobject_introspection 1.0
 
     version         2.58.5
     revision        1
@@ -166,5 +164,7 @@ post-deactivate {
     system "${prefix}/bin/gdk-pixbuf-query-loaders --update-cache"
 }
 
+#we use regex to avoid catching '.90' (beta) releases
 livecheck.type      gnome
 livecheck.name      ${my_name}
+livecheck.regex     {"(\d+\.\d*[02468]\.(?!9\d)\d+(?:\.\d+)*)"}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
