### PR TITLE
osm2pgsql: update to 2.3.1

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           boost 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        osm2pgsql-dev osm2pgsql 2.3.0
+github.setup        osm2pgsql-dev osm2pgsql 2.3.1
 revision            0
 github.tarball_from archive
 
@@ -22,9 +22,9 @@ license             GPL-2+
 
 homepage            https://osm2pgsql.org
 
-checksums           rmd160  61749fa43a42a2f5ef00d328026433a58bd281c4 \
-                    sha256  334c19fd58140e48216ec842fd63d7a978c7a2aea034858c2a62f32ad9e94c06 \
-                    size    2854813
+checksums           rmd160  0e77688854c587e4d0abe6d0ee1c158230cb5a94 \
+                    sha256  e90461bd78787fd5cf82f73ac4bc0cfccbc4f498f35dce59eb4d168a380d6ac0 \
+                    size    2855093
 
 # It uses include variant
 compiler.cxx_standard 2017


### PR DESCRIPTION
#### Description
https://github.com/osm2pgsql-dev/osm2pgsql/releases/tag/2.3.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
