### PR TITLE
rsync: update to 3.4.4

### DIFF
--- a/net/rsync/Portfile
+++ b/net/rsync/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                rsync
-version             3.4.1
-checksums           rmd160  b0f3e9ba2bb2c370a7c08587856e43e163f08d5e \
-                    sha256  2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52 \
-                    size    1172739
+version             3.4.4
+checksums           rmd160  429e420e517616cbbf6878bf9901a11da24d87e3 \
+                    sha256  bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96 \
+                    size    1223040
 
 categories          net
 license             {GPL-3+ OpenSSLException}
@@ -16,8 +16,6 @@ maintainers         {ryandesign @ryandesign} openmaintainer
 
 homepage            https://rsync.samba.org
 master_sites        https://download.samba.org/pub/rsync/src/
-
-patch.pre_args-replace  -p0 -p1
 
 if {${subport} eq ${name}} {
     revision            0
@@ -40,14 +38,15 @@ if {${subport} eq ${name}} {
                         port:zstd \
                         path:lib/libssl.dylib:openssl
 
-    # This patch comes from
-    # https://download.samba.org/pub/rsync/src/rsync-patches-3.4.1.tar.gz
-    # and needs to be updated with each release.
+    # This patch comes from the FreeBSD ports collection and needs to be
+    # updated with each release:
+    # https://github.com/freebsd/freebsd-ports/blob/main/net/rsync/files/extra-patch-file-flags.diff
     # We used to use hfs-compression.diff but it has been deliberately
     # disabled by its developers as of 3.1.3 because it needs to be reworked
     # to account for changes that occurred in rsync's rsync_xal_get function:
     # https://trac.macports.org/ticket/60792#comment:2
-    patchfiles          fileflags.diff
+    patchfiles          fileflags.diff \
+                        legacy-darwin-at-syscalls.diff
 
     pre-configure {
         # fileflags.diff patches aclocal.m4 so the configure script needs
@@ -58,6 +57,13 @@ if {${subport} eq ${name}} {
     compiler.blacklist  {clang >= 1100 < 1103}
 
     configure.args      --with-rsyncd-conf=${prefix}/etc/rsyncd.conf
+
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        # macOS 10.6 defines AT_FDCWD but lacks several *at() system calls.
+        # Disable their use so rsync falls back to the compatible code paths.
+        # https://github.com/RsyncProject/rsync/issues/1025
+        configure.cppflags-append -DRSYNC_NO_AT_SYSCALLS
+    }
 
     test.run            yes
     test.target         check

--- a/net/rsync/files/fileflags.diff
+++ b/net/rsync/files/fileflags.diff
@@ -1,16 +1,21 @@
-This patch provides --fileflags, which preserves the st_flags stat() field.
-Modified from a patch that was written by Rolf Grossmann.
+Add support for preserving BSD file flags
 
-To use this patch, run these commands for a successful build:
+Original patch by Rolf Grossmann <grossman@progtech.net>
+Rsync 3.4.4 port by Dag-Erling Smørgrav <des@FreeBSD.org>
 
-    patch -p1 <patches/fileflags.diff
-    ./configure                         (optional if already run)
-    make
-
-based-on: 3305a7a063ab0167cab5bf7029da53abaa9fdb6e
-diff --git a/compat.c b/compat.c
---- a/compat.c
-+++ b/compat.c
+--- backup.c.orig
++++ backup.c
+@@ -207,7 +207,7 @@ static inline int link_or_rename(const char *from, const char *to,
+ 			return 0;
+ 	}
+ #endif
+-	if (do_rename_at(from, to) == 0) {
++	if (do_rename_at(from, to, stp->st_mode, ST_FLAGS(*stp)) == 0) {
+ 		if (stp->st_nlink > 1 && !S_ISDIR(stp->st_mode)) {
+ 			/* If someone has hard-linked the file into the backup
+ 			 * dir, rename() might return success but do nothing! */
+--- compat.c.orig
++++ compat.c
 @@ -40,6 +40,7 @@ extern int checksum_seed;
  extern int basis_dir_cnt;
  extern int prune_empty_dirs;
@@ -23,42 +28,41 @@ diff --git a/compat.c b/compat.c
  extern int preserve_crtimes;
  extern int preserve_acls;
  extern int preserve_xattrs;
-+extern int preserve_fileflags;
++extern int preserve_file_flags;
  extern int xfer_flags_as_varint;
  extern int need_messages_from_generator;
  extern int delete_mode, delete_before, delete_during, delete_after;
-@@ -86,7 +88,7 @@ struct name_num_item *xattr_sum_nni;
+@@ -87,7 +89,7 @@ struct name_num_item *xattr_sum_nni;
  int xattr_sum_len = 0;
  
  /* These index values are for the file-list's extra-attribute array. */
 -int pathname_ndx, depth_ndx, atimes_ndx, crtimes_ndx, uid_ndx, gid_ndx, acls_ndx, xattrs_ndx, unsort_ndx;
-+int pathname_ndx, depth_ndx, atimes_ndx, crtimes_ndx, uid_ndx, gid_ndx, fileflags_ndx, acls_ndx, xattrs_ndx, unsort_ndx;
++int pathname_ndx, depth_ndx, atimes_ndx, crtimes_ndx, uid_ndx, gid_ndx, file_flags_ndx, acls_ndx, xattrs_ndx, unsort_ndx;
  
  int receiver_symlink_times = 0; /* receiver can set the time on a symlink */
  int sender_symlink_iconv = 0;	/* sender should convert symlink content */
-@@ -588,6 +590,8 @@ void setup_protocol(int f_out,int f_in)
+@@ -589,6 +591,8 @@ void setup_protocol(int f_out,int f_in)
  		uid_ndx = ++file_extra_cnt;
  	if (preserve_gid)
  		gid_ndx = ++file_extra_cnt;
-+	if (preserve_fileflags || (force_change && !am_sender))
-+		fileflags_ndx = ++file_extra_cnt;
++	if (preserve_file_flags || (force_change && !am_sender))
++		file_flags_ndx = ++file_extra_cnt;
  	if (preserve_acls && !am_sender)
  		acls_ndx = ++file_extra_cnt;
  	if (preserve_xattrs)
-@@ -751,6 +755,10 @@ void setup_protocol(int f_out,int f_in)
+@@ -752,6 +756,10 @@ void setup_protocol(int f_out,int f_in)
  			fprintf(stderr, "Both rsync versions must be at least 3.2.0 for --crtimes.\n");
  			exit_cleanup(RERR_PROTOCOL);
  		}
-+		if (!xfer_flags_as_varint && preserve_fileflags) {
-+			fprintf(stderr, "Both rsync versions must be at least 3.2.0 for --fileflags.\n");
++		if (!xfer_flags_as_varint && preserve_file_flags) {
++			fprintf(stderr, "Both rsync versions must be at least 3.2.0 for --file-flags.\n");
 +			exit_cleanup(RERR_PROTOCOL);
 +		}
  		if (am_sender) {
  			receiver_symlink_times = am_server
  			    ? strchr(client_info, 'L') != NULL
-diff --git a/delete.c b/delete.c
---- a/delete.c
-+++ b/delete.c
+--- delete.c.orig
++++ delete.c
 @@ -25,6 +25,7 @@
  extern int am_root;
  extern int make_backups;
@@ -76,8 +80,8 @@ diff --git a/delete.c b/delete.c
 +			make_mutable(fname, fp->mode, F_FFLAGS(fp), force_change);
 +#endif
  		if (!(fp->mode & S_IWUSR) && !am_root && fp->flags & FLAG_OWNED_BY_US)
--			do_chmod(fname, fp->mode | S_IWUSR);
-+			do_chmod(fname, fp->mode | S_IWUSR, NO_FFLAGS);
+-			do_chmod_at(fname, fp->mode | S_IWUSR);
++			do_chmod_at(fname, fp->mode | S_IWUSR, NO_FFLAGS);
  		/* Save stack by recursing to ourself directly. */
  		if (S_ISDIR(fp->mode)) {
  			if (delete_dir_contents(fname, flags | DEL_RECURSE) != DR_SUCCESS)
@@ -85,8 +89,8 @@ diff --git a/delete.c b/delete.c
  	}
  
  	if (flags & DEL_NO_UID_WRITE)
--		do_chmod(fbuf, mode | S_IWUSR);
-+		do_chmod(fbuf, mode | S_IWUSR, NO_FFLAGS);
+-		do_chmod_at(fbuf, mode | S_IWUSR);
++		do_chmod_at(fbuf, mode | S_IWUSR, NO_FFLAGS);
  
  	if (S_ISDIR(mode) && !(flags & DEL_DIR_IS_EMPTY)) {
  		/* This only happens on the first call to delete_item() since
@@ -101,115 +105,113 @@ diff --git a/delete.c b/delete.c
  		ignore_perishable = 1;
  		/* If DEL_RECURSE is not set, this just reports emptiness. */
  		ret = delete_dir_contents(fbuf, flags);
-diff --git a/flist.c b/flist.c
---- a/flist.c
-+++ b/flist.c
+--- flist.c.orig
++++ flist.c
 @@ -52,6 +52,7 @@ extern int preserve_links;
  extern int preserve_hard_links;
  extern int preserve_devices;
  extern int preserve_specials;
-+extern int preserve_fileflags;
++extern int preserve_file_flags;
  extern int delete_during;
  extern int missing_args;
  extern int eol_nulls;
-@@ -388,6 +389,9 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -400,6 +401,9 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  	static time_t crtime;
  #endif
  	static mode_t mode;
-+#ifdef SUPPORT_FILEFLAGS
-+	static uint32 fileflags;
++#ifdef SUPPORT_FILE_FLAGS
++	static uint32 file_flags;
 +#endif
  #ifdef SUPPORT_HARD_LINKS
  	static int64 dev;
  #endif
-@@ -431,6 +435,14 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -443,6 +447,14 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  		xflags |= XMIT_SAME_MODE;
  	else
  		mode = file->mode;
-+#ifdef SUPPORT_FILEFLAGS
-+	if (preserve_fileflags) {
-+		if (F_FFLAGS(file) == fileflags)
++#ifdef SUPPORT_FILE_FLAGS
++	if (preserve_file_flags) {
++		if (F_FFLAGS(file) == file_flags)
 +			xflags |= XMIT_SAME_FLAGS;
 +		else
-+			fileflags = F_FFLAGS(file);
++			file_flags = F_FFLAGS(file);
 +	}
 +#endif
  
  	if (preserve_devices && IS_DEVICE(mode)) {
  		if (protocol_version < 28) {
-@@ -592,6 +604,10 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -604,6 +616,10 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  #endif
  	if (!(xflags & XMIT_SAME_MODE))
  		write_int(f, to_wire_mode(mode));
-+#ifdef SUPPORT_FILEFLAGS
-+	if (preserve_fileflags && !(xflags & XMIT_SAME_FLAGS))
-+		write_int(f, (int)fileflags);
++#ifdef SUPPORT_FILE_FLAGS
++	if (preserve_file_flags && !(xflags & XMIT_SAME_FLAGS))
++		write_int(f, (int)file_flags);
 +#endif
  	if (atimes_ndx && !S_ISDIR(mode) && !(xflags & XMIT_SAME_ATIME))
  		write_varlong(f, atime, 4);
  	if (preserve_uid && !(xflags & XMIT_SAME_UID)) {
-@@ -686,6 +702,9 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -698,6 +714,9 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  	static time_t crtime;
  #endif
  	static mode_t mode;
-+#ifdef SUPPORT_FILEFLAGS
-+	static uint32 fileflags;
++#ifdef SUPPORT_FILE_FLAGS
++	static uint32 file_flags;
 +#endif
  #ifdef SUPPORT_HARD_LINKS
  	static int64 dev;
  #endif
-@@ -803,6 +822,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -815,6 +834,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  #ifdef SUPPORT_CRTIMES
  			if (crtimes_ndx)
  				crtime = F_CRTIME(first);
 +#endif
-+#ifdef SUPPORT_FILEFLAGS
-+			if (preserve_fileflags)
-+				fileflags = F_FFLAGS(first);
++#ifdef SUPPORT_FILE_FLAGS
++			if (preserve_file_flags)
++				file_flags = F_FFLAGS(first);
  #endif
  			if (preserve_uid)
  				uid = F_OWNER(first);
-@@ -876,6 +899,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -904,6 +927,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  
  	if (chmod_modes && !S_ISLNK(mode) && mode)
  		mode = tweak_mode(mode, chmod_modes);
-+#ifdef SUPPORT_FILEFLAGS
-+	if (preserve_fileflags && !(xflags & XMIT_SAME_FLAGS))
-+		fileflags = (uint32)read_int(f);
++#ifdef SUPPORT_FILE_FLAGS
++	if (preserve_file_flags && !(xflags & XMIT_SAME_FLAGS))
++		file_flags = (uint32)read_int(f);
 +#endif
  
  	if (preserve_uid && !(xflags & XMIT_SAME_UID)) {
  		if (protocol_version < 30)
-@@ -1057,6 +1084,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -1085,6 +1112,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  	}
  #endif
  	file->mode = mode;
-+#ifdef SUPPORT_FILEFLAGS
-+	if (preserve_fileflags)
-+		F_FFLAGS(file) = fileflags;
++#ifdef SUPPORT_FILE_FLAGS
++	if (preserve_file_flags)
++		F_FFLAGS(file) = file_flags;
 +#endif
  	if (preserve_uid)
  		F_OWNER(file) = uid;
  	if (preserve_gid) {
-@@ -1470,6 +1501,10 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
+@@ -1506,6 +1537,10 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
  	}
  #endif
  	file->mode = st.st_mode;
-+#if defined SUPPORT_FILEFLAGS || defined SUPPORT_FORCE_CHANGE
-+	if (fileflags_ndx)
++#if defined SUPPORT_FILE_FLAGS || defined SUPPORT_FORCE_CHANGE
++	if (file_flags_ndx)
 +		F_FFLAGS(file) = st.st_flags;
 +#endif
  	if (preserve_uid)
  		F_OWNER(file) = st.st_uid;
  	if (preserve_gid)
-diff --git a/generator.c b/generator.c
---- a/generator.c
-+++ b/generator.c
+--- generator.c.orig
++++ generator.c
 @@ -43,10 +43,12 @@ extern int preserve_devices;
  extern int preserve_specials;
  extern int preserve_hard_links;
  extern int preserve_executability;
-+extern int preserve_fileflags;
++extern int preserve_file_flags;
  extern int preserve_perms;
  extern int preserve_mtimes;
  extern int omit_dir_times;
@@ -218,41 +220,41 @@ diff --git a/generator.c b/generator.c
  extern int delete_mode;
  extern int delete_before;
  extern int delete_during;
-@@ -486,6 +488,10 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
+@@ -493,6 +495,10 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
  			return 0;
  		if (perms_differ(file, sxp))
  			return 0;
-+#ifdef SUPPORT_FILEFLAGS
-+		if (preserve_fileflags && sxp->st.st_flags != F_FFLAGS(file))
++#ifdef SUPPORT_FILE_FLAGS
++		if (preserve_file_flags && sxp->st.st_flags != F_FFLAGS(file))
 +			return 0;
 +#endif
  		if (ownership_differs(file, sxp))
  			return 0;
  #ifdef SUPPORT_ACLS
-@@ -547,6 +553,11 @@ void itemize(const char *fnamecmp, struct file_struct *file, int ndx, int statre
+@@ -554,6 +560,11 @@ void itemize(const char *fnamecmp, struct file_struct *file, int ndx, int statre
  			iflags |= ITEM_REPORT_OWNER;
  		if (gid_ndx && !(file->flags & FLAG_SKIP_GROUP) && sxp->st.st_gid != (gid_t)F_GROUP(file))
  			iflags |= ITEM_REPORT_GROUP;
-+#ifdef SUPPORT_FILEFLAGS
-+		if (preserve_fileflags && !S_ISLNK(file->mode)
++#ifdef SUPPORT_FILE_FLAGS
++		if (preserve_file_flags && !S_ISLNK(file->mode)
 +		 && sxp->st.st_flags != F_FFLAGS(file))
 +			iflags |= ITEM_REPORT_FFLAGS;
 +#endif
  #ifdef SUPPORT_ACLS
  		if (preserve_acls && !S_ISLNK(file->mode)) {
  			if (!ACL_READY(*sxp))
-@@ -1454,6 +1465,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1466,6 +1477,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  		if (!preserve_perms) { /* See comment in non-dir code below. */
  			file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms, statret == 0);
  		}
 +#ifdef SUPPORT_FORCE_CHANGE
-+		if (force_change && !preserve_fileflags)
++		if (force_change && !preserve_file_flags)
 +			F_FFLAGS(file) = sx.st.st_flags;
 +#endif
  		if (statret != 0 && basis_dir[0] != NULL) {
  			int j = try_dests_non(file, fname, ndx, fnamecmpbuf, &sx, itemizing, code);
  			if (j == -2) {
-@@ -1496,10 +1511,15 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1508,10 +1523,15 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  		 * readable and writable permissions during the time we are
  		 * putting files within them.  This is then restored to the
  		 * former permissions after the transfer is done. */
@@ -264,28 +266,37 @@ diff --git a/generator.c b/generator.c
  #ifdef HAVE_CHMOD
  		if (!am_root && (file->mode & S_IRWXU) != S_IRWXU && dir_tweaking) {
  			mode_t mode = file->mode | S_IRWXU;
--			if (do_chmod(fname, mode) < 0) {
-+			if (do_chmod(fname, mode, 0) < 0) {
+-			if (do_chmod_at(fname, mode) < 0) {
++			if (do_chmod_at(fname, mode, 0) < 0) {
  				rsyserr(FERROR_XFER, errno,
  					"failed to modify permissions on %s",
  					full_fname(fname));
-@@ -1534,6 +1554,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1546,6 +1566,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  		int exists = statret == 0 && stype != FT_DIR;
  		file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms, exists);
  	}
 +#ifdef SUPPORT_FORCE_CHANGE
-+	if (force_change && !preserve_fileflags)
++	if (force_change && !preserve_file_flags)
 +		F_FFLAGS(file) = sx.st.st_flags;
 +#endif
  
  #ifdef SUPPORT_HARD_LINKS
  	if (preserve_hard_links && F_HLINK_NOT_FIRST(file)
-@@ -2111,17 +2135,25 @@ static void touch_up_dirs(struct file_list *flist, int ndx)
+@@ -2053,7 +2077,7 @@ int atomic_create(struct file_struct *file, char *fname, const char *slnk, const
+ 	}
+ 
+ 	if (!skip_atomic) {
+-		if (do_rename_at(tmpname, fname) < 0) {
++		if (do_rename_at(tmpname, fname, file->mode, NO_FFLAGS) < 0) {
+ 			char *full_tmpname = strdup(full_fname(tmpname));
+ 			if (full_tmpname == NULL)
+ 				out_of_memory("atomic_create");
+@@ -2124,17 +2148,25 @@ static void touch_up_dirs(struct file_list *flist, int ndx)
  			continue;
  		fname = f_name(file, NULL);
  		if (fix_dir_perms)
--			do_chmod(fname, file->mode);
-+			do_chmod(fname, file->mode, 0);
+-			do_chmod_at(fname, file->mode);
++			do_chmod_at(fname, file->mode, 0);
  		if (need_retouch_dir_times) {
  			STRUCT_STAT st;
  			if (link_stat(fname, &st, 0) == 0 && mtime_differs(&st, file)) {
@@ -307,10 +318,9 @@ diff --git a/generator.c b/generator.c
  		if (counter >= loopchk_limit) {
  			if (allowed_lull)
  				maybe_send_keepalive(time(NULL), MSK_ALLOW_FLUSH);
-diff --git a/log.c b/log.c
---- a/log.c
-+++ b/log.c
-@@ -725,7 +725,8 @@ static void log_formatted(enum logcode code, const char *format, const char *op,
+--- log.c.orig
++++ log.c
+@@ -731,7 +731,8 @@ static void log_formatted(enum logcode code, const char *format, const char *op,
  			     : iflags & ITEM_REPORT_ATIME ? 'u' : 'n';
  			c[9] = !(iflags & ITEM_REPORT_ACL) ? '.' : 'a';
  			c[10] = !(iflags & ITEM_REPORT_XATTR) ? '.' : 'x';
@@ -320,9 +330,8 @@ diff --git a/log.c b/log.c
  
  			if (iflags & (ITEM_IS_NEW|ITEM_MISSING_DATA)) {
  				char ch = iflags & ITEM_IS_NEW ? '+' : '?';
-diff --git a/main.c b/main.c
---- a/main.c
-+++ b/main.c
+--- main.c.orig
++++ main.c
 @@ -31,6 +31,9 @@
  #ifdef __TANDEM
  #include <floss.h(floss_execlp)>
@@ -341,7 +350,7 @@ diff --git a/main.c b/main.c
  extern int msgs2stderr;
  extern int module_id;
  extern int read_only;
-@@ -977,6 +981,22 @@ static int do_recv(int f_in, int f_out, char *local_name)
+@@ -995,6 +999,22 @@ static int do_recv(int f_in, int f_out, char *local_name)
  	 * points to an identical file won't be replaced by the referent. */
  	copy_links = copy_dirlinks = copy_unsafe_links = 0;
  
@@ -364,18 +373,17 @@ diff --git a/main.c b/main.c
  #ifdef SUPPORT_HARD_LINKS
  	if (preserve_hard_links && !inc_recurse)
  		match_hard_links(first_flist);
-diff --git a/options.c b/options.c
---- a/options.c
-+++ b/options.c
+--- options.c.orig
++++ options.c
 @@ -56,6 +56,7 @@ int preserve_hard_links = 0;
  int preserve_acls = 0;
  int preserve_xattrs = 0;
  int preserve_perms = 0;
-+int preserve_fileflags = 0;
++int preserve_file_flags = 0;
  int preserve_executability = 0;
  int preserve_devices = 0;
  int preserve_specials = 0;
-@@ -98,6 +99,7 @@ int msgs2stderr = 2; /* Default: send errors to stderr for local & remote-shell
+@@ -99,6 +100,7 @@ int msgs2stderr = 2; /* Default: send errors to stderr for local & remote-shell
  int saw_stderr_opt = 0;
  int allow_8bit_chars = 0;
  int force_delete = 0;
@@ -383,16 +391,18 @@ diff --git a/options.c b/options.c
  int io_timeout = 0;
  int prune_empty_dirs = 0;
  int use_qsort = 0;
-@@ -623,6 +625,8 @@ static struct poptOption long_options[] = {
+@@ -633,6 +635,10 @@ static struct poptOption long_options[] = {
    {"perms",           'p', POPT_ARG_VAL,    &preserve_perms, 1, 0, 0 },
    {"no-perms",         0,  POPT_ARG_VAL,    &preserve_perms, 0, 0, 0 },
    {"no-p",             0,  POPT_ARG_VAL,    &preserve_perms, 0, 0, 0 },
-+  {"fileflags",        0,  POPT_ARG_VAL,    &preserve_fileflags, 1, 0, 0 },
-+  {"no-fileflags",     0,  POPT_ARG_VAL,    &preserve_fileflags, 0, 0, 0 },
++  {"file-flags",       0,  POPT_ARG_VAL,    &preserve_file_flags, 1, 0, 0 },
++  {"fileflags",        0,  POPT_ARG_VAL,    &preserve_file_flags, 1, 0, 0 },
++  {"no-file-flags",    0,  POPT_ARG_VAL,    &preserve_file_flags, 0, 0, 0 },
++  {"no-fileflags",     0,  POPT_ARG_VAL,    &preserve_file_flags, 0, 0, 0 },
    {"executability",   'E', POPT_ARG_NONE,   &preserve_executability, 0, 0, 0 },
    {"acls",            'A', POPT_ARG_NONE,   0, 'A', 0, 0 },
    {"no-acls",          0,  POPT_ARG_VAL,    &preserve_acls, 0, 0, 0 },
-@@ -721,6 +725,12 @@ static struct poptOption long_options[] = {
+@@ -731,6 +737,12 @@ static struct poptOption long_options[] = {
    {"remove-source-files",0,POPT_ARG_VAL,    &remove_source_files, 1, 0, 0 },
    {"force",            0,  POPT_ARG_VAL,    &force_delete, 1, 0, 0 },
    {"no-force",         0,  POPT_ARG_VAL,    &force_delete, 0, 0, 0 },
@@ -405,11 +415,12 @@ diff --git a/options.c b/options.c
    {"ignore-errors",    0,  POPT_ARG_VAL,    &ignore_errors, 1, 0, 0 },
    {"no-ignore-errors", 0,  POPT_ARG_VAL,    &ignore_errors, 0, 0, 0 },
    {"max-delete",       0,  POPT_ARG_INT,    &max_delete, 0, 0, 0 },
-@@ -1016,6 +1026,14 @@ static void set_refuse_options(void)
+@@ -1028,6 +1040,15 @@ static void set_refuse_options(void)
  #ifndef SUPPORT_CRTIMES
  	parse_one_refuse_match(0, "crtimes", list_end);
  #endif
-+#ifndef SUPPORT_FILEFLAGS
++#ifndef SUPPORT_FILE_FLAGS
++	parse_one_refuse_match(0, "file-flags", list_end);
 +	parse_one_refuse_match(0, "fileflags", list_end);
 +#endif
 +#ifndef SUPPORT_FORCE_CHANGE
@@ -420,17 +431,17 @@ diff --git a/options.c b/options.c
  
  	/* Now we use the descrip values to actually mark the options for refusal. */
  	for (op = long_options; op != list_end; op++) {
-@@ -2734,6 +2752,9 @@ void server_options(char **args, int *argc_p)
+@@ -2752,6 +2773,9 @@ void server_options(char **args, int *argc_p)
  	if (xfer_dirs && !recurse && delete_mode && am_sender)
  		args[ac++] = "--no-r";
  
-+	if (preserve_fileflags)
++	if (preserve_file_flags)
 +		args[ac++] = "--fileflags";
 +
  	if (do_compression && do_compression_level != CLVL_NOT_SPECIFIED) {
  		if (asprintf(&arg, "--compress-level=%d", do_compression_level) < 0)
  			goto oom;
-@@ -2829,6 +2850,16 @@ void server_options(char **args, int *argc_p)
+@@ -2847,6 +2871,16 @@ void server_options(char **args, int *argc_p)
  			args[ac++] = "--delete-excluded";
  		if (force_delete)
  			args[ac++] = "--force";
@@ -447,22 +458,33 @@ diff --git a/options.c b/options.c
  		if (write_batch < 0)
  			args[ac++] = "--only-write-batch=X";
  		if (am_root > 1)
-diff --git a/rsync.1.md b/rsync.1.md
---- a/rsync.1.md
-+++ b/rsync.1.md
+--- receiver.c.orig
++++ receiver.c
+@@ -543,7 +543,7 @@ static void handle_delayed_updates(char *local_name)
+ 			}
+ 			/* We don't use robust_rename() here because the
+ 			 * partial-dir must be on the same drive. */
+-			if (do_rename_at(partialptr, fname) < 0) {
++			if (do_rename_at(partialptr, fname, 0, NO_FFLAGS) < 0) {
+ 				rsyserr(FERROR_XFER, errno,
+ 					"rename failed for %s (from %s)",
+ 					full_fname(fname), partialptr);
+--- rsync.1.md.orig
++++ rsync.1.md
 @@ -446,6 +446,7 @@ has its own detailed description later in this manpage.
  --keep-dirlinks, -K      treat symlinked dir on receiver as dir
  --hard-links, -H         preserve hard links
  --perms, -p              preserve permissions
-+--fileflags              preserve file-flags (aka chflags)
++--file-flags             preserve file flags (aka chflags)
  --executability, -E      preserve executability
  --chmod=CHMOD            affect file and/or directory permissions
  --acls, -A               preserve ACLs (implies --perms)
-@@ -487,7 +488,10 @@ has its own detailed description later in this manpage.
+@@ -487,7 +488,11 @@ has its own detailed description later in this manpage.
  --ignore-missing-args    ignore missing source args without error
  --delete-missing-args    delete missing source args from destination
  --ignore-errors          delete even if there are I/O errors
 ---force                  force deletion of dirs even if not empty
++--force                  an alias for --force-delete
 +--force-delete           force deletion of directories even if not empty
 +--force-change           affect user-/system-immutable files/dirs
 +--force-uchange          affect user-immutable files/dirs
@@ -470,15 +492,15 @@ diff --git a/rsync.1.md b/rsync.1.md
  --max-delete=NUM         don't delete more than NUM files
  --max-size=SIZE          don't transfer any file larger than SIZE
  --min-size=SIZE          don't transfer any file smaller than SIZE
-@@ -831,6 +835,7 @@ expand it.
+@@ -832,6 +837,7 @@ expand it.
      recursion and want to preserve almost everything.  Be aware that it does
      **not** include preserving ACLs (`-A`), xattrs (`-X`), atimes (`-U`),
      crtimes (`-N`), nor the finding and preserving of hardlinks (`-H`).
-+    It also does **not** imply [`--fileflags`](#opt).
++    It also does **not** imply [`--file-flags`](#opt).
  
      The only exception to the above equivalence is when [`--files-from`](#opt)
      is specified, in which case [`-r`](#opt) is not implied.
-@@ -1295,7 +1300,7 @@ expand it.
+@@ -1296,7 +1302,7 @@ expand it.
      Without this option, if the sending side has replaced a directory with a
      symlink to a directory, the receiving side will delete anything that is in
      the way of the new symlink, including a directory hierarchy (as long as
@@ -487,13 +509,13 @@ diff --git a/rsync.1.md b/rsync.1.md
  
      See also [`--keep-dirlinks`](#opt) for an analogous option for the
      receiving side.
-@@ -1490,6 +1495,37 @@ expand it.
+@@ -1491,6 +1497,37 @@ expand it.
      those used by [`--fake-super`](#opt)) unless you repeat the option (e.g. `-XX`).
      This "copy all xattrs" mode cannot be used with [`--fake-super`](#opt).
  
-+0.  `--fileflags`
++0.  `--file-flags`
 +
-+    This option causes rsync to update the file-flags to be the same as the
++    This option causes rsync to update the file flags to be the same as the
 +    source files and directories (if your OS supports the **chflags**(2) system
 +    call).   Some flags can only be altered by the super-user and some might
 +    only be unset below a certain secure-level (usually single-user mode). It
@@ -525,7 +547,7 @@ diff --git a/rsync.1.md b/rsync.1.md
  0.  `--chmod=CHMOD`
  
      This option tells rsync to apply one or more comma-separated "chmod" modes
-@@ -2019,8 +2055,8 @@ expand it.
+@@ -2020,8 +2057,8 @@ expand it.
      [`--ignore-missing-args`](#opt) option a step farther: each missing arg
      will become a deletion request of the corresponding destination file on the
      receiving side (should it exist).  If the destination file is a non-empty
@@ -536,7 +558,7 @@ diff --git a/rsync.1.md b/rsync.1.md
      independent of any other type of delete processing.
  
      The missing source files are represented by special file-list entries which
-@@ -2031,14 +2067,14 @@ expand it.
+@@ -2032,14 +2069,14 @@ expand it.
      Tells [`--delete`](#opt) to go ahead and delete files even when there are
      I/O errors.
  
@@ -554,7 +576,7 @@ diff --git a/rsync.1.md b/rsync.1.md
      [`--recursive`](#opt) option was also enabled.
  
  0.  `--max-delete=NUM`
-@@ -3099,7 +3135,7 @@ expand it.
+@@ -3116,7 +3153,7 @@ expand it.
      also turns on the output of other verbose messages).
  
      The "%i" escape has a cryptic output that is 11 letters long.  The general
@@ -563,14 +585,13 @@ diff --git a/rsync.1.md b/rsync.1.md
      of update being done, **X** is replaced by the file-type, and the other
      letters represent attributes that may be output if they are being modified.
  
-diff --git a/rsync.c b/rsync.c
---- a/rsync.c
-+++ b/rsync.c
+--- rsync.c.orig
++++ rsync.c
 @@ -31,6 +31,7 @@ extern int dry_run;
  extern int preserve_acls;
  extern int preserve_xattrs;
  extern int preserve_perms;
-+extern int preserve_fileflags;
++extern int preserve_file_flags;
  extern int preserve_executability;
  extern int preserve_mtimes;
  extern int omit_dir_times;
@@ -578,11 +599,11 @@ diff --git a/rsync.c b/rsync.c
  	return new_mode;
  }
  
-+#if defined SUPPORT_FILEFLAGS || defined SUPPORT_FORCE_CHANGE
++#if defined SUPPORT_FILE_FLAGS || defined SUPPORT_FORCE_CHANGE
 +/* Set a file's st_flags. */
-+static int set_fileflags(const char *fname, uint32 fileflags)
++static int set_file_flags(const char *fname, uint32 file_flags)
 +{
-+	if (do_chflags(fname, fileflags) != 0) {
++	if (do_chflags(fname, file_flags) != 0) {
 +		rsyserr(FERROR_XFER, errno,
 +			"failed to set file flags on %s",
 +			full_fname(fname));
@@ -593,19 +614,19 @@ diff --git a/rsync.c b/rsync.c
 +}
 +
 +/* Remove immutable flags from an object, so it can be altered/removed. */
-+int make_mutable(const char *fname, mode_t mode, uint32 fileflags, uint32 iflags)
++int make_mutable(const char *fname, mode_t mode, uint32 file_flags, uint32 iflags)
 +{
-+	if (S_ISLNK(mode) || !(fileflags & iflags))
++	if (S_ISLNK(mode) || !(file_flags & iflags))
 +		return 0;
-+	if (!set_fileflags(fname, fileflags & ~iflags))
++	if (!set_file_flags(fname, file_flags & ~iflags))
 +		return -1;
 +	return 1;
 +}
 +
 +/* Undo a prior make_mutable() call that returned a 1. */
-+int undo_make_mutable(const char *fname, uint32 fileflags)
++int undo_make_mutable(const char *fname, uint32 file_flags)
 +{
-+	if (!set_fileflags(fname, fileflags))
++	if (!set_file_flags(fname, file_flags))
 +		return -1;
 +	return 1;
 +}
@@ -618,8 +639,8 @@ diff --git a/rsync.c b/rsync.c
  		if (am_root >= 0) {
  			uid_t uid = change_uid ? (uid_t)F_OWNER(file) : sxp->st.st_uid;
  			gid_t gid = change_gid ? (gid_t)F_GROUP(file) : sxp->st.st_gid;
--			if (do_lchown(fname, uid, gid) != 0) {
-+			if (do_lchown(fname, uid, gid, sxp->st.st_mode, ST_FLAGS(sxp->st)) != 0) {
+-			if (do_lchown_at(fname, uid, gid) != 0) {
++			if (do_lchown_at(fname, uid, gid, sxp->st.st_mode, ST_FLAGS(sxp->st)) != 0) {
  				/* We shouldn't have attempted to change uid
  				 * or gid unless have the privilege. */
  				rsyserr(FERROR_XFER, errno, "%s %s failed",
@@ -627,8 +648,8 @@ diff --git a/rsync.c b/rsync.c
  
  #ifdef HAVE_CHMOD
  	if (!BITS_EQUAL(sxp->st.st_mode, new_mode, CHMOD_BITS)) {
--		int ret = am_root < 0 ? 0 : do_chmod(fname, new_mode);
-+		int ret = am_root < 0 ? 0 : do_chmod(fname, new_mode, ST_FLAGS(sxp->st));
+-		int ret = am_root < 0 ? 0 : do_chmod_at(fname, new_mode);
++		int ret = am_root < 0 ? 0 : do_chmod_at(fname, new_mode, ST_FLAGS(sxp->st));
  		if (ret < 0) {
  			rsyserr(FERROR_XFER, errno,
  				"failed to set permissions on %s",
@@ -636,14 +657,14 @@ diff --git a/rsync.c b/rsync.c
  	}
  #endif
  
-+#ifdef SUPPORT_FILEFLAGS
-+	if (preserve_fileflags && !S_ISLNK(sxp->st.st_mode)
++#ifdef SUPPORT_FILE_FLAGS
++	if (preserve_file_flags && !S_ISLNK(sxp->st.st_mode)
 +	 && sxp->st.st_flags != F_FFLAGS(file)) {
-+		uint32 fileflags = F_FFLAGS(file);
++		uint32 file_flags = F_FFLAGS(file);
 +		if (flags & ATTRS_DELAY_IMMUTABLE)
-+			fileflags &= ~ALL_IMMUTABLE;
-+		if (sxp->st.st_flags != fileflags
-+		 && !set_fileflags(fname, fileflags))
++			file_flags &= ~ALL_IMMUTABLE;
++		if (sxp->st.st_flags != file_flags
++		 && !set_file_flags(fname, file_flags))
 +			goto cleanup;
 +		updated = 1;
 +	}
@@ -666,16 +687,24 @@ diff --git a/rsync.c b/rsync.c
  	}
  	if (ret == 0) {
  		/* The file was moved into place (not copied), so it's done. */
-+#ifdef SUPPORT_FILEFLAGS
-+		if (preserve_fileflags && F_FFLAGS(file) & ALL_IMMUTABLE)
-+			set_fileflags(fname, F_FFLAGS(file));
++#ifdef SUPPORT_FILE_FLAGS
++		if (preserve_file_flags && F_FFLAGS(file) & ALL_IMMUTABLE)
++			set_file_flags(fname, F_FFLAGS(file));
 +#endif
  		return 1;
  	}
  	/* The file was copied, so tweak the perms of the copied file.  If it
-diff --git a/rsync.h b/rsync.h
---- a/rsync.h
-+++ b/rsync.h
+@@ -774,7 +826,7 @@ int finish_transfer(const char *fname, const char *fnametmp,
+ 		       ok_to_set_time ? ATTRS_ACCURATE_TIME : ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME);
+ 
+ 	if (temp_copy_name) {
+-		if (do_rename_at(fnametmp, fname) < 0) {
++		if (do_rename_at(fnametmp, fname, file->mode, NO_FFLAGS) < 0) {
+ 			rsyserr(FERROR_XFER, errno, "rename %s -> \"%s\"",
+ 				full_fname(fnametmp), fname);
+ 			return 0;
+--- rsync.h.orig
++++ rsync.h
 @@ -69,7 +69,7 @@
  
  /* The following XMIT flags require an rsync that uses a varint for the flag values */
@@ -685,7 +714,7 @@ diff --git a/rsync.h b/rsync.h
  #define XMIT_CRTIME_EQ_MTIME (1<<17)	/* any protocol - restricted by command-line option */
  
  /* These flags are used in the live flist data. */
-@@ -193,6 +193,7 @@
+@@ -216,6 +216,7 @@
  #define ATTRS_SKIP_MTIME	(1<<1)
  #define ATTRS_ACCURATE_TIME	(1<<2)
  #define ATTRS_SKIP_ATIME	(1<<3)
@@ -693,7 +722,7 @@ diff --git a/rsync.h b/rsync.h
  #define ATTRS_SKIP_CRTIME	(1<<5)
  
  #define MSG_FLUSH	2
-@@ -221,6 +222,7 @@
+@@ -244,6 +245,7 @@
  #define ITEM_REPORT_GROUP (1<<6)
  #define ITEM_REPORT_ACL (1<<7)
  #define ITEM_REPORT_XATTR (1<<8)
@@ -701,18 +730,18 @@ diff --git a/rsync.h b/rsync.h
  #define ITEM_REPORT_CRTIME (1<<10)
  #define ITEM_BASIS_TYPE_FOLLOWS (1<<11)
  #define ITEM_XNAME_FOLLOWS (1<<12)
-@@ -588,6 +590,31 @@ typedef unsigned int size_t;
+@@ -611,6 +613,31 @@ typedef unsigned int size_t;
  #define SUPPORT_CRTIMES 1
  #endif
  
 +#define NO_FFLAGS ((uint32)-1)
 +
 +#ifdef HAVE_CHFLAGS
-+#define SUPPORT_FILEFLAGS 1
++#define SUPPORT_FILE_FLAGS 1
 +#define SUPPORT_FORCE_CHANGE 1
 +#endif
 +
-+#if defined SUPPORT_FILEFLAGS || defined SUPPORT_FORCE_CHANGE
++#if defined SUPPORT_FILE_FLAGS || defined SUPPORT_FORCE_CHANGE
 +#ifndef UF_NOUNLINK
 +#define UF_NOUNLINK 0
 +#endif
@@ -733,30 +762,29 @@ diff --git a/rsync.h b/rsync.h
  /* Find a variable that is either exactly 32-bits or longer.
   * If some code depends on 32-bit truncation, it will need to
   * take special action in a "#if SIZEOF_INT32 > 4" section. */
-@@ -819,6 +846,7 @@ extern int pathname_ndx;
+@@ -842,6 +869,7 @@ extern int pathname_ndx;
  extern int depth_ndx;
  extern int uid_ndx;
  extern int gid_ndx;
-+extern int fileflags_ndx;
++extern int file_flags_ndx;
  extern int acls_ndx;
  extern int xattrs_ndx;
  extern int file_sum_extra_cnt;
-@@ -874,6 +902,11 @@ extern int file_sum_extra_cnt;
+@@ -897,6 +925,11 @@ extern int file_sum_extra_cnt;
  /* When the associated option is on, all entries will have these present: */
  #define F_OWNER(f) REQ_EXTRA(f, uid_ndx)->unum
  #define F_GROUP(f) REQ_EXTRA(f, gid_ndx)->unum
-+#if defined SUPPORT_FILEFLAGS || defined SUPPORT_FORCE_CHANGE
-+#define F_FFLAGS(f) REQ_EXTRA(f, fileflags_ndx)->unum
++#if defined SUPPORT_FILE_FLAGS || defined SUPPORT_FORCE_CHANGE
++#define F_FFLAGS(f) REQ_EXTRA(f, file_flags_ndx)->unum
 +#else
 +#define F_FFLAGS(f) NO_FFLAGS
 +#endif
  #define F_ACL(f) REQ_EXTRA(f, acls_ndx)->num
  #define F_XATTR(f) REQ_EXTRA(f, xattrs_ndx)->num
  #define F_NDX(f) REQ_EXTRA(f, unsort_ndx)->num
-diff --git a/syscall.c b/syscall.c
---- a/syscall.c
-+++ b/syscall.c
-@@ -40,6 +40,7 @@ extern int am_root;
+--- syscall.c.orig
++++ syscall.c
+@@ -45,6 +45,7 @@ extern int am_root;
  extern int am_sender;
  extern int read_only;
  extern int list_only;
@@ -764,7 +792,7 @@ diff --git a/syscall.c b/syscall.c
  extern int inplace;
  extern int preallocate_files;
  extern int preserve_perms;
-@@ -85,7 +86,23 @@ int do_unlink(const char *path)
+@@ -90,7 +91,23 @@ int do_unlink(const char *path)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -775,8 +803,8 @@ diff --git a/syscall.c b/syscall.c
 +	if (force_change && errno == EPERM) {
 +		STRUCT_STAT st;
 +
-+		if (x_lstat(path, &st, NULL) == 0
-+		 && make_mutable(path, st.st_mode, st.st_flags, force_change) > 0) {
++		if (do_lstat(path, &st) == 0
++		    && make_mutable(path, st.st_mode, st.st_flags, force_change) > 0) {
 +			if (unlink(path) == 0)
 +				return 0;
 +			undo_make_mutable(path, st.st_flags);
@@ -788,13 +816,32 @@ diff --git a/syscall.c b/syscall.c
 +	return -1;
  }
  
- #ifdef SUPPORT_LINKS
-@@ -150,14 +167,35 @@ int do_link(const char *old_path, const char *new_path)
+ /*
+@@ -142,6 +159,18 @@ int do_unlink_at(const char *path)
+ 
+ 	ret = unlinkat(dfd, bname, 0);
+ 	e = errno;
++#ifdef SUPPORT_FORCE_CHANGE
++	if (force_change && e == EPERM) {
++		STRUCT_STAT st;
++		if (do_lstat(path, &st) == 0
++		    && make_mutable(path, st.st_mode, st.st_flags, force_change) > 0) {
++			ret = unlinkat(dfd, bname, 0);
++			e = errno;
++			if (ret != 0)
++				undo_make_mutable(path, st.st_flags);
++		}
++	}
++#endif
+ 	close(dfd);
+ 	errno = e;
+ 	return ret;
+@@ -399,14 +428,35 @@ int do_link_at(const char *old_path, const char *new_path)
  }
  #endif
  
 -int do_lchown(const char *path, uid_t owner, gid_t group)
-+int do_lchown(const char *path, uid_t owner, gid_t group, UNUSED(mode_t mode), UNUSED(uint32 fileflags))
++int do_lchown(const char *path, uid_t owner, gid_t group, UNUSED(mode_t mode), UNUSED(uint32 file_flags))
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -806,17 +853,17 @@ diff --git a/syscall.c b/syscall.c
 +		return 0;
 +#ifdef SUPPORT_FORCE_CHANGE
 +	if (force_change && errno == EPERM) {
-+		if (fileflags == NO_FFLAGS) {
++		if (file_flags == NO_FFLAGS) {
 +			STRUCT_STAT st;
-+			if (x_lstat(path, &st, NULL) == 0) {
++			if (do_lstat(path, &st) == 0) {
 +				mode = st.st_mode;
-+				fileflags = st.st_flags;
++				file_flags = st.st_flags;
 +			}
 +		}
-+		if (fileflags != NO_FFLAGS
-+		 && make_mutable(path, mode, fileflags, force_change) > 0) {
++		if (file_flags != NO_FFLAGS
++		    && make_mutable(path, mode, file_flags, force_change) > 0) {
 +			int ret = lchown(path, owner, group);
-+			undo_make_mutable(path, fileflags);
++			undo_make_mutable(path, file_flags);
 +			if (ret == 0)
 +				return 0;
 +		}
@@ -826,8 +873,59 @@ diff --git a/syscall.c b/syscall.c
 +	return -1;
  }
  
- int do_mknod(const char *pathname, mode_t mode, dev_t dev)
-@@ -197,7 +235,7 @@ int do_mknod(const char *pathname, mode_t mode, dev_t dev)
+ /*
+@@ -423,7 +473,7 @@ int do_lchown(const char *path, uid_t owner, gid_t group)
+   Falls through to do_lchown() in the dry-run / non-daemon / chrooted /
+   absolute-path / no-parent cases, identical to do_chmod_at().
+ */
+-int do_lchown_at(const char *fname, uid_t owner, gid_t group)
++int do_lchown_at(const char *fname, uid_t owner, gid_t group, UNUSED(mode_t mode), UNUSED(uint32 file_flags))
+ {
+ #ifdef AT_FDCWD
+ 	extern int am_daemon, am_chrooted;
+@@ -437,14 +487,14 @@ int do_lchown_at(const char *fname, uid_t owner, gid_t group)
+ 	RETURN_ERROR_IF_RO_OR_LO;
+ 
+ 	if (!am_daemon || am_chrooted)
+-		return do_lchown(fname, owner, group);
++		return do_lchown(fname, owner, group, mode, file_flags);
+ 
+ 	if (!fname || !*fname || *fname == '/')
+-		return do_lchown(fname, owner, group);
++		return do_lchown(fname, owner, group, mode, file_flags);
+ 
+ 	slash = strrchr(fname, '/');
+ 	if (!slash)
+-		return do_lchown(fname, owner, group);
++		return do_lchown(fname, owner, group, mode, file_flags);
+ 
+ 	dlen = slash - fname;
+ 	if (dlen >= sizeof dirpath) {
+@@ -461,6 +511,23 @@ int do_lchown_at(const char *fname, uid_t owner, gid_t group)
+ 
+ 	ret = fchownat(dfd, bname, owner, group, AT_SYMLINK_NOFOLLOW);
+ 	e = errno;
++#ifdef SUPPORT_FORCE_CHANGE
++	if (force_change && e == EPERM) {
++		if (file_flags == NO_FFLAGS) {
++			STRUCT_STAT st;
++			if (do_lstat(fname, &st) == 0) {
++				mode = st.st_mode;
++				file_flags = st.st_flags;
++			}
++		}
++		if (file_flags != NO_FFLAGS
++		    && make_mutable(fname, mode, file_flags, force_change) > 0) {
++			ret = fchownat(dfd, bname, owner, group, AT_SYMLINK_NOFOLLOW);
++			e = errno;
++			undo_make_mutable(fname, file_flags);
++		}
++	}
++#endif
+ 	close(dfd);
+ 	errno = e;
+ 	return ret;
+@@ -506,7 +573,7 @@ int do_mknod(const char *pathname, mode_t mode, dev_t dev)
  			return -1;
  		close(sock);
  #ifdef HAVE_CHMOD
@@ -836,7 +934,7 @@ diff --git a/syscall.c b/syscall.c
  #else
  		return 0;
  #endif
-@@ -214,7 +252,22 @@ int do_rmdir(const char *pathname)
+@@ -618,7 +685,21 @@ int do_rmdir(const char *pathname)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -846,9 +944,8 @@ diff --git a/syscall.c b/syscall.c
 +#ifdef SUPPORT_FORCE_CHANGE
 +	if (force_change && errno == EPERM) {
 +		STRUCT_STAT st;
-+
-+		if (x_lstat(pathname, &st, NULL) == 0
-+		 && make_mutable(pathname, st.st_mode, st.st_flags, force_change) > 0) {
++		if (do_lstat(pathname, &st) == 0
++		    && make_mutable(pathname, st.st_mode, st.st_flags, force_change) > 0) {
 +			if (rmdir(pathname) == 0)
 +				return 0;
 +			undo_make_mutable(pathname, st.st_flags);
@@ -859,31 +956,50 @@ diff --git a/syscall.c b/syscall.c
 +	return -1;
  }
  
- int do_open(const char *pathname, int flags, mode_t mode)
-@@ -233,7 +286,7 @@ int do_open(const char *pathname, int flags, mode_t mode)
+ /*
+@@ -664,6 +745,18 @@ int do_rmdir_at(const char *pathname)
+ 
+ 	ret = unlinkat(dfd, bname, AT_REMOVEDIR);
+ 	e = errno;
++#ifdef SUPPORT_FORCE_CHANGE
++	if (force_change && e == EPERM) {
++		STRUCT_STAT st;
++		if (do_lstat(pathname, &st) == 0
++		    && make_mutable(pathname, st.st_mode, st.st_flags, force_change) > 0) {
++			ret = unlinkat(dfd, bname, AT_REMOVEDIR);
++			e = errno;
++			if (ret != 0)
++				undo_make_mutable(pathname, st.st_flags);
++		}
++	}
++#endif
+ 	close(dfd);
+ 	errno = e;
+ 	return ret;
+@@ -758,7 +851,7 @@ int do_open_at(const char *pathname, int flags, mode_t mode)
  }
  
  #ifdef HAVE_CHMOD
 -int do_chmod(const char *path, mode_t mode)
-+int do_chmod(const char *path, mode_t mode, UNUSED(uint32 fileflags))
++int do_chmod(const char *path, mode_t mode, UNUSED(uint32 file_flags))
  {
  	static int switch_step = 0;
  	int code;
-@@ -272,17 +325,72 @@ int do_chmod(const char *path, mode_t mode)
+@@ -797,6 +890,23 @@ int do_chmod(const char *path, mode_t mode)
  			code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
  		break;
  	}
 +#ifdef SUPPORT_FORCE_CHANGE
 +	if (code < 0 && force_change && errno == EPERM && !S_ISLNK(mode)) {
-+		if (fileflags == NO_FFLAGS) {
++		if (file_flags == NO_FFLAGS) {
 +			STRUCT_STAT st;
-+			if (x_lstat(path, &st, NULL) == 0)
-+				fileflags = st.st_flags;
++			if (do_lstat(path, &st) == 0)
++				file_flags = st.st_flags;
 +		}
-+		if (fileflags != NO_FFLAGS
-+		 && make_mutable(path, mode, fileflags, force_change) > 0) {
++		if (file_flags != NO_FFLAGS
++		    && make_mutable(path, mode, file_flags, force_change) > 0) {
 +			code = chmod(path, mode & CHMOD_BITS);
-+			undo_make_mutable(path, fileflags);
++			undo_make_mutable(path, file_flags);
 +			if (code == 0)
 +				return 0;
 +		}
@@ -893,81 +1009,213 @@ diff --git a/syscall.c b/syscall.c
  	if (code != 0 && (preserve_perms || preserve_executability))
  		return code;
  	return 0;
+@@ -830,7 +940,7 @@ int do_chmod(const char *path, mode_t mode)
+   Falls back to do_chmod() for absolute paths and for paths with no parent
+   component, where there is nothing to protect against.
+ */
+-int do_chmod_at(const char *fname, mode_t mode)
++int do_chmod_at(const char *fname, mode_t mode, UNUSED(uint32 file_flags))
+ {
+ #ifdef AT_FDCWD
+ 	extern int am_daemon, am_chrooted;
+@@ -850,14 +960,14 @@ int do_chmod_at(const char *fname, mode_t mode)
+ 	 * already access.  Everywhere else, fall through to plain
+ 	 * do_chmod() to avoid the dirfd-open overhead on every call. */
+ 	if (!am_daemon || am_chrooted)
+-		return do_chmod(fname, mode);
++		return do_chmod(fname, mode, file_flags);
+ 
+ 	if (!fname || !*fname || *fname == '/' || S_ISLNK(mode))
+-		return do_chmod(fname, mode);
++		return do_chmod(fname, mode, file_flags);
+ 
+ 	slash = strrchr(fname, '/');
+ 	if (!slash)
+-		return do_chmod(fname, mode);
++		return do_chmod(fname, mode, file_flags);
+ 
+ 	dlen = slash - fname;
+ 	if (dlen >= sizeof dirpath) {
+@@ -872,8 +982,23 @@ int do_chmod_at(const char *fname, mode_t mode)
+ 	if (dfd < 0)
+ 		return -1;
+ 
+-	ret = fchmodat(dfd, bname, mode, 0);
++	ret = fchmodat(dfd, bname, mode & CHMOD_BITS, 0);
+ 	e = errno;
++#ifdef SUPPORT_FORCE_CHANGE
++	if (ret < 0 && force_change && e == EPERM && !S_ISLNK(mode)) {
++		if (file_flags == NO_FFLAGS) {
++			STRUCT_STAT st;
++			if (do_lstat(fname, &st) == 0)
++				file_flags = st.st_flags;
++		}
++		if (file_flags != NO_FFLAGS
++		    && make_mutable(fname, mode, file_flags, force_change) > 0) {
++			ret = fchmodat(dfd, bname, mode & CHMOD_BITS, 0);
++			e = errno;
++			undo_make_mutable(fname, file_flags);
++		}
++	}
++#endif
+ 	close(dfd);
+ 	errno = e;
+ 	return ret;
+@@ -883,11 +1008,40 @@ int do_chmod_at(const char *fname, mode_t mode)
  }
  #endif
  
+-int do_rename(const char *old_path, const char *new_path)
 +#ifdef HAVE_CHFLAGS
-+int do_chflags(const char *path, uint32 fileflags)
-+{
-+	if (dry_run) return 0;
-+	RETURN_ERROR_IF_RO_OR_LO;
-+	return chflags(path, fileflags);
-+}
-+#endif
-+
- int do_rename(const char *old_path, const char *new_path)
++int do_chflags(const char *path, uint32 file_flags)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
 -	return rename(old_path, new_path);
-+	if (rename(old_path, new_path) == 0)
-+		return 0;
-+#ifdef SUPPORT_FORCE_CHANGE
-+	if (force_change && errno == EPERM) {
-+		STRUCT_STAT st1, st2;
-+		int became_mutable;
++	return chflags(path, file_flags);
++}
++#endif
 +
-+		if (x_lstat(old_path, &st1, NULL) != 0)
-+			goto failed;
-+		became_mutable = make_mutable(old_path, st1.st_mode, st1.st_flags, force_change) > 0;
-+		if (became_mutable && rename(old_path, new_path) == 0)
-+			goto success;
-+		if (x_lstat(new_path, &st2, NULL) == 0
-+		 && make_mutable(new_path, st2.st_mode, st2.st_flags, force_change) > 0) {
-+			if (rename(old_path, new_path) == 0) {
-+			  success:
-+				if (became_mutable) /* Yes, use new_path and st1! */
-+					undo_make_mutable(new_path, st1.st_flags);
-+				return 0;
-+			}
-+			undo_make_mutable(new_path, st2.st_flags);
++int do_rename(const char *old_path, const char *new_path, UNUSED(mode_t mode), UNUSED(uint32 file_flags))
++{
++	int ret;
++
++	if (dry_run) return 0;
++	RETURN_ERROR_IF_RO_OR_LO;
++	ret = rename(old_path, new_path);
++#ifdef SUPPORT_FORCE_CHANGE
++	if (ret < 0 && force_change && errno == EPERM) {
++		if (file_flags == NO_FFLAGS) {
++			STRUCT_STAT st;
++			if (do_lstat(new_path, &st) == 0)
++				file_flags = st.st_flags;
 +		}
-+		/* TODO: handle immutable directories */
-+		if (became_mutable)
-+			undo_make_mutable(old_path, st1.st_flags);
-+	  failed:
++		if (file_flags != NO_FFLAGS
++		    && make_mutable(new_path, mode, file_flags, force_change) > 0) {
++			ret = rename(old_path, new_path);
++			undo_make_mutable(new_path, file_flags);
++			if (ret == 0)
++				return 0;
++		}
 +		errno = EPERM;
 +	}
 +#endif
-+	return -1;
++	return ret;
  }
  
- #ifdef HAVE_FTRUNCATE
-diff --git a/t_stub.c b/t_stub.c
---- a/t_stub.c
-+++ b/t_stub.c
-@@ -28,6 +28,8 @@ int protect_args = 0;
+ /*
+@@ -907,7 +1061,7 @@ int do_rename(const char *old_path, const char *new_path)
+   parent and absolute-path cases, identical to the other do_*_at()
+   wrappers.
+ */
+-int do_rename_at(const char *old_path, const char *new_path)
++int do_rename_at(const char *old_path, const char *new_path, UNUSED(mode_t mode), UNUSED(uint32 file_flags))
+ {
+ #ifdef AT_FDCWD
+ 	extern int am_daemon, am_chrooted;
+@@ -921,16 +1075,16 @@ int do_rename_at(const char *old_path, const char *new_path)
+ 	RETURN_ERROR_IF_RO_OR_LO;
+ 
+ 	if (!am_daemon || am_chrooted)
+-		return do_rename(old_path, new_path);
++		return do_rename(old_path, new_path, mode, file_flags);
+ 
+ 	if (!old_path || !*old_path || *old_path == '/'
+ 	 || !new_path || !*new_path || *new_path == '/')
+-		return do_rename(old_path, new_path);
++		return do_rename(old_path, new_path, mode, file_flags);
+ 
+ 	old_slash = strrchr(old_path, '/');
+ 	new_slash = strrchr(new_path, '/');
+ 	if (!old_slash || !new_slash)
+-		return do_rename(old_path, new_path);
++		return do_rename(old_path, new_path, mode, file_flags);
+ 
+ 	old_dlen = old_slash - old_path;
+ 	new_dlen = new_slash - new_path;
+@@ -963,6 +1117,24 @@ int do_rename_at(const char *old_path, const char *new_path)
+ 
+ 	ret = renameat(old_dfd, old_bname, new_dfd, new_bname);
+ 	e = errno;
++#ifdef SUPPORT_FORCE_CHANGE
++	if (ret < 0 && force_change && e == EPERM) {
++		if (file_flags == NO_FFLAGS) {
++			STRUCT_STAT st;
++			if (do_lstat(new_path, &st) == 0)
++				file_flags = st.st_flags;
++		}
++		if (file_flags != NO_FFLAGS
++		    && make_mutable(new_path, mode, file_flags, force_change) > 0) {
++			ret = renameat(old_dfd, old_bname, new_dfd, new_bname);
++			e = errno;
++			undo_make_mutable(new_path, file_flags);
++			if (ret == 0)
++				return 0;
++		}
++		errno = EPERM;
++	}
++#endif
+ 	if (new_dfd != old_dfd)
+ 		close(new_dfd);
+ 	close(old_dfd);
+--- t_chmod_secure.c.orig
++++ t_chmod_secure.c
+@@ -88,26 +88,26 @@ int main(int argc, char **argv)
+ 	 */
+ 
+ 	/* Scenario A: legitimate parent dir-symlink, chmod must succeed. */
+-	int rc = do_chmod_at("inside_link/sentinel", 0640);
++	int rc = do_chmod_at("inside_link/sentinel", 0640, 0);
+ 	check("A: legit dir-symlink within tree",
+ 	      rc, 1, "realdir/sentinel", 0640);
+ 
+ 	/* Scenario B: parent symlink escapes the tree -- chmod must be
+ 	 * rejected and the outside file's mode must be unchanged. */
+-	rc = do_chmod_at("escape_link/sentinel", 0666);
++	rc = do_chmod_at("escape_link/sentinel", 0666, 0);
+ 	check("B: parent symlink escapes tree (the attack)",
+ 	      rc, 0, "../trap/sentinel", 0600);
+ 
+ 	/* Scenario C: plain relative path with no symlink components,
+ 	 * regression check that the safe wrapper doesn't break the
+ 	 * normal case. */
+-	rc = do_chmod_at("realdir/sentinel", 0644);
++	rc = do_chmod_at("realdir/sentinel", 0644, 0);
+ 	check("C: plain relative path (regression check)",
+ 	      rc, 1, "realdir/sentinel", 0644);
+ 
+ 	/* Scenario D: top-level file, no parent directory component.
+ 	 * Falls back to do_chmod(); should succeed. */
+-	rc = do_chmod_at("topfile", 0640);
++	rc = do_chmod_at("topfile", 0640, 0);
+ 	check("D: top-level file, no parent component",
+ 	      rc, 1, "topfile", 0640);
+ 
+--- t_stub.c.orig
++++ t_stub.c
+@@ -30,7 +30,9 @@ int preallocate_files = 0;
+ int protect_args = 0;
  int module_id = -1;
  int relative_paths = 0;
- unsigned int module_dirlen = 0;
 +int force_change = 0;
+ unsigned int module_dirlen = 0;
 +int preserve_acls = 0;
  int preserve_xattrs = 0;
  int preserve_perms = 0;
  int preserve_executability = 0;
-@@ -111,3 +113,23 @@ filter_rule_list daemon_filter_list;
+@@ -118,3 +120,23 @@ filter_rule_list daemon_filter_list;
  {
  	return cst ? 0 : 0;
  }
 +
-+#if defined SUPPORT_FILEFLAGS || defined SUPPORT_FORCE_CHANGE
-+ int make_mutable(UNUSED(const char *fname), UNUSED(mode_t mode), UNUSED(uint32 fileflags), UNUSED(uint32 iflags))
++#if defined SUPPORT_FILE_FLAGS || defined SUPPORT_FORCE_CHANGE
++ int make_mutable(UNUSED(const char *fname), UNUSED(mode_t mode), UNUSED(uint32 file_flags), UNUSED(uint32 iflags))
 +{
 +	return 0;
 +}
 +
 +/* Undo a prior make_mutable() call that returned a 1. */
-+ int undo_make_mutable(UNUSED(const char *fname), UNUSED(uint32 fileflags))
++ int undo_make_mutable(UNUSED(const char *fname), UNUSED(uint32 file_flags))
 +{
 +	return 0;
 +}
@@ -979,9 +1227,8 @@ diff --git a/t_stub.c b/t_stub.c
 +	return -1;
 +}
 +#endif
-diff --git a/testsuite/rsync.fns b/testsuite/rsync.fns
---- a/testsuite/rsync.fns
-+++ b/testsuite/rsync.fns
+--- testsuite/rsync.fns.orig
++++ testsuite/rsync.fns
 @@ -26,9 +26,9 @@ chkfile="$scratchdir/rsync.chk"
  outfile="$scratchdir/rsync.out"
  
@@ -995,14 +1242,13 @@ diff --git a/testsuite/rsync.fns b/testsuite/rsync.fns
  tab_ch='	' # a single tab character
  
  # Berkley's nice.
-diff --git a/usage.c b/usage.c
---- a/usage.c
-+++ b/usage.c
+--- usage.c.orig
++++ usage.c
 @@ -138,6 +138,11 @@ static void print_info_flags(enum logcode f)
  #endif
  			"crtimes",
  
-+#ifndef SUPPORT_FILEFLAGS
++#ifndef SUPPORT_FILE_FLAGS
 +		"no "
 +#endif
 +			"file-flags",
@@ -1010,9 +1256,8 @@ diff --git a/usage.c b/usage.c
  	"*Optimizations",
  
  #ifndef USE_ROLL_SIMD
-diff --git a/util1.c b/util1.c
---- a/util1.c
-+++ b/util1.c
+--- util1.c.orig
++++ util1.c
 @@ -34,6 +34,7 @@ extern int relative_paths;
  extern int preserve_xattrs;
  extern int omit_link_times;
@@ -1028,20 +1273,20 @@ diff --git a/util1.c b/util1.c
 +#ifdef SUPPORT_FORCE_CHANGE
 +static int try_a_force_change(const char *fname, STRUCT_STAT *stp)
 +{
-+	uint32 fileflags = ST_FLAGS(*stp);
-+	if (fileflags == NO_FFLAGS) {
++	uint32 file_flags = ST_FLAGS(*stp);
++	if (file_flags == NO_FFLAGS) {
 +		STRUCT_STAT st;
 +		if (x_lstat(fname, &st, NULL) == 0)
-+			fileflags = st.st_flags;
++			file_flags = st.st_flags;
 +	}
-+	if (fileflags != NO_FFLAGS && make_mutable(fname, stp->st_mode, fileflags, force_change) > 0) {
++	if (file_flags != NO_FFLAGS && make_mutable(fname, stp->st_mode, file_flags, force_change) > 0) {
 +		int ret, save_force_change = force_change;
 +
 +		force_change = 0; /* Make certain we can't come back here. */
 +		ret = set_times(fname, stp);
 +		force_change = save_force_change;
 +
-+		undo_make_mutable(fname, fileflags);
++		undo_make_mutable(fname, file_flags);
 +
 +		return ret;
 +	}
@@ -1057,7 +1302,7 @@ diff --git a/util1.c b/util1.c
  int set_times(const char *fname, STRUCT_STAT *stp)
 @@ -143,6 +171,10 @@ int set_times(const char *fname, STRUCT_STAT *stp)
  #include "case_N.h"
- 		if (do_utimensat(fname, stp) == 0)
+ 		if (do_utimensat_at(fname, stp) == 0)
  			break;
 +#ifdef SUPPORT_FORCE_CHANGE
 +		if (force_change && errno == EPERM && try_a_force_change(fname, stp) == 0)
@@ -1088,52 +1333,69 @@ diff --git a/util1.c b/util1.c
  
  		return -1;
  	}
-diff --git a/xattrs.c b/xattrs.c
---- a/xattrs.c
-+++ b/xattrs.c
-@@ -1086,7 +1086,7 @@ int set_xattr(const char *fname, const struct file_struct *file, const char *fna
+@@ -532,7 +572,7 @@ int robust_unlink(const char *fname)
+ 	}
+ 
+ 	/* maybe we should return rename()'s exit status? Nah. */
+-	if (do_rename_at(fname, path) != 0) {
++	if (do_rename_at(fname, path, 0, NO_FFLAGS) != 0) {
+ 		errno = ETXTBSY;
+ 		return -1;
+ 	}
+@@ -555,7 +595,7 @@ int robust_rename(const char *from, const char *to, const char *partialptr,
+ 		return 0;
+ 
+ 	while (tries--) {
+-		if (do_rename_at(from, to) == 0)
++		if (do_rename_at(from, to, 0, NO_FFLAGS) == 0)
+ 			return 0;
+ 
+ 		switch (errno) {
+--- xattrs.c.orig
++++ xattrs.c
+@@ -1094,7 +1094,7 @@ int set_xattr(const char *fname, const struct file_struct *file, const char *fna
  	 && !S_ISLNK(sxp->st.st_mode)
  #endif
  	 && access(fname, W_OK) < 0
--	 && do_chmod(fname, (sxp->st.st_mode & CHMOD_BITS) | S_IWUSR) == 0)
-+	 && do_chmod(fname, (sxp->st.st_mode & CHMOD_BITS) | S_IWUSR, ST_FLAGS(sxp->st)) == 0)
+-	 && do_chmod_at(fname, (sxp->st.st_mode & CHMOD_BITS) | S_IWUSR) == 0)
++	 && do_chmod_at(fname, (sxp->st.st_mode & CHMOD_BITS) | S_IWUSR, ST_FLAGS(sxp->st)) == 0)
  		added_write_perm = 1;
  
  	ndx = F_XATTR(file);
-@@ -1094,7 +1094,7 @@ int set_xattr(const char *fname, const struct file_struct *file, const char *fna
+@@ -1102,7 +1102,7 @@ int set_xattr(const char *fname, const struct file_struct *file, const char *fna
  	lst = &glst->xa_items;
  	int return_value = rsync_xal_set(fname, lst, fnamecmp, sxp);
  	if (added_write_perm) /* remove the temporary write permission */
--		do_chmod(fname, sxp->st.st_mode);
-+		do_chmod(fname, sxp->st.st_mode, ST_FLAGS(sxp->st));
+-		do_chmod_at(fname, sxp->st.st_mode);
++		do_chmod_at(fname, sxp->st.st_mode, ST_FLAGS(sxp->st));
  	return return_value;
  }
  
-@@ -1211,7 +1211,7 @@ int set_stat_xattr(const char *fname, struct file_struct *file, mode_t new_mode)
+@@ -1219,7 +1219,7 @@ int set_stat_xattr(const char *fname, struct file_struct *file, mode_t new_mode)
  	mode = (fst.st_mode & _S_IFMT) | (fmode & ACCESSPERMS)
  	     | (S_ISDIR(fst.st_mode) ? 0700 : 0600);
  	if (fst.st_mode != mode)
--		do_chmod(fname, mode);
-+		do_chmod(fname, mode, ST_FLAGS(fst));
- 	if (!IS_DEVICE(fst.st_mode))
- 		fst.st_rdev = 0; /* just in case */
- 
-diff -Nurp a/rsync.1 b/rsync.1
---- a/rsync.1
-+++ b/rsync.1
-@@ -545,6 +545,7 @@ has its own detailed description later i
+-		do_chmod_at(fname, mode);
++		do_chmod_at(fname, mode, ST_FLAGS(fst));
+	if (!IS_DEVICE(fst.st_mode))
+		fst.st_rdev = 0; /* just in case */
+
+--- rsync.1.orig
++++ rsync.1
+@@ -545,6 +545,7 @@
  --keep-dirlinks, -K      treat symlinked dir on receiver as dir
  --hard-links, -H         preserve hard links
  --perms, -p              preserve permissions
-+--fileflags              preserve file-flags (aka chflags)
++--file-flags             preserve file flags (aka chflags)
  --executability, -E      preserve executability
  --chmod=CHMOD            affect file and/or directory permissions
  --acls, -A               preserve ACLs (implies --perms)
-@@ -586,7 +587,10 @@ has its own detailed description later i
+@@ -586,7 +587,11 @@
  --ignore-missing-args    ignore missing source args without error
  --delete-missing-args    delete missing source args from destination
  --ignore-errors          delete even if there are I/O errors
 ---force                  force deletion of dirs even if not empty
++--force                  an alias for --force-delete
 +--force-delete           force deletion of directories even if not empty
 +--force-change           affect user-/system-immutable files/dirs
 +--force-uchange          affect user-immutable files/dirs
@@ -1141,203 +1403,87 @@ diff -Nurp a/rsync.1 b/rsync.1
  --max-delete=NUM         don't delete more than NUM files
  --max-size=SIZE          don't transfer any file larger than SIZE
  --min-size=SIZE          don't transfer any file smaller than SIZE
-@@ -917,6 +921,7 @@ This is equivalent to \fB\-rlptgoD\fP.
+@@ -918,6 +923,7 @@
  recursion and want to preserve almost everything.  Be aware that it does
  \fBnot\fP include preserving ACLs (\fB\-A\fP), xattrs (\fB\-X\fP), atimes (\fB\-U\fP),
  crtimes (\fB\-N\fP), nor the finding and preserving of hardlinks (\fB\-H\fP).
-+It also does \fBnot\fP imply \fB\-\-fileflags\fP.
++It also does \fBnot\fP imply \fB\-\-file\-flags\fP.
  .IP
- The only exception to the above equivalence is when \fB\-\-files-from\fP
+ The only exception to the above equivalence is when \fB\-\-files\-from\fP
  is specified, in which case \fB\-r\fP is not implied.
-@@ -1381,7 +1386,7 @@ to non-directories to be affected, as th
+@@ -1382,7 +1388,7 @@
  Without this option, if the sending side has replaced a directory with a
  symlink to a directory, the receiving side will delete anything that is in
  the way of the new symlink, including a directory hierarchy (as long as
 -\fB\-\-force\fP or \fB\-\-delete\fP is in effect).
-+\fB\-\-force-delete\fP or \fB\-\-delete\fP is in effect).
++\fB\-\-force\-delete\fP or \fB\-\-delete\fP is in effect).
  .IP
- See also \fB\-\-keep-dirlinks\fP for an analogous option for the
+ See also \fB\-\-keep\-dirlinks\fP for an analogous option for the
  receiving side.
-@@ -1599,6 +1604,29 @@ receiver-only rule that excludes all nam
+@@ -1600,6 +1606,29 @@
  Note that the \fB\-X\fP option does not copy rsync's special xattr values (e.g.
- those used by \fB\-\-fake-super\fP) unless you repeat the option (e.g. \fB\-XX\fP).
- This "copy all xattrs" mode cannot be used with \fB\-\-fake-super\fP.
-+.IP "\fB\-\-fileflags\fP"
-+This option causes rsync to update the file-flags to be the same as the
+ those used by \fB\-\-fake\-super\fP) unless you repeat the option (e.g. \fB\-XX\fP).
+ This "copy all xattrs" mode cannot be used with \fB\-\-fake\-super\fP.
++.IP "\fB\-\-file\-flags\fP"
++This option causes rsync to update the file flags to be the same as the
 +source files and directories (if your OS supports the \fBchflags\fP(2) system
 +call).   Some flags can only be altered by the super-user and some might
 +only be unset below a certain secure-level (usually single-user mode). It
 +will not make files alterable that are set to immutable on the receiver.
-+To do that, see \fB\-\-force-change\fP, \fB\-\-force-uchange\fP, and
-+\fB\-\-force-schange\fP.
-+.IP "\fB\-\-force-change\fP"
++To do that, see \fB\-\-force\-change\fP, \fB\-\-force\-uchange\fP, and
++\fB\-\-force\-schange\fP.
++.IP "\fB\-\-force\-change\fP"
 +This option causes rsync to disable both user-immutable and
 +system-immutable flags on files and directories that are being updated or
 +deleted on the receiving side.  This option overrides
-+\fB\-\-force-uchange\fP and \fB\-\-force-schange\fP.
-+.IP "\fB\-\-force-uchange\fP"
++\fB\-\-force\-uchange\fP and \fB\-\-force\-schange\fP.
++.IP "\fB\-\-force\-uchange\fP"
 +This option causes rsync to disable user-immutable flags on files and
 +directories that are being updated or deleted on the receiving side.  It
 +does not try to affect system flags.  This option overrides
-+\fB\-\-force-change\fP and \fB\-\-force-schange\fP.
-+.IP "\fB\-\-force-schange\fP"
++\fB\-\-force\-change\fP and \fB\-\-force\-schange\fP.
++.IP "\fB\-\-force\-schange\fP"
 +This option causes rsync to disable system-immutable flags on files and
 +directories that are being updated or deleted on the receiving side.  It
 +does not try to affect user flags.  This option overrides
-+\fB\-\-force-change\fP and \fB\-\-force-uchange\fP.
++\fB\-\-force\-change\fP and \fB\-\-force\-uchange\fP.
  .IP "\fB\-\-chmod=CHMOD\fP"
  This option tells rsync to apply one or more comma-separated "chmod" modes
  to the permission of the files in the transfer.  The resulting value is
-@@ -2082,8 +2110,8 @@ This option takes the behavior of the (i
- \fB\-\-ignore-missing-args\fP option a step farther: each missing arg
+@@ -2083,8 +2112,8 @@
+ \fB\-\-ignore\-missing\-args\fP option a step farther: each missing arg
  will become a deletion request of the corresponding destination file on the
  receiving side (should it exist).  If the destination file is a non-empty
 -directory, it will only be successfully deleted if \fB\-\-force\fP or
 -\fB\-\-delete\fP are in effect.  Other than that, this option is
-+directory, it will only be successfully deleted if \fB\-\-force-delete\fP
++directory, it will only be successfully deleted if \fB\-\-force\-delete\fP
 +or \fB\-\-delete\fP are in effect.  Other than that, this option is
  independent of any other type of delete processing.
  .IP
  The missing source files are represented by special file-list entries which
-@@ -2091,13 +2119,13 @@ display as a "\fB*missing\fP" entry in t
- .IP "\fB\-\-ignore-errors\fP"
+@@ -2092,13 +2121,13 @@
+ .IP "\fB\-\-ignore\-errors\fP"
  Tells \fB\-\-delete\fP to go ahead and delete files even when there are
  I/O errors.
 -.IP "\fB\-\-force\fP"
-+.IP "\fB\-\-force-delete\fP, \fB\-\-force\fP"
++.IP "\fB\-\-force\-delete\fP, \fB\-\-force\fP"
  This option tells rsync to delete a non-empty directory when it is to be
  replaced by a non-directory.  This is only relevant if deletions are not
  active (see \fB\-\-delete\fP for details).
  .IP
 -Note for older rsync versions: \fB\-\-force\fP used to still be required when
--using \fB\-\-delete-after\fP, and it used to be non-functional unless the
+-using \fB\-\-delete\-after\fP, and it used to be non-functional unless the
 +Note that some older rsync versions used to require \fB\-\-force\fP when using
-+\fB\-\-delete-after\fP, and it used to be non-functional unless the
++\fB\-\-delete\-after\fP, and it used to be non-functional unless the
  \fB\-\-recursive\fP option was also enabled.
- .IP "\fB\-\-max-delete=NUM\fP"
+ .IP "\fB\-\-max\-delete=NUM\fP"
  This tells rsync not to delete more than NUM files or directories.  If that
-@@ -3159,7 +3187,7 @@ version 2.6.7 (you can use \fB\-vv\fP wi
+@@ -3177,7 +3206,7 @@
  also turns on the output of other verbose messages).
  .IP
  The "%i" escape has a cryptic output that is 11 letters long.  The general
 -format is like the string \fBYXcstpoguax\fP, where \fBY\fP is replaced by the type
 +format is like the string \fBYXcstpoguaxf\fP, where \fBY\fP is replaced by the type
  of update being done, \fBX\fP is replaced by the file-type, and the other
- letters represent attributes that may be output if they are being modified.
+ letters represent attributes that may be output if they are modified.
  .IP
-diff -Nurp a/rsync.1.html b/rsync.1.html
---- a/rsync.1.html
-+++ b/rsync.1.html
-@@ -438,6 +438,7 @@ has its own detailed description later i
- --keep-dirlinks, -K      treat symlinked dir on receiver as dir
- --hard-links, -H         preserve hard links
- --perms, -p              preserve permissions
-+--fileflags              preserve file-flags (aka chflags)
- --executability, -E      preserve executability
- --chmod=CHMOD            affect file and/or directory permissions
- --acls, -A               preserve ACLs (implies --perms)
-@@ -479,7 +480,10 @@ has its own detailed description later i
- --ignore-missing-args    ignore missing source args without error
- --delete-missing-args    delete missing source args from destination
- --ignore-errors          delete even if there are I/O errors
----force                  force deletion of dirs even if not empty
-+--force-delete           force deletion of directories even if not empty
-+--force-change           affect user-/system-immutable files/dirs
-+--force-uchange          affect user-immutable files/dirs
-+--force-schange          affect system-immutable files/dirs
- --max-delete=NUM         don't delete more than NUM files
- --max-size=SIZE          don't transfer any file larger than SIZE
- --min-size=SIZE          don't transfer any file smaller than SIZE
-@@ -806,7 +810,8 @@ section.</p>
- <p>This is equivalent to <code>-rlptgoD</code>.  It is a quick way of saying you want
- recursion and want to preserve almost everything.  Be aware that it does
- <strong>not</strong> include preserving ACLs (<code>-A</code>), xattrs (<code>-X</code>), atimes (<code>-U</code>),
--crtimes (<code>-N</code>), nor the finding and preserving of hardlinks (<code>-H</code>).</p>
-+crtimes (<code>-N</code>), nor the finding and preserving of hardlinks (<code>-H</code>).
-+It also does <strong>not</strong> imply <a href="#opt--fileflags"><code>--fileflags</code></a>.</p>
- <p>The only exception to the above equivalence is when <a href="#opt--files-from"><code>--files-from</code></a>
- is specified, in which case <a href="#opt-r"><code>-r</code></a> is not implied.</p>
- </dd>
-@@ -1234,7 +1239,7 @@ to non-directories to be affected, as th
- <p>Without this option, if the sending side has replaced a directory with a
- symlink to a directory, the receiving side will delete anything that is in
- the way of the new symlink, including a directory hierarchy (as long as
--<a href="#opt--force"><code>--force</code></a> or <a href="#opt--delete"><code>--delete</code></a> is in effect).</p>
-+<a href="#opt--force-delete"><code>--force-delete</code></a> or <a href="#opt--delete"><code>--delete</code></a> is in effect).</p>
- <p>See also <a href="#opt--keep-dirlinks"><code>--keep-dirlinks</code></a> for an analogous option for the
- receiving side.</p>
- <p><code>--copy-dirlinks</code> applies to all symlinks to directories in the source.  If
-@@ -1421,6 +1426,37 @@ those used by <a href="#opt--fake-super"
- This &quot;copy all xattrs&quot; mode cannot be used with <a href="#opt--fake-super"><code>--fake-super</code></a>.</p>
- </dd>
- 
-+<dt id="opt--fileflags"><code>--fileflags</code><a href="#opt--fileflags" class="tgt"></a></dt><dd>
-+<p>This option causes rsync to update the file-flags to be the same as the
-+source files and directories (if your OS supports the <strong>chflags</strong>(2) system
-+call).   Some flags can only be altered by the super-user and some might
-+only be unset below a certain secure-level (usually single-user mode). It
-+will not make files alterable that are set to immutable on the receiver.
-+To do that, see <a href="#opt--force-change"><code>--force-change</code></a>, <a href="#opt--force-uchange"><code>--force-uchange</code></a>, and
-+<a href="#opt--force-schange"><code>--force-schange</code></a>.</p>
-+</dd>
-+
-+<dt id="opt--force-change"><code>--force-change</code><a href="#opt--force-change" class="tgt"></a></dt><dd>
-+<p>This option causes rsync to disable both user-immutable and
-+system-immutable flags on files and directories that are being updated or
-+deleted on the receiving side.  This option overrides
-+<a href="#opt--force-uchange"><code>--force-uchange</code></a> and <a href="#opt--force-schange"><code>--force-schange</code></a>.</p>
-+</dd>
-+
-+<dt id="opt--force-uchange"><code>--force-uchange</code><a href="#opt--force-uchange" class="tgt"></a></dt><dd>
-+<p>This option causes rsync to disable user-immutable flags on files and
-+directories that are being updated or deleted on the receiving side.  It
-+does not try to affect system flags.  This option overrides
-+<a href="#opt--force-change"><code>--force-change</code></a> and <a href="#opt--force-schange"><code>--force-schange</code></a>.</p>
-+</dd>
-+
-+<dt id="opt--force-schange"><code>--force-schange</code><a href="#opt--force-schange" class="tgt"></a></dt><dd>
-+<p>This option causes rsync to disable system-immutable flags on files and
-+directories that are being updated or deleted on the receiving side.  It
-+does not try to affect user flags.  This option overrides
-+<a href="#opt--force-change"><code>--force-change</code></a> and <a href="#opt--force-uchange"><code>--force-uchange</code></a>.</p>
-+</dd>
-+
- <dt id="opt--chmod"><code>--chmod=CHMOD</code><a href="#opt--chmod" class="tgt"></a></dt><dd>
- <p>This option tells rsync to apply one or more comma-separated &quot;chmod&quot; modes
- to the permission of the files in the transfer.  The resulting value is
-@@ -1904,8 +1940,8 @@ is no longer there.</p>
- <a href="#opt--ignore-missing-args"><code>--ignore-missing-args</code></a> option a step farther: each missing arg
- will become a deletion request of the corresponding destination file on the
- receiving side (should it exist).  If the destination file is a non-empty
--directory, it will only be successfully deleted if <a href="#opt--force"><code>--force</code></a> or
--<a href="#opt--delete"><code>--delete</code></a> are in effect.  Other than that, this option is
-+directory, it will only be successfully deleted if <a href="#opt--force-delete"><code>--force-delete</code></a>
-+or <a href="#opt--delete"><code>--delete</code></a> are in effect.  Other than that, this option is
- independent of any other type of delete processing.</p>
- <p>The missing source files are represented by special file-list entries which
- display as a &quot;<code>*missing</code>&quot; entry in the <a href="#opt--list-only"><code>--list-only</code></a> output.</p>
-@@ -1916,12 +1952,12 @@ display as a &quot;<code>*missing</code>
- I/O errors.</p>
- </dd>
- 
--<dt id="opt--force"><code>--force</code><a href="#opt--force" class="tgt"></a></dt><dd>
-+<span id="opt--force"></span><dt id="opt--force-delete"><code>--force-delete</code>, <code>--force</code><a href="#opt--force-delete" class="tgt"></a></dt><dd>
- <p>This option tells rsync to delete a non-empty directory when it is to be
- replaced by a non-directory.  This is only relevant if deletions are not
- active (see <a href="#opt--delete"><code>--delete</code></a> for details).</p>
--<p>Note for older rsync versions: <code>--force</code> used to still be required when
--using <a href="#opt--delete-after"><code>--delete-after</code></a>, and it used to be non-functional unless the
-+<p>Note that some older rsync versions used to require <code>--force</code> when using
-+<a href="#opt--delete-after"><code>--delete-after</code></a>, and it used to be non-functional unless the
- <a href="#opt--recursive"><code>--recursive</code></a> option was also enabled.</p>
- </dd>
- 
-@@ -2894,7 +2930,7 @@ files will also be output, but only if t
- version 2.6.7 (you can use <code>-vv</code> with older versions of rsync, but that
- also turns on the output of other verbose messages).</p>
- <p>The &quot;%i&quot; escape has a cryptic output that is 11 letters long.  The general
--format is like the string <code>YXcstpoguax</code>, where <strong>Y</strong> is replaced by the type
-+format is like the string <code>YXcstpoguaxf</code>, where <strong>Y</strong> is replaced by the type
- of update being done, <strong>X</strong> is replaced by the file-type, and the other
- letters represent attributes that may be output if they are being modified.</p>
- <p>The update types that replace the <strong>Y</strong> are as follows:</p>

--- a/net/rsync/files/legacy-darwin-at-syscalls.diff
+++ b/net/rsync/files/legacy-darwin-at-syscalls.diff
@@ -1,0 +1,44 @@
+--- syscall.c.orig
++++ syscall.c
+@@ -126,1 +126,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -221,1 +221,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -346,1 +346,1 @@
+-#if defined AT_FDCWD && defined HAVE_LINKAT
++#if defined AT_FDCWD && defined HAVE_LINKAT && !defined RSYNC_NO_AT_SYSCALLS
+@@ -478,1 +478,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -535,1 +535,1 @@
+-	return do_lchown(fname, owner, group);
++	return do_lchown(fname, owner, group, mode, file_flags);
+@@ -712,1 +712,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -802,1 +802,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -945,1 +945,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -1006,1 +1006,1 @@
+-	return do_chmod(fname, mode);
++	return do_chmod(fname, mode, file_flags);
+@@ -1066,1 +1066,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -1144,1 +1144,1 @@
+-	return do_rename(old_path, new_path);
++	return do_rename(old_path, new_path, mode, file_flags);
+@@ -1205,1 +1205,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -1318,1 +1318,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS
+@@ -1560,1 +1560,1 @@
+-#ifdef AT_FDCWD
++#if defined AT_FDCWD && !defined RSYNC_NO_AT_SYSCALLS


### PR DESCRIPTION
Refresh fileflags.diff using FreeBSD's patch ported to rsync 3.4.4. This retains the existing --fileflags aliases while adding the documented --file-flags spelling and immutable-file handling.

Update the generated rsync.1 manpage to match the patched rsync.1.md documentation.