### PR TITLE
wsddn: fixing build breaks

### DIFF
--- a/net/wsddn/Portfile
+++ b/net/wsddn/Portfile
@@ -16,6 +16,7 @@ long_description        Allows your Mac to be discovered by systems running Wind
                         or later and to appear in their Explorer \"Network\" view.
 license                 BSD
 installs_libs           no
+platforms               {darwin >= 10}
 
 github.tarball_from     releases
 distname                wsddn-src-prefetch-${github.version}
@@ -27,14 +28,12 @@ checksums               rmd160  8151bee28c6ba30a3b5e33c9ebed690baa02074b \
 worksrcdir              wsdd-native-${github.version}
 compiler.cxx_standard   2020
 compiler.c_standard     2011
+patchfiles              patch-fmt-uint128-operator-not.diff
 
 # By default, we do not need legacysupport at least as far back as Snow Leopard
 legacysupport.newest_darwin_requires_legacy    9
 
-if {${os.major} < 10} {
-    # Use consistent version of libstdc++ on old ppc systems.
-    legacysupport.redirect_bins wsddn
-} elseif {${os.major} == 10} {
+if {${os.major} == 10} {
     # Snow Leopard (10.6) has broken ld that crashes on modern clang's Mach-O output.
     # Build with gcc and its own libstdc++, whose output the old linker handles.
     compiler.blacklist-append   *clang*
@@ -44,16 +43,14 @@ if {${os.major} < 10} {
         # Use consistent version of libstdc++ on 10.6 ppc
         legacysupport.redirect_bins wsddn
     }
-} elseif {${os.major} < 19 && ${configure.cxx_stdlib} eq "libc++"} {
+} elseif {${os.major} < 19 && [regexp {^macports-clang-(\d+)$} ${configure.compiler} -> llvmver]} {
     # Neither system libc++ before 10.15 nor the libc++ provided by legacysupport 
-    # have sufficient C++20 support. Use the llvm provided libc++ version. 
-    # The llvm libc++ needs legacysupport.
+    # have sufficient C++20 support. Use the clang's own libc++ version. 
+    # That libc++ needs legacysupport.
 
     legacysupport.newest_darwin_requires_legacy    18
 
-    set llvmver 16
-    depends_lib-append   port:llvm-${llvmver}
-    # The availability annotations are bogus for the llvm-16 libc++
+    # The availability annotations are bogus for the non-system libc++
     configure.cxxflags-append -D_LIBCPP_DISABLE_AVAILABILITY=1
     configure.cxxflags-append -nostdinc++ -isystem ${prefix}/libexec/llvm-${llvmver}/include/c++/v1
     configure.ldflags-append  -nostdlib++ -L${prefix}/libexec/llvm-${llvmver}/lib/libc++ -Wl,-rpath,${prefix}/libexec/llvm-${llvmver}/lib/libc++ -lc++ -lc++abi
@@ -174,7 +171,7 @@ Daemon logs are located in /var/log/wsddn.log"
 }
 
 notes-append "
-To customize ${name}, you can edit ${prefix}/etc/wsddn.conf.
+To customize ${name}, you can edit ${prefix}/etc/wsddn.conf
 An up-to-date sample is provided in ${prefix}/etc/wsddn.conf.sample
 ${loginfo}
 "

--- a/net/wsddn/files/patch-fmt-uint128-operator-not.diff
+++ b/net/wsddn/files/patch-fmt-uint128-operator-not.diff
@@ -1,0 +1,20 @@
+Add the missing operator~ to fmt's software uint128 fallback.
+
+On targets without a native __int128 (e.g. i386), fmt uses its own uint128
+class instead of __uint128_t. format_hexfloat() does `f.f &= ~(inc - 1);`,
+but the fallback class never defines operator~, so the build fails with
+"no match for 'operator~' (operand type is 'fmt::v12::detail::uint128')".
+
+--- external/fmt/include/fmt/format.h.orig
++++ external/fmt/include/fmt/format.h
+@@ -531,6 +531,9 @@
+   friend constexpr auto operator&(const uint128& lhs, const uint128& rhs)
+       -> uint128 {
+     return {lhs.hi_ & rhs.hi_, lhs.lo_ & rhs.lo_};
+   }
++  friend constexpr auto operator~(const uint128& n) -> uint128 {
++    return {~n.hi_, ~n.lo_};
++  }
+   friend FMT_CONSTEXPR auto operator+(const uint128& lhs, const uint128& rhs)
+       -> uint128 {
+     auto result = uint128(lhs);


### PR DESCRIPTION
#### Description

* Fixed builds on Mojave and High Sierra. The original logic for libc++ selection on darwin 11-18 wasn't quite correct.
* Added a patch to enable compilation on 32-bit. This fixes broken i386 and ppc (32-bit) builds (if any)
* Blocked darwin < 10. The product uses Apple frameworks unavailable before Snow Leopard

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
* macOS 26.5.2 25F84 arm64
  Xcode 26.5 17F42
* macOS 10.14.6 18G9323 x86_64
  Command Line Tools 10.3.0.0.1.1562985497
* macOS 10.13.6 17G14042 x86_64
  Command Line Tools 10.1.0.0.1.1539992718
* macOS 10.12.6 16G2136 x86_64
  Command Line Tools 9.2.0.0.1.1510905681
* macOS 10.6.8 10K549 i386
  Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
  Blocked by https://trac.macports.org/ticket/66358
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
