### PR TITLE
icann-rdap: update to 0.30

### DIFF
--- a/net/icann-rdap/Portfile
+++ b/net/icann-rdap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo 1.0
 PortGroup           github 1.0
 
-github.setup        icann icann-rdap 0.0.29 v
+github.setup        icann icann-rdap 0.0.30 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    {*}${description}. RDAP (Registration Data Access Protocol) 
                     and autonomous system numbers.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  aa341a084a82a56d7d632f0dfce23bf6a0142e8d \
-                    sha256  f7a717aa9d428af9e88fac770f0433bc557c82d682f0091d4e1d12a420fd428f \
-                    size    362377
+                    rmd160  89b5dbc24ba0d3efc5584ad0ba1f3f9f0f1342d6 \
+                    sha256  7dcdd36e6f36ebb8c11b6576c7ba10e314de8594adddde242c8f801ed1a3f4f4 \
+                    size    376216
 
 destroot {
     set bins {rdap rdap-test rdap-srv rdap-srv-data rdap-srv-store rdap-srv-test-data}
@@ -44,45 +44,47 @@ cargo.crates \
     anstyle-parse                            1.0.0                52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                            1.1.5                40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                           3.0.11               291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
-    anyhow                                   1.0.102              7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
-    assert_cmd                               2.2.1                39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
+    anyhow                                   1.0.103              2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
+    array-const-fn-init                      0.1.1                8bcb85e548c05d407fa6faff46b750ba287714ef32afc0f5e15b4641ffd6affb \
+    assert_cmd                               2.2.2                2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
     async-trait                              0.1.89               9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atoi                                     2.0.0                f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528 \
     atomic-waker                             1.1.2                1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                                  1.5.0                c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    aws-lc-rs                                1.16.3               0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f \
-    aws-lc-sys                               0.40.0               f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7 \
+    autocfg                                  1.5.1                f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
+    aws-lc-rs                                1.17.1               4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad \
+    aws-lc-sys                               0.42.0               6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444 \
     axum                                     0.8.9                31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90 \
-    axum-client-ip                           0.7.0                dff8ee1869817523c8f91c20bf17fd932707f66c2e7e0b0f811b29a227289562 \
+    axum-client-ip                           1.3.1                a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67 \
     axum-core                                0.5.6                08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1 \
-    axum-extra                               0.10.3               9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96 \
+    axum-extra                               0.12.6               be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970 \
     axum-macros                              0.5.1                7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca \
     base64                                   0.22.1               72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    base64ct                                 1.8.3                2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06 \
-    bitflags                                 2.11.1               c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
+    bitflags                                 2.13.0               b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
     block-buffer                             0.10.4               3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    bstr                                     1.12.1               63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
+    block-buffer                             0.12.1               d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
+    bstr                                     1.12.3               5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79 \
     buildstructor                            0.6.0                caabaaee17b2a78d7aa349a33edc9090c6bb47e6dfb25b0da281df57628bba68 \
-    bumpalo                                  3.20.2               5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    bumpalo                                  3.20.3               72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     byteorder                                1.5.0                1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                                    1.11.1               1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
-    cc                                       1.2.61               d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d \
+    bytes                                    1.12.0               8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593 \
+    cc                                       1.2.66               f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996 \
     cfg-if                                   1.0.4                9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                              0.2.1                613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chrono                                   0.4.44               c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0 \
-    cidr                                     0.2.3                6bdf600c45bd958cf2945c445264471cca8b6c8e67bc87b71affd6d7e5682621 \
+    chacha20                                 0.10.1               d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
+    chrono                                   0.4.45               1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     cidr                                     0.3.2                579504560394e388085d0c080ea587dfa5c15f7e251b4d5247d1e1a61d1d6928 \
-    cidr-utils                               0.6.2                0c494106d7fef49cfc120713ff18ddb52ed7fc65b19a60e1cf2104073a8ef4c7 \
+    cidr-utils                               0.7.1                1f59aae4103f56b79b449c67bde6d1e96aa9f617d95af57ed1d72d6f948fe597 \
     clap                                     4.6.1                1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap_builder                             4.6.0                714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
     clap_derive                              4.6.1                f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                                 1.1.0                c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    client-ip                                0.2.1                39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729 \
     cmake                                    0.1.58               c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
+    cmov                                     0.5.4                0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     colorchoice                              1.0.5                1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     combine                                  4.6.7                ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
     concurrent-queue                         2.5.0                4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     console                                  0.15.11              054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
-    const-oid                                0.9.6                c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const_format                             0.2.36               4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e \
     const_format_proc_macros                 0.2.34               1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     convert_case                             0.10.0               633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
@@ -91,35 +93,37 @@ cargo.crates \
     core-foundation                          0.10.1               b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys                      0.8.7                773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpufeatures                              0.2.17               59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
+    cpufeatures                              0.3.0                8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
     crc                                      3.4.0                5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
     crc-catalog                              2.5.0                217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
     critical-section                         1.2.0                790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b \
     crokey                                   1.4.0                04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c \
     crokey-proc_macros                       1.4.0                847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231 \
     crossbeam                                0.8.4                1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
-    crossbeam-channel                        0.5.15               82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
-    crossbeam-deque                          0.8.6                9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
-    crossbeam-epoch                          0.9.18               5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-queue                          0.3.12               0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115 \
-    crossbeam-utils                          0.8.21               d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
-    crossterm                                0.27.0               f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
+    crossbeam-channel                        0.5.16               d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
+    crossbeam-deque                          0.8.7                5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
+    crossbeam-epoch                          0.9.20               2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
+    crossbeam-queue                          0.3.13               803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26 \
+    crossbeam-utils                          0.8.22               61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
     crossterm                                0.29.0               d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                         0.9.1                acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
-    crypto-common                            0.1.7                78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
+    crypto-common                            0.1.6                1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    crypto-common                            0.2.2                ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
+    ctutils                                  0.4.2                7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     data-encoding                            2.11.0               a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
-    der                                      0.7.10               e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     derive_more                              2.1.1                d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                         2.1.1                799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
     difflib                                  0.4.0                6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                                   0.10.7               9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    digest                                   0.11.3               f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
     directories                              6.0.0                16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs-sys                                 0.5.0                e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    displaydoc                               0.2.5                97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
+    displaydoc                               0.2.6                1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
     document-features                        0.2.12               d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                                  0.15.7               1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     dunce                                    1.0.5                92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                                1.0.20               d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
-    either                                   1.15.0               48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    either                                   1.16.0               91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
     encode_unicode                           1.0.0                34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                              0.8.35               75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     endian-type                              0.1.2                c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d \
@@ -130,17 +134,16 @@ cargo.crates \
     envmnt                                   0.10.4               d73999a2b8871e74c8b8bc23759ee9f3d85011b24fafc91a4b3b5c8cc8185501 \
     equivalent                               1.0.2                877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                                    0.3.14               39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
-    etcetera                                 0.8.0                136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
+    etcetera                                 0.11.0               de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96 \
     event-listener                           5.4.1                e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab \
     fastrand                                 2.4.1                9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     find-msvc-tools                          0.1.9                5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
-    flume                                    0.11.1               da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095 \
+    flume                                    0.12.0               5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be \
     fnv                                      1.0.7                3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                                 0.1.5                d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    foldhash                                 0.2.0                77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     foreign-types                            0.3.2                f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared                     0.1.1                00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                          1.2.2                cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
-    forwarded-header-value                   0.1.1                8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9 \
     fs_extra                                 1.3.0                42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsio                                     0.4.1                f4944f16eb6a05b4b2b79986b4786867bb275f52882adea798f17cc2588f25b2 \
     futures-channel                          0.3.32               07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
@@ -151,19 +154,19 @@ cargo.crates \
     futures-macro                            0.3.32               e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b \
     futures-sink                             0.3.32               c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
     futures-task                             0.3.32               037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
-    futures-timer                            3.0.3                f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24 \
+    futures-timer                            3.0.4                af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968 \
     futures-util                             0.3.32               389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
-    generic-array                            0.14.7               85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    generic-array                            0.14.9               4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2 \
     getrandom                                0.2.17               ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                                0.3.4                899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
-    getrandom                                0.4.2                0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
+    getrandom                                0.4.3                300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     glob                                     0.3.3                0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     goldenfile                               1.11.0               206600f27ef687e85a572315eb297c79f66620b2b3eeb3a6cde17f25e049ae5b \
-    h2                                       0.4.14               171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733 \
+    h2                                       0.4.15               6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155 \
     hashbrown                                0.12.3               8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
-    hashbrown                                0.15.5               9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
-    hashbrown                                0.17.0               4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
-    hashlink                                 0.10.0               7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1 \
+    hashbrown                                0.16.1               841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hashbrown                                0.17.1               ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
+    hashlink                                 0.11.1               824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f \
     headers                                  0.4.1                b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb \
     headers-core                             0.3.0                54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4 \
     heck                                     0.5.0                2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
@@ -171,16 +174,16 @@ cargo.crates \
     hex                                      0.4.3                7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hickory-client                           0.25.2               c466cd63a4217d5b2b8e32f23f58312741ce96e3c84bf7438677d2baff0fc555 \
     hickory-proto                            0.25.2               f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502 \
-    hkdf                                     0.12.4               7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
-    hmac                                     0.12.1               6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
-    home                                     0.5.12               cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d \
-    http                                     1.4.0                e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
+    hkdf                                     0.13.0               4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018 \
+    hmac                                     0.13.0               6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
+    http                                     1.4.2                6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
     http-body                                1.0.1                1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                           0.1.3                b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                                 1.10.1               6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                                 1.0.3                df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    humantime                                2.3.0                135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424 \
-    hyper                                    1.9.0                6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
+    humantime                                2.4.0                15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
+    hybrid-array                             0.4.13               818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c \
+    hyper                                    1.10.1               55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
     hyper-rustls                             0.27.9               33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                                0.6.0                70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                               0.1.20               96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
@@ -193,14 +196,12 @@ cargo.crates \
     icu_properties                           2.2.0                bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
     icu_properties_data                      2.2.0                8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
     icu_provider                             2.2.0                139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
-    id-arena                                 2.3.0                3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     idna                                     1.1.0                3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                             1.2.2                cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
     indexmap                                 1.9.3                bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                                 2.14.0               d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indoc                                    2.0.7                79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     ipnet                                    2.12.0               d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
-    iri-string                               0.7.12               25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20 \
     is-terminal                              0.4.17               3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46 \
     is_terminal_polyfill                     1.70.2               a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itoa                                     1.0.18               8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
@@ -208,8 +209,8 @@ cargo.crates \
     jni-macros                               0.22.4               a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
     jni-sys                                  0.4.1                c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                           0.4.1                38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
-    jobserver                                0.1.34               9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                                   0.3.97               a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf \
+    jobserver                                0.1.35               1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
+    js-sys                                   0.3.103              53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
     json-pretty-compact                      0.1.2                62a9c1f06b173b0da0ccc8cae00599d7b3ceda6e76d68be9b6bc2c941adafe0e \
     jsonpath-rust                            1.0.4                633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa \
     jsonpath_lib                             0.3.0                eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f \
@@ -218,146 +219,134 @@ cargo.crates \
     lazy-regex                               3.6.0                6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
     lazy-regex-proc_macros                   3.6.0                4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                              1.5.0                bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    leb128fmt                                0.1.0                09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libc                                     0.2.186              68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
-    libm                                     0.2.16               b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                                 0.1.16               e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    libsqlite3-sys                           0.30.1               2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149 \
+    libredox                                 0.1.18               c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652 \
+    libsqlite3-sys                           0.37.0               b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1 \
     linux-raw-sys                            0.12.1               32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                                  0.8.2                92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     litrs                                    1.0.0                11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                                 0.4.14               224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                                      0.4.29               5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    log                                      0.4.33               0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
     lru-slab                                 0.1.2                112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     matchers                                 0.2.0                d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     matchit                                  0.8.4                47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
-    md-5                                     0.10.6               d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
-    memchr                                   2.8.0                f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
+    md-5                                     0.11.0               69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
+    memchr                                   2.8.2                88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
     mime                                     0.3.17               6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimad                                  0.14.0               df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f \
-    minus                                    5.6.1                093bd0520d2a37943566a73750e6d44094dac75d66a978d1f0d97ffc78686832 \
-    mio                                      0.8.11               a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
-    mio                                      1.2.0                50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
+    minus                                    5.7.1                2657ec5f6a6edc55a85c8db0c572436b612eb036af00e7eee47e0a622095ed96 \
+    mio                                      1.2.1                02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
     native-tls                               0.2.18               465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
     nibble_vec                               0.1.0                77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
-    nonempty                                 0.7.0                e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7 \
     nu-ansi-term                             0.50.3               7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
-    num-bigint                               0.4.6                a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
-    num-bigint-dig                           0.8.6                e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
+    num-bigint                               0.4.8                c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367 \
     num-integer                              0.1.46               7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
-    num-iter                                 0.1.45               1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
     num-traits                               0.2.19               071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     once_cell                                1.21.4               9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill                       1.70.2               384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
-    openssl                                  0.10.79              bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
+    openssl                                  0.10.81              77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45 \
     openssl-macros                           0.1.1                a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                            0.2.1                7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
-    openssl-src                              300.6.0+3.6.2        a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4 \
-    openssl-sys                              0.9.115              158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781 \
+    openssl-src                              300.6.1+3.6.3        46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846 \
+    openssl-sys                              0.9.117              b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695 \
     option-ext                               0.2.0                04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     parking                                  2.2.1                f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                              0.12.5               93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                         0.9.12               2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     pct-str                                  3.0.1                756dc82399e1ef9b37bd698266e4b7fed5f3d3cccb09fbc6b602086c9077e4ad \
-    pem-rfc7468                              0.7.0                88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     percent-encoding                         2.3.2                9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                                     2.8.6                e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662 \
-    pest_derive                              2.8.6                11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77 \
-    pest_generator                           2.8.6                8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f \
-    pest_meta                                2.8.6                89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
+    pest                                     2.8.7                47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9 \
+    pest_derive                              2.8.7                4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58 \
+    pest_generator                           2.8.7                6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7 \
+    pest_meta                                2.8.7                f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210 \
     pin-project-lite                         0.2.17               a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
-    pkcs1                                    0.7.5                c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
-    pkcs8                                    0.10.2               f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                               0.3.33               19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    plain                                    0.2.3                b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
     portable-atomic                          1.13.1               c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
     potential_utf                            0.1.5                0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     ppv-lite86                               0.2.21               85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     predicates                               3.1.4                ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
     predicates-core                          1.0.10               cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144 \
     predicates-tree                          1.0.13               d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
-    prefix-trie                              0.8.3                90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966 \
-    prettyplease                             0.2.37               479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
+    prefix-trie                              0.9.3                b81f62da691716444e46e43a913c84b3301ef8a732ad2720306bcbe7320aa4ef \
     proc-macro-crate                         3.5.0                e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f \
     proc-macro2                              1.0.106              8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
-    quinn                                    0.11.9               b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
-    quinn-proto                              0.11.14              434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
-    quinn-udp                                0.5.14               addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
-    quote                                    1.0.45               41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    quinn                                    0.11.11              0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
+    quinn-proto                              0.11.16              2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560 \
+    quinn-udp                                0.5.15               35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
+    quote                                    1.0.46               dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
     r-efi                                    5.3.0                69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                    6.0.0                f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radix_trie                               0.2.1                c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd \
     rand                                     0.8.6                5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
     rand                                     0.9.4                44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
+    rand                                     0.10.2               c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                              0.3.1                e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                              0.9.0                d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                                0.6.4                ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                                0.9.5                76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    rand_core                                0.10.1               63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    rand_pcg                                 0.10.2               caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     rangemap                                 1.7.1                973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68 \
     redox_syscall                            0.5.18               ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
-    redox_syscall                            0.7.5                4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b \
     redox_users                              0.5.2                a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    regex                                    1.12.3               e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex                                    1.12.4               f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
     regex-automata                           0.4.14               6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
-    regex-syntax                             0.8.10               dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    regex-syntax                             0.8.11               d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     relative-path                            1.9.3                ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
-    reqwest                                  0.13.3               62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
+    reqwest                                  0.13.4               219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     ring                                     0.17.14              a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rsa                                      0.9.10               b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
     rstest                                   0.26.1               f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49 \
     rstest_macros                            0.26.1               9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0 \
-    rustc-hash                               2.1.2                94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
+    rustc-hash                               2.1.3                6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                            0.4.1                cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                                   1.1.4                b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                                   0.23.40              ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
-    rustls-native-certs                      0.8.3                612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
-    rustls-pki-types                         1.14.1               30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
+    rustls                                   0.23.41              6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f \
+    rustls-native-certs                      0.8.4                dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
+    rustls-pki-types                         1.15.0               764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046 \
     rustls-platform-verifier                 0.7.0                26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android         0.1.1                f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                            0.103.13             61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
-    rustversion                              1.0.22               b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    rustversion                              1.0.23               cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     ryu                                      1.0.23               9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
     same-file                                1.0.6                93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    scc                                      2.4.0                46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc \
     schannel                                 0.1.29               91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     schemars                                 0.8.22               3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615 \
     scopeguard                               1.2.0                94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    sdd                                      3.0.10               490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
     security-framework                       3.7.0                b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys                   2.17.0               6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
     semver                                   1.0.28               8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                                    1.0.228              9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
     serde_core                               1.0.228              41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                             1.0.228              d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                               1.0.149              83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_json                               1.0.150              e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_path_to_error                      0.1.20               10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
     serde_urlencoded                         0.7.1                d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serial_test                              3.4.0                911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f \
-    serial_test_derive                       3.4.0                0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9 \
+    serial_test                              3.5.0                699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
+    serial_test_derive                       3.5.0                94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
     sha1                                     0.10.6               e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha1                                     0.11.0               aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha2                                     0.10.9               a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
+    sha2                                     0.11.0               446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     sharded-slab                             0.1.7                f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
-    shlex                                    1.3.0                0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    shlex                                    2.0.1                f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
     signal-hook                              0.3.18               d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-mio                          0.2.5                b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc \
     signal-hook-registry                     1.4.8                c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
-    signature                                2.2.0                77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     simd_cesu8                               1.1.1                94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
     simdutf8                                 0.1.5                e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
     similar                                  2.7.0                bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     similar-asserts                          1.7.0                b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a \
     slab                                     0.4.12               0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
-    smallvec                                 1.15.1               67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    socket2                                  0.6.3                3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
+    smallvec                                 1.15.2               8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
+    socket2                                  0.6.4                52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
     spin                                     0.9.8                6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
-    spki                                     0.7.3                d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
-    sqlx                                     0.8.6                1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc \
-    sqlx-core                                0.8.6                ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6 \
-    sqlx-macros                              0.8.6                a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d \
-    sqlx-macros-core                         0.8.6                19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b \
-    sqlx-mysql                               0.8.6                aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526 \
-    sqlx-postgres                            0.8.6                db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46 \
-    sqlx-sqlite                              0.8.6                c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea \
+    sqlx                                     0.9.0                378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71 \
+    sqlx-core                                0.9.0                05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb \
+    sqlx-macros                              0.9.0                bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf \
+    sqlx-macros-core                         0.9.0                fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3 \
+    sqlx-mysql                               0.9.0                90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27 \
+    sqlx-postgres                            0.9.0                87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e \
+    sqlx-sqlite                              0.9.0                488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c \
     stable_deref_trait                       1.2.1                6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                        1.1.0                a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     str_inflector                            0.12.0               ec0b848d5a7695b33ad1be00f84a3c079fe85c9278a325ff9159e6c99cef4ef7 \
@@ -367,7 +356,7 @@ cargo.crates \
     strum                                    0.28.0               9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                             0.28.0               ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     subtle                                   2.6.1                13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    syn                                      2.0.117              e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    syn                                      2.0.118              1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
     sync_wrapper                             1.0.2                0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                             0.13.2               728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     system-configuration                     0.7.0                a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
@@ -386,17 +375,18 @@ cargo.crates \
     tinystr                                  0.8.3                c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
     tinyvec                                  1.11.0               3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
     tinyvec_macros                           0.1.1                1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                                    1.52.2               110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386 \
+    tokio                                    1.52.3               8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
     tokio-macros                             2.7.0                385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-native-tls                         0.3.1                bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                             0.26.4               1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                             0.1.18               32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
     tokio-util                               0.7.18               9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
     toml_datetime                            1.1.1+spec-1.1.0     3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
-    toml_edit                                0.25.11+spec-1.1.0   0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
+    toml_edit                                0.25.12+spec-1.1.0   d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7 \
     toml_parser                              1.1.2+spec-1.1.0     a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
     tower                                    0.5.3                ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
-    tower-http                               0.6.8                d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
+    tower-http                               0.6.11               4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
+    tower-http                               0.7.0                b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233 \
     tower-layer                              0.3.3                121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                            0.3.3                8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                                  0.1.44               63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
@@ -407,13 +397,13 @@ cargo.crates \
     try-lock                                 0.2.5                e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     try_match                                0.4.2                b065c869a3f832418e279aa4c1d7088f9d5d323bde15a60a08e20c2cd4549082 \
     try_match_inner                          0.5.2                b9c81686f7ab4065ccac3df7a910c4249f8c0f3fb70421d6ddec19b9311f63f9 \
-    typenum                                  1.20.0               40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
+    typenum                                  1.20.1               b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
     ucd-trie                                 0.1.7                2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     unicode-bidi                             0.3.18               5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5 \
     unicode-ident                            1.0.24               e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-normalization                    0.1.25               5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8 \
     unicode-properties                       0.1.4                7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d \
-    unicode-segmentation                     1.13.2               9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c \
+    unicode-segmentation                     1.13.3               c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8 \
     unicode-width                            0.1.14               7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                            0.2.2                b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unicode-xid                              0.2.6                ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
@@ -429,24 +419,18 @@ cargo.crates \
     walkdir                                  2.5.0                29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                                     0.3.1                bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi                                     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasip2                                   1.0.3+wasi-0.2.9     20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
-    wasip3                                   0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasite                                   0.1.0                b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b \
-    wasm-bindgen                             0.2.120              df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1 \
-    wasm-bindgen-futures                     0.4.70               af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084 \
-    wasm-bindgen-macro                       0.2.120              78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103 \
-    wasm-bindgen-macro-support               0.2.120              9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41 \
-    wasm-bindgen-shared                      0.2.120              49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea \
-    wasm-encoder                             0.244.0              990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
-    wasm-metadata                            0.244.0              bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
+    wasip2                                   1.0.4+wasi-0.2.12    b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
+    wasm-bindgen                             0.2.126              4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4 \
+    wasm-bindgen-futures                     0.4.76               c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d \
+    wasm-bindgen-macro                       0.2.126              167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1 \
+    wasm-bindgen-macro-support               0.2.126              f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e \
+    wasm-bindgen-shared                      0.2.126              dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24 \
     wasm-streams                             0.5.0                9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
-    wasmparser                               0.244.0              47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
-    web-sys                                  0.3.97               2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602 \
+    web-sys                                  0.3.103              8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
     web-time                                 1.1.0                5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-root-certs                        1.0.7                f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
-    webpki-roots                             0.26.11              521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9 \
-    webpki-roots                             1.0.7                52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
-    whoami                                   1.6.1                5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d \
+    webpki-root-certs                        1.0.8                0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267 \
+    webpki-roots                             1.0.8                bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf \
+    whoami                                   2.1.2                998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d \
     winapi                                   0.3.9                5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu               0.4.0                ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                              0.1.11               c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
@@ -458,54 +442,29 @@ cargo.crates \
     windows-registry                         0.6.1                02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
     windows-result                           0.4.1                7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                          0.5.1                7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
-    windows-sys                              0.48.0               677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                              0.52.0               282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                              0.59.0               1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
-    windows-sys                              0.60.2               f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-sys                              0.61.2               ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
-    windows-targets                          0.48.5               9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                          0.52.6               9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                          0.53.5               4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
-    windows_aarch64_gnullvm                  0.48.5               2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm                  0.52.6               32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
-    windows_aarch64_gnullvm                  0.53.1               a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
-    windows_aarch64_msvc                     0.48.5               dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc                     0.52.6               09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
-    windows_aarch64_msvc                     0.53.1               b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
-    windows_i686_gnu                         0.48.5               a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                         0.52.6               8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
-    windows_i686_gnu                         0.53.1               960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
     windows_i686_gnullvm                     0.52.6               0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
-    windows_i686_gnullvm                     0.53.1               fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
-    windows_i686_msvc                        0.48.5               8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc                        0.52.6               240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
-    windows_i686_msvc                        0.53.1               1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
-    windows_x86_64_gnu                       0.48.5               53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu                       0.52.6               147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
-    windows_x86_64_gnu                       0.53.1               9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
-    windows_x86_64_gnullvm                   0.48.5               0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm                   0.52.6               24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_gnullvm                   0.53.1               0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
-    windows_x86_64_msvc                      0.48.5               ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc                      0.52.6               589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    windows_x86_64_msvc                      0.53.1               d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    winnow                                   1.0.2                2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0 \
-    wit-bindgen                              0.51.0               d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
+    winnow                                   1.0.3                0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
     wit-bindgen                              0.57.1               1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    wit-bindgen-core                         0.51.0               ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
-    wit-bindgen-rust                         0.51.0               b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
-    wit-bindgen-rust-macro                   0.51.0               0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
-    wit-component                            0.244.0              9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
-    wit-parser                               0.244.0              ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
     writeable                                0.6.3                1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
     yansi                                    1.0.1                cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
-    yoke                                     0.8.2                abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
+    yoke                                     0.8.3                709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                              0.8.2                de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                                 0.8.48               eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
-    zerocopy-derive                          0.8.48               70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
-    zerofrom                                 0.1.7                69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df \
+    zerocopy                                 0.8.53               75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1 \
+    zerocopy-derive                          0.8.53               4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71 \
+    zerofrom                                 0.1.8                0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                          0.1.7                11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
-    zeroize                                  1.8.2                b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
+    zeroize                                  1.9.0                e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
     zerotrie                                 0.2.4                0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
     zerovec                                  0.11.6               90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
     zerovec-derive                           0.11.3               625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \


### PR DESCRIPTION
#### Description
icann-rdap: update to 0.30

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?