### PR TITLE
podman: update to 6.0.0

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 # After the upgrade, it is highly recommended to test the `podman machine`.
 # This port has problems with this command from time to time.
 # See https://gist.github.com/judaew/85c6e8a62bf0e7f5be5188e020492e21
-go.setup            github.com/containers/podman 5.8.3 v
+go.setup            github.com/containers/podman 6.0.0 v
 revision            0
 epoch               0
 
@@ -21,10 +21,15 @@ long_description    \
     inside of a VM on the host, or available via the network. You need to \
     install the remote client and then setup ssh connection information.
 
+# Podman 6.0.0 moved its Go module path to go.podman.io/podman/v6 (source
+# still hosted at github.com/containers/podman); internal imports use the
+# new path, so go.package must match it for GOPATH-mode builds to resolve.
+go.package          go.podman.io/podman/v6
+
 checksums           ${distname}${extract.suffix} \
-                    rmd160  669580350879182d7b64a2f51172d27bb032fa7f \
-                    sha256  c54a2ec4b4fb5577288992aaa78684397ec3552fb2d1234d910ec50097d05c0f \
-                    size    20826467
+                    rmd160  4226c51609a4e6822c0c6d451447df8cf73ce109 \
+                    sha256  f35ac7c40f0fd01bfedfe627c23ff7a577b071d50f2b0726e4734d51810f5a7d \
+                    size    20510790
 
 set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Podman 6.0.0 renamed its Go module path to go.podman.io/podman/v6 (source is still hosted at github.com/containers/podman, now under the podman-container-tools org). Internal imports use the new path, so go.package is set explicitly to match it; otherwise the GOPATH-mode build cannot resolve podman's own packages. Verified podman-remote and podman-mac-helper build cleanly with the new go.package.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
