### PR TITLE
xcode-build-server: update to 1.3.0

### DIFF
--- a/devel/xcode-build-server/Portfile
+++ b/devel/xcode-build-server/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        SolaWing xcode-build-server 1.2.0 v
+github.setup        SolaWing xcode-build-server 1.3.0 v
 github.tarball_from archive
 revision            0
 platforms           {macosx any}
@@ -23,9 +23,9 @@ long_description    ${name} integrates Xcode with Apple's sourcekit-lsp. \
                     server to provide sourcekit-lsp with the build \
                     information it needs for an Xcode project.
 
-checksums           rmd160  c691dd2fc9c4a8010851038b47ea2e28f7321d3b \
-                    sha256  dc2a7019e00ff0d2b0d8c2761900395b39fb69543b9278285d2e85bd57382531 \
-                    size    21947
+checksums           rmd160  b5dfae46468edf61b8a00bb826005f62c65f2c46 \
+                    sha256  92c4bb848af5c8128d4600a93f45e49b89ed953d885c60092459303a5d80e312 \
+                    size    23291
 
 build {}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update xcode-build-server to version 1.3.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 27.0 26A5378j arm64
Xcode 27.0 27A5194q

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Note: I failed to run `sudo port -vst install` due to: https://trac.macports.org/ticket/60818.