### PR TITLE
GPXSee: update to 16.11

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake6 1.0
 
-github.setup        tumic0 GPXSee 16.10
+github.setup        tumic0 GPXSee 16.11
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  f72027bdd0d7cce14d929f9285147ab9b2297285 \
-                    sha256  a99740cfab36d60a944b9938aa71eae0a0427407f75d617709df88179d1d06d8 \
-                    size    6481438
+checksums           rmd160  8888ef158aab30e5009aed6c398c620ceb3ccd07 \
+                    sha256  1542387d670d870829e1d52d66f7ea3ac6628a05fcaa39a78963ab7a18ebc70b \
+                    size    6481773
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
