### PR TITLE
claude-code: update to 2.1.201

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.200
+version             2.1.201
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  27563dd07bf5d53b85076416ae63544701f46294 \
-                 sha256  b0a4dd56a91b24e18c9f83b50a7f19989ecbaba3d2ae4bf6f3f95f4033a87371 \
+    checksums    rmd160  0b706ca6bc5cecbf3bcf2dc9606b66428c0e9e6b \
+                 sha256  1889287a92d25356ae8bd8d8e67b11456015516ee8ba4277a0c7074786c49bb6 \
                  size    241100240
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  ba61bccbc325c58a1a29f09335da27ea4875cbaa \
-                 sha256  e6fd52c0c72ff83663bf3cbfc833b45faaba2b9a9952863279dc3cfc1a0492b6 \
+    checksums    rmd160  48bf3cf95566798166efc30109d57bf77d87302d \
+                 sha256  a0852d76afc47b30f5cb0b7625ec9a7714cb189f2eeef6c28c77e2be954fb7fd \
                  size    231708784
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.201.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?