### PR TITLE
jxrlib: Update to 1.4.1

### DIFF
--- a/graphics/jxrlib/Portfile
+++ b/graphics/jxrlib/Portfile
@@ -4,22 +4,22 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mircomir jxrlib 1.4.0
+github.setup        mircomir jxrlib 1.4.1
 revision            0
 categories          graphics
 license             BSD
-maintainers         nomaintainer
+maintainers         {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
 github.tarball_from archive
 
 description         jxrlib is JPEG XR Image Codec reference implementation library
-
 long_description    {*}${description}
 
 patchfiles          0001-Add-ability-to-build-using-cmake.patch
 
-checksums           rmd160  aea547d6890b8183984c267d192a7f28a12c535a \
-                    sha256  5cd7571fe621549b52c1fd64ab2309e3d04de95e6f1ad3f749230a95022efc4e \
-                    size    352072
+checksums           rmd160  0b7a422f315d5ee075c837179a6ce554baab9271 \
+                    sha256  bb46ce30d5719cfffba8da0df314b7bca9aa68dfbf156ecb5670d1c325ad021e \
+                    size    352075
 
 patch.pre_args-replace \
                     -p0 \


### PR DESCRIPTION
#### Description

* Update jxrlib 1.4.0 --> 1.4.1.
* Add self as maintainer.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?