### PR TITLE
mise: Update to 2026.7.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.6.14 v
+github.setup        jdx mise 2026.7.0 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dbaba3ff9849876a4a30d0def109a650bd4bae67 \
-                    sha256  2480b1bd8ed693300551113b4dd7771828dcc65651e46edef8ec38e0e37a0fba \
-                    size    12331607
+                    rmd160  95dfb5f864da0f6c56fa9fea63d95a9da3725f7a \
+                    sha256  c2e581ac26551e324a2bdb726d6dd34356f865ebb4220d3998dc3f99de9ec42a \
+                    size    12370965
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -119,7 +119,6 @@ cargo.crates \
     async-compression                   0.4.42  e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac \
     async-fd-lock                        0.2.0  7569377d7062165f6f7834d9cb3051974a2d141433cc201c2f94c149e993cccf \
     async-once-cell                      0.5.4  4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a \
-    async-recursion                      1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
     async-trait                         0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
@@ -442,6 +441,7 @@ cargo.crates \
     homedir                              0.3.6  68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527 \
     http                                0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                                 1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
+    http-auth                           0.1.10  150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822 \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
@@ -495,6 +495,7 @@ cargo.crates \
     itertools                           0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                           0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itertools                           0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     jiff                                0.2.29  34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46 \
     jiff-static                         0.2.29  0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f \
@@ -582,7 +583,6 @@ cargo.crates \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                            1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     object                              0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
-    olpc-cjson                           0.1.4  696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083 \
     once_cell                           1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
@@ -670,20 +670,20 @@ cargo.crates \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.44.4  611ee9a35405e2c18b0c580e0c865632eee10164c258d9aa02a93aea31759d32 \
-    rattler_cache                        0.9.2  32c96ef6f35bffb3fb1ba9879de944a0d3477fa0c6c642f29b83100822c9f82f \
-    rattler_conda_types                 0.47.1  7647a414fef338ed377096a263f23728ff8a8a0d33416a2d32e8cb4ab0355cb6 \
+    rattler                             0.45.0  6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661 \
+    rattler_cache                       0.10.0  1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955 \
+    rattler_conda_types                 0.47.2  385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd \
     rattler_digest                       1.3.1  2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69 \
     rattler_macros                       1.1.1  ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff \
-    rattler_menuinst                    0.2.66  26cb8c41131de072608b789c2069ca9c1293b309c278ff95f39a4fe1949d283e \
-    rattler_networking                  0.28.1  9528ad148dd32f978e355a07b7b5f7a557091b34d6846aff0084afa8c4bd0c64 \
-    rattler_package_streaming           0.26.4  fefd549117f3f0e6f4679aae4f0f3c26514bc6d5e7734994915a173c16cb0052 \
+    rattler_menuinst                    0.2.67  0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d \
+    rattler_networking                  0.29.0  e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821 \
+    rattler_package_streaming           0.26.5  97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034 \
     rattler_pty                         0.2.13  ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a \
     rattler_redaction                    0.2.1  2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b \
-    rattler_repodata_gateway            0.29.5  f5f156179615c31cc410933d5dfcfc2c15b3578c1accf5be1439eb8ef430a323 \
-    rattler_shell                       0.27.6  7e7d8d4fa67349c86006241e3863ebd8c144d790c6e2f0cc55f0074ff7842d1c \
-    rattler_solve                        7.1.3  7317fb3ff057a7aa151ea34a0f0eae4b09560e51e3961f262cca9d2d03b46646 \
-    rattler_virtual_packages             3.0.1  5a447bfff51679f9662c3bc48811942acff7bb27efd3ce6bb0d19b6c26045f86 \
+    rattler_repodata_gateway            0.29.6  86a8db70f13a7841d523b995c2b79669e3045e3e6a711ceb7fa00ffe681e2255 \
+    rattler_shell                       0.27.7  8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192 \
+    rattler_solve                        7.2.0  0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6 \
+    rattler_virtual_packages             3.0.2  312c7e886ca90e83d562cadfb3d88af9dcef42f7c2489dae569df84c4bd07890 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
@@ -699,7 +699,7 @@ cargo.crates \
     rend                                 0.5.3  cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
-    resolvo                             0.10.3  2985c35f7dd19ed00659031b77ce05d1828a12eb9c6b37104da21b09d218fc24 \
+    resolvo                             0.11.1  cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rkyv                                0.8.16  73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3 \
@@ -759,7 +759,6 @@ cargo.crates \
     serde_ignored                       0.1.14  115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798 \
     serde_json                         1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_json_canonicalizer             0.3.2  fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2 \
-    serde_plain                          1.0.2  9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50 \
     serde_regex                          1.2.0  bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012 \
     serde_repr                          0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
     serde_spanned                        0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
@@ -788,14 +787,15 @@ cargo.crates \
     signal-hook                          0.4.4  b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d \
     signal-hook-registry                 1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
     signature                            2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
-    sigstore-bundle                      0.8.0  9a86d28a25d9e6107e02ca60fc60dfeb7cdc2b98251950d6fcd055f2afa31acb \
-    sigstore-crypto                      0.8.0  9cdc66f1480e176533425cc880bc5f8a8e0d88ae1fe2701e98de4fb68984b71c \
-    sigstore-merkle                      0.8.0  a4dbea5d8d5f293dfc2ed6abd06dc26a5ef017af126e53e3e36a6b2f7b7dac8c \
-    sigstore-rekor                       0.8.0  fbe0bf948de89bed9b3b5c9d62940264a4da60db3518006b952b107d0e71926f \
-    sigstore-trust-root                  0.8.0  54fdf65b1207f96d4b1e5b44028fe3e078d40a50f6316715f6ad97ae21b0bfeb \
-    sigstore-tsa                         0.8.0  860eb6a645e0a22fa316031b06e9e87f9310c21915743bfa83901472dd3e7146 \
-    sigstore-types                       0.8.0  7fb0334b69834c1f29757e57ade7e9bdbc42f5383cc22d003256d4d2df47af13 \
-    sigstore-verify                      0.8.0  c23f74b41da93e92dc1de793d5450b662fce5c8cea887daa46002a793d78bca9 \
+    sigstore-bundle                     0.10.0  18b51b097b7e9d898efad51e1031c855ce4008b4866d0c38ac8b0fac5745a84c \
+    sigstore-crypto                     0.10.0  1210ea5dd0dd07b1466449a6c5c79000f8ca10ac30b4e8f64031c3bed4c5c662 \
+    sigstore-merkle                     0.10.0  9ae98f8a270885497dbe84e6dae10fa29066df0388f62980923728e38d844716 \
+    sigstore-rekor                      0.10.0  4e1c153f4f89f7570d0f625f660cadcb1b2fba72583f378d2d2b308c752ac45f \
+    sigstore-trust-root                 0.10.0  ded6afc37295a10dba6569e033dd15f85f04f00980bfcf2c64009bc8ed279985 \
+    sigstore-tsa                        0.10.0  a88505b71600a791e52bed3777ed9cfeefd4b03dee6575d38c5542ae80e2bbdc \
+    sigstore-tuf                        0.10.0  dfc7cced094bd306ef561312cfffa3ea05ac7eea4a62cfa81680c07a10addbc0 \
+    sigstore-types                      0.10.0  56f034e86c3b8d91b32608c83f4a18939eed32c6ca08d17d2f52b88be365aac6 \
+    sigstore-verify                     0.10.0  f4720f300d093ecac6dcd75d4498fd1b2d9133600e679837bb9d944a4229eda7 \
     simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
     simd_cesu8                           1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
@@ -806,8 +806,6 @@ cargo.crates \
     slab                                0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slug                                 0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                            1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
-    snafu                                0.8.9  6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2 \
-    snafu-derive                         0.8.9  c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451 \
     snap                                 1.1.1  1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b \
     socket2                              0.6.4  52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
     socks                                0.3.4  f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b \
@@ -877,7 +875,6 @@ cargo.crates \
     toml_parser               1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
     toml_write                           0.1.2  5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801 \
     toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
-    tough                               0.22.0  8031cff0872dd1c6312370515a6be8098f6ea5512f1bad725016046fc725f272 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                          0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
     tower-layer                          0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -890,7 +887,6 @@ cargo.crates \
     tracing-subscriber                  0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
     try-lock                             0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     type-map                             0.5.1  cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90 \
-    typed-path                           0.9.3  82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607 \
     typed-path                          0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typeid                               1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                             1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
@@ -939,7 +935,6 @@ cargo.crates \
     wasm-bindgen-macro                 0.2.125  4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d \
     wasm-bindgen-macro-support         0.2.125  fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd \
     wasm-bindgen-shared                0.2.125  23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f \
-    wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
     web-sys                            0.3.102  a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d \


### PR DESCRIPTION
#### Description

mise: Update to 2026.7.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
