### PR TITLE
ruby40: update to 4.0.6

### DIFF
--- a/lang/ruby40/Portfile
+++ b/lang/ruby40/Portfile
@@ -16,7 +16,7 @@ legacysupport.newest_darwin_requires_legacy 15
 # This property should be preserved.
 
 set ruby_ver        4.0
-set ruby_patch      5
+set ruby_patch      6
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
@@ -41,9 +41,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  32affbff17eb7cca396f675d0235054262de12b4 \
-                    sha256  7d6149079a63f8ae1d326c9fa65c6019ba2dc3155eae7b39159817911c88958e \
-                    size    23818557
+checksums           rmd160  ebd6039370c4afbb191a58ddf39821fcc9272a98 \
+                    sha256  837d299e8f7ddf2be31a229a7a7e019d354979825117989acb3b32b1a9be262a \
+                    size    23904779
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.
@@ -68,7 +68,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 
 # patch-sources.diff: fixes for various issues.
 #
-# This diff is from v4.0.5 vs. macports-4_0_5.
+# This diff is from v4.0.6 vs. macports-4_0_6.
 #
 patchfiles-append   patch-sources.diff
 
@@ -78,7 +78,7 @@ patchfiles-append   patch-sources.diff
 # At present, the only patched generated file is 'configure', to avoid
 # the need to rerun autoconf, whose output has reproducibility issues.
 #
-# This diff is from tarball-4_0_5 vs. macports-tarball-4_0_5.
+# This diff is from tarball-4_0_6 vs. macports-tarball-4_0_6.
 #
 patchfiles-append   patch-generated.diff
 

--- a/lang/ruby40/files/patch-generated.diff
+++ b/lang/ruby40/files/patch-generated.diff
@@ -1,5 +1,5 @@
---- configure.orig	2026-05-19 16:22:56.000000000 -0700
-+++ configure	2026-05-21 17:41:22.000000000 -0700
+--- configure.orig	2026-07-13 17:22:12.000000000 -0700
++++ configure	2026-07-15 13:28:32.000000000 -0700
 @@ -8524,7 +8524,8 @@ printf %s "checking for $CC linker warni
  	   >/dev/null
  then :

--- a/lang/ruby40/files/patch-sources.diff
+++ b/lang/ruby40/files/patch-sources.diff
@@ -1,5 +1,5 @@
---- configure.ac.orig	2026-05-19 16:22:54.000000000 -0700
-+++ configure.ac	2026-05-21 17:41:21.000000000 -0700
+--- configure.ac.orig	2026-07-13 17:22:10.000000000 -0700
++++ configure.ac	2026-07-15 13:28:31.000000000 -0700
 @@ -458,7 +458,8 @@ AS_CASE(["$build_os"],
  	      -e '^ld: warning: text-based stub file' \
  	      -e '^ld: warning: -multiply_defined is obsolete' \
@@ -22,8 +22,8 @@
  AC_OUTPUT
  }
  
---- file.c.orig	2026-05-19 16:22:54.000000000 -0700
-+++ file.c	2026-05-21 17:41:21.000000000 -0700
+--- file.c.orig	2026-07-13 17:22:10.000000000 -0700
++++ file.c	2026-07-15 13:28:31.000000000 -0700
 @@ -291,9 +291,27 @@ static CFMutableStringRef
  mutable_CFString_new(CFStringRef *s, const char *ptr, long len)
  {
@@ -52,8 +52,8 @@
      return CFStringCreateMutableCopy(alloc, len, *s);
  }
  
---- lib/bundler/gem_helper.rb.orig	2026-05-19 16:22:54.000000000 -0700
-+++ lib/bundler/gem_helper.rb	2026-05-21 17:41:21.000000000 -0700
+--- lib/bundler/gem_helper.rb.orig	2026-07-13 17:22:10.000000000 -0700
++++ lib/bundler/gem_helper.rb	2026-07-15 13:28:31.000000000 -0700
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -63,8 +63,8 @@
      end
    end
  end
---- template/Makefile.in.orig	2026-05-19 16:22:54.000000000 -0700
-+++ template/Makefile.in	2026-05-21 17:41:21.000000000 -0700
+--- template/Makefile.in.orig	2026-07-13 17:22:10.000000000 -0700
++++ template/Makefile.in	2026-07-15 13:28:31.000000000 -0700
 @@ -513,7 +513,7 @@ _PREFIXED_SYMBOL = TOKEN_PASTE($(SYMBOL_
  
  .d.h:
@@ -74,8 +74,8 @@
  	$(Q) sed -e 's/RUBY_/RUBY_DTRACE_/g' -e 's/PROBES_H_TMP/RUBY_PROBES_H/' -e 's/(char \*/(const char */g' -e 's/, char \*/, const char */g' $@.tmp > $@
  	$(Q) $(RM) $@.tmp
  
---- thread_pthread.c.orig	2026-05-19 16:22:54.000000000 -0700
-+++ thread_pthread.c	2026-05-21 17:41:21.000000000 -0700
+--- thread_pthread.c.orig	2026-07-13 17:22:10.000000000 -0700
++++ thread_pthread.c	2026-07-15 13:28:31.000000000 -0700
 @@ -42,6 +42,22 @@
  
  #if defined __APPLE__
@@ -99,9 +99,9 @@
  #endif
  
  #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
---- vm_dump.c.orig	2026-05-19 16:22:54.000000000 -0700
-+++ vm_dump.c	2026-05-21 17:41:21.000000000 -0700
-@@ -793,7 +793,7 @@ backtrace(void **trace, int size)
+--- vm_dump.c.orig	2026-07-13 17:22:10.000000000 -0700
++++ vm_dump.c	2026-07-15 13:28:31.000000000 -0700
+@@ -796,7 +796,7 @@ backtrace(void **trace, int size)
  
      unw_getcontext(&uc);
      unw_init_local(&cursor, &uc);
@@ -110,7 +110,7 @@
      while (unw_step(&cursor) > 0) {
          unw_get_reg(&cursor, UNW_REG_IP, &ip);
          trace[n++] = (void *)ip;
-@@ -808,6 +808,7 @@ backtrace(void **trace, int size)
+@@ -811,6 +811,7 @@ backtrace(void **trace, int size)
      return n;
  darwin_sigtramp:
      /* darwin's bundled libunwind doesn't support signal trampoline */
@@ -118,7 +118,7 @@
      {
          ucontext_t *uctx;
          char vec[1];
-@@ -877,6 +878,8 @@ darwin_sigtramp:
+@@ -880,6 +881,8 @@ darwin_sigtramp:
          unw_get_reg(&cursor, UNW_REG_IP, &ip);
          trace[n++] = (void *)ip;
      }


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2026/07/14/ruby-4-0-6-released/

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-26.x arm64.  Included all variants compatible with available dependencies on the respective platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.7 23J520, arm64, Xcode 16.2 16C5032a
macOS 15.7.7 24G720, arm64, Xcode 26.3 17C529
macOS 26.5.2 25F84, arm64, Xcode 26.6 17F113
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
