### PR TITLE
scamper: update to 20260713

### DIFF
--- a/net/scamper/Portfile
+++ b/net/scamper/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 
 name                scamper
-version             20260420
+version             20260713
 revision            0
 categories          net
 license             GPL-2
@@ -21,9 +21,9 @@ long_description    ${name} is a program that is able to conduct Internet \
 homepage            https://www.caida.org/catalog/software/scamper
 master_sites        ${homepage}/code/
 
-checksums           rmd160  696704458ed8b25370c5e1e070d2b5f740eb6568 \
-                    sha256  7d6f6b94e0b80439e45218318a92d30645a7bdbb23c711f68536c8f243fd3317 \
-                    size    3417544
+checksums           rmd160  0c459dceec14155398abfd64f8c7552eb233058f \
+                    sha256  9fc67d6483e240dc38f098a3db13e99fcf678ad00667c6b32a0a2bedba7be697 \
+                    size    3486558
 
 distname            ${name}-cvs-${version}
 


### PR DESCRIPTION
#### Description

Update scamper to 20260713.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
