### PR TITLE
algol68g: Update to 3.12.3

### DIFF
--- a/lang/algol68g/Portfile
+++ b/lang/algol68g/Portfile
@@ -3,21 +3,23 @@
 PortSystem          1.0
 
 name                algol68g
-version             3.12.0
+version             3.12.3
 revision            0
 categories          lang algol devel
 license             GPL-3
-maintainers         nomaintainer
+maintainers         {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
+
 description         Algol 68 implementation as defined by the Revised Report
 long_description    Algol68G is an implementation of Algol 68 as defined by the Revised Report. \
                     It ranks among the most complete implementations of the language.
 
 homepage            https://algol68genie.nl/en/algol-68-genie/
-master_sites        https://algol68genie.nl/
+master_sites        https://algol68genie.nl
 
-checksums           rmd160  f704fa7465536245dae137f8a6092def59757a42 \
-                    sha256  7d88ee8afafa00a44ae0d9f8e50fa8825a53327a7e3e13ba28e906663c152a7d \
-                    size    681262
+checksums           rmd160  73232151ae7026869c6b54306ac64c34afb6bd63 \
+                    sha256  4d2e66f81ca2fb98f88e23ae41b475e7d40445f349b1088636782da320bd22b1 \
+                    size    681167
 
 extract.rename      yes
 
@@ -126,5 +128,6 @@ variant R description {Enable R support} {
                         -L${frameworks_dir}/R.framework/Versions/${r_branch}/Resources/lib
 }
 
+livecheck.url       ${master_sites}/en/algol-68-genie-source-code-repository/
 livecheck.type      regex
 livecheck.regex     algol68g-(\[0-9.\]+)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
#### Description

* Update algol68g 3.12.0 --> 3.12.3.
* Fix livecheck for new upstream website.
* Add self as maintainer.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?