### PR TITLE
cspice: fix pre-Xcode 15 (pre-macOS 14) build

### DIFF
--- a/science/cspice/files/patch-dylib.diff
+++ b/science/cspice/files/patch-dylib.diff
@@ -35,7 +35,7 @@ diff -ur makeall.csh makeall.csh
 +# libraries. Arrange for those links to link against libcspice.dylib instead.
 +rm ../lib/cspice.a ../lib/csupport.a
 +$TKCOMPILER -x c -c -o empty.o - < /dev/null
-+ar -cr ../lib/cspice.a empty.o
++ar -crs ../lib/cspice.a empty.o
 +rm empty.o
 +cp ../lib/cspice.a ../lib/csupport.a
 +setenv TKLINKOPTIONS "${TKLINKOPTIONS} -L../../lib -lcspice"


### PR DESCRIPTION
Before Xcode 15 (and equivalent macOS 14 developer tools), the `ar` tool did not normally write a table of contents (__.SYMDEF SORTED) to an archive (.a file) when there weren’t any global symbols to index. `ld` required the table of contents when reading any .a file. 33c831aeaf70 added a symbol-less (and thus TOC-less before Xcode 15) .a file to cspice’s build. This resulted in errors such as:

```
ld: archive has no table of contents file '../../lib/cspice.a' for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The table of contents can be produced by running `ranlib`, or by adding the `-s` option to `ar`.

This should fix the build for OS X 10.8 through macOS 13.

[Sample broken build from ports-13_x86_64-watcher](https://build.macports.org/builders/ports-13_x86_64-watcher/builds/45171).

---

This doesn’t fix Mac OS X 10.6–10.7, which are affected by a separate bug. I do know how to fix that, but it looks like it would have been broken for the previous version, N0066. Since nobody complained, I’m assuming that it’s not important to fix the bug for those very old systems.

[Sample broken build from ports-10.7_x86_64-watcher](https://build.macports.org/builders/ports-10.7_x86_64-watcher/builds/82625).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
