### PR TITLE
opencode: update to 1.18.1

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.17.20
+version             1.18.1
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  90fe546f54e3f37fd17d4f6e81cd568663ad7455 \
-                    sha256  aaf91e431e00483022214d418ed83192a7c470984393bafab0c594cd1d44bcc0 \
-                    size    3047
+checksums           rmd160  d245fe67eb640310a3c00951198048445edbb989 \
+                    sha256  290b0ccfa63cfec793bdb123f6fd46ec38a8d19e33c202a3631810bc2f61170c \
+                    size    3042


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.1.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?