### PR TITLE
sqlite3-tcl: split into tcl8 and tcl9 subports

### DIFF
--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -87,7 +87,18 @@ if {${subport} eq ${name}} {
 }
 
 subport ${name}-tcl {
-    depends_lib             port:tcl \
+    PortGroup obsolete 1.0
+    version     3.53.3
+    revision    1
+    replaced_by ${name}-tcl8
+    # Can be removed after 2027-07-07
+}
+subport ${name}-tcl8 {}
+subport ${name}-tcl9 {}
+if {[string match *-tcl? $subport]} {
+    set tclport tcl[string index $subport end]
+    set tclshver [expr {$tclport eq "tcl8" ? "8.6" : "9.0"}]
+    depends_lib             port:${tclport} \
                             port:zlib
 
     configure.dir           ${worksrcpath}/tea
@@ -96,10 +107,15 @@ subport ${name}-tcl {
 
     configure.args          --exec-prefix=${prefix} \
                             --tcl-stubs \
-                            --with-tcl=${prefix}/lib 
+                            --with-tcl=${prefix}/lib/${tclport} \
+                            --with-tclsh=${prefix}/bin/tclsh${tclshver}
+    configure.env-append    autosetup_tclsh=${prefix}/bin/tclsh${tclshver}
 
-    configure.cppflags-prepend \
-                            -I${worksrcpath}
+    configure.cppflags      -I${worksrcpath} \
+                            -I${prefix}/include/${tclport} \
+                            -I${prefix}/include
+    configure.ldflags       -L${prefix}/lib/${tclport} \
+                            -L${prefix}/lib
 }
 
 subport ${name}-tools {


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tested basic functionality of all binary files?
