### PR TITLE
lima: Update to 2.1.4

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 2.1.3 v
+go.setup            github.com/lima-vm/lima 2.1.4 v
 go.offline_build    no
 revision            0
 
@@ -28,9 +28,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  cf12fd36957d6b293abe183ad43fcc7710d122d6 \
-                    sha256  3f6dd39922eb42ff6aa497c28b7573775864a38554002719fdbf64a05033f87e \
-                    size    7812914
+checksums           rmd160  5b650b16072307ab128581fb3292bbd3ea32197a \
+                    sha256  39209f4f573fc753aea3e95f52713a6432f32f73da5bb60ba913ca46edb1924c \
+                    size    7813236
 
 build.cmd           make
 build.args-append   native


### PR DESCRIPTION
#### Description

lima: Update to 2.1.4


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
