### PR TITLE
mingw-w64-wine-mono: new subport 11.2.0

### DIFF
--- a/cross/mingw-w64-wine-mono/Portfile
+++ b/cross/mingw-w64-wine-mono/Portfile
@@ -21,7 +21,7 @@ build {}
 
 if {${subport} eq ${name}} {
     PortGroup       stub 1.0
-    version         11.1.0
+    version         11.2.0
     revision        0
     depends_run     port:mingw-w64-wine-mono-${version}
 
@@ -31,6 +31,17 @@ if {${subport} eq ${name}} {
             registry_deactivate_composite mingw-w64-wine-mono-${version} "" [list ports_nodepcheck 1]
         }
     }
+}
+
+# wine-devel (11.12)
+subport ${name}-11.2.0 {
+    version         11.2.0
+    revision        0
+    distname        wine-mono-${version}-x86
+    checksums       rmd160  20eff45e28b8379d60ab7fbf618834baed4a2def \
+                    sha256  c9fb2e2823acf30b000b8806177db0f40751786136dd3f8fb2be7897b1643d06 \
+                    size    39415892
+    use_xz          yes
 }
 
 # wine-devel (11.8)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
