### PR TITLE
ImageMagick, p5-perlmagick: Update to 6.9.13-52

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem                  1.0
 PortGroup                   conflicts_build 1.0
+PortGroup                   github 1.0
 PortGroup                   legacysupport 1.1
 
 # TARGET_OS_IOS, TARGET_OS_WATCH, TARGET_OS_TV missing in TargetConditionals.h:
@@ -13,17 +14,21 @@ legacysupport.newest_darwin_requires_legacy 11
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-50
+github.setup                ImageMagick ImageMagick6 6.9.13-52
 revision                    0
 
-checksums                   rmd160  df530172d65e3acf80318ffabc1fa4dd2f8613d3 \
-                            sha256  f45877cb5d758b0460e73435a9fd40b9133c4b02bb48ccfb49bbaccacb9ad13a \
-                            size    9637808
+github.tarball_from         releases
+distname                    ${name}-${version}
+use_xz                      yes
+
+checksums                   rmd160  d255f948705898e3d63afd0c26a8ed534b8402f5 \
+                            sha256  0e313e1a4d3bcac8bdce22fcaa31589ccb5450a17966e7ce8d22c407b04b437b \
+                            size    9727724
 
 categories                  graphics devel
-maintainers                 {ryandesign @ryandesign}
+maintainers                 {ryandesign @ryandesign} \
+                            openmaintainer
 license                     Apache-2
-use_xz                      yes
 
 description                 Tools and libraries to manipulate images in many formats
 
@@ -46,14 +51,6 @@ long_description            This is the legacy ImageMagick version 6.  For the \
                             PhotoCD and TIFF.
 
 homepage                    https://legacy.imagemagick.org
-master_sites                https://imagemagick.org/archive/ \
-                            https://imagemagick.org/archive/releases/ \
-                            https://mirror.aarnet.edu.au/pub/imagemagick/ \
-                            https://ftp.icm.edu.pl/pub/unix/graphics/ImageMagick/ \
-                            https://mirror.accum.se/mirror/imagemagick.org/ftp/ \
-                            https://mirror.metanet.ch/imagemagick/ \
-                            http://mirror.checkdomain.de/imagemagick/releases/ \
-                            ftp://sunsite.icm.edu.pl/packages/ImageMagick/releases/
 
 depends_lib                 port:bzip2 \
                             port:djvulibre \
@@ -186,7 +183,3 @@ variant x11 {
 }
 
 default_variants            +openexr +x11
-
-livecheck.type              regex
-livecheck.url               [lindex ${master_sites} 0]
-livecheck.regex             ${name}-(6(?:\\.\\d+)+(?:-\\d+)?)\.tar

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -1,25 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           perl5 1.0
 
 # Keep relevant lines in sync between ImageMagick and p5-perlmagick.
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.13-50
+perl5.setup         PerlMagick 6.9.13-52
+github.setup        ImageMagick ImageMagick6 6.9.13-52
 revision            0
 
-checksums           rmd160  df530172d65e3acf80318ffabc1fa4dd2f8613d3 \
-                    sha256  f45877cb5d758b0460e73435a9fd40b9133c4b02bb48ccfb49bbaccacb9ad13a \
-                    size    9637808
-
 set my_name         ImageMagick
-maintainers         {ryandesign @ryandesign}
+github.tarball_from releases
+distname            ${my_name}-${version}
+use_xz              yes
+
+checksums           rmd160  d255f948705898e3d63afd0c26a8ed534b8402f5 \
+                    sha256  0e313e1a4d3bcac8bdce22fcaa31589ccb5450a17966e7ce8d22c407b04b437b \
+                    size    9727724
+
+maintainers         {ryandesign @ryandesign} \
+                    openmaintainer
 description         Perl extension for calling ImageMagick's libMagick methods
 long_description    {*}${description}
 license             Apache-2
-use_xz              yes
 
 # We use the ImageMagick distribution version of PerlMagick to
 # ensure it will always match the ImageMagick version.
@@ -35,7 +41,6 @@ master_sites        https://imagemagick.org/archive/ \
                     ftp://sunsite.icm.edu.pl/packages/ImageMagick/releases/
 
 dist_subdir         ImageMagick
-distname            ${my_name}-${version}
 
 if {${perl5.major} != ""} {
 depends_lib-append  port:ImageMagick
@@ -57,7 +62,6 @@ use_parallel_build  no
 
 livecheck.type      none
 } else {
-livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     ${my_name}-(6(?:\\.\\d+)+(?:-\\d+)?)\.tar
+livecheck.url       https://github.com/ImageMagick/ImageMagick6/tags
+livecheck.regex     archive/refs/tags/(\[^"\]+)\.tar\.gz
 }

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -62,6 +62,6 @@ use_parallel_build  no
 
 livecheck.type      none
 } else {
-livecheck.url       https://github.com/ImageMagick/ImageMagick6/tags
-livecheck.regex     archive/refs/tags/(\[^"\]+)\.tar\.gz
+livecheck.url       ${github.homepage}/tags
+livecheck.regex     archive/refs/tags/[join ${github.livecheck.regex}]\\.tar\\.gz
 }


### PR DESCRIPTION
#### Description

* Update ImageMagick 6.9.13-50 --> 6.9.13-52.
* Keep p5-perlmagick in sync.
* Avoid chaos from interim 6.9.13-51 with invalid soname change.
* Upstream changed.  Change source from archive website to Github releases.
* Add Github portgroup.
* Fix livecheck.
* Drop mirror sites. No longer relevant, I think.  Let me know if this is wrong.
* Add openmaintainer.

###### Type(s)

###### Tested on

 CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?