### PR TITLE
claude-code: update to 2.1.209

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.207
+version             2.1.209
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  edfab07065017a555164c6c5eca9ecc03d60633a \
-                 sha256  8a4355d251a60c90d8cf08f32fdb22a8157dd3d085542f95d0da0475f9a2c57c \
-                 size    249273680
+    checksums    rmd160  6d7ed00c18fcfceb95b4e9cb7906977767de6a80 \
+                 sha256  4cc3f44b905d45bd27a6db9306ec6de928aea758537205329851ae478f2fa2c6 \
+                 size    249886224
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  61441ebde2d0da8b92ab143a221d7794d993169f \
-                 sha256  1397a062c6889675055e3314dd956376ac51262a7734ad9e819c26975d71547a \
-                 size    241237136
+    checksums    rmd160  41813f07bb35ce7b86b5f6defef9f1c27ea29262 \
+                 sha256  59d2de7f49db2f75d5c33bbb46a6b8f288ad24d40b61e30602a502bb7ddc380c \
+                 size    240377264
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.209.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?