### PR TITLE
ruby-build: Update to 20260716

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260701 v
+github.setup        rbenv ruby-build 20260716 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  1e4f1e4f8b655936ac4edf36edca11f3e1f866b0 \
-                    sha256  68d109c22559a7fcd87255f3f22baae24e201bce89bc3f883f24e4f33f59595b \
-                    size    103318
+checksums           rmd160  530eebb0788aae915a330964d78ef2795a49bf18 \
+                    sha256  591d0cd20f1c4b335dbe1257037e74385002a788f9bf0a3dec034bbc2108be84 \
+                    size    103395
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260716


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
