### PR TITLE
glab: update to 1.107.0

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/cli 1.103.0 v
+go.setup            gitlab.com/gitlab-org/cli 1.107.0 v
 name                glab
 revision            0
 categories          devel
@@ -16,9 +16,9 @@ long_description    ${name} is an open source GitLab CLI tool \
                     you are already working with git and your code.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c2a9db5053c6478ce4ade62e23cba77d88b611f0 \
-                    sha256  b6f1c0477491ba506ca7d01d301c8a4efaf514d63f4a997e27af03508a5527e5 \
-                    size    17695993
+                    rmd160  fea975b549e2d16effad3673ad16b9b1aeae2009 \
+                    sha256  10b7acef12221dda93901b125c4502cfb5594820216faf40880b8f079acd48d8 \
+                    size    17712714
 
 # If not set, it states that it's a developer build
 # Suppress build date for reproducible builds


### PR DESCRIPTION
#### Description

Update to glab 1.107.0.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?