### PR TITLE
mp3rgain: update to 2.9.6

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.5 v
+github.setup        M-Igashi mp3rgain 2.9.6 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  719ca4fcb73fe8c8bc7f6566abaf247c56d3f88d \
-                    sha256  cf9ae5f82a96a0c4247c64737d4398ff951bfc96506cb40fbd8408365182dd63 \
-                    size    518545
+                    rmd160  dc642c2af5a593f796d2274e2b8e0001ef274e71 \
+                    sha256  8c453bded2dfcb30487a218f291cbc5a70f9285a711df328855d12a2ec277bc0 \
+                    size    526011
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -43,7 +43,7 @@ cargo.crates \
     console                      0.16.4           4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     crc32fast                    1.5.0            9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-deque              0.8.6            9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
-    crossbeam-epoch              0.9.18           5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-epoch              0.9.20           2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
     crossbeam-utils              0.8.21           d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     either                       1.15.0           48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode               1.0.0            34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \


### PR DESCRIPTION
Update audio/mp3rgain to version 2.9.6.

- Bumped `github.setup` to 2.9.6
- Recomputed rmd160 / sha256 / size for the source tarball
- Updated `cargo.crates` (crossbeam-epoch 0.9.18 → 0.9.20) from the new Cargo.lock

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.6

###### Type of change
- [ ] bug fix
- [ ] enhancement
- [x] update to a newer version

###### Tested on
macOS (release built and validated upstream via CI)

###### Verification
- [x] Have you followed our [guidelines](https://guide.macports.org/#project.update-port)?
- [x] Have you squashed your commits?