### PR TITLE
lagrange: update to 1.20.9

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           codeberg 1.0
 
-codeberg.setup      skyjake lagrange 1.20.8 v
+codeberg.setup      skyjake lagrange 1.20.9 v
 revision            0
 categories          net gemini
 license             BSD
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  824e3681b56b359c41bd3dbf211205be5941397d \
-                    sha256  cea13ea2e1266f23e59fbb2913448b79b7d20dbe47f9d8a8561d50a55535f7d9 \
-                    size    9802967
+checksums           rmd160  468ff5baff2cf19bd2a21647293e5ba5072fbf5b \
+                    sha256  a12fd4d3a5f6cc4aa1d2a0c5012295bbe0b1abaaa5c889a35673b0d63a25bcee \
+                    size    9816056
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://codeberg.org/skyjake/lagrange/releases/tag/v1.20.9

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
