### PR TITLE
apfel: Update to 1.8.3

### DIFF
--- a/llm/apfel/Portfile
+++ b/llm/apfel/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Arthur-Ficial apfel 1.8.0 v
+github.setup        Arthur-Ficial apfel 1.8.3 v
 revision            0
 github.tarball_from archive
 
@@ -23,9 +23,9 @@ license             MIT
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  c898d7cf95994ffe086fa9eb99582d78e1fb5254 \
-                    sha256  48993710c230d77dd287a4c032705cbf9c1181cfcf70e4ad440bfbdf34602e34 \
-                    size    2044747
+checksums           rmd160  d0008c1aa588d616e90d186af1b681d64dc36d42 \
+                    sha256  d52dd518cb0c086f1620884b8a2ae6a5528b08c45b0c9e5e2cd5fa3512afe730 \
+                    size    2062566
 
 platforms           {darwin >= 26}
 supported_archs     arm64


### PR DESCRIPTION
#### Description

apfel: Update to 1.8.3


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
