### PR TITLE
py-graph-tool: Update to version 3.1; Use cgal6, boost 1.91; livecheck fix

### DIFF
--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 PortGroup           python 1.0
 
 name                py-graph-tool
-version             2.91
+version             3.1
 revision            0
 epoch               20190711
 supported_archs     arm64 x86_64
@@ -26,14 +26,14 @@ homepage            https://graph-tool.skewed.de
 master_sites        https://downloads.skewed.de/graph-tool/
 use_bzip2           yes
 
-checksums           rmd160  a8bbbc535313542edd9863c666cf185e74925cee \
-                    sha256  3c850e92b35efdd71ef2abd26d9fe5c0212ec2a07990fbe7323408e127a3fd02 \
-                    size    15344011
+checksums           rmd160  75cb5fddb73ac3fb702cb67399871f3e5f9c0c74 \
+                    sha256  1e8a887b93d0e97390d0c016a0585fc7438841e5b221aa8a2d680dac49b71718 \
+                    size    15526759
 
-# please ensure that this boost.version matches that specified in cgal5
-boost.version       1.81
+# please ensure that this boost.version matches that specified in cgal6
+boost.version       1.91
 
-python.versions     310 311 312 313
+python.versions     310 311 312 313 314
 
 if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
     version         2.2.26
@@ -44,10 +44,16 @@ if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
                     size    29644168
 } else {
     if {${name} ne ${subport}} {
-        compiler.cxx_standard   2017
+        compiler.cxx_standard   2023
 
-        # https://git.skewed.de/count0/graph-tool/-/issues/785
-        compiler.blacklist *macports-clang-19*
+        # blacklist clang < 22
+        compiler.blacklist-append \
+                    {clang < 1600} \
+                    {macports-clang-[3-9].0} \
+                    {macports-clang-1[0-9].0} \
+                    {macports-clang-2[0-1]}
+        compiler.fallback  \
+                    macports-clang-22 clang
 
         variant openmp description "Enable OpenMP" {
             compiler.openmp_version 2.5
@@ -65,9 +71,13 @@ if {${name} ne ${subport}} {
                     port:pkgconfig
 
     depends_lib-append \
+                    port:autoconf \
+                    port:automake \
                     port:cairomm \
-                    port:cgal5 \
+                    port:cctools \
+                    port:cgal6 \
                     port:expat \
+                    port:libtool \
                     port:py${python.version}-cairo \
                     port:py${python.version}-gobject3 \
                     port:py${python.version}-numpy \
@@ -76,25 +86,22 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-matplotlib
 
+    # https://git.skewed.de/count0/graph-tool/-/work_items/835
+    # diff -NaurdwB ./py-graph-tool-orig ./py-graph-tool-new | sed -E -e 's/\.\/py-graph-tool-(orig|new)/\./g' | sed -E -e 's|/opt/local|@@PREFIX@@|g' > ~/Downloads/patch-pragma_GCC_visibility.diff
+    # patchfiles-append \
+    #                 d0d1442efab8bc30119fb87aec8d300ea4cc78a5.patch
+
     # graph-tool relies on Boost.Python, so make sure it is installed.
     require_active_variants boost[boost::version_nodot] python${python.version}
 
-    # remove after this issue is fixed:
-    # https://git.skewed.de/count0/graph-tool/-/issues/761
-    post-patch {
-        fs-traverse f ${worksrcpath}/src {
-            if { [file isfile ${f}]
-                && [regexp {\.(cc|hh)$} [file extension ${f}]] } {
-                reinplace -q -E \
-                    {s|:[[:space:]]+public[[:space:]]+std::unary_function<.+,.+>||} \
-                    ${f}
-            }
-        }
-    }
-
-    use_configure   yes
     # parallel build starts swapping with 8GB of RAM.
     #use_parallel_build no
+
+    use_configure   yes
+
+    pre-configure {
+        system -W ${worksrcpath} ./autogen.sh
+    }
 
     # PYTHON_EXTRA_LDFLAGS is set to work around incorrect detection of
     # link flags by configure
@@ -109,7 +116,7 @@ if {${name} ne ${subport}} {
     macosx_deployment_target
 
     configure.cppflags-append -I${prefix}/include -I${python.include}/..
-    configure.ldflags-append -L${prefix}/lib
+
     configure.args-append \
                     --exec-prefix=${python.prefix} \
                     --with-boost=[boost::install_area] \
@@ -164,6 +171,6 @@ if {${name} ne ${subport}} {
     }
 } else {
     livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex ${master_sites}${python.rootname}-(\[0-9.\]+)\\.tar
+    livecheck.url   ${master_sites}
+    livecheck.regex ${python.rootname}-(\[0-9.\]+)[string map {"." "\\."} ${extract.suffix}]
 }


### PR DESCRIPTION
py-graph-tool: Update to version 3.0; Use cgal6, boost 1.88; livecheck fix

This PR depends upon #33513, #33570.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
