### PR TITLE
PrismLauncher: update 11.0.3

### DIFF
--- a/games/PrismLauncher/Portfile
+++ b/games/PrismLauncher/Portfile
@@ -6,7 +6,7 @@ PortGroup           qt6 1.0
 PortGroup           java 1.0
 PortGroup           cmake 1.1
 
-github.setup        PrismLauncher PrismLauncher 11.0.1
+github.setup        PrismLauncher PrismLauncher 11.0.3
 github.tarball_from releases
 revision            0
 categories          games
@@ -16,11 +16,11 @@ description         A custom launcher for Minecraft
 long_description    PrismLauncher is {*}${description} that allows you to easily manage \
                     multiple installations of Minecraft at once.
 homepage            https://prismlauncher.org/
-checksums           rmd160 27f4a22cad174cdeaacb91f94d5877e585f997e7 \
-                    sha256 8dc12c1d5bfd67b1e07047313c606826da0079f214a81311d6f5e24005894e8d \
-                    size 4114142
+checksums           rmd160 3bcc8a11a7b04afe61e776ee0de525319bab16e7 \
+                    sha256 78c368140a4d49bf2a12ef0e03d045c6723fe8e5a5c9590668fb63ee0a264ef2 \
+                    size 4111624
 
-platforms           {darwin >= 21}
+platforms           {darwin >= 22}
 
 patchfiles          patch-fetch-tomlplusplus.diff \
                     patch-destdir-qt-deploy.diff
@@ -40,7 +40,7 @@ cmake.build_type    Release
 java.fallback       openjdk8
 java.version        1.8
 
-compiler.cxx_standard 2017
+compiler.cxx_standard 2020
 
 qt6.depends_build   qtnetworkauth
 


### PR DESCRIPTION
#### Description
* bump version
* bump Darwin requirements (qt6 doesn't support Darwin 21)
* bump cxx standard per the CMakeLists.txt

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.3 24G419 arm64
Command Line Tools 26.3.0.0.1.1771626560

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? None relevant
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?