### PR TITLE
pi-coding-agent: update to 0.80.7

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.80.6
+version             0.80.7
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  5b110e46a255c631a2325d56d474096ff8c63c97 \
-                    sha256  2a77634640b2d86d90d24087bb67559ecf2366e0fb52a42c55eed416147da411 \
-                    size    4868728
+checksums           rmd160  0e25cbe0b6d35e8cbe57b394ce83c93991180bd9 \
+                    sha256  c010db218d57d561765651bf42ec13adc22736693880b46cf1919b9bfc260ab3 \
+                    size    4877339
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
