### PR TITLE
muon: new port

### DIFF
--- a/devel/muon/Portfile
+++ b/devel/muon/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               meson 1.0
+PortGroup               sourcehut 1.0
+PortGroup               legacysupport 1.1
+
+# clock_gettime, CLOCK_MONOTONIC
+legacysupport.newest_darwin_requires_legacy 15
+
+sourcehut.setup         lattis muon 0.6.0
+revision                0
+categories              devel
+license                 GPL-3
+maintainers             {@commitmaniac} openmaintainer
+
+description             An implementation of the Meson build system in C99
+long_description        {*}${description}, with minimal dependencies. ${name} includes a \
+                        static analyzer and LSP for build files, a code formatter, and \
+                        an interactive stepping debugger.
+
+homepage                https://muon.build/
+
+checksums               rmd160  886b1b26a3ad518385a978213a47a12d01975d04 \
+                        sha256  5300e58c4b4d43e3026856004c79d746075aaa9d9e66d76ba9f32ce249495b81 \
+                        size    646049
+
+depends_build-append    path:bin/pkg-config:pkgconfig \
+                        port:scdoc
+
+depends_lib-append      port:libarchive \
+                        port:curl
+
+configure.args-append   -Dmeson-docs=disabled \
+                        -Dmeson-tests=disabled \
+                        -Dman-pages=enabled \
+                        -Dtracy=disabled \
+                        -Dlibarchive=enabled \
+                        -Dlibcurl=enabled \
+                        -Dlibpkgconf=disabled \
+                        -Dsamurai=disabled \
+                        --buildtype=release


### PR DESCRIPTION
#### Description

Add muon, a Meson build system implementation written in C

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
