### PR TITLE
opkssh: update to 0.16.0

### DIFF
--- a/net/opkssh/Portfile
+++ b/net/opkssh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/openpubkey/opkssh 0.15.0 v
+go.setup            github.com/openpubkey/opkssh 0.16.0 v
 revision            0
 categories          net security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -15,9 +15,9 @@ long_description    {*}${description}
 build.args-append   -ldflags \" -X main.Version=${version} \"
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  1867df7021016dcd7362888cf5b77d828c1e938e \
-                        sha256  036287cf27ce2baa3715fe917e2d6b300a499ee8766c1895bfb708690162502c \
-                        size    3129209
+                        rmd160  5b7c383d45f7e7b6e1459eaefbb6b3b7e2490d26 \
+                        sha256  b7c326b24d6fe97056d459f2d5ef7eafb25890b70279537746a368467fe2dc3b \
+                        size    3129764
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -227,10 +227,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
                     github.com/openpubkey/openpubkey \
-                        lock    v0.23.0 \
-                        rmd160  fb01f3ae3f0738539083f9f662c854803267f4d8 \
-                        sha256  46f82e7e6c1bfb6b59bf1468c016f845312733c20a6fc5bb14cfaed5cb21be80 \
-                        size    194804 \
+                        lock    v0.25.0 \
+                        rmd160  12de3b5453b5f9f0c33a09ca140b44d06bf8c357 \
+                        sha256  ffbe3814eb132dfc89488e58143eca499bcd1a8353e81aeceed7c8085fcd439e \
+                        size    199436 \
                     github.com/opencontainers/image-spec \
                         lock    v1.1.1 \
                         rmd160  9d1f2f7143d6e5d700f21c083ec5b82171bf4e48 \
@@ -407,15 +407,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  71c00041c33e2cb2361ef4d4ac2a50e6f8f8da5c2e50a7a5938f2e6a2fa1b227 \
                         size    57472 \
                     github.com/go-jose/go-jose/v4 \
-                        lock    v4.0.5 \
-                        rmd160  2a6ecc7134a1bfa9e78e7690a3644eabd30aaef4 \
-                        sha256  0c556ed030776c6dbe37c82f30b14a5950a1f68d2c829d98d38e103d47555c3f \
-                        size    319081 \
+                        lock    v4.1.4 \
+                        rmd160  529856437450ef55edb66f48b2a8c03e4f625985 \
+                        sha256  8446d67b193501db2078d8127833a6c01fb100384d4993f22f322fb794b192d7 \
+                        size    322467 \
                     github.com/go-chi/chi/v5 \
-                        lock    v5.2.2 \
-                        rmd160  f38088a31a9baa4085a848e085ce05a5fbbfea2c \
-                        sha256  0e046b7c10eabb6ec5a3314c6e362526616086681f0bcaf94d3fcab3a1b2dd5e \
-                        size    86884 \
+                        lock    v5.2.4 \
+                        rmd160  8f6e66c2992fce5f0d76de9a176de565c1a8924f \
+                        sha256  611237316198c79eb551dc208da63bd043fc9b98252b1b461f66cfe823cbedbd \
+                        size    88272 \
                     github.com/felixge/httpsnoop \
                         lock    v1.0.4 \
                         rmd160  1d362d3a3cbafe1cfb75642a476e46ca8249231f \


### PR DESCRIPTION
#### Description
https://github.com/openpubkey/opkssh/releases/tag/v0.16.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
