### PR TITLE
php86: new version

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -26,7 +26,7 @@ long_description        PHP is a widely-used general-purpose scripting \
 categories              lang php
 
 # The list of PHP branches this port provides.
-php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 
 # Fix for users specifying the subport name with the wrong case.
 set subport             [string tolower ${subport}]
@@ -209,6 +209,21 @@ switch ${subport_branch} {
                         sha256  58910198d19e873048fe87cdfe16bc790025417ede3d1651bfa1c4b533d573f2 \
                         size    14410156
     }
+    8.6 {
+        # When this becomes a stable version, remove the overrides for homepage,
+        # master_sites and livecheck, and update php.latest_stable_branch in the
+        # php-1.1 portgroup.
+        epoch           0
+        version         8.6.0alpha1
+        homepage        https://www.php.net/pre-release-builds.php
+        master_sites    https://downloads.php.net/~mbeccati/
+        use_xz          yes
+        checksums       rmd160  f7191e895337c43a84cd42ebae13833c86564008 \
+                        sha256  2d4cba8e5511b026b0c786c69b3272fe53dc8643f086cd10fc0e902c20a1757c \
+                        size    14572124
+        livecheck.url   ${homepage}
+        livecheck.regex php-([strsed ${subport_branch} {g/\\./\\./}](?:\\.\[0-9.\]+)*(?:(?:alpha|beta|RC)\\d+|-latest))\\.tar
+    }
 }
 #### RCstart template
 #    RCbranch {
@@ -217,8 +232,8 @@ switch ${subport_branch} {
 #        # php-1.1 portgroup.
 #        epoch           0
 #        version         RCversion
-#        homepage        https://www.php.net/release-candidates.php
-#        master_sites    https://downloads.php.net/~saki/
+#        homepage        https://www.php.net/pre-release-builds.php
+#        master_sites    https://downloads.php.net/~mbeccati/
 #        use_xz          yes
 #        checksums       rmd160  d78af388868bc0a1ca36955971c21ad77da81cf4 \
 #                        sha256  5c42173cbde7d0add8249c2e8a0c19ae271f41d8c47d67d72bdf91a88dcc7e4b \
@@ -528,6 +543,7 @@ subport ${php} {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     depends_run             port:php_select
@@ -694,6 +710,7 @@ subport ${php}-apache2handler {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     description             ${php} Apache 2 Handler SAPI
@@ -765,6 +782,7 @@ subport ${php}-cgi {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     description             ${php} CGI SAPI
@@ -811,6 +829,7 @@ subport ${php}-fpm {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     description             ${php} FPM SAPI
@@ -886,6 +905,7 @@ subport ${php}-calendar {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     description             a PHP extension for converting between different \
@@ -912,6 +932,7 @@ subport ${php}-curl {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       net www
@@ -954,6 +975,7 @@ subport ${php}-dba {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       databases
@@ -992,6 +1014,7 @@ subport ${php}-enchant {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       textproc devel
@@ -1049,6 +1072,7 @@ subport ${php}-exif {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       graphics
@@ -1068,6 +1092,7 @@ subport ${php}-ffi {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       devel
@@ -1102,6 +1127,7 @@ subport ${php}-ftp {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       net
@@ -1142,6 +1168,7 @@ subport ${php}-gd {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       graphics
@@ -1214,10 +1241,11 @@ subport ${php}-gettext {
         7.4.33              {revision 0}
         8.0.30              {revision 0}
         8.1.34              {revision 0}
-        8.2.31              {revision 0}
-        8.3.31              {revision 0}
-        8.4.21              {revision 0}
-        8.5.6               {revision 0}
+        8.2.32              {revision 0}
+        8.3.32              {revision 0}
+        8.4.23              {revision 0}
+        8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       devel
@@ -1246,10 +1274,11 @@ subport ${php}-gmp {
         7.4.33              {revision 0}
         8.0.30              {revision 0}
         8.1.34              {revision 0}
-        8.2.31              {revision 0}
-        8.3.31              {revision 0}
-        8.4.21              {revision 0}
-        8.5.6               {revision 0}
+        8.2.32              {revision 0}
+        8.3.32              {revision 0}
+        8.4.23              {revision 0}
+        8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       devel math
@@ -1283,11 +1312,11 @@ subport ${php}-iconv {
         7.4.33              {revision 0}
         8.0.30              {revision 0}
         8.1.34              {revision 0}
-        8.2.31              {revision 0}
-        8.3.31              {revision 0}
-        8.4.21              {revision 0}
-        8.4.13              {revision 0}
-        8.5.6               {revision 0}
+        8.2.32              {revision 0}
+        8.3.32              {revision 0}
+        8.4.23              {revision 0}
+        8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       textproc
@@ -1364,6 +1393,7 @@ subport ${php}-intl {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       devel
@@ -1436,6 +1466,7 @@ subport ${php}-ipc {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     php.extensions          shmop sysvmsg sysvsem sysvshm
@@ -1464,6 +1495,7 @@ subport ${php}-ldap {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       databases
@@ -1506,6 +1538,7 @@ subport ${php}-mbstring {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       textproc
@@ -1599,6 +1632,7 @@ subport ${php}-mysql {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     php.extensions          mysqli pdo_mysql
@@ -1788,6 +1822,7 @@ subport ${php}-odbc {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     php.extensions          odbc pdo_odbc
@@ -1916,6 +1951,7 @@ subport ${php}-openssl {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       devel security
@@ -2024,6 +2060,7 @@ subport ${php}-pcntl {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       sysutils
@@ -2064,6 +2101,7 @@ subport ${php}-posix {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       sysutils
@@ -2093,6 +2131,7 @@ subport ${php}-postgresql {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     php.extensions          pgsql pdo_pgsql
@@ -2198,6 +2237,7 @@ subport ${php}-snmp {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       sysutils
@@ -2230,6 +2270,7 @@ subport ${php}-soap {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       net
@@ -2270,6 +2311,7 @@ subport ${php}-sockets {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       net
@@ -2292,6 +2334,7 @@ subport ${php}-sodium {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     php.extensions          sodium
@@ -2333,6 +2376,7 @@ subport ${php}-sqlite {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     php.extensions          sqlite sqlite3 pdo_sqlite
@@ -2387,6 +2431,7 @@ subport ${php}-tidy {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       www
@@ -2494,6 +2539,7 @@ subport ${php}-xsl {
         8.3.32              {revision 0}
         8.4.23              {revision 0}
         8.5.8               {revision 0}
+        8.6.0alpha1         {revision 0}
     }
 
     categories-append       textproc

--- a/lang/php/files/patch-php86-atomic.diff
+++ b/lang/php/files/patch-php86-atomic.diff
@@ -1,0 +1,17 @@
+Fix:
+
+error: address argument to atomic operation must be a pointer to non-const _Atomic type ('const _Atomic(bool) *' invalid)
+
+https://github.com/php/php-src/issues/8881
+https://github.com/php/php-src/pull/11931
+--- a/Zend/zend_atomic.h.orig	2024-02-13 09:41:14.000000000 -0600
++++ b/Zend/zend_atomic.h	2024-03-03 17:16:17.000000000 -0600
+@@ -23,7 +23,7 @@
+ 	((__GNUC__ == (x) && __GNUC_MINOR__ >= (y)) || (__GNUC__ > (x)))
+ 
+ /* Builtins are used to avoid library linkage */
+-#if __has_feature(c_atomic) && defined(__clang__)
++#if __has_feature(c_atomic) && defined(__clang__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201710L
+ #define	HAVE_C11_ATOMICS 1
+ #elif ZEND_GCC_PREREQ(4, 7)
+ #define	HAVE_GNUC_ATOMICS 1

--- a/lang/php/files/patch-php86-iODBC.diff
+++ b/lang/php/files/patch-php86-iODBC.diff
@@ -1,0 +1,18 @@
+--- ext/odbc/config.m4.orig	2025-10-17 02:21:26
++++ ext/odbc/config.m4	2025-10-17 02:37:19
+@@ -11,6 +11,7 @@
+ dnl configure options
+ dnl
+ 
++:<<'MACPORTS_DISABLED'
+ AS_VAR_IF([ODBC_TYPE],, [
+ PHP_ARG_WITH([ibm-db2],
+   [for IBM DB2 support],
+@@ -71,6 +72,7 @@
+       [Define to 1 if the odbc extension uses custom ODBC installation.])
+   ])
+ ])
++MACPORTS_DISABLED
+ 
+ AS_VAR_IF([ODBC_TYPE],, [
+ PHP_ARG_WITH([iodbc],

--- a/lang/php/files/patch-php86-sapi-fpm-php-fpm.conf.in.diff
+++ b/lang/php/files/patch-php86-sapi-fpm-php-fpm.conf.in.diff
@@ -1,0 +1,39 @@
+--- a/sapi/fpm/php-fpm.conf.in.orig	2020-11-24 11:04:03.000000000 -0600
++++ b/sapi/fpm/php-fpm.conf.in	2020-12-02 15:27:04.000000000 -0600
+@@ -14,14 +14,14 @@
+ ; Pid file
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: none
+-;pid = run/php-fpm.pid
++;pid = run/@PHP@/php-fpm.pid
+ 
+ ; Error log file
+ ; If it's set to "syslog", log is sent to syslogd instead of being written
+ ; into a local file.
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: log/php-fpm.log
+-;error_log = log/php-fpm.log
++error_log = log/@PHP@/php-fpm.log
+ 
+ ; syslog_facility is used to specify what type of program is logging the
+ ; message. This lets syslogd specify that messages from different facilities
+@@ -34,7 +34,7 @@
+ ; instances running on the same server, you can change the default value
+ ; which must suit common needs.
+ ; Default Value: php-fpm
+-;syslog.ident = php-fpm
++syslog.ident = @PHP@-fpm
+ 
+ ; Log level
+ ; Possible Values: alert, error, warning, notice, debug
+@@ -95,8 +95,9 @@
+ ; process.priority = -19
+ 
+ ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
++; or for use with launchd.
+ ; Default Value: yes
+-;daemonize = yes
++daemonize = no
+ 
+ ; Set open file descriptor rlimit for the master process.
+ ; Default Value: system defined value

--- a/lang/php/files/patch-php86-scripts-php-config.in.diff
+++ b/lang/php/files/patch-php86-scripts-php-config.in.diff
@@ -1,0 +1,11 @@
+--- a/scripts/php-config.in.orig	2024-07-02 08:43:13.000000000 -0500
++++ b/scripts/php-config.in	2024-07-21 19:58:40.000000000 -0500
+@@ -8,7 +8,7 @@
+ vernum="@PHP_VERSION_ID@"
+ include_dir="@includedir@/php"
+ lib_dir="@orig_libdir@"
+-includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
++includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib -I@prefix@/include"
+ ldflags="@PHP_LDFLAGS@"
+ libs="@EXTRA_LIBS@"
+ extension_dir="@EXTENSION_DIR@"

--- a/lang/php/files/patch-php86-unixODBC.diff
+++ b/lang/php/files/patch-php86-unixODBC.diff
@@ -1,0 +1,18 @@
+--- ext/odbc/config.m4.orig	2025-10-17 02:21:26
++++ ext/odbc/config.m4	2025-10-17 02:40:28
+@@ -11,6 +11,7 @@
+ dnl configure options
+ dnl
+ 
++:<<'MACPORTS_DISABLED'
+ AS_VAR_IF([ODBC_TYPE],, [
+ PHP_ARG_WITH([ibm-db2],
+   [for IBM DB2 support],
+@@ -86,6 +87,7 @@
+       [Define to 1 if the odbc extension uses the iODBC.])
+   ])
+ ])
++MACPORTS_DISABLED
+ 
+ AS_VAR_IF([ODBC_TYPE],, [
+ PHP_ARG_WITH([unixODBC],

--- a/lang/php/files/php86
+++ b/lang/php/files/php86
@@ -1,0 +1,6 @@
+bin/php86
+bin/php-config86
+bin/phpize86
+share/man/man1/php86.1.gz
+share/man/man1/php-config86.1.gz
+share/man/man1/phpize86.1.gz

--- a/php/php-geoip/Portfile
+++ b/php/php-geoip/Portfile
@@ -8,7 +8,7 @@ license                 PHP
 categories-append       devel
 maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl                yes
 
 if {[vercmp ${php.branch} >= 7.0]} {

--- a/php/php-mailparse/Portfile
+++ b/php/php-mailparse/Portfile
@@ -9,7 +9,7 @@ categories-append       mail devel
 maintainers     {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 
 # Compatible with PHP 8.4 as of 3.1.8
-php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl        yes
 
 # This extension must load after the mbstring extension.

--- a/php/php-meminfo/Portfile
+++ b/php/php-meminfo/Portfile
@@ -8,7 +8,7 @@ name                    php-meminfo
 maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license                 MIT
 
-php.branches            5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches            5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 
 if {[vercmp ${php.branch} >= 5.6]} {
     github.setup        BitOne php-meminfo 1.1.1 v

--- a/php/php-mongodb/Portfile
+++ b/php/php-mongodb/Portfile
@@ -8,7 +8,7 @@ categories-append   databases devel
 maintainers         {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license             Apache-2
 
-php.branches        5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches        5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl            yes
 
 # https://www.mongodb.com/docs/drivers/compatibility/?driver-language=php&php-driver-framework=php-driver

--- a/php/php-psr/Portfile
+++ b/php/php-psr/Portfile
@@ -7,7 +7,7 @@ name                    php-psr
 maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license                 BSD
 
-php.branches            7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches            7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl                yes
 
 if {[vercmp ${php.branch} >= 7.3]} {

--- a/php/php-timezonedb/Portfile
+++ b/php/php-timezonedb/Portfile
@@ -8,7 +8,7 @@ categories-append   devel
 maintainers         {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl            yes
 
 description         A PECL Timezone Database.

--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -8,7 +8,7 @@ categories-append       net www
 maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license                 LGPL-2.1+
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl                yes
 
 description             A wrapper around libuuid from the ext2utils project.

--- a/php/php-vld/Portfile
+++ b/php/php-vld/Portfile
@@ -8,7 +8,7 @@ categories-append   devel
 maintainers         {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license             BSD
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl            yes
 php.pecl.prerelease yes
 

--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -8,7 +8,7 @@ categories-append       devel
 maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license                 Apache-2
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
 php.pecl                yes
 
 if {[vercmp ${php.branch} >= 7.0]} {


### PR DESCRIPTION
```
    php86: new branch   
            modified:   lang/php/Portfile
            new file:   lang/php/files/patch-php86-atomic.diff
            new file:   lang/php/files/patch-php86-iODBC.diff
            new file:   lang/php/files/patch-php86-sapi-fpm-php-fpm.conf.in.diff
            new file:   lang/php/files/patch-php86-scripts-php-config.in.diff
            new file:   lang/php/files/patch-php86-unixODBC.diff
            new file:   lang/php/files/php86

    php-extensions : added php86 working extensions
            modified:   php/php-geoip/Portfile
            modified:   php/php-mailparse/Portfile
            modified:   php/php-meminfo/Portfile
            modified:   php/php-mongodb/Portfile
            modified:   php/php-psr/Portfile
            modified:   php/php-timezonedb/Portfile
            modified:   php/php-uuid/Portfile
            modified:   php/php-vld/Portfile
            modified:   php/php-xhprof/Portfile
```
```
extension           🆗 supported notes
----------
amqp                ⛔️     ✔️    2.2.0 	 	stable 	2026-01-02
APCu                ⛔️     ✔️    5.1.28 	stable 	2025-12-07
dbase               ⛔️     ✔️    7.1.1 	 	stable 	2021-10-29
event               ⛔️     ✔️    3.1.4 	 	stable 	2024-07-16
gearman             ⛔️     ✔️    2.2.1 	 	stable 	2026-04-07
geoip               ✅     ✔️    1.1.1 	 	beta 	2016-08-19
gmagick             ⛔️     ✔️    2.0.6RC1 	beta 	2021-02-11
igbinary            ⛔️     ✔️    3.2.17RC1 	stable 	2025-11-27
imagick             ⛔️     ✔️    3.8.1 	 	stable 	2025-11-26 	
imap                ⛔️     ✔️    1.0.3 		stable 	2024-10-15
jsmin               ⛔️     ✔️    3.0.0 	 	stable 	2018-01-23
Judy                ⛔️     ✔️    2.4.0 	 	stable 	2026-03-03
lzf                 ⛔️     ✔️    1.7.0 	 	stable 	2022-01-04
mailparse           ✅     ✔️    3.2.0 	 	stable 	2026-04-09
maxminddb           ⛔️     ✔️    1.13.1 	stable 	2025-11-21
mcrypt              ⛔️     🤔    1.0.9 	 	stable 	2025-08-05
memcache            ⛔️     ✔️    8.2 	 	stable 	2023-04-30
memcached           ⛔️     ✔️    3.4.0 	 	stable 	2025-10-13
meminfo             ✅     ✔️    1.1.1 	 	stable 	2021-02-17
mongodb             ✅     ✔️    2.3.3 	 	stable 	2026-05-22 	m
oauth               ⛔️     ✔️    2.0.10 	stable 	2025-10-09
openswoole          ⛔️     ✔️    26.2.0 	stable 	2026-02-28
oracle              ⛔️     ✔️    1.2.0 	 	stable 	2026-01-07
pcov                ⛔️     ✔️    1.0.12 	stable 	2024-12-04
phalcon5            ⛔️     ✔️    5.16.0 	stable 	2026-06-23
pspell              ⛔️     ✔️    1.0.1 	 	stable 	2023-11-23
psr                 ✅     ✔️    1.2.0 	 	stable 	2021-12-11
raphf               ⛔️     ✔️    2.0.2 	 	stable 	2025-08-29
redis               ⛔️     ✔️    6.3.0 	 	stable 	2025-11-06
scrypt              ⛔️     ✔️    2.0.1 	 	stable 	2023-05-07
solr                ⛔️     ✔️    2.9.3 	 	stable 	2026-04-13
sqlsrv              ⛔️     ✔️    5.13.1 	stable 	2026-04-30
ssh2                ⛔️     ✔️    1.5.0 	 	stable 	2026-04-04
stomp               ⛔️     ✔️    2.0.3 	 	stable 	2022-05-31
svm                 ⛔️     ✔️    0.2.3 	 	beta 	2018-08-20
swoole              ⛔️     ✔️    6.2.1 	 	stable 	2026-05-15
timezonedb          ✅     ✔️    2026.1 	stable 	2026-03-02
uploadprogress      ⛔️     ✔️    2.0.2 	 	stable 	2021-10-01
uuid                ✅     ✔️    1.3.0 	 	stable 	2025-05-12
vld                 ✅     ✔️    0.19.1 	beta 	2025-07-15
xapian              ⛔️     ✔️    2.0.0
xdebug              ⛔️     ✔️    3.5.3 	 	stable 	2026-06-08
xhprof              ✅     ✔️    2.3.10 	stable 	2024-07-11
xmlrpc              ⛔️     🤔    1.0.0RC3 	beta 	2021-12-04
yaf                 ⛔️     ✔️    3.3.7 	 	stable 	2025-07-29
yaml                ⛔️     ✔️    2.3.0 	 	stable 	2025-11-12
yaz                 ⛔️     ✔️    1.2.4 	 	stable 	2022-08-22
zip                 ⛔️     ✔️    1.22.8 	stable 	2026-03-06
zstd                ⛔️     ✔️    0.17.0 	stable 	2026-07-02
```
