### PR TITLE
claude-code: update to 2.1.205

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.203
+version             2.1.205
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  30a84cb7a30511a2292d6c55d3c319546fa03ad4 \
-                 sha256  1481cffd33d5d19219b53d832fb14e4c2c2def781fc4f1db6c5a4b2d1e596763 \
-                 size    246384080
+    checksums    rmd160  74426f04bbb5293cb796d8b10bbc9965784ad59a \
+                 sha256  4299a3f48551ef365f2d056f24d87e84b822c4c10b6acc46979446b7b5c60ceb \
+                 size    246862928
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e816a76c5fae13d9ff923b68b5f139a51d4bf624 \
-                 sha256  57b5aec68a35f42036bd2f82836d91c2d2990c2d589fb3465e3ee87142af9a1e \
-                 size    236961904
+    checksums    rmd160  5549aca443b69a31c100544c4c1ce7b57b365e46 \
+                 sha256  33e28624c5ae84f2bd7d2d8761e5d2e77997ba965cb11b6448de6b6e2c566f9c \
+                 size    237437968
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.205.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?