### PR TITLE
claude-code: update to 2.1.206

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.205
+version             2.1.206
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  74426f04bbb5293cb796d8b10bbc9965784ad59a \
-                 sha256  4299a3f48551ef365f2d056f24d87e84b822c4c10b6acc46979446b7b5c60ceb \
-                 size    246862928
+    checksums    rmd160  bbc9592c0004bc04bb3fe6614378babef5ac487f \
+                 sha256  b1e1636917a12c7d4e1fa54cd13f7f76ba3779fb988180610b6ca483258c2f46 \
+                 size    248431568
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5549aca443b69a31c100544c4c1ce7b57b365e46 \
-                 sha256  33e28624c5ae84f2bd7d2d8761e5d2e77997ba965cb11b6448de6b6e2c566f9c \
-                 size    237437968
+    checksums    rmd160  44128f3dc23049a40a2803f5768ad9f64c704831 \
+                 sha256  3197aba4442dbd5b3df42b6f35e6d7bd03b5e48ce18b7a3c5c6f5f8c28e03b7f \
+                 size    240395024
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.206.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?