### PR TITLE
chezmoi: Update to 2.71.0

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.70.5 v
+go.setup            github.com/twpayne/chezmoi 2.71.0 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  61b14923635170c4307287dcda34c2d9bee7d387 \
-                    sha256  653b6585db407c92ab902304136fa4516263c4e7e6e84163a3c1a186b3ddf55f \
-                    size    2596537
+checksums           rmd160  9c6aa9206ab0e8ebe98f8b74c65cfd96c3d82ec5 \
+                    sha256  77f85f4d164f8ce0fc784b5d6ca86b0576a00729c5b23a113b92665e0509f252 \
+                    size    2598600
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.71.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
