### PR TITLE
claude-code: update to 2.1.203

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.202
+version             2.1.203
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d2ac4292fb0c2cf48247839e47430d0e86b78aae \
-                 sha256  0dc578bb294094f5041e99a0444030ac6ae7236b387e56f00d4a5214816763bd \
-                 size    251667920
+    checksums    rmd160  30a84cb7a30511a2292d6c55d3c319546fa03ad4 \
+                 sha256  1481cffd33d5d19219b53d832fb14e4c2c2def781fc4f1db6c5a4b2d1e596763 \
+                 size    246384080
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  97f24fdf9bd0670716c0601683810ad5325688fc \
-                 sha256  7414f707861e2fe5afef33a466f888a8d2170e5028f5e9d2858f1d3ef45ffca5 \
-                 size    243631376
+    checksums    rmd160  e816a76c5fae13d9ff923b68b5f139a51d4bf624 \
+                 sha256  57b5aec68a35f42036bd2f82836d91c2d2990c2d589fb3465e3ee87142af9a1e \
+                 size    236961904
 } else {
     set arch_classifier unsupported_arch
     distfiles
@@ -75,7 +75,7 @@ destroot {
     # Create launch script
     set launch_script [open ${destroot}${prefix}/bin/claude w 0755]
     puts $launch_script "#!/bin/sh"
-    set launch_command "DISABLE_UPDATES=1"
+    set launch_command "DISABLE_UPDATES=1 DISABLE_INSTALLATION_CHECKS=1"
     if {![variant_isset telemetry]} {
         append launch_command " DISABLE_TELEMETRY=1"
     }


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.203 and disable installation checks.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?