### PR TITLE
neovim: update to 0.12.4

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -48,7 +48,8 @@ patch.pre_args-replace  -p0 -p1
 
 # Building parsers is normally an extra step, see https://github.com/neovim/neovim/issues/29042
 patchfiles              0001-build-and-install-tree-sitter-parsers.patch \
-                        0002-include-lua51-headers-to-build-properly.patch
+                        0002-include-lua51-headers-to-build-properly.patch \
+                        0003-Revert-fix-excmd-use-realtime-for-v-starttime-uptime.patch
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/CMakeLists.txt
@@ -71,7 +72,7 @@ subport neovim-devel {}
 if {${subport} eq ${name}} {
     # stable
 
-    github.setup        neovim neovim 0.12.2 v
+    github.setup        neovim neovim 0.12.4 v
     github.tarball_from archive
     revision            0
     conflicts           neovim-devel
@@ -89,9 +90,9 @@ if {${subport} eq ${name}} {
     }
 
     checksums           ${name}-${version}.tar.gz \
-                        rmd160  5b2572e9ef1ae4a2d0cded4f156d79799fcf68e5 \
-                        sha256  ef9f58da7d687ed4d1dad9715542bf0dabdeedbfe8089e2ce17fff21b920a268 \
-                        size    13689620 \
+                        rmd160  69a78c158baf57bf7039aed8624c4356daf0e3fa \
+                        sha256  2727da95d2b8b809bc7c71e085452e47dfe1d8aa7cfaa15c68004e23f6f0a6dd \
+                        size    13711232 \
                         tree-sitter-c-0.24.1.tar.gz \
                         rmd160  12c732f8ccc097fd1ef4f171c19a89d06cfb85cd \
                         sha256  25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48 \
@@ -165,6 +166,8 @@ if {${subport} eq ${name}} {
                         rmd160  f3dba82f10baaed2f2e3cb134f0f62f652fd1d42 \
                         sha256  df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6 \
                         size    422303
+
+    patchfiles-replace  0003-Revert-fix-excmd-use-realtime-for-v-starttime-uptime.patch
 }
 
 # Add each dependency's master_site, tag it and associate it back to the distfile

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -167,7 +167,7 @@ if {${subport} eq ${name}} {
                         sha256  df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6 \
                         size    422303
 
-    patchfiles-replace  0003-Revert-fix-excmd-use-realtime-for-v-starttime-uptime.patch
+    patchfiles-strsed   g/0003-Revert-fix-excmd-use-realtime-for-v-starttime-uptime.patch//
 }
 
 # Add each dependency's master_site, tag it and associate it back to the distfile

--- a/editors/neovim/files/0001-build-and-install-tree-sitter-parsers.patch
+++ b/editors/neovim/files/0001-build-and-install-tree-sitter-parsers.patch
@@ -1,7 +1,7 @@
-From 8a790cba559e22955f35c4089da597de10c406f8 Mon Sep 17 00:00:00 2001
+From 963028a65daf6a5b7153044282fc49c36c25946f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Florian=20M=C3=A4rkl?= <info@florianmaerkl.de>
 Date: Sat, 8 Jun 2024 07:47:36 +0200
-Subject: [PATCH 1/2] build and install tree-sitter parsers
+Subject: [PATCH 1/3] build and install tree-sitter parsers
 
 neovim needs a number of prebuilt parsers in <prefix>/lib/nvim/parser/
 or else it will throw errors when opening e.g. ":help".
@@ -14,10 +14,10 @@ anymore, but applies to the one in cmake.deps/.
  3 files changed, 21 insertions(+), 8 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f7c9956325..1b89b6b606 100644
+index c99b0e0675..70966ccae9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -102,6 +102,19 @@ endif()
+@@ -104,6 +104,19 @@ endif()
  
  list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})
  
@@ -59,10 +59,10 @@ index 060447e6fe..9c3f7165e4 100644
    BuildTSParser(LANG ${lang})
  endforeach()
 diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
-index 574344e4e0..04bc3cb842 100644
+index 42bd94acd0..c04e477bc6 100644
 --- a/src/nvim/CMakeLists.txt
 +++ b/src/nvim/CMakeLists.txt
-@@ -771,13 +771,11 @@ endif()
+@@ -827,13 +827,11 @@ endif()
  
  file(MAKE_DIRECTORY ${BINARY_LIB_DIR})
  
@@ -79,8 +79,8 @@ index 574344e4e0..04bc3cb842 100644
 +  POST_BUILD
 +  COMMAND ${CMAKE_COMMAND} -E ${COPY_DIRECTORY} ${DEPS_INSTALL_DIR}/lib/nvim/parser ${BINARY_LIB_DIR}/parser)
  
- install(DIRECTORY ${BINARY_LIB_DIR}
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ if(CYGWIN)
+   if(NOT PREFER_LUA)
 -- 
-2.48.0
+2.55.0
 

--- a/editors/neovim/files/0002-include-lua51-headers-to-build-properly.patch
+++ b/editors/neovim/files/0002-include-lua51-headers-to-build-properly.patch
@@ -1,17 +1,17 @@
-From a1ffaae2f304c58c14cc111dd7c9b72efd392dd3 Mon Sep 17 00:00:00 2001
+From 94eda9928d10dc7d080357d17d8c7a82e5b9c94a Mon Sep 17 00:00:00 2001
 From: Chris Haumesser <5400416-wryfi@users.noreply.gitlab.com>
 Date: Wed, 7 Aug 2024 16:41:39 -0700
-Subject: [PATCH 2/2] include lua51 headers to build properly
+Subject: [PATCH 2/3] include lua51 headers to build properly
 
 ---
  CMakeLists.txt | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1b89b6b606..21d98c52a3 100644
+index 70966ccae9..c4f3a72afc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -23,6 +23,8 @@ if(XCODE)
+@@ -19,6 +19,8 @@ if(XCODE)
    message(FATAL_ERROR [[Xcode generator is not supported. Use "Ninja" or "Unix Makefiles" instead]])
  endif()
  
@@ -21,5 +21,5 @@ index 1b89b6b606..21d98c52a3 100644
  list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
  
 -- 
-2.48.0
+2.55.0
 

--- a/editors/neovim/files/0003-Revert-fix-excmd-use-realtime-for-v-starttime-uptime.patch
+++ b/editors/neovim/files/0003-Revert-fix-excmd-use-realtime-for-v-starttime-uptime.patch
@@ -1,0 +1,142 @@
+From 2efc0f237a7f3d05fe243dfb352c722432572a98 Mon Sep 17 00:00:00 2001
+From: Chris Rawnsley <566719+casr@users.noreply.github.com>
+Date: Mon, 6 Jul 2026 06:35:07 +0100
+Subject: [PATCH 3/3] Revert "fix(excmd): use realtime for v:starttime, :uptime
+ #39425"
+
+This revert can be removed once MacPort's libuv is upgraded equal to or
+beyond 1.45.0.
+
+Previous attempts to update MacPort's libuv version have been attempted
+in the past but nothing has been merged yet. See related links below.
+
+See: https://github.com/macports/macports-ports/pull/27671
+See: https://github.com/macports/macports-ports/pull/27670
+See: https://github.com/macports/macports-ports/pull/21329
+See: https://github.com/macports/macports-ports/pull/20421
+
+This reverts commit 822778f7e56bd6340a5d590056f35e93e4a02fa1.
+---
+ runtime/doc/news.txt                |  2 +-
+ runtime/doc/vvars.txt               |  4 ++--
+ runtime/lua/vim/_meta/vvars.gen.lua |  4 ++--
+ src/nvim/main.c                     |  2 +-
+ src/nvim/os/time.c                  | 19 -------------------
+ src/nvim/vvars.lua                  |  4 ++--
+ 6 files changed, 8 insertions(+), 27 deletions(-)
+
+diff --git a/runtime/doc/news.txt b/runtime/doc/news.txt
+index 1ab7346ff0..e4a8bc2070 100644
+--- a/runtime/doc/news.txt
++++ b/runtime/doc/news.txt
+@@ -453,7 +453,7 @@ VIMSCRIPT
+ • |v:vim_did_init| is set after sourcing |init.vim| but before |load-plugins|.
+ • |prompt_appendbuf()| appends text to prompt-buffer.
+ • |v:exitreason| is set before |QuitPre|.
+-• |v:starttime| is the process start time (nanoseconds since UNIX epoch).
++• |v:starttime| is the process start time (monotonic nanoseconds).
+ 
+ ==============================================================================
+ CHANGED FEATURES                                                 *news-changed*
+diff --git a/runtime/doc/vvars.txt b/runtime/doc/vvars.txt
+index e61bc78624..6a885f6a4f 100644
+--- a/runtime/doc/vvars.txt
++++ b/runtime/doc/vvars.txt
+@@ -635,11 +635,11 @@ v:stacktrace
+ 
+ 				*v:starttime* *starttime-variable*
+ v:starttime
+-		Timestamp (nanoseconds since UNIX epoch) when the Nvim process
++		Timestamp (monotonic nanoseconds) when the Nvim process
+ 		started.
+ 
+ 		To see the current "uptime": >lua
+-		  vim.print(('uptime: %d seconds'):format(os.time() - (vim.v.starttime / 1e9)))
++		  vim.print(('uptime: %d seconds'):format((vim.uv.hrtime() - vim.v.starttime) / 1e9))
+ <
+ 		Read-only.
+ 
+diff --git a/runtime/lua/vim/_meta/vvars.gen.lua b/runtime/lua/vim/_meta/vvars.gen.lua
+index 543d4169c1..7b5ca0e417 100644
+--- a/runtime/lua/vim/_meta/vvars.gen.lua
++++ b/runtime/lua/vim/_meta/vvars.gen.lua
+@@ -667,13 +667,13 @@ vim.v.shell_error = ...
+ --- @type table[]
+ vim.v.stacktrace = ...
+ 
+---- Timestamp (nanoseconds since UNIX epoch) when the Nvim process
++--- Timestamp (monotonic nanoseconds) when the Nvim process
+ --- started.
+ ---
+ --- To see the current "uptime":
+ ---
+ --- ```lua
+----   vim.print(('uptime: %d seconds'):format(os.time() - (vim.v.starttime / 1e9)))
++---   vim.print(('uptime: %d seconds'):format((vim.uv.hrtime() - vim.v.starttime) / 1e9))
+ --- ```
+ ---
+ --- Read-only.
+diff --git a/src/nvim/main.c b/src/nvim/main.c
+index bbd8db1ee9..dc957526f3 100644
+--- a/src/nvim/main.c
++++ b/src/nvim/main.c
+@@ -197,7 +197,7 @@ void early_init(mparm_T *paramp)
+   estack_init();
+   cmdline_init();
+   eval_init();          // init global variables
+-  set_vim_var_nr(VV_STARTTIME, (varnumber_T)os_realtime());
++  set_vim_var_nr(VV_STARTTIME, (varnumber_T)os_hrtime());
+   init_path(argv0 ? argv0 : "nvim");
+   init_normal_cmds();   // Init the table of Normal mode commands.
+   runtime_init();
+diff --git a/src/nvim/os/time.c b/src/nvim/os/time.c
+index 2e6bf3e56d..f243eda047 100644
+--- a/src/nvim/os/time.c
++++ b/src/nvim/os/time.c
+@@ -32,25 +32,6 @@ uint64_t os_hrtime(void)
+   return uv_hrtime();
+ }
+ 
+-/// Obtain the current system time from a high-resolution
+-/// real-time clock source.
+-///
+-/// The real-time clock counts from the UNIX epoch (1970-01-01)
+-/// and is subject to time adjustments; it can jump back in time.
+-///
+-/// @return Nanoseconds since epoch or 0
+-int64_t os_realtime(void)
+-  FUNC_ATTR_WARN_UNUSED_RESULT
+-{
+-  uv_timespec64_t ts = { 0 };
+-  int error_number;
+-  if ((error_number = uv_clock_gettime(UV_CLOCK_REALTIME, &ts)) != 0) {
+-    ELOG("uv_clock_gettime failed: %d %s", error_number, uv_err_name(error_number));
+-    return 0;
+-  }
+-  return ts.tv_sec * 1000000000L + ts.tv_nsec;
+-}
+-
+ /// Gets a millisecond-resolution, monotonically-increasing time relative to an
+ /// arbitrary time in the past.
+ ///
+diff --git a/src/nvim/vvars.lua b/src/nvim/vvars.lua
+index db87bcda28..648e5f1310 100644
+--- a/src/nvim/vvars.lua
++++ b/src/nvim/vvars.lua
+@@ -756,11 +756,11 @@ M.vars = {
+   starttime = {
+     type = 'integer',
+     desc = [=[
+-      Timestamp (nanoseconds since UNIX epoch) when the Nvim process
++      Timestamp (monotonic nanoseconds) when the Nvim process
+       started.
+ 
+       To see the current "uptime": >lua
+-        vim.print(('uptime: %d seconds'):format(os.time() - (vim.v.starttime / 1e9)))
++        vim.print(('uptime: %d seconds'):format((vim.uv.hrtime() - vim.v.starttime) / 1e9))
+       <
+       Read-only.
+     ]=],
+-- 
+2.55.0
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

update neovim to 0.12.4

(skipped doing nightly because of the issues with libuv. See additional patch)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->