### PR TITLE
pkgconf: Update to 3.0.0

### DIFF
--- a/devel/pkgconf/Portfile
+++ b/devel/pkgconf/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem                  1.0
 PortGroup                   legacysupport 1.1
+PortGroup                   meson 1.0
 
 # readlinkat
 legacysupport.newest_darwin_requires_legacy 13
 
 name                        pkgconf
-version                     2.5.1
+version                     3.0.0
 revision                    0
 categories                  devel
 license                     ISC
@@ -19,15 +20,18 @@ long_description            pkgconf is ${description}. \
 homepage                    https://github.com/pkgconf/pkgconf
 master_sites                https://distfiles.ariadne.space/pkgconf/
 
-checksums                   rmd160  db66f42f4359ffee7b4da1247b33f530e6e43b8e \
-                            sha256  ab89d59810d9cad5dfcd508f25efab8ea0b1c8e7bad91c2b6351f13e6a5940d8 \
-                            size    477734
+checksums                   rmd160  3ea5a1d07c2fe2a2e7fd31b527846418fc70afb4 \
+                            sha256  5105aa1c8a524e27a20cbacfe39125e6fe8501a3e8e8ad0fb3c4282ccf10f8ba \
+                            size    609033
 
 # both ports install ${prefix}/share/aclocal/pkg.m4
 conflicts                   pkgconfig
 
-# See: https://trac.macports.org/wiki/WimplicitFunctionDeclaration#AddnamestowhitelistviaPortfile
-configure.checks.implicit_function_declaration.whitelist-append strchr
+# These are intended in order to filter ${prefix}/include and ${prefix}/lib
+# See: https://trac.macports.org/ticket/73393
+configure.args-append       -Dwith-pkg-config-dir="${prefix}/lib/pkgconfig:/usr/lib/pkgconfig" \
+                            -Dwith-system-includedir=${configure.sdkroot}/usr/include \
+                            -Dwith-system-libdir=/usr/lib
 
 post-destroot {
     # since ports already conflict, follow https://github.com/pkgconf/pkgconf/#pkg-config-symlink
@@ -35,5 +39,5 @@ post-destroot {
     ln -s pkgconf.1 ${destroot}${prefix}/share/man/man1/pkg-config.1
 }
 
-#skip '.9' (development) releases
-livecheck.regex             {pkgconf-((?!\d+\.9\y)\d+(?:\.\d+)*)}
+# Skip 'x.x.90+' (development) releases
+livecheck.regex             {pkgconf-(\d+\.\d+\.(?!9[0-9])\d+)}


### PR DESCRIPTION
#### Description

Update pkgconf to 3.0.0. This pull request also fixes issues regarding reported compiler flags, notably from gnutls, which was due to a misconfiguration of the package itself. See [Trac#73393](https://trac.macports.org/ticket/73393) and [pkgconf/pkgconf#439](https://github.com/pkgconf/pkgconf/issues/439).

Finally, the regular expression was changed to consider x.x.90+ releases as development releases, rather than x.9.x.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
