### PR TITLE
netcdf: Update to 4.10.1

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -11,10 +11,12 @@ PortGroup                   legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 epoch                       3
-github.setup                Unidata netcdf-c 4.10.0 v
-revision                    3
+github.setup                Unidata netcdf-c 4.10.1 v
+revision                    0
 name                        netcdf
-maintainers                 {takeshi @tenomoto} openmaintainer
+maintainers                 {@Dave-Allured noaa.gov:dave.allured} \
+                            {takeshi @tenomoto} \
+                            openmaintainer
 categories                  science
 license                     Permissive
 
@@ -31,9 +33,9 @@ homepage                    https://www.unidata.ucar.edu/software/netcdf
 master_sites                https://downloads.unidata.ucar.edu/netcdf-c/${version}
 distname                    netcdf-c-${version}
 
-checksums           rmd160  f227127be3d4d4d2bc9b2dd5911c900a2977dba6 \
-                    sha256  bd4bfa239385802a6cbea71a2f038dadcaba756a38c56804f829ed8262e7912f \
-                    size    13334202
+checksums                   rmd160  0cdd9a6e1ac028720e0ad0d4cdceb7ebc1d0bf87 \
+                            sha256  db3b69ff4a5ee1a7d79a5c36664d2128b752c266e966369fcf7311ec5f927564 \
+                            size    13360012
 
 compilers.choose            cc cpp cxx
 mpi.setup


### PR DESCRIPTION
#### Description

* Update netcdf 4.10.0 --> 4.10.1.
* Add self as first maintainer.
* No dependent rev bumps.  SO version = 22, did not change.
  (grep SO_VERSION CMakeLists.txt)

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?