### PR TITLE
appstream: Use legacysupport for faccessat

### DIFF
--- a/gnome/appstream/Portfile
+++ b/gnome/appstream/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           meson 1.0
 PortGroup           gobject_introspection 1.0
+PortGroup           legacysupport 1.1
 
 name                appstream
 version             1.1.3
@@ -68,3 +69,6 @@ configure.args-append \
 pre-configure {
     configure.args-replace  -Dintrospection=enabled -Dgir=true
 }
+
+# faccessat
+legacysupport.newest_darwin_requires_legacy 18


### PR DESCRIPTION
#### Description

Should fix: https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/264270/steps/install-port/logs/stdio

```
[119/155] /opt/local/var/macports/build/appstream-9aa901d7/work/build/tools/appstreamcli news-to-metainfo --limit=6 ../AppStream-1.1.3/data/../NEWS ../AppStream-1.1.3/data/org.freedesktop.appstream.cli.metainfo.xml data/nol10n_withrelinfo_org.freedesktop.appstream.cli.metainfo.xml
FAILED: [code=4] data/nol10n_withrelinfo_org.freedesktop.appstream.cli.metainfo.xml 
/opt/local/var/macports/build/appstream-9aa901d7/work/build/tools/appstreamcli news-to-metainfo --limit=6 ../AppStream-1.1.3/data/../NEWS ../AppStream-1.1.3/data/org.freedesktop.appstream.cli.metainfo.xml data/nol10n_withrelinfo_org.freedesktop.appstream.cli.metainfo.xml

(appstreamcli:37294): GLib-GIO-CRITICAL **: 21:53:14.805: g_local_file_query_exists: faccessat doesn't support supplied flags
Metainfo file '../AppStream-1.1.3/data/org.freedesktop.appstream.cli.metainfo.xml' does not exist.
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
