### PR TITLE
mp3rgain: update to 2.9.5

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.4 v
+github.setup        M-Igashi mp3rgain 2.9.5 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  a705479e41be426bf7977e235a4603591e5aabd0 \
-                    sha256  586a30a3b656e575124a892008099cd9433add57a86a92a4c6362a6043f62a0b \
-                    size    517746
+                    rmd160  719ca4fcb73fe8c8bc7f6566abaf247c56d3f88d \
+                    sha256  cf9ae5f82a96a0c4247c64737d4398ff951bfc96506cb40fbd8408365182dd63 \
+                    size    518545
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 2.9.5.

- Bump `github.setup` to 2.9.5, reset `revision` to 0
- Recomputed distfile checksums (rmd160 / sha256 / size)
- `cargo.crates` unchanged (no dependency changes this release)

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.5

`port lint --nitpick` clean.