### PR TITLE
claude-code: update to 2.1.202

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.201
+version             2.1.202
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  0b706ca6bc5cecbf3bcf2dc9606b66428c0e9e6b \
-                 sha256  1889287a92d25356ae8bd8d8e67b11456015516ee8ba4277a0c7074786c49bb6 \
-                 size    241100240
+    checksums    rmd160  d2ac4292fb0c2cf48247839e47430d0e86b78aae \
+                 sha256  0dc578bb294094f5041e99a0444030ac6ae7236b387e56f00d4a5214816763bd \
+                 size    251667920
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  48bf3cf95566798166efc30109d57bf77d87302d \
-                 sha256  a0852d76afc47b30f5cb0b7625ec9a7714cb189f2eeef6c28c77e2be954fb7fd \
-                 size    231708784
+    checksums    rmd160  97f24fdf9bd0670716c0601683810ad5325688fc \
+                 sha256  7414f707861e2fe5afef33a466f888a8d2170e5028f5e9d2858f1d3ef45ffca5 \
+                 size    243631376
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.202.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?