### PR TITLE
yt-dlp: update to 2026.07.04

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2026.06.09
+    github.setup    yt-dlp ${subport} 2026.07.04
     revision        0
-    checksums       rmd160  6d9a07df7d549d3bdf5d5632a9578dca3b633921 \
-                    sha256  7603f876b78d08b5fdd5bcd1d368590fde22c3c18e4ea00766d51120d21cc679 \
-                    size    5980415
+    checksums       rmd160  d6aef8374c3fba9187dcd3695a1a24aa98eb9205 \
+                    sha256  31c32457d1a573a341bb0929386c624fe47339a5338829e6e9c9454bdfa7397a \
+                    size    6015962
     dist_subdir     ${subport}/${version}
     distname        ${subport}
 


### PR DESCRIPTION
#### Description

yt-dlp: update to 2026.07.04

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
