### PR TITLE
ImageMagick7: Update to 7.1.2-27

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 # IM7 7.1.1-29, 2024 March, for OS 10.6/Snow Leopard;
@@ -19,12 +20,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-version             7.1.2-25
-revision            1
+github.setup        ImageMagick ImageMagick 7.1.2-27
+github.tarball_from releases
+revision            0
 use_xz              yes
-checksums           rmd160  391a90d4839dff6b28cd522686357826ec3b5ad9 \
-                    sha256  2b2070802de374871737ff1a516b3d9d1e66643779b7ed9c52e2534db7772006 \
-                    size    10807420
+checksums           rmd160  07c5256f79bc3d3002305a996a73a631458c02af \
+                    sha256  f65773f1f465c730f1c025c92a2524966f772ebeb77de0d817c336e1f565e9ef \
+                    size    10889824
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
@@ -52,15 +54,6 @@ long_description    For the ImageMagick-6 legacy version, please see \
                     PhotoCD and TIFF.
 
 homepage            https://imagemagick.org
-master_sites        https://imagemagick.org/archive/ \
-                    https://imagemagick.org/archive/releases/ \
-                    https://mirror.aarnet.edu.au/pub/imagemagick/ \
-                    https://ftp.icm.edu.pl/pub/unix/graphics/ImageMagick/ \
-                    https://mirror.accum.se/mirror/imagemagick.org/ftp/ \
-                    https://mirror.metanet.ch/imagemagick/ \
-                    http://mirror.checkdomain.de/imagemagick/releases/ \
-                    ftp://sunsite.icm.edu.pl/packages/ImageMagick/releases/
-distname            ImageMagick-${version}
 
 depends_lib         port:bzip2 \
                     port:djvulibre \
@@ -201,10 +194,6 @@ variant x11 {
 }
 
 default_variants    +openexr +x11
-
-livecheck.type              regex
-livecheck.url               [lindex ${master_sites} 0]
-livecheck.regex             ImageMagick-(7(?:\\.\\d+)+(?:-\\d+)?)\.tar
 
 notes-append {
 To use the ImageMagick7 command-line interface, add\


### PR DESCRIPTION
#### Description

* Update ImageMagick7 7.1.2-25 --> 7.1.2-27.
* Avoid chaos from interim 7.1.2-26 with invalid soname change.
* Change source from upstream archive site, to Github releases.
* Add Github portgroup.
* Fix livecheck.
* Drop mirror sites.  No longer relevant, I think.  Please speak up if this is wrong.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
