### PR TITLE
google-cloud-sdk: update to 576.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             575.0.1
+version             576.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  d0d5075ff0e7d795bb45786721804b3f13a40068 \
-                    sha256  bd24ed83e7c5933c551cddbf47f333b8ace86809625fc64cc52ab4bc8f05aca3 \
-                    size    59528913
+    checksums       rmd160  205074cf0245f82989e812b60f02e2f68c8ab135 \
+                    sha256  59bfea027b9a9e614763bba1b154ce7d52720d0c2a7d9cf32245b9a5e7006835 \
+                    size    59631983
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  6138a270ea8b8c56b13d38a9e1cbacaaac08c9ec \
-                    sha256  f59f942bf79de62a2425c6cee90394fb13e4bdb50ea11aec68e3692b8d46ada5 \
-                    size    61185597
+    checksums       rmd160  75a3ff1ab5af7012a5af8197f2d8aeec11bc0cf8 \
+                    sha256  ce3f37637805f60e24e4648053354af041aac2407e63dd63b4b48193677da681 \
+                    size    61291475
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  7d1dfc9467a14b79f68204dca5ec78badb107f6e \
-                    sha256  616b4c88b8f0e068e8db56ab86329de48a7692aa8bb26cfb22a6199b6a027255 \
-                    size    61093561
+    checksums       rmd160  4b25dda6f0c3d3c3580e35aa64d25e280033b32f \
+                    sha256  307d0a7cf3a911d90df01c3d6cb09b79d6be5c4a8cb1590ce3debc7629f5ce2c \
+                    size    61202654
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 576.0.0.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?