### PR TITLE
auge: Update to 1.9.0

### DIFF
--- a/graphics/auge/Portfile
+++ b/graphics/auge/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Arthur-Ficial auge 1.8.0 v
+github.setup        Arthur-Ficial auge 1.9.0 v
 revision            0
 github.tarball_from archive
 
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  c4d2e3e3de92d8f010259721b8e40de469e4bbf9 \
-                    sha256  14562354b44d6ac803927e85501db910047527a9b7d8c684073db5c014a52648 \
-                    size    347165
+checksums           rmd160  25c80e97c52a1d54dfe00a2fe7ae91ad62b1e170 \
+                    sha256  684b1afcc92bd4cdfeb603060f97ccc332c1ec1a3acc643c5eaaba9c26d8fa17 \
+                    size    344968
 
 platforms           {darwin >= 26}
 


### PR DESCRIPTION
#### Description

auge: Update to 1.9.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
