### PR TITLE
flint: Update to 3.6.0

### DIFF
--- a/math/flint/Portfile
+++ b/math/flint/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   muniversal 1.1
 
-github.setup                flintlib flint 3.1.3-p1 v
+github.setup                flintlib flint 3.6.0 v
 revision                    0
 categories                  math devel
 license                     LGPL-2.1+
@@ -14,11 +14,12 @@ long_description            FLINT is a C library for doing number theory
 
 homepage                    https://www.flintlib.org
 
-checksums                   rmd160  2dd98dd68b9f65035944075c0aa1be6abdb53e8c \
-                            sha256  96637ba9de43397d06657deefe8e6dee9d226992b5526bb1c9a9d563b983e027 \
-                            size    8136205
+checksums                   rmd160  3976b5801da7347e750266fbe4d88e12304d0f62 \
+                            sha256  134d39731a6dd926254625d646d85bf5990c68a3f2326cd54d2a6983e3e11dd8 \
+                            size    6565572
 
 github.tarball_from         releases
+use_xz                      yes
 
 # Autotools are explicitly preferred by upstream
 # for anything but Windows. As of now (2024.04),
@@ -47,5 +48,3 @@ configure.cxxflags-append   -std=c++11
 
 test.run                    yes
 test.target                 check
-
-livecheck.url               ${homepage}/downloads.html


### PR DESCRIPTION
#### Description

* Update flint 3.1.3-p1 --> 3.6.0.
* Use XZ for distfile.
* Fix livecheck.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?