### PR TITLE
pi-coding-agent: update to 0.80.6

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.80.3
+version             0.80.6
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  9b4ad1c14e5553f90d2f28253c0ecf9ab9d52149 \
-                    sha256  155c5800134cb8df6c47adb3eab56415e8fa7746e0b1cba6687134137c451d90 \
-                    size    4818396
+checksums           rmd160  5b110e46a255c631a2325d56d474096ff8c63c97 \
+                    sha256  2a77634640b2d86d90d24087bb67559ecf2366e0fb52a42c55eed416147da411 \
+                    size    4868728
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
