### PR TITLE
djvulibre: Fix builds <= 10.14

### DIFF
--- a/graphics/djvulibre/Portfile
+++ b/graphics/djvulibre/Portfile
@@ -25,6 +25,17 @@ checksums           rmd160  3214e6f1695cd64902880d29fbba432f53382e04 \
                     sha256  ee5e457d4cfebe566f94b99e5e3d3cc7f5c79ddb741c2ac2ba2e456f00329644 \
                     size    3721274
 
+# Temporary workaround for "tar: Ignoring malformed pax extended attribute"
+# on older systems (macos <= 10.14)
+# Unknown xattrs make older BSD tar fail
+# Reference: https://trac.macports.org/ticket/73560 ... etc.
+# Currently affecting djvulibre-3.5.30.tar.gz, file date 2026 May 5
+#---------------------
+if {${os.platform} eq "darwin" && ${os.major} <= 18} {
+    depends_extract port:libarchive
+    extract.post_args | ${prefix}/bin/bsdtar -xf -
+}
+
 depends_lib         port:libiconv \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:tiff


### PR DESCRIPTION
#### Description

* Build fix for "tar: Ignoring malformed pax extended attribute" on older systems.
* No rev bump, build fixes only.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.
* Waiting for merge to check builds for <= 10.14.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?