### PR TITLE
libheif: Update to 1.23.1

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -25,28 +25,16 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
         # On 10.6 a failure happens during the linking phase
         # even with the latest compatible version of ld.
         set which_version "1.18"
-    } elseif {${os.major} < 19} {
-        # Fall back to last release not using std::ranges.
-        set which_version "1.22"
     }
 }
 
 if {${which_version} eq "latest"} {
-    github.setup            strukturag libheif 1.23.0 v
+    github.setup            strukturag libheif 1.23.1 v
     revision                0
 
-    checksums               rmd160  a2690fbe15adefc6b6826e2842f8347d97ade4cb \
-                            sha256  4c9182b18897617182eed12ab5eb9f9d855b3aa3a736d6bdb31abc034ec7d393 \
-                            size    2064049
-
-    compiler.cxx_standard   2020
-} elseif {${which_version} eq "1.22"} {
-    github.setup            strukturag libheif 1.22.2 v
-    revision                0
-
-    checksums               rmd160  b6306bd92e1951af0859a8e8ccef14674e16be04 \
-                            sha256  eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3 \
-                            size    2049684
+    checksums               rmd160  52f1ade573cd8c3137d06e09a0019462d4481193 \
+                            sha256  0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a \
+                            size    2071186
 
     compiler.cxx_standard   2020
 } else {


### PR DESCRIPTION
#### Description

* Update libheif 1.23.0 --> 1.23.1.
* Avoid "ranges" error on macOS <= 10.14, because upstream graciously removed "ranges" for compatibility with older compilers.
* Remove the pinned libheif version for macOS 10.7 - 10.14, this is no longer needed because of that upstream change.

###### Type(s)

###### Tested on

* CI only.
* Devel version @ 1.23.1 passed testing on all builders 10.6 through Tahoe 26:
* https://ports.macports.org/port/libheif-devel/details/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?