### PR TITLE
arti: update to 2.5.0

### DIFF
--- a/security/arti/Portfile
+++ b/security/arti/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           gitlab  1.0
 
 gitlab.instance     https://gitlab.torproject.org/tpo
-gitlab.setup        core arti 2.4.0 arti-v
+gitlab.setup        core arti 2.5.0 arti-v
 revision            0
 
 homepage            https://tpo.pages.torproject.net/core/arti
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 distname            ${name}-${gitlab.tag_prefix}${version}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b2769029ce711ca07ea9a47b898b65474ee91551 \
-                    sha256  d169c5fffa689d2b2cc63a71834683a713b7c1d8033ed2685d46ed20eaad606a \
-                    size    3351140
+                    rmd160  a7a997acd2220bcc8aeaa4c03af3efe70c7a4cda \
+                    sha256  5bf75420fe60d64262777855617af6c2b72e3c8134ad4c7032d2f119483122e0 \
+                    size    3381420
 
 destroot {
     xinstall -m 0755 \
@@ -42,7 +42,7 @@ cargo.crates \
     alloca                           0.4.0  e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4 \
     amplify                          4.9.0  3f7fb4ac7c881e54a8e7015e399b6112a2a5bc958b6c89ac510840ff20273b31 \
     amplify_derive                   4.0.1  2a6309e6b8d89b36b9f959b7a8fa093583b94922a0f6438a24fb08936de4d428 \
-    amplify_num                      0.5.3  99bcb75a2982047f733547042fc3968c0f460dfcf7d90b90dea3b2744580e9ad \
+    amplify_num                      0.5.4  afed304556696656d2d71495e1e5f2c4b524a3fb6eb0f2f3778ffc482a40b8a8 \
     amplify_syn                      2.0.1  7736fb8d473c0d83098b5bac44df6a561e20470375cd8bcae30516dc889fd62a \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
@@ -51,16 +51,16 @@ cargo.crates \
     anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
-    anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    anyhow                         1.0.103  2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
     approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     ascii                            1.1.0  d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16 \
-    asn1-rs                          0.7.1  56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60 \
+    asn1-rs                          0.7.2  b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8 \
     asn1-rs-derive                   0.6.0  3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c \
     asn1-rs-impl                     0.2.0  7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7 \
     assert-impl                      0.1.3  c3464313de0c867016e3e69d7e1e9ae3499bcc4c18e12283d381359ed38b5b9e \
-    assert_cmd                       2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
+    assert_cmd                       2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
     assert_matches                   1.5.0  9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9 \
     async-broadcast                  0.7.2  435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532 \
     async-channel                    1.9.0  81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35 \
@@ -84,10 +84,10 @@ cargo.crates \
     atomic                           0.5.3  c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba \
     atomic                           0.6.1  a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    automod                         1.0.16  e8b5778837666541195063243828c5b6139221b47dc4ec3ba81738e532469ab1 \
-    aws-lc-rs                       1.16.3  0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f \
-    aws-lc-sys                      0.40.0  f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7 \
+    autocfg                          1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
+    automod                         1.0.17  a273e731a7fb8c2268fd2932c9e9a3469f4fd171d85d070d2687190229653bd3 \
+    aws-lc-rs                       1.17.0  5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00 \
+    aws-lc-sys                      0.41.0  1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4 \
     axum                             0.8.9  31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90 \
     axum-core                        0.5.6  08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1 \
     base16ct                         0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
@@ -105,17 +105,17 @@ cargo.crates \
     blake2                          0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     blanket                          0.3.0  e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    block-buffer                    0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
     blocking                         1.6.2  e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21 \
+    bs58                             0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
     bstr                            1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
-    bumpalo                         3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    bumpalo                         3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     by_address                       1.2.1  64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06 \
     bytemuck                        1.25.0  c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                           1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                              1.2.61  d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d \
+    cc                              1.2.63  556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
@@ -130,7 +130,7 @@ cargo.crates \
     clap_derive                      4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     cmake                           0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
-    cmov                             0.5.3  3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746 \
+    cmov                             0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     coarsetime                      0.1.37  e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2 \
     colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
@@ -139,7 +139,7 @@ cargo.crates \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     console-api                      0.9.0  e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3 \
     console-subscriber               0.5.0  fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592 \
-    const-hex                       1.19.0  20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0 \
+    const-hex                       1.19.1  33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558 \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const-oid                       0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     content_inspector                0.2.4  b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38 \
@@ -166,7 +166,7 @@ cargo.crates \
     crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
     crypto-bigint                    0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
-    crypto-common                    0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
+    crypto-common                    0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
     ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctrlc                            3.5.2  e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162 \
     ctutils                          0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
@@ -187,8 +187,8 @@ cargo.crates \
     der-parser                      10.0.0  07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6 \
     der_derive                       0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
     deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
-    derive-deftly                   1.11.1  79fc7a4d4fef137732d8d0d4e58a9e46e168e5b2a7f728c20f87e7cda69a14e9 \
-    derive-deftly-macros            1.11.1  2a93511fd122bc7b22e361806e84f1c31a53894f0564a4ba7f28e799104318c7 \
+    derive-deftly                   1.11.3  0bc153c91ebf221a2e7feb166aee259acf8a00ecf35c83df8b79fe8f5c3861d7 \
+    derive-deftly-macros            1.11.3  1747ed5fb4ab3a9f8253da3401efe7ca8f8e5ec373b2e700ff55c3304d84e31f \
     derive_arbitrary                 1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
     derive_builder_core_fork_arti   0.11.2  24c1b715c79be6328caa9a5e1a387a196ea503740f0722ec3dd8f67a9e72314d \
     derive_builder_fork_arti        0.11.2  c3eae24d595f4d0ecc90a9a5a6d11c2bd8dafe2375ec4a1ec63250e5ade7d228 \
@@ -202,7 +202,7 @@ cargo.crates \
     dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     dispatch2                        0.3.1  1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38 \
-    displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
+    displaydoc                       0.2.6  1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
     downcast-rs                      2.0.2  117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc \
     dsa                              0.6.3  48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
@@ -213,7 +213,7 @@ cargo.crates \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                    2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     educe                           0.4.23  0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f \
-    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    either                          1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
     elliptic-curve                  0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     enum-map                         2.7.3  6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9 \
     enum-map-derive                 0.17.0  f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb \
@@ -235,7 +235,7 @@ cargo.crates \
     ff                              0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     figment                        0.10.19  8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3 \
-    filetime                        0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
+    filetime                        0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
     fixed-capacity-vec               1.0.1  6b31a14f5ee08ed1a40e1252b35af18bed062e3f39b69aab34decde36bc43e40 \
     flagset                          0.4.7  b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe \
@@ -265,7 +265,7 @@ cargo.crates \
     futures-sink                    0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
     futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
     futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
-    generator                        0.8.8  52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9 \
+    generator                        0.8.9  b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
@@ -282,7 +282,7 @@ cargo.crates \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
-    hashbrown                       0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
+    hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
     hashlink                        0.11.0  ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230 \
     hdrhistogram                     7.5.4  765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
@@ -293,15 +293,15 @@ cargo.crates \
     hkdf                            0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     hostname-validator               1.1.1  f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2 \
-    http                             1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
+    http                             1.4.1  8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0 \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     humantime                        2.3.0  135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424 \
     humantime-serde                  1.1.1  57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c \
-    hybrid-array                    0.4.11  08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5 \
-    hyper                            1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
+    hybrid-array                    0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
+    hyper                           1.10.1  55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
     hyper-timeout                    0.5.2  2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0 \
     hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
     iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
@@ -338,12 +338,12 @@ cargo.crates \
     jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                          0.3.98  67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08 \
+    js-sys                          0.3.99  142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11 \
     k12                              0.3.0  f4dc5fdb62af2f520116927304f15d25b3c2667b4817b90efdc045194c912c54 \
     keccak                           0.1.6  cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653 \
     keccak                           0.2.0  9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa \
-    kqueue                           1.1.1  eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a \
-    kqueue-sys                       1.1.0  a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f \
+    kqueue                           1.2.0  273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5 \
+    kqueue-sys                       1.1.2  07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087 \
     kv-log-macro                     1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
@@ -352,31 +352,31 @@ cargo.crates \
     liblzma                          0.4.6  b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899 \
     liblzma-sys                      0.4.6  1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6 \
     libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                        0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
+    libredox                        0.1.17  f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3 \
     libsqlite3-sys                  0.37.0  b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    log                             0.4.30  616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5 \
     loom                             0.7.2  419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca \
     lzma-rs                          0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     matchers                         0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     matchit                          0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
     matrixmultiply                  0.3.10  a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08 \
     maybenot                         2.2.2  44731ed644f441efeb5ca66a440a84555a40883e2873e20c9afde89b5b4836c8 \
-    memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
-    memmap2                         0.9.10  714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3 \
+    memchr                           2.8.1  6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8 \
+    memmap2                         0.9.11  d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0 \
     merlin                           3.0.0  58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d \
     metrics                         0.24.6  89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2 \
     metrics-exporter-prometheus     0.18.3  1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108 \
-    metrics-util                    0.20.3  9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a \
+    metrics-util                    0.20.4  96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
+    mio                              1.2.1  02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
     nalgebra                        0.33.3  9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd \
     native-tls                      0.2.18  465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
-    nix                             0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
+    nix                             0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nonany                           0.3.0  f6b8866ec53810a9a4b3d434a29801e78c707430a9ae11c2db4b8b62bb9675a0 \
     normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
@@ -387,7 +387,7 @@ cargo.crates \
     num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
     num-bigint-dig                   0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
     num-complex                      0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
-    num-conv                         0.2.1  c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967 \
+    num-conv                         0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
     num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
     num-iter                        0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
     num-rational                     0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
@@ -401,17 +401,17 @@ cargo.crates \
     once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     oorandom                        11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
-    openssl                        0.10.79  bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
+    openssl                        0.10.80  a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
     openssl-src              300.6.0+3.6.2  a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4 \
-    openssl-sys                    0.9.115  158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781 \
-    opentelemetry                   0.31.0  b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0 \
-    opentelemetry-appender-tracing  0.31.1  ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2 \
-    opentelemetry-http              0.31.0  d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d \
-    opentelemetry-otlp              0.31.1  1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f \
-    opentelemetry-proto             0.31.0  a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f \
-    opentelemetry_sdk               0.31.0  e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd \
+    openssl-sys                    0.9.116  f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4 \
+    opentelemetry                   0.32.0  b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682 \
+    opentelemetry-appender-tracing  0.32.0  2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837 \
+    opentelemetry-http              0.32.0  5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331 \
+    opentelemetry-otlp              0.32.0  9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35 \
+    opentelemetry-proto             0.32.0  56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638 \
+    opentelemetry_sdk               0.32.1  9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os_pipe                          1.2.3  7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967 \
@@ -434,15 +434,14 @@ cargo.crates \
     phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
     phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
     pico-args                        0.5.0  5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315 \
-    pin-project                     1.1.12  cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9 \
-    pin-project-internal            1.1.12  a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389 \
+    pin-project                     1.1.13  2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924 \
+    pin-project-internal            1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
     pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     piper                            0.2.5  c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1 \
     pkcs1                            0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
     plotters                         0.3.7  5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747 \
     plotters-backend                 0.3.7  df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a \
     plotters-svg                     0.3.7  51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670 \
@@ -487,7 +486,7 @@ cargo.crates \
     rand_core                       0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_distr                       0.4.3  32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31 \
     rand_distr                       0.5.1  6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463 \
-    rand_jitter                      0.6.0  a02dd27aa28665e46e60168c8f355240c73b8a344d2557a92318849441ffda33 \
+    rand_jitter                      0.6.1  3fdcd80e68f0a8f9ca5ec7cfd02fd5fbb8fbe6ef4e9b90ea2f48bb929b74f88e \
     rand_xorshift                    0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
     rand_xoshiro                     0.7.0  f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41 \
     rangemap                         1.7.1  973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68 \
@@ -498,14 +497,13 @@ cargo.crates \
     rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     rdrand                           0.8.3  d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655 \
     redox_syscall                   0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
-    redox_syscall                    0.7.5  4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                        1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                   1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
     regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
     regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
-    reqwest                        0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
+    reqwest                         0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     reseeding_rng                   0.10.6  35d8fa137e1f0bbc1139893fcf4fff5f099d76658e6da2b10fadd04f0cadc2d4 \
     rfc6979                          0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
@@ -513,14 +511,14 @@ cargo.crates \
     rmp                             0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                        1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     rsa                             0.9.10  b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
-    rsqlite-vfs                      0.1.0  a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d \
+    rsqlite-vfs                      0.1.1  c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c \
     rusqlite                        0.39.0  a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rusticata-macros                 4.1.0  faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustix-linux-procfs              0.1.1  2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056 \
     rustls                         0.23.40  ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
-    rustls-native-certs              0.8.3  612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
+    rustls-native-certs              0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
     rustls-pki-types                1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
     rustls-platform-verifier         0.6.2  1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784 \
     rustls-platform-verifier-android 0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
@@ -531,15 +529,13 @@ cargo.crates \
     safe_arch                        0.7.4  96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     sanitize-filename                0.6.0  bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d \
-    saturating-time                  0.3.0  b63583a1dd0647d1484228529ab4ecaa874048d2956f117362aa5f5826456230 \
-    scc                              2.4.0  46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc \
+    saturating-time                  0.4.0  802bdbfcca9a239cb46eeaaedea507e37bb13ba1a673762d2e2ef7a9dac63144 \
     schannel                        0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     scheduled-thread-pool            0.2.7  3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19 \
     schemars                         0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
     schemars                         1.2.1  a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    sdd                             3.0.10  490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
     sec1                             0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     secmem-proc                      0.3.8  ca48b73b5429ef7a6e951cd0f215ef2c3c7eb60a852bda40fe41b6a6846422bb \
     security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
@@ -551,46 +547,48 @@ cargo.crates \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
     serde_ignored                   0.1.14  115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798 \
-    serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_path_to_error             0.1.20  10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
     serde_spanned                    0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
     serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_test                     1.0.177  7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                      3.19.0  f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19 \
-    serde_with_macros               3.19.0  cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334 \
-    serial_test                      3.4.0  911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f \
-    serial_test_derive               3.4.0  0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9 \
+    serde_with                      3.20.0  e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2 \
+    serde_with_macros               3.20.0  b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac \
+    serial_test                      3.5.0  699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
+    serial_test_derive               3.5.0  94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha1-asm                         0.5.3  286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sha256                           1.6.0  f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6 \
     sha3                            0.10.9  77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874 \
-    sha3                            0.11.0  be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1 \
+    sha3                            0.12.0  bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shellexpand                      3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    shlex                            2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
     signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
     signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     simba                            0.9.1  c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95 \
     simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd_cesu8                       1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
     simdutf8                         0.1.5  e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
-    similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
+    similar                          3.1.1  e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16 \
     siphasher                        1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     sketches-ddsketch                0.3.1  0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slotmap                          1.1.1  bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     smol                             2.0.2  a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f \
-    snapbox                          1.2.1  f92ac911648d788a6435401d9b4803959039d4de9919fdabdb415a8bebd027be \
+    snapbox                          1.2.2  8de56eb4784a2c5c1efede55a0f06fbf481bc12b42b355b9525c15db1e3581a8 \
     snapbox-macros                   1.1.0  ed4a172e483585ebbc7c7f7d1705ca7e3f94f606ed78caa14805673189fd5455 \
     socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
-    socket2                          0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
+    socket2                          0.6.4  52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
     socketpair                      0.19.8  20296a054f6fb573c1f73e49b0e3afd1efcc643548928fc9c21144f5ecf4f7e3 \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
-    sqlite-wasm-rs                   0.5.3  1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36 \
+    sponge-cursor                    0.1.0  3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620 \
+    sqlite-wasm-rs                   0.5.5  dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75 \
     ssh-cipher-fork-arti             0.2.0  125c5795103fc93fced42d123c8044180afc55469caa1ab56487c3c5543c898d \
     ssh-encoding-fork-arti           0.2.0  e0cf03c3a7ea88451ff83a129a79451fd9891d44fc76c25e916a11848b81814c \
     ssh-key-fork-arti                0.6.7  433782176b73ea7907763dc314c4a17438a231864d4aa683ba47c07c1cf0a388 \
@@ -631,10 +629,10 @@ cargo.crates \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tls_codec                        0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
     tls_codec_derive                 0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
-    tokio                           1.52.2  110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386 \
+    tokio                           1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
     tokio-macros                     2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
-    tokio-socks                      0.5.2  0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f \
+    tokio-socks                      0.5.3  a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615 \
     tokio-stream                    0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
     tokio-util                      0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
     toml                            0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
@@ -642,7 +640,7 @@ cargo.crates \
     toml_datetime                   0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
     toml_datetime         1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
     toml_edit                      0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
-    toml_edit           0.25.11+spec-1.1.0  0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
+    toml_edit           0.25.12+spec-1.1.0  d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7 \
     toml_parser           1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
     toml_write                       0.1.2  5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801 \
     toml_writer           1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
@@ -650,7 +648,7 @@ cargo.crates \
     tonic-prost                     0.14.6  50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0 \
     tor-geoip-db                0.1.0-pre2  5baacfe724d837c0da5558fe5e544b0c99181001606b9eb066e4fd98a9b77952 \
     tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
-    tower-http                      0.6.10  68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51 \
+    tower-http                      0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
@@ -659,7 +657,7 @@ cargo.crates \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
     tracing-journald                 0.3.2  2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0 \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
-    tracing-opentelemetry           0.32.1  1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc \
+    tracing-opentelemetry           0.33.0  adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26 \
     tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
     tracing-test                     0.2.6  19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051 \
     tracing-test-macro               0.2.6  ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d \
@@ -667,13 +665,13 @@ cargo.crates \
     trycmd                           1.2.0  218889993f76bda9b2ef57c12c3cab0eef4fd54ec7b36d1704849867f69e7bb4 \
     typed-index-collections          3.3.0  3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7 \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
-    typenum                         1.20.0  40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
-    typetag                         0.2.21  be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf \
-    typetag-impl                    0.2.21  27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846 \
+    typenum                         1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
+    typetag                         0.2.22  c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c \
+    typetag-impl                    0.2.22  cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5 \
     unarray                          0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
-    unicode-segmentation            1.13.2  9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c \
+    unicode-segmentation            1.13.3  c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8 \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     universal-hash                   0.6.1  f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
@@ -684,7 +682,7 @@ cargo.crates \
     utf8-zero                        0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
+    uuid                            1.23.2  d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7 \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     value-bag                       1.12.0  7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
@@ -699,16 +697,16 @@ cargo.crates \
     wasip2                1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
     wasip3  0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
     wasix                           0.13.1  1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332 \
-    wasm-bindgen                   0.2.121  49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790 \
-    wasm-bindgen-futures            0.4.71  96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8 \
-    wasm-bindgen-macro             0.2.121  8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578 \
-    wasm-bindgen-macro-support     0.2.121  d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2 \
-    wasm-bindgen-shared            0.2.121  c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441 \
+    wasm-bindgen                   0.2.122  3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409 \
+    wasm-bindgen-futures            0.4.72  9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f \
+    wasm-bindgen-macro             0.2.122  916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6 \
+    wasm-bindgen-macro-support     0.2.122  299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e \
+    wasm-bindgen-shared            0.2.122  9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437 \
     wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     weak-table                       0.3.2  323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549 \
-    web-sys                         0.3.98  4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa \
+    web-sys                         0.3.99  6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-root-certs                1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
     webpki-roots                     1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
@@ -761,7 +759,7 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
     winnow                          0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
-    winnow                           1.0.2  2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0 \
+    winnow                           1.0.3  0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
     wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
     wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
     wit-bindgen-core                0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
@@ -776,9 +774,9 @@ cargo.crates \
     xxhash-rust                     0.8.15  fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3 \
     yoke                             0.8.2  abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
     yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                        0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
-    zerocopy-derive                 0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
-    zerofrom                         0.1.7  69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df \
+    zerocopy                        0.8.50  3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1 \
+    zerocopy-derive                 0.8.50  0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639 \
+    zerofrom                         0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                          1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
     zeroize_derive                   1.4.3  85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e \


### PR DESCRIPTION
#### Description

https://blog.torproject.org/arti_2_5_0_released/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix