### PR TITLE
gnubg: Add patch to fix AudioToolbox typo in configure.ac

### DIFF
--- a/games/gnubg/Portfile
+++ b/games/gnubg/Portfile
@@ -20,9 +20,11 @@ long_description        GNU Backgammon (gnubg) is an application for playing and
                         command line or with a graphical interface using GTK.
 
 master_sites            gnu
-                        
+
 distfiles               ${name}-release-${version}-sources.tar.gz
-                        
+
+patchfiles              audiotoolbox-typo.diff
+
 checksums               ${name}-release-${version}-sources.tar.gz \
                         rmd160  89c51870ae21c84fe2ebc635ea2c53f05d88c520 \
                         sha256  6f7d969b13cfff786fba90ff8cc5e5d564b97f4f0aa69afe4f3838f18c445979
@@ -84,9 +86,9 @@ variant board3d conflicts quartz description "enable OpenGL board" {
     ## because of the display issue
     ## see also https://mail.gnome.org/archives/gtkglext-list/2009-December/msg00023.html
     require_active_variants port:gtkglext {} quartz
-  
+
     configure.args-replace  --without-board3d --with-board3d
-  
+
     ## gtkglext+x11 links to libgl that is provided by macports.
     ## Therefore, it should include macports' opengl headers
     ## instead of the ones provided by OSX

--- a/games/gnubg/files/audiotoolbox-typo.diff
+++ b/games/gnubg/files/audiotoolbox-typo.diff
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -219,7 +219,7 @@ if test "x$darwin" = "xyes"; then
+ 
+                if test "x$coreaudio" = "xyes"; then
+                        AC_DEFINE(HAVE_APPLE_COREAUDIO,1, [Define if you have Apple CoreAudio])
+-                       LDFLAGS="$LDFLAGS -framework AudioUnit -framework CoreServices -framework AudioToolBox -framework CoreAudio"
++                       LDFLAGS="$LDFLAGS -framework AudioUnit -framework CoreServices -framework AudioToolbox -framework CoreAudio"
+                fi
+     fi
+ fi

--- a/games/gnubg/files/audiotoolbox-typo.diff
+++ b/games/gnubg/files/audiotoolbox-typo.diff
@@ -1,11 +1,11 @@
---- a/configure.ac
-+++ b/configure.ac
-@@ -219,7 +219,7 @@ if test "x$darwin" = "xyes"; then
+--- configure.ac
++++ configure.ac
+@@ -219,7 +219,7 @@
  
-                if test "x$coreaudio" = "xyes"; then
-                        AC_DEFINE(HAVE_APPLE_COREAUDIO,1, [Define if you have Apple CoreAudio])
--                       LDFLAGS="$LDFLAGS -framework AudioUnit -framework CoreServices -framework AudioToolBox -framework CoreAudio"
-+                       LDFLAGS="$LDFLAGS -framework AudioUnit -framework CoreServices -framework AudioToolbox -framework CoreAudio"
-                fi
+ 		if test "x$coreaudio" = "xyes"; then
+ 			AC_DEFINE(HAVE_APPLE_COREAUDIO,1, [Define if you have Apple CoreAudio])
+-			LDFLAGS="$LDFLAGS -framework AudioUnit -framework CoreServices -framework AudioToolBox -framework CoreAudio"
++			LDFLAGS="$LDFLAGS -framework AudioUnit -framework CoreServices -framework AudioToolbox -framework CoreAudio"
+ 		fi
      fi
  fi


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/74200

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
