### PR TITLE
google-cloud-sdk: update to 575.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             575.0.0
+version             575.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  c17637713c546293e090b778dfda94670bda2029 \
-                    sha256  e39d0afa34d1f661932ed3b990e586d47c39d29f9d25f3cbb379da4fb61a8b9e \
-                    size    59528822
+    checksums       rmd160  d0d5075ff0e7d795bb45786721804b3f13a40068 \
+                    sha256  bd24ed83e7c5933c551cddbf47f333b8ace86809625fc64cc52ab4bc8f05aca3 \
+                    size    59528913
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  64933e711025d03046cef270427c31eaadfba1e3 \
-                    sha256  1ecd73028d093885ffdb51759f0580d2c2e50ba38512e8eb02e3ff5578b44f22 \
-                    size    61185607
+    checksums       rmd160  6138a270ea8b8c56b13d38a9e1cbacaaac08c9ec \
+                    sha256  f59f942bf79de62a2425c6cee90394fb13e4bdb50ea11aec68e3692b8d46ada5 \
+                    size    61185597
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  917483910a801e46cdeb0c30f11490818b60ca6c \
-                    sha256  eb9e8aab8f86ef485e3392473bb460cd6dd00384509ce33546ad38635682ea48 \
-                    size    61093541
+    checksums       rmd160  7d1dfc9467a14b79f68204dca5ec78badb107f6e \
+                    sha256  616b4c88b8f0e068e8db56ab86329de48a7692aa8bb26cfb22a6199b6a027255 \
+                    size    61093561
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 575.0.1.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?