### PR TITLE
claude-code: update to 2.1.200

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.199
+version             2.1.200
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  4169257b74b7f63b0fedc1cc38bffa7b5912f45e \
-                 sha256  e64853ff3bc2ae6ed8115581c851e1176762d445d0b8b9e0dd37d0d560224a88 \
-                 size    240192080
+    checksums    rmd160  27563dd07bf5d53b85076416ae63544701f46294 \
+                 sha256  b0a4dd56a91b24e18c9f83b50a7f19989ecbaba3d2ae4bf6f3f95f4033a87371 \
+                 size    241100240
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  32433a636c6554c9fe7e1af65572237822acdf1c \
-                 sha256  e3cb61abc8a2ec7b98976cee1ffdde5a3fa755c9990bc8d688cd89290e0dcec0 \
-                 size    232155536
+    checksums    rmd160  ba61bccbc325c58a1a29f09335da27ea4875cbaa \
+                 sha256  e6fd52c0c72ff83663bf3cbfc833b45faaba2b9a9952863279dc3cfc1a0492b6 \
+                 size    231708784
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
## Summary
- Bump `llm/claude-code` from 2.1.199 to 2.1.200 (latest release per the GCS release bucket `/latest` pointer, matching the port's existing livecheck).
- Updated `sha256`/`rmd160`/`size` checksums for both the `x86_64` and `arm64` distfiles.

## Test plan
- [x] `port lint --nitpick` — 0 errors, 0 warnings
- [x] `port install +telemetry` on arm64 — succeeds, activates cleanly
- [x] `port test` — passes (`claude --version`)
- [x] `claude --version` reports `2.1.200 (Claude Code)` post-install