### PR TITLE
py-meson: add exe_wrapper to fix universal build on arm64 host

### DIFF
--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.11.1
 github.tarball_from releases
-revision            4
+revision            5
 
 checksums           rmd160  c7bd966adc6b4b9ebd8f63ef988ac768cabec5eb \
                     sha256  6788ae299979643f8d841bcaf64352558436cae45a0355148a3aeeccf7913866 \
@@ -87,8 +87,15 @@ if {${subport} ne ${name}} {
         fs-traverse f ${destroot}${prefix}/share/${subport}/meson/cross/ {
             if {![file isdirectory ${f}]} {
                 reinplace "s|@@PREFIX@@|${prefix}|g" ${f}
+                reinplace "s|@@SUBPORT@@|${subport}|g" ${f}
             }
         }
+
+        # install the Rosetta exe_wrapper used by the x86_64-darwin cross file
+        # for +universal builds on Apple Silicon
+        xinstall -m 0755 -d ${destroot}${prefix}/libexec/${subport}
+        xinstall -m 0755 ${filespath}/rosetta-exe-wrapper.sh \
+            ${destroot}${prefix}/libexec/${subport}/rosetta-exe-wrapper.sh
 
         # install shell completion files
         set bash_completion_dir ${prefix}/share/${subport}/bash-completion/completions

--- a/python/py-meson/files/cross/x86_64-darwin
+++ b/python/py-meson/files/cross/x86_64-darwin
@@ -6,6 +6,7 @@ cpu = 'x86_64'
 endian = 'little'
 
 [binaries]
+exe_wrapper = '@@PREFIX@@/libexec/@@SUBPORT@@/rosetta-exe-wrapper.sh'
 pkgconfig = '@@PREFIX@@/bin/pkg-config'
 cmake = '@@PREFIX@@/bin/cmake'
 llvm-config = 'llvm-config'

--- a/python/py-meson/files/rosetta-exe-wrapper.sh
+++ b/python/py-meson/files/rosetta-exe-wrapper.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# rosetta-exe-wrapper.sh
+#
+# Meson `exe_wrapper` for the x86_64-darwin cross file, used when building
+# an x86_64 slice as part of a +universal build on an arm64 host.
+#
+# Meson invokes this as:  rosetta-exe-wrapper.sh <binary> [args...]
+#
+# x86_64 Mach-O binaries run directly on Apple Silicon via Rosetta 2 (no
+# translation shim to invoke, unlike qemu-style wrappers on Linux) -- but
+# only if Rosetta is actually installed. This wrapper checks that once,
+# up front, so a missing install produces one clear error message instead
+# of an obscure crash deep inside g-ir-scanner or a test binary.
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "rosetta-exe-wrapper: no command given" >&2
+    exit 1
+fi
+
+build_arch="$(/usr/bin/uname -m)"
+
+# Only relevant on Apple Silicon; on a native x86_64 host there's nothing
+# to translate, so just run it.
+if [ "${build_arch}" = "arm64" ]; then
+    if ! /usr/bin/arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+        cat >&2 <<EOF
+rosetta-exe-wrapper: cannot execute x86_64 binaries on this arm64 host.
+
+Building +universal requires Rosetta 2 to run x86_64 binaries produced
+during the build (e.g. gobject-introspection scanning, test suites).
+Install it with:
+
+    softwareupdate --install-rosetta --agree-to-license
+
+then retry the build.
+EOF
+        exit 1
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
#### Description

Hopefully this fixes the build failures for `glib2 +universal` - I personally cannot test this, but hopefully someone affected by this issue can... please report back here whether or not it works.

Closes: https://trac.macports.org/ticket/73976

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
