### PR TITLE
ffmpeg, ffmpeg8: update to 8.1.2

### DIFF
--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -17,8 +17,8 @@ set my_name         ffmpeg
 conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
-version             8.1.1
-revision            1
+version             8.1.2
+revision            0
 epoch               1
 
 license             LGPL-2.1+
@@ -61,9 +61,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  35674c08071dd040d8a223e91b9ce3a3ea3d6e8a \
-                    sha256  b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3 \
-                    size    11709440
+checksums           rmd160  7b6b2b982a22338f38022a0149f7c9f15f6df4ff \
+                    sha256  464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c \
+                    size    11710924
 
 depends_build-append \
                     port:cctools \

--- a/multimedia/ffmpeg8/Portfile
+++ b/multimedia/ffmpeg8/Portfile
@@ -11,7 +11,7 @@ name                ffmpeg8
 set my_name         ffmpeg
 
 # version synced with ffmpeg port
-version             8.1.1
+version             8.1.2
 revision            0
 
 license             LGPL-2.1+
@@ -54,9 +54,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  35674c08071dd040d8a223e91b9ce3a3ea3d6e8a \
-                    sha256  b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3 \
-                    size    11709440
+checksums           rmd160  7b6b2b982a22338f38022a0149f7c9f15f6df4ff \
+                    sha256  464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c \
+                    size    11710924
 
 depends_build-append \
                     port:cctools \


### PR DESCRIPTION
Addresses https://app.opencve.io/cve/CVE-2026-8461

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.9 22G830 arm64
Command Line Tools 14.3.1.0.1.1683849156

and

macOS 26.5 25F71 x86_64
Command Line Tools 26.5.0.0.1777544298


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
  - **Note:** ffmpeg does not have tests that run with `sudo port test`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
  - **Note:** it is not clear to me which variants are or are not "important" in this context.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
