### PR TITLE
mise: Update to 2026.7.8

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.7.5 v
+github.setup        jdx mise 2026.7.8 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8a03d3db5795de0335109f4539619e0aaeb13cf7 \
-                    sha256  51a980970caad3f7db89135ded8a6e91d8c95eeec02b6204d29404580373b9db \
-                    size    12408881
+                    rmd160  93b8ad4ec245eb931fa9a6dd469c33bd103fd4cf \
+                    sha256  e4b2c02406c55bd0fca9544dc45960532ec8d462777135e392dec981d8396cbd \
+                    size    12495180
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -86,6 +86,7 @@ cargo.crates \
     addr2line                           0.25.1  1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b \
     adler2                               2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
     aead                                 0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
+    aead                                 0.6.1  1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99 \
     aes                                  0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
     aes                                  0.9.1  f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138 \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
@@ -197,6 +198,7 @@ cargo.crates \
     chacha20                             0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
     chacha20                            0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
     chacha20poly1305                    0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
+    chacha20poly1305                    0.11.0  9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb \
     chrono                              0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     chrono-tz                            0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                      0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
@@ -276,7 +278,7 @@ cargo.crates \
     defmt                                1.1.1  e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1 \
     defmt-macros                         1.1.1  bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8 \
     defmt-parser                         1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
-    demand                               2.0.2  9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad \
+    demand                               2.0.3  c96e17936c1a2340dde9999f89a2f749020a3dd3f8bcf5c321741047b15ca024 \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
     deranged                             0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
@@ -340,6 +342,7 @@ cargo.crates \
     foreign-types                        0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared                 0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                      1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
+    formatx                              0.3.0  c40f9ee993b100102723f778c82d3daf1808c494ce2fd6e9a06d58d6e8e59748 \
     fs-err                               3.3.1  b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a \
     fs4                                 0.13.1  8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4 \
     fs_extra                             1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
@@ -497,6 +500,7 @@ cargo.crates \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itertools                           0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+    jdx-tar                              1.1.0  ea172082e0f86db95eb1eb387cf802b02749322e79219378e59ca390dd0cd284 \
     jiff                                0.2.31  ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634 \
     jiff-static                         0.2.31  e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2 \
     jiff-tzdb                            0.1.7  6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590 \
@@ -615,13 +619,13 @@ cargo.crates \
     pest_meta                            2.8.7  f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210 \
     petgraph                             0.8.3  8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455 \
     phf                                 0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
-    phf                                 0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
+    phf                                 0.14.0  010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6 \
     phf_codegen                         0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
-    phf_codegen                         0.13.1  49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1 \
+    phf_codegen                         0.14.0  41b585a510fb76fdebead6897982ef2a03a21d8e6cbcca904999742a4afc6ffe \
     phf_generator                       0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
-    phf_generator                       0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
+    phf_generator                       0.14.0  aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100 \
     phf_shared                          0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
-    phf_shared                          0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
+    phf_shared                          0.14.0  c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89 \
     pin-project                         1.1.13  2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924 \
     pin-project-internal                1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
     pin-project-lite                    0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
@@ -632,6 +636,7 @@ cargo.crates \
     platforms                           3.12.0  9245c6e7c5a6bcdd7977fdf6d1e1c67f4cc2d0d58c041df0ea5940953033e6ca \
     plist                               1.10.0  7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85 \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
+    poly1305                             0.9.1  6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c \
     polyval                              0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
     portable-atomic                     1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
     portable-atomic-util                 0.2.7  c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618 \
@@ -705,8 +710,8 @@ cargo.crates \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rkyv                                0.8.17  815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874 \
     rkyv_derive                         0.8.17  c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c \
-    rmcp                                 1.8.0  1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59 \
-    rmcp-macros                          1.8.0  1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5 \
+    rmcp                                 2.2.0  14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af \
+    rmcp-macros                          2.2.0  783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
@@ -840,6 +845,7 @@ cargo.crates \
     tempfile                            3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     tera                                1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
     tera                                 2.0.0  38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c \
+    tera-contrib                         0.2.0  a3792553c620406661d510095e5885bfb77b2296db30369bcc8308329a6fe78c \
     termcolor                            1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                        0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
     test-log                            0.2.21  9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1 \
@@ -908,6 +914,7 @@ cargo.crates \
     unicode-xid                          0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     unit-prefix                          0.5.2  81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3 \
     universal-hash                       0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
+    universal-hash                       0.6.1  f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96 \
     unsafe-libyaml                      0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                            0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
     untrusted                            0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
@@ -915,7 +922,7 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.5.3  51ff6c8c25dd3850cf7dd48aa2802c0eb40243d842299c577d1f6c5217b6559b \
+    usage-lib                            3.5.4  80738ec537e63ca00453a217231683a2cc52e8c07a802ff96c1bf28ec42eac99 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -965,7 +972,6 @@ cargo.crates \
     windows-numerics                     0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-numerics                     0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
     windows-registry                     0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
-    windows-registry                     0.6.1  02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
     windows-result                       0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                       0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                      0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \


### PR DESCRIPTION
#### Description

mise: Update to 2026.7.8


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
