### PR TITLE
libtheora: Reenable ASM

### DIFF
--- a/multimedia/libtheora/Portfile
+++ b/multimedia/libtheora/Portfile
@@ -6,10 +6,10 @@ PortGroup       xcodeversion 1.0
 name            libtheora
 epoch           1
 version         1.2.0
-revision        0
+revision        1
 checksums       rmd160  cc16202316db077064aa2ae317663bed20d16ccb \
                 sha256  ebdf77a8f5c0a8f7a9e42323844fa09502b34eb1d1fece7b5f54da41fe2122ec \
-                size     1803124
+                size    1803124
 
 categories      multimedia
 license         BSD
@@ -37,9 +37,7 @@ configure.env   SDL_CONFIG=/usr/bin/false \
                 HAVE_BIBTEX=no            \
                 HAVE_TRANSFIG=no
 
-configure.args  --disable-asm \
-                --disable-examples \
-                --disable-oggtest \
+configure.args  --disable-examples \
                 --disable-vorbistest
 
 minimum_xcodeversions   {8 2.5}
@@ -54,9 +52,6 @@ test.run        yes
 test.target     check
 
 platform darwin powerpc {
-    # http://trac.macports.org/ticket/13033
-    # http://trac.macports.org/ticket/20141
-    configure.args-delete   --disable-asm
     # https://trac.macports.org/ticket/64607
     configure.args-append   --build=powerpc-apple-darwin${os.major}
 }


### PR DESCRIPTION
#### Description

* libtheora @1.2.0: Reenable ASM for performance improvement.
* ASM was disabled in https://trac.macports.org/ticket/13033, ~apparently because of lack of ARM support~.
* **Correction:**  The original build failure was on Intel, not ARM.
* Assume that Intel support has been fixed in the interim.
* It looks like ARM support was also added since then.
* All three current ARM CI runners pass build and test, with no problem.
* Rev bump for users to get enhanced build.

###### Type(s)

- [x] enhancement

###### Tested on

* CI only.  That is OS 14, 15, 26, ARM only.
* Expect that there will be no ASM problem on x86_64 machines, because this code should be many years mature by now.
* 32-bit:  Unknown.  Try and see.
* PPC:  No change.  ASM was already enabled for PPC.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?