### PR TITLE
rust, rust-src: fix -Z build-std, enable build on macOS 27

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -44,7 +44,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 16} {
     revision                1
 }
 
-subport rust-src            {revision  1}
+subport rust-src            {revision  2}
 
 categories                  lang devel
 license                     {MIT Apache-2} BSD zlib NCSA Permissive
@@ -280,7 +280,6 @@ subport rust-src {
     description             Rust source code for the Rust programming language
     long_description        {*}${description} to trace `panic!` calls.
 
-    # even though this subport only installs source files, the directory structure depends on the architectures
     universal_variant       yes
 
     depends_build
@@ -290,24 +289,36 @@ subport rust-src {
     build                   {}
     test.run                no
 
+    # mirror https://github.com/rust-lang/rust/blob/main/src/bootstrap/src/core/build_steps/dist.rs
     destroot {
-        fs-traverse f "${worksrcpath} ${workpath}/.home/.cargo" {
-            # see RUSTC_DEBUGINFO_MAP
-            set fm          [string map "${workpath} ${destroot}${rust_source_dir}" ${f}]
-
-            if {[file isdirectory ${f}]} {
-                xinstall -d -m 0755 ${fm}
-            } elseif {[file extension ${f}] eq ".rs"} {
-                xinstall    -m 0644 ${f} ${fm}
-            }
+        set dst             "${destroot}${rust_source_dir}/rustc-${version}-src"
+        xinstall -d -m 0755 "${dst}/src/llvm-project"
+        copy "${worksrcpath}/library" "${dst}/library"
+        copy "${worksrcpath}/src/llvm-project/libunwind" "${dst}/src/llvm-project/libunwind"
+        if {${version} eq "1.78.0"} {
+            # rust-src used the root lockfile before library got its own
+            copy "${worksrcpath}/Cargo.lock" "${dst}/Cargo.lock"
         }
-        xinstall -d -m 0755 "${destroot}${prefix}/lib/rustlib"
-        file mkdir "${destroot}${prefix}/lib/rustlib/src/"
+        delete "${dst}/library/backtrace/crates" \
+               "${dst}/library/stdarch/Cargo.toml" \
+               "${dst}/library/stdarch/crates/stdarch-verify" \
+               "${dst}/library/stdarch/crates/intrinsic-test"
+        xinstall -d -m 0755 "${destroot}${prefix}/lib/rustlib/src"
         ln -s "../../../libexec/rust/src/rustc-${version}-src" "${destroot}${prefix}/lib/rustlib/src/rust"
     }
 
+    # skip crate distfiles and extraction
+    proc rust::handle_crates {} {
+        cargo.crates
+        cargo.crates_github
+        dist_subdir cargo-crates
+    }
     proc rust::rust_pg_callback {} {}
     proc rust::set_environment  {} {}
+    # keep only the source master site
+    proc rust_build::callback {} {
+        master_sites-append https://static.rust-lang.org/dist:apple_vendor
+    }
 }
 
 livecheck.type              regex

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -253,7 +253,7 @@ build.args                  BOOTSTRAP_ARGS="-j${build.jobs}"
 test.run                    yes
 test.target                 check
 
-rust::append_envs           RUST_BACKTRACE=full 
+rust::append_envs           RUST_BACKTRACE=full
 rust::append_envs           RUST_LOG="bootstrap::core::builder::trace"
 
 # lists of installed files, so they should include files from all architectures

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -149,6 +149,11 @@ if {${os.platform} eq "darwin" && ${os.major} > 16} {
 
 patchfiles-append           patch-offline_bootstrap.diff
 
+if { ${os.platform} eq "darwin" && ${os.major} >= 27 } {
+    # see https://github.com/rust-lang/rust/issues/157750
+    patchfiles-append       patch-fix_strtab_alignment.diff
+}
+
 if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     # follow LLVM
     # see https://github.com/llvm/llvm-project/blob/01f924d0e37a5deae51df0d77e10a15b63aa0c0f/clang/lib/Driver/ToolChains/Arch/X86.cpp#L79-L82

--- a/lang/rust/files/patch-fix_strtab_alignment.diff
+++ b/lang/rust/files/patch-fix_strtab_alignment.diff
@@ -1,0 +1,20 @@
+--- src/bootstrap/Cargo.toml
++++ src/bootstrap/Cargo.toml
+@@ -90,6 +90,7 @@
+ # dependencies, only bootstrap itself.
+ [profile.dev]
+ debug = 0
++strip = "none"
+ 
+ [profile.dev.package]
+ # Only use debuginfo=1 to further reduce compile times.
+--- src/llvm-project/llvm/lib/ObjCopy/MachO/MachOLayoutBuilder.cpp
++++ src/llvm-project/llvm/lib/ObjCopy/MachO/MachOLayoutBuilder.cpp
+@@ -283,6 +283,7 @@
+   uint64_t StartOfSymbols = updateOffset(NListSize * O.SymTable.Symbols.size());
+   uint64_t StartOfIndirectSymbols =
+       updateOffset(sizeof(uint32_t) * O.IndirectSymTable.Symbols.size());
++  Offset = alignTo(Offset, Is64Bit ? 8 : 4);
+   uint64_t StartOfSymbolStrings = updateOffset(StrTableBuilder.getSize());
+   uint64_t StartOfDylibCodeSignDRs = updateOffset(O.DylibCodeSignDRs.Data.size());
+ 


### PR DESCRIPTION
#### Description

- Update rust-src to install the same source set and layout as the upstream rust-src component:
  https://github.com/rust-lang/rust/blob/1.97.0/src/bootstrap/src/core/build_steps/dist.rs
  This allows the installed sources to be used by Cargo's experimental -Z build-std feature.
- Limit the rust-src callbacks to avoid fetching crate and bootstrap distfiles that are only needed when building the rust compiler.
- Fix Rust builds on macOS 27.
  Although macOS 27 is currently in beta, this allows Rust to build and run correctly on it.
  The complete upstream fix has landed in:
  - https://github.com/llvm/llvm-project/pull/203680
  - https://github.com/rust-lang/llvm-project/pull/198
  - https://github.com/rust-lang/rust/pull/158410

  The attached patch is a much smaller backport. I have used it locally for a month and verified that it works. The downstream patch can be removed once Rust 1.98.0 lands with the upstream fix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 27.0 26A5378n arm64
Xcode 27.0 27A5194q

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Note: I ran `sudo port -vs install` instead of `-vst` due to: https://trac.macports.org/ticket/60818.
Also: `sudo port test` fails due to: https://trac.macports.org/ticket/70016, I worked around the issue, and all test passed except for test: https://github.com/rust-lang/rust/blob/1.97.0/tests/ui/process/process-spawn-failure.rs that fails due to the sandbox.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
