### PR TITLE
ipatool: Update to 2.3.1

### DIFF
--- a/sysutils/ipatool/Portfile
+++ b/sysutils/ipatool/Portfile
@@ -3,20 +3,20 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/majd/ipatool 2.3.0 v
+go.setup                github.com/majd/ipatool 2.3.1 v
 revision                0
 categories              sysutils
 license                 MIT
-platforms               {darwin >= 19}
+platforms               {darwin >= 21}
 installs_libs           no
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             CLI for searching and downloading iOS app packages from the App Store
 long_description        {*}${description}.
 
-checksums               rmd160  8798f09043646fe8e519a8af82bc5b45ae42f367 \
-                        sha256  36c589ad88cea989b3a5bc3cd35223e12907c609789802b59d3cfb07596a07e7 \
-                        size    712526
+checksums               rmd160  3adc2270aafd50890ce70020e1347ada2579ffda \
+                        sha256  2fe03975acd6eb184c3cc6e0bb5d49f973c39aa518d36279685f442c23e87956 \
+                        size    723049
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no


### PR DESCRIPTION
#### Description

Update ipatool to 2.3.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
