### PR TITLE
mp3rgain: update to 2.10.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.9.6 v
+github.setup        M-Igashi mp3rgain 2.10.0 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dc642c2af5a593f796d2274e2b8e0001ef274e71 \
-                    sha256  8c453bded2dfcb30487a218f291cbc5a70f9285a711df328855d12a2ec277bc0 \
-                    size    526011
+                    rmd160  af287651d78c7db5de8d3d2af574873f17742c03 \
+                    sha256  82562f9a15174c4afbf6beb445f680763c967e2961ac6de2ea6d83be4bf98d72 \
+                    size    528616
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
#### Description

Update mp3rgain to 2.10.0.

Upstream release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.10.0

- Version bump in `github.setup`, checksums (rmd160/sha256/size) recomputed for the new tag
- `cargo.crates` unchanged (no dependency changes since 2.9.6)
- `revision` stays 0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15, Apple Silicon (upstream CI builds and tests the same source on macOS)

###### Verification
- [x] all changed Portfiles are stylistically sound (4-space indents, no trailing whitespace)
- [x] checksums recomputed from the release tarball