### PR TITLE
llama-swap: update to 235, pass version args to make

### DIFF
--- a/llm/llama-swap/Portfile
+++ b/llm/llama-swap/Portfile
@@ -3,14 +3,15 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/mostlygeek/llama-swap 229 v
+go.setup                github.com/mostlygeek/llama-swap 235 v
 go.offline_build        no
 revision                0
+set git-commit          c59816b
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  0a9aa819d2890cf58da45b042f5d77724c9346a8 \
-                        sha256  42b144fcba9ebabb9b520e0d75ff01c25005e41bc9b0a027bbad2de4bf601f84 \
-                        size    1284928
+                        rmd160  fdfc648399114445a8ba4b0effc9a1a661170768 \
+                        sha256  e7f80958bb641ba5e01e04a5234a3731aa7e7b7c6191dc17cb2334d224c38c22 \
+                        size    3660911
 
 categories              llm
 license                 MIT
@@ -24,6 +25,8 @@ long_description        Run multiple generative AI models on your machine and ho
 depends_build-append    \
                         bin:npm:npm10
 
+build.args              GIT_HASH=${git-commit} \
+                        GIT_VERSION=v${version}
 build.cmd               make
 build.target            mac
 supported_archs         arm64


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
