### PR TITLE
immich-go: update to 0.32

### DIFF
--- a/graphics/immich-go/Portfile
+++ b/graphics/immich-go/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/simulot/immich-go 0.31.0 v
+go.setup            github.com/simulot/immich-go 0.32.0 v
 go.offline_build    no
 revision            0
 
-checksums           rmd160  7bacc4e8c53287734872cafce20cc6194460a264 \
-                    sha256  b24fd12f28d9691853cae1f48ff846b33794a36a4d356912060d019314789fd4 \
-                    size    89749890
+checksums           rmd160  a0838705e00162190af22ebecf2362f61c364150 \
+                    sha256  1c07ce22e5b46e3691867025154751063d4b9e4cf5df6ef4335102711e017d92 \
+                    size    89750241
 
 categories          graphics net
 installs_libs       no


### PR DESCRIPTION
#### Description
immich-go: update to 0.32

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?