### PR TITLE
micronaut: update to 5.0.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.0.4 v
+github.setup    micronaut-projects micronaut-starter 5.0.5 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  f02b755ff6c160e4b6eb22ac5fca6dbe6532502c \
-                 sha256  870ee56c31a92724ba8a205a865f6910feecaea9438391aa4c735abf9707b9f5 \
-                 size    33762076
+    checksums    rmd160  4102b5a479dc2905e3b6ab38d6d0484d39e54939 \
+                 sha256  ea640a2794e0c6eb17e8ad96ccf963c96a9fc490b27fbfc95fbee165ca8e67ee \
+                 size    33756005
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  33ca1b589928f8912cff74beed5e75b6eae738bd \
-                 sha256  10efa570b9cf3168cb91d370eebab345c2f84feb6d978813b118968acbaabcd0 \
-                 size    38826958
+    checksums    rmd160  37a3fa60e45a6a1eef946673c82d850a7ea0060b \
+                 sha256  88af16e2f4e77e9d39e46cd46c4335860f263cef93dbe40b8375b33b0ec6977f \
+                 size    38772844
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.0.5.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?