### PR TITLE
cmake: fix livecheck regex

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -388,8 +388,15 @@ if {${subport} eq ${name}} {
     test.target             test
 
     # Restrict to CMake version 3.x ONLY.  For 4.x, go to cmake-devel.
-    # Ignore RC versions
-    github.livecheck.regex  {(3.[0-9.]+)}
+    # Ignore RC versions.
+    #
+    # The default github livecheck.url (.../tags) only returns the most
+    # recent page of tags, which is now entirely 4.x releases, so a 3.x
+    # release is never seen there. Query the GitHub API instead, which
+    # returns enough recent tags (across both branches) to include the
+    # latest 3.x release.
+    livecheck.url            https://api.github.com/repos/Kitware/CMake/tags?per_page=100
+    livecheck.regex          {"name": "v(3\.[0-9.]+)"}
 } else {
     livecheck.type          none
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The default github livecheck.url (.../tags) now returns only the most recent page of tags, which is entirely 4.x releases, so the pinned 3.x branch is never seen there and livecheck fails with 'regex didn't match'. Query the GitHub API tags endpoint instead, which returns enough recent tags across both branches to include the latest 3.x release.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
