### PR TITLE
weechat: update to 4.9.3, update Python and Ruby variants

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.9.2
+version             4.9.3
 revision            0
-checksums           rmd160  11af2dbebf71dcd312f026e8f720c0d498d9abe4 \
-                    sha256  d1389a9e521bda0c4ebfa108e2abf885ee6c5150c385299f5dca0181a43a0914 \
-                    size    2797372
+checksums           rmd160  6f831fbb3c6d80d6a9e37a98a0a8ccd6ab770375 \
+                    sha256  5c7d9539fa86c99ea76a551a889a92bac21eab7bb2790dbd346452d00b10c37c \
+                    size    2797720
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -76,52 +76,53 @@ configure.args-append \
                     -DENABLE_TCL=OFF \
                     -DENABLE_TESTS=OFF
 
-variant python requires python313 description {Compatibility variant, requires +python313} {}
 
-variant python310 description "Bindings for Python 3.10 plugins" conflicts python311 python312 python313 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.pkg_config_path-append \
-                            ${frameworks_dir}/Python.framework/Versions/3.10/lib/pkgconfig
-    depends_lib-append      port:python310
+set python_suffixes {310 311 312 313 314}
+
+set python_ports {}
+foreach s ${python_suffixes} {
+    lappend python_ports python${s}
 }
 
-variant python311 description "Bindings for Python 3.11 plugins" conflicts python310 python312 python313 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.pkg_config_path-append \
-                            ${frameworks_dir}/Python.framework/Versions/3.11/lib/pkgconfig
-    depends_lib-append      port:python311
+variant python requires python[lindex ${python_suffixes} end] \
+    description "Compatibility variant, requires +python[lindex ${python_suffixes} end]" {}
+
+foreach s ${python_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string range ${s} 1 end]
+    set i [lsearch -exact ${python_ports} ${p}]
+    set c [lreplace ${python_ports} ${i} ${i}]
+    variant ${p} description "Bindings for Python ${v} plugins" conflicts {*}${c} "
+        configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+        configure.args-append   -DPython_EXECUTABLE=\${prefix}/bin/python${v}
+        depends_lib-append      port:${p}
+    "
 }
 
-variant python312 description "Bindings for Python 3.12 plugins" conflicts python310 python311 python313 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.pkg_config_path-append \
-                            ${frameworks_dir}/Python.framework/Versions/3.12/lib/pkgconfig
-    depends_lib-append      port:python312
+
+set ruby_suffixes {33 34}
+
+set ruby_ports {}
+foreach s ${ruby_suffixes} {
+    lappend ruby_ports ruby${s}
 }
 
-variant python313 description "Bindings for Python 3.13 plugins" conflicts python310 python311 python312 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.pkg_config_path-append \
-                            ${frameworks_dir}/Python.framework/Versions/3.13/lib/pkgconfig
-    depends_lib-append      port:python313
+variant ruby requires ruby[lindex ${ruby_suffixes} end] \
+    description "Compatibility variant, requires +ruby[lindex ${ruby_suffixes} end]" {}
+
+foreach s ${ruby_suffixes} {
+    set p ruby${s}
+    set v [string index ${s} 0].[string range ${s} 1 end]
+    set i [lsearch -exact ${ruby_ports} ${p}]
+    set c [lreplace ${ruby_ports} ${i} ${i}]
+    variant ${p} description "Bindings for Ruby ${v} plugins" conflicts {*}${c} "
+        configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
+        configure.args-append   -DRuby_EXECUTABLE=\${prefix}/bin/ruby${v} \
+                                -DRuby_LIBRARY=\${prefix}/lib/libruby${v}.dylib
+        depends_lib-append      port:${p}
+    "
 }
 
-variant ruby requires ruby33 description {Compatibility variant, requires +ruby33} {}
-
-variant ruby31 description "Bindings for Ruby 3.1 plugins" conflicts ruby32 ruby33 {
-    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
-    depends_lib-append      port:ruby31
-}
-
-variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby31 ruby33 {
-    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
-    depends_lib-append      port:ruby32
-}
-
-variant ruby33 description "Bindings for Ruby 3.3 plugins" conflicts ruby31 ruby32 {
-    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
-    depends_lib-append      port:ruby33
-}
 
 variant aspell description {Support for Spellcheck (aspell)} {
     configure.args-delete   -DENABLE_SPELL=OFF


### PR DESCRIPTION
#### Description

weechat: update to 4.9.3, update Python and Ruby variants
* create loop for python and ruby variants (copied from gdb's Portfile)
* add +python314 for python 3.14, and update +python to use +python314
* add +ruby34 for ruby 3.4, and update +ruby to use +ruby34
* drop end-of-life +ruby31, +ruby32
* drop `pkg_config_path` for Python variants as CMake doesn't use it and specify Python and Ruby executable and library paths for Python and Ruby variants, respectively (thanks barracuda156)

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
