### PR TITLE
ruby-pg: Fix livecheck

### DIFF
--- a/_resources/port1.0/group/ruby-1.0.tcl
+++ b/_resources/port1.0/group/ruby-1.0.tcl
@@ -222,8 +222,9 @@ proc ruby.setup {module vers {type "install.rb"} {docs {}} {source "custom"} {im
             homepage        https://www.rubygems.org/gems/${ruby.project}
             master_sites    https://www.rubygems.org/downloads/
             livecheck.type  regex
-            livecheck.url   https://www.rubygems.org/gems/${ruby.project}
-            livecheck.regex {<i class="page__subheading">(\d|\d[0-9.]*\d)</i>}
+            livecheck.url   \
+                https://www.rubygems.org/gems/${ruby.project}/versions
+            livecheck.regex /gems/${ruby.project}/versions/(\\d|\\d\[0-9.]*\\d)
         }
         sourceforge:* {
             set ruby.project [lindex [split ${source} {:}] 1]


### PR DESCRIPTION
The rubygems.org website changed their page layout, breaking the old scheme.  This updates both the URL and the regex to something that (mostly) works with the new layout.  A few ports still need fixes.

TESTED:
Fixes 120 of 124 cases of "regex didn't match" errors on 10.9. Or 120 of 127 cases on 26.x (SSL differences).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
OS X 10.9.5 13F1911
macOS 26.5.1 25F80
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
