### PR TITLE
claude-code: update to 2.1.211

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.210
+version             2.1.211
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  871cd50d391028c04668b22847fcd72b2688c2bd \
-                 sha256  892f2c878050d8829e67119328dd9768345fba18a58c169212b70597c9175c40 \
-                 size    251025552
+    checksums    rmd160  3a53ab7d41510230616230f42656e259606b8873 \
+                 sha256  33049eb14cf4702b992b7eda41ec077fc6e76539f7fd046e6d32538757235da4 \
+                 size    251966736
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  8795c5c74ed5285bb2ddb45f8b6f981e933c6c92 \
-                 sha256  1b471d62d1117482689d75447f5e050c640da717a5a3c91e6c13792450f8c662 \
-                 size    241509968
+    checksums    rmd160  568d30d9d3b945193fed48e679343261a6dcab2f \
+                 sha256  5a728a76198b6eca7f3c7cdbff43bab44b77b48c2108f7a3107d889773382629 \
+                 size    242445680
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.211.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?