### PR TITLE
gallery-dl: update to 1.32.6, drop maintainership

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           codeberg 1.0
 PortGroup           python 1.0
 
-codeberg.setup      mikf gallery-dl 1.32.5 v
+codeberg.setup      mikf gallery-dl 1.32.6 v
 
 categories          net
-maintainers         {@akierig fastmail.de:akierig} openmaintainer
+maintainers         nonmaintainer
 revision            0
 
-checksums           rmd160  4d1fd31ff26515055d42130d170f9ad69b14cd97 \
-                    sha256  af994f7c677059578ef718697500d5b2778f4ecf6234575585adf4d997a3a304 \
-                    size    1203668
+checksums           rmd160  78ad7138c8efcb6dafa261398cd4867fbfe671ec \
+                    sha256  f798649c7258258edb943f2148c6ffd55a6b1f23826fef0f07bc0010fcb22c74 \
+                    size    1213610
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: update to 1.32.6, drop maintainership

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
