### PR TITLE
mise: Update to 2026.7.5

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.7.0 v
+github.setup        jdx mise 2026.7.5 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  95dfb5f864da0f6c56fa9fea63d95a9da3725f7a \
-                    sha256  c2e581ac26551e324a2bdb726d6dd34356f865ebb4220d3998dc3f99de9ec42a \
-                    size    12370965
+                    rmd160  8a03d3db5795de0335109f4539619e0aaeb13cf7 \
+                    sha256  51a980970caad3f7db89135ded8a6e91d8c95eeec02b6204d29404580373b9db \
+                    size    12408881
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -103,15 +103,15 @@ cargo.crates \
     anstyle-parse                        1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                        1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                      3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
-    anyhow                             1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    anyhow                             1.0.103  2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
     arbitrary                            1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
-    arc-swap                             1.9.1  6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207 \
+    arc-swap                             1.9.2  c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b \
     archspec                             0.2.0  3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33 \
     arrayref                             0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
-    arrayvec                             0.7.7  f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe \
+    arrayvec                             0.7.8  d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     astral-reqwest-middleware            0.5.1  98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9 \
-    astral-tokio-tar                     0.6.2  cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277 \
+    astral-tokio-tar                     0.6.3  08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd \
     astral_async_http_range_reader      0.11.0  4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f \
     astral_async_zip                    0.0.18  c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
@@ -125,9 +125,9 @@ cargo.crates \
     autocfg                              1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
     aws-credential-types                1.2.13  6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0 \
-    aws-lc-fips-sys                    0.13.14  d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568 \
-    aws-lc-rs                           1.17.0  5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00 \
-    aws-lc-sys                          0.41.0  1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4 \
+    aws-lc-fips-sys                    0.13.15  6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1 \
+    aws-lc-rs                           1.17.1  4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad \
+    aws-lc-sys                          0.42.0  6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444 \
     aws-runtime                          1.7.1  ede2ddc593e6c8acc6ce3358c28d6677a6dc49b65ba4b37a2befe14a11297e75 \
     aws-sdk-s3                         1.119.0  1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c \
     aws-sdk-sso                         1.95.0  00c5ff27c6ba2cbd95e6e26e2e736676fdf6bcf96495b187733f521cfe4ce448 \
@@ -173,7 +173,7 @@ cargo.crates \
     block-padding                        0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     blowfish                             0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     bs58                                 0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
-    bstr                                1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
+    bstr                                1.12.3  5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79 \
     built                                0.8.1  5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9 \
     bumpalo                             3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     bytecheck                            0.8.2  0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b \
@@ -182,7 +182,7 @@ cargo.crates \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                               1.12.0  8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593 \
     bytes-utils                          0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
-    bytesize                             2.4.0  49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d \
+    bytesize                             2.4.2  3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e \
     bzip2                                0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2                                0.6.1  f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c \
     bzip2-sys                     0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
@@ -190,12 +190,12 @@ cargo.crates \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.65  e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96 \
+    cc                                  1.2.66  f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996 \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                          0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                             0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
-    chacha20                            0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
+    chacha20                            0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
     chacha20poly1305                    0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
     chrono                              0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     chrono-tz                            0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
@@ -230,7 +230,7 @@ cargo.crates \
     configparser                         3.2.0  b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4 \
     confique                             0.4.0  06b4f5ec222421e22bb0a8cbaa36b1d2b50fd45cdd30c915ded34108da78b29f \
     confique-macro                      0.0.13  e4d1754680cd218e7bcb4c960cc9bae3444b5197d64563dccccfdf83cab9e1a7 \
-    console                             0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
+    console                             0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     const-oid                            0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const-oid                           0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     constant_time_eq                     0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
@@ -252,15 +252,15 @@ cargo.crates \
     crc-fast                             1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
     crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crmf                                 0.2.0  36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92 \
-    crossbeam-channel                   0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
-    crossbeam-deque                      0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
-    crossbeam-epoch                     0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                     0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    crossbeam-channel                   0.5.16  d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
+    crossbeam-deque                      0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
+    crossbeam-epoch                     0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
+    crossbeam-utils                     0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
     crossterm                           0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    ctor                                 1.0.7  01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a \
+    ctor                                 1.0.8  fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -273,8 +273,8 @@ cargo.crates \
     deadpool                            0.12.3  0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b \
     deadpool-runtime                     0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
     deflate64                           0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
-    defmt                                1.1.0  a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f \
-    defmt-macros                         1.1.0  f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b \
+    defmt                                1.1.1  e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1 \
+    defmt-macros                         1.1.1  bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8 \
     defmt-parser                         1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
     demand                               2.0.2  9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
@@ -306,8 +306,8 @@ cargo.crates \
     enum_dispatch                       0.3.13  aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd \
     enumflags2                          0.7.12  1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef \
     enumflags2_derive                   0.7.12  67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827 \
-    env_filter                           1.0.1  32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef \
-    env_logger                         0.11.10  0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a \
+    env_filter                           2.0.0  900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217 \
+    env_logger                         0.11.11  de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6 \
     envmnt                              0.10.4  d73999a2b8871e74c8b8bc23759ee9f3d85011b24fafc91a4b3b5c8cc8185501 \
     equivalent                           1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     erased-serde                        0.4.10  d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec \
@@ -340,7 +340,7 @@ cargo.crates \
     foreign-types                        0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared                 0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                      1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
-    fs-err                               3.3.0  73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0 \
+    fs-err                               3.3.1  b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a \
     fs4                                 0.13.1  8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4 \
     fs_extra                             1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsio                                 0.4.1  f4944f16eb6a05b4b2b79986b4786867bb275f52882adea798f17cc2588f25b2 \
@@ -446,14 +446,14 @@ cargo.crates \
     http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     http-cache-semantics                 3.0.0  0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7 \
-    http-content-range                   0.2.4  66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1 \
+    http-content-range                   0.2.5  0298eab7a8b2346aa6e6b3502dfddf643735e45864cbe4ce9c73606cecb8b53f \
     http-serde                           2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                            1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                             1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     human_format                         1.2.1  eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b \
     humansize                            2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
-    humantime                            2.3.0  135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424 \
-    hybrid-array                        0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
+    humantime                            2.4.0  15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
+    hybrid-array                        0.4.13  818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c \
     hyper                               1.10.1  55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
     hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
@@ -474,13 +474,13 @@ cargo.crates \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                         1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
-    ignore                              0.4.26  b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d \
+    ignore                              0.4.27  fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f \
     impl-tools                          0.11.4  0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208 \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
     indexmap                             1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                            2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
-    indicatif                           0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
+    indicatif                           0.18.6  9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
     indoc                                2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inout                                0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
     inout                                0.2.2  4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7 \
@@ -497,16 +497,16 @@ cargo.crates \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itertools                           0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jiff                                0.2.29  34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46 \
-    jiff-static                         0.2.29  0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f \
-    jiff-tzdb                            0.1.6  c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076 \
+    jiff                                0.2.31  ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634 \
+    jiff-static                         0.2.31  e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2 \
+    jiff-tzdb                            0.1.7  6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590 \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
     jni-macros                          0.22.4  a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
-    jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                             0.3.102  03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31 \
+    jobserver                           0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
+    js-sys                             0.3.103  53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
@@ -522,8 +522,8 @@ cargo.crates \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                            0.1.17  f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3 \
-    link-section                        0.18.2  c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f \
+    libredox                            0.1.18  c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652 \
+    link-section                        0.19.0  e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9 \
     linktime-proc-macro                  0.2.0  8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
@@ -539,14 +539,14 @@ cargo.crates \
     lua-src                            550.0.0  e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb \
     luajit-src                 210.6.6+707c12b  a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295 \
     lzma-rs                              0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
-    lzma-rust2                          0.16.4  ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02 \
+    lzma-rust2                          0.16.5  ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
     memchr                               2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
-    memmap2                             0.9.10  714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3 \
+    memmap2                             0.9.11  d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0 \
     memoffset                            0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                               7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
     miette-derive                        7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
@@ -565,7 +565,7 @@ cargo.crates \
     netrc-rs                             0.1.2  ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836 \
     nix                                 0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
     nix                                 0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
-    nodejs-semver                        4.2.0  2a29bc3430baa1e00e10d9aa5f4ed19ce4433eecb40e3926ade5ff2954cc2f3a \
+    nodejs-semver                        5.0.0  364dd919c4d6feef8c3a3f3e2b64af729187902156e17481618622cbbf1353a1 \
     nom                                  7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nom                                  8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
     nom-language                         0.1.0  2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29 \
@@ -573,7 +573,7 @@ cargo.crates \
     nu-ansi-term                        0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
     nucleo-matcher                       0.3.1  bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85 \
     num                                  0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
-    num-bigint                           0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
+    num-bigint                           0.4.8  c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367 \
     num-bigint-dig                       0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
     num-complex                          0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                             0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
@@ -609,10 +609,10 @@ cargo.crates \
     pem                                  3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
     pem-rfc7468                          0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     percent-encoding                     2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                                 2.8.6  e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662 \
-    pest_derive                          2.8.6  11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77 \
-    pest_generator                       2.8.6  8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f \
-    pest_meta                            2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
+    pest                                 2.8.7  47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9 \
+    pest_derive                          2.8.7  4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58 \
+    pest_generator                       2.8.7  6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7 \
+    pest_meta                            2.8.7  f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210 \
     petgraph                             0.8.3  8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455 \
     phf                                 0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
     phf                                 0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
@@ -629,8 +629,8 @@ cargo.crates \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    platforms                           3.11.0  366f9622ebb8981452cd68eba56dd73eccc76fa093dc1d7dd5f5495da05cc977 \
-    plist                                1.9.0  092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1 \
+    platforms                           3.12.0  9245c6e7c5a6bcdd7977fdf6d1e1c67f4cc2d0d58c041df0ea5940953033e6ca \
+    plist                               1.10.0  7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85 \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                              0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
     portable-atomic                     1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
@@ -652,36 +652,37 @@ cargo.crates \
     quick-error                          1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quick-xml                           0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quick-xml                           0.38.4  b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c \
-    quick-xml                           0.39.4  cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e \
+    quick-xml                           0.41.0  e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1 \
     quinn                              0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
-    quinn-proto                        0.11.15  4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e \
-    quinn-udp                           0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
+    quinn-proto                        0.11.16  2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560 \
+    quinn-udp                           0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
     quote                               1.0.46  dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
     r-efi                                5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
-    rancor                               0.1.1  a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee \
+    rancor                               0.1.2  daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c \
     rand                                 0.8.6  5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
     rand                                 0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
-    rand                                0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
+    rand                                0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                          0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                            0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    rand_pcg                            0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.45.0  6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661 \
-    rattler_cache                       0.10.0  1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955 \
+    rattler                             0.46.0  67961cc1ccb170208f10169542752dbe730353a874a13cb0749c13b960d72d5b \
+    rattler_cache                       0.10.1  24205a6af611e71f346e5e170c32f00ce1a9b49077f699f18d8404e711dc2209 \
     rattler_conda_types                 0.47.2  385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd \
     rattler_digest                       1.3.1  2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69 \
     rattler_macros                       1.1.1  ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff \
-    rattler_menuinst                    0.2.67  0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d \
-    rattler_networking                  0.29.0  e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821 \
-    rattler_package_streaming           0.26.5  97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034 \
-    rattler_pty                         0.2.13  ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a \
+    rattler_menuinst                    0.2.68  957dbd0e8fb9ed66dce0bd6922914fb8bf795a4334d92e2190f34314a0b1f170 \
+    rattler_networking                  0.30.0  5014e4f5aedcbe01a83a5be0e8669b305adc82cc10985fc83f51c5fe07e0d198 \
+    rattler_package_streaming           0.26.6  2b4440ad7368a66ddd370a8160d8fb2a4d0a825b7a050f9c421dac350b37bed2 \
+    rattler_pty                         0.2.14  d19145200e8c578be6dca325fbacf375a57f86d4a7ccf85d2d8ee193ddfb10dd \
     rattler_redaction                    0.2.1  2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b \
-    rattler_repodata_gateway            0.29.6  86a8db70f13a7841d523b995c2b79669e3045e3e6a711ceb7fa00ffe681e2255 \
-    rattler_shell                       0.27.7  8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192 \
+    rattler_repodata_gateway            0.29.7  dbd05b4c6fbad5fae62d1d67c22c2bb411a7d21a026aeb079893df1d6d157a61 \
+    rattler_shell                       0.27.8  9794276d154c19579fe7982ab2c1e9a960f0d51e5e56cd8d9fafe36373a71dd3 \
     rattler_solve                        7.2.0  0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6 \
     rattler_virtual_packages             3.0.2  312c7e886ca90e83d562cadfb3d88af9dcef42f7c2489dae569df84c4bd07890 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
@@ -696,34 +697,34 @@ cargo.crates \
     regex-lite                           0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     regex-syntax                        0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
-    rend                                 0.5.3  cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6 \
+    rend                                 0.5.4  663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     resolvo                             0.11.1  cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rkyv                                0.8.16  73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3 \
-    rkyv_derive                         0.8.16  5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6 \
-    rmcp                                 1.7.0  0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e \
-    rmcp-macros                          1.7.0  6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d \
+    rkyv                                0.8.17  815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874 \
+    rkyv_derive                         0.8.17  c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c \
+    rmcp                                 1.8.0  1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59 \
+    rmcp-macros                          1.8.0  1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
     rops                                 0.1.7  b4beb52a5d008a707436d388c05e9fee9ae81039cce62813ee750918a13c0aaf \
-    rowan                              0.15.18  62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208 \
+    rowan                              0.15.19  a2441aaccb50f4267d4f0f58b21e0138e96a449f361ed57a2673a83c9bca0772 \
     rsa                                 0.9.10  b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
     rust-embed                          8.11.0  04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27 \
     rust-embed-impl                     8.11.0  da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa \
     rust-embed-utils                    8.11.0  5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1 \
     rustc-demangle                      0.1.27  b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d \
     rustc-hash                           1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
-    rustc-hash                           2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
+    rustc-hash                           2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                        0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                             0.23.41  6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f \
     rustls-native-certs                  0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
-    rustls-pki-types                    1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
+    rustls-pki-types                    1.15.0  764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
@@ -838,6 +839,7 @@ cargo.crates \
     tar                                 0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                            3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     tera                                1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
+    tera                                 2.0.0  38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c \
     termcolor                            1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                        0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
     test-log                            0.2.21  9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1 \
@@ -851,9 +853,9 @@ cargo.crates \
     thiserror-impl                      1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                      2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
     thread_local                         1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    time                                0.3.51  85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327 \
+    time                                0.3.53  18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50 \
     time-core                            0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
-    time-macros                         0.2.30  dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935 \
+    time-macros                         0.2.31  c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f \
     tinystr                              0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
     tinyvec                             1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
@@ -913,11 +915,11 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.5.2  fd4e84470f848f8cea3efba8d1245cf6c2051d0fe2fe9ddd29b5977d0e906844 \
+    usage-lib                            3.5.3  51ff6c8c25dd3850cf7dd48aa2802c0eb40243d842299c577d1f6c5217b6559b \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                                1.23.3  144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7 \
+    uuid                                1.23.4  bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53 \
     valuable                             0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     value-trait                         0.12.1  8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59 \
     vcpkg                               0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
@@ -930,14 +932,14 @@ cargo.crates \
     want                                 0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                   1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
-    wasm-bindgen                       0.2.125  8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a \
-    wasm-bindgen-futures                0.4.75  503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280 \
-    wasm-bindgen-macro                 0.2.125  4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d \
-    wasm-bindgen-macro-support         0.2.125  fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd \
-    wasm-bindgen-shared                0.2.125  23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f \
+    wasm-bindgen                       0.2.126  4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4 \
+    wasm-bindgen-futures                0.4.76  c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d \
+    wasm-bindgen-macro                 0.2.126  167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1 \
+    wasm-bindgen-macro-support         0.2.126  f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e \
+    wasm-bindgen-shared                0.2.126  dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24 \
     wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                            0.3.102  a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d \
+    web-sys                            0.3.103  8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-root-certs                    1.0.8  0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267 \
     webpki-roots                         1.0.8  bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf \
@@ -1018,8 +1020,8 @@ cargo.crates \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                 0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                            0.8.52  ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f \
-    zerocopy-derive                     0.8.52  1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930 \
+    zerocopy                            0.8.53  75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1 \
+    zerocopy-derive                     0.8.53  4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71 \
     zerofrom                             0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                      0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                              1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
@@ -1033,7 +1035,7 @@ cargo.crates \
     zip                                  8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zipsign-api                          0.2.1  32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99 \
-    zlib-rs                              0.6.4  977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3 \
+    zlib-rs                              0.6.5  5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5 \
     zmij                                1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
     zopfli                               0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249 \
     zstd                                0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \


### PR DESCRIPTION
#### Description

mise: Update to 2026.7.5


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
