### PR TITLE
ruby-build: Update to 20260701

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260616 v
+github.setup        rbenv ruby-build 20260701 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  bd823a1f2727c24eadccfe2bd7a78fb3db2d0ce3 \
-                    sha256  c9d3517ee7f2ed0e65c9f0ec847ed3559f82a83d43d40fb8413c06dd9978902c \
-                    size    103206
+checksums           rmd160  1e4f1e4f8b655936ac4edf36edca11f3e1f866b0 \
+                    sha256  68d109c22559a7fcd87255f3f22baae24e201bce89bc3f883f24e4f33f59595b \
+                    size    103318
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260701


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
