### PR TITLE
py-Pillow: correct handling build args for x11 variant

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-Pillow
 version             12.3.0
-revision            0
+revision            1
 categories-append   devel
 license             BSD
 
@@ -39,21 +39,23 @@ if {${name} ne ${subport}} {
         distname            pillow-${version}
         patchfiles-append   patch-setup.py.diff patch-ImageQt.py.diff
 
-        build.args-append   -C raqm=disable \
-                            -C imagequant=disable \
-                            -C xcb=disable
+        build.args-append   -C imagequant=disable
 
         depends_build-append \
                             port:py${python.version}-pybind11
 
         variant raqm description {build with raqm feature} {
-            build.args-delete      -C raqm=disable
             depends_lib-append     port:libraqm
+        }
+        if {![variant_isset raqm]} {
+            build.args-append      -C raqm=disable
         }
 
         variant x11 {
-            build.args-delete      -C xcb=disable
             depends_lib-append     port:xorg-libxcb
+        }
+        if {![variant_isset x11]} {
+            build.args-append      -C xcb=disable
         }
     }
 

--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-Pillow
 version             12.3.0
-revision            1
+revision            0
 categories-append   devel
 license             BSD
 


### PR DESCRIPTION
#### Description

Closes https://trac.macports.org/ticket/74151

The py-Pillow portfile uses `build.args-delete` to delete two arguments (`-C xcb=disable`) from a list (`-C raqm=disable -C imagequant=disable -C xcb=disable`) for the x11 variant - except that it deletes `-C` from the start, and `xcb=disable` from the end, leaving the broken `raqm=disable -C imagequant=disable -C`.

This rearranges the variants to use `build.args-append` consistently instead.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
