### PR TITLE
tcllib: update to 2.0, build tcllibc

### DIFF
--- a/devel/tcllib/Portfile
+++ b/devel/tcllib/Portfile
@@ -3,27 +3,58 @@
 PortSystem          1.0
 
 name                tcllib
-version             1.21
+version             2.0
 revision            0
-checksums           rmd160  6fd8ece9c66ed762e9d1cd2e20d541cf4e9207ec \
-                    sha256  10c7749e30fdd6092251930e8a1aa289b193a3b7f1abf17fee1d4fa89814762f \
-                    size    6467488
+checksums           rmd160  4f57e22c2f54ddbef0262131cb41e8f254185146 \
+                    sha256  642c2c679c9017ab6fded03324e4ce9b5f4292473b62520e82aacebb63c0ce20 \
+                    size    14872556
 
 categories          devel
 license             Tcl/Tk
-platforms           any
 maintainers         {ryandesign @ryandesign} openmaintainer
-supported_archs     noarch
 
 description         tcllib standardized library
 
-long_description    tcllib is a set of pure-Tcl extensions that you can use to \
+long_description    tcllib is a set of Tcl extensions that you can use to \
                     become even more productive with Tcl.
 
 homepage            http://tcllib.sf.net/
 master_sites        sourceforge:project/tcllib/tcllib/${version}
 use_xz              yes
 
-configure.args      --mandir=${prefix}/share/man
+subport tcl8-tcllib {}
+subport tcl9-tcllib {}
 
-depends_lib         port:tcl
+if {$subport eq $name} {
+    PortGroup stub 1.0
+    platforms   any
+    # Not noarch so arch checking works transitively
+    test.ignore_archs   yes
+    depends_lib port:tcl8-tcllib
+} else {
+    set tclport [string range $subport 0 3]
+    set tclsh [expr {$tclport eq "tcl8" ? "tclsh8.6" : "tclsh9.0"}]
+
+    depends_build       port:${tclport}-critcl
+    depends_lib         port:${tclport}
+
+    patchfiles          graphops.tcl.patch \
+                        json-typedef.patch
+
+    configure.args      --bindir=${prefix}/libexec/${tclport} \
+                        --includedir=${prefix}/include/${tclport} \
+                        --libdir=${prefix}/lib/${tclport} \
+                        --mandir=${prefix}/share/${tclport}/man \
+                        --with-tclsh=${prefix}/bin/${tclsh}
+
+    build.env           PATH=${prefix}/libexec/${tclport}:$env(PATH)
+    build.args          DESTDIR=${destroot}
+    destroot.env        {*}${build.env}
+
+    platform darwin {
+        patchfiles-append       Makefile.in.patch
+        set target_arg          {CRITCL_TARGET="-target macosx-macports"}
+        build.args-append       ${target_arg}
+        destroot.args-append    ${target_arg}
+    }
+}

--- a/devel/tcllib/files/Makefile.in.patch
+++ b/devel/tcllib/files/Makefile.in.patch
@@ -1,0 +1,11 @@
+--- Makefile.in.orig
++++ Makefile.in
+@@ -64,7 +64,7 @@ install-binaries:
+ 	$(TCLSH_PROG) `$(CYGPATH) $(srcdir)/sak.tcl` critcl \
+ 	  -includedir `$(CYGPATH) $(DESTDIR)$(incdir)` \
+ 	  -libdir     `$(CYGPATH) $(DESTDIR)$(libdir)` \
+-	  -pkg $(PKGCNAME)
++	  $(CRITCL_TARGET) -pkg $(PKGCNAME)
+ 
+ install-libraries:
+ 	$(TCLSH_PROG) `$(CYGPATH) $(srcdir)/installer.tcl` \

--- a/devel/tcllib/files/graphops.tcl.patch
+++ b/devel/tcllib/files/graphops.tcl.patch
@@ -1,0 +1,10 @@
+--- modules/struct/graphops.tcl.orig	2024-09-14 04:48:12
++++ modules/struct/graphops.tcl	2025-02-05 02:16:16
+@@ -18,6 +18,7 @@
+ package require struct::disjointset ; # Used by kruskal -- 8.6 required
+ package require struct::prioqueue   ; # Used by kruskal, prim
+ package require struct::queue       ; # Used by isBipartite?, connectedComponent(Of)
++package require struct::set         ; # Used by multiple procs
+ package require struct::stack       ; # Used by tarjan
+ package require struct::graph       ; # isBridge, isCutVertex
+ package require struct::tree        ; # Used by BFS

--- a/devel/tcllib/files/json-typedef.patch
+++ b/devel/tcllib/files/json-typedef.patch
@@ -1,0 +1,10 @@
+--- modules/json/c/json.tab.c.orig	2024-09-14 04:48:12
++++ modules/json/c/json.tab.c	2025-02-17 07:32:48
+@@ -133,7 +133,6 @@ typedef union YYSTYPE YYSTYPE;
+ 
+ /* Value type.  */
+ #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+-typedef union YYSTYPE YYSTYPE;
+ union YYSTYPE
+ {
+ #line 40 "json.y" /* yacc.c:355  */


### PR DESCRIPTION
Also split into tcl8 and tcl9 subports.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?
