### PR TITLE
zizmor: Update to 1.27.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.26.1 v
+github.setup        zizmorcore zizmor 1.27.0 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 livecheck.regex     {v(\d+\.\d+\.\d+)}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  0ef6a71e83764c9729153c2767e52bc049604f62 \
-                    sha256  ec5540b3bd6d347df61dcd24ecd2eaffd3181808f4dafc59a9c889e26b075eb8 \
-                    size    693285
+                    rmd160  16b60ca1e86295a40f29a1ba1ba2a4dd2933b1ec \
+                    sha256  2ef4347065e91b9a07c337d7161085b494866b5239605440b457cdcda4318136 \
+                    size    706463
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -43,7 +43,7 @@ cargo.crates \
     anstyle-parse                                                           1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                                                           1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
     anstyle-wincon                                                         3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
-    anyhow                                                                1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    anyhow                                                                1.0.103  2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
     arrayvec                                                                0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                                                              2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
     async-lock                                                              3.4.1  5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc \
@@ -66,7 +66,7 @@ cargo.crates \
     bytecount                                                               0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     bytes                                                                  1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
     cacache                                                                13.1.0  5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b \
-    camino                                                                  1.2.2  e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48 \
+    camino                                                                  1.2.4  5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0 \
     cc                                                                     1.2.49  90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215 \
     cesu8                                                                   1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                                                                  1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
@@ -74,7 +74,7 @@ cargo.crates \
     clap                                                                    4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-verbosity-flag                                                     3.0.4  9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394 \
     clap_builder                                                            4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_complete                                                           4.6.5  e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772 \
+    clap_complete                                                           4.6.7  db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b \
     clap_complete_nushell                                                   4.6.0  fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897 \
     clap_derive                                                             4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                                                                1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
@@ -83,7 +83,7 @@ cargo.crates \
     colorchoice                                                             1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     combine                                                                 4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
     concurrent-queue                                                        2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
-    console                                                                0.16.1  b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4 \
+    console                                                                0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     core-foundation                                                         0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation                                                        0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys                                                     0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
@@ -104,7 +104,7 @@ cargo.crates \
     displaydoc                                                              0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     dunce                                                                   1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                                                              1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
-    either                                                                 1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    either                                                                 1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
     email_address                                                           0.2.9  e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449 \
     embedded-io                                                             0.4.0  ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced \
     embedded-io                                                             0.6.1  edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d \
@@ -174,21 +174,22 @@ cargo.crates \
     id-arena                                                                2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     idna                                                                    1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                                                            1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
-    ignore                                                                 0.4.26  b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d \
+    ignore                                                                 0.4.28  2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7 \
     indexmap                                                               2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
-    indicatif                                                              0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
-    insta                                                                  1.47.2  7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e \
+    indicatif                                                              0.18.6  9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
+    insta                                                                  1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
     ipnet                                                                  2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
     iri-string                                                              0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
     is_terminal_polyfill                                                   1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
-    itertools                                                              0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
     itertools                                                              0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itertools                                                              0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                                                   1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     jni                                                                    0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
     jni-sys                                                                 0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                                                              0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     js-sys                                                                 0.3.85  8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3 \
-    jsonschema                                                             0.46.5  6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631 \
+    jsonschema                                                            0.46.10  f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05 \
+    jsonschema-regex                                                      0.46.10  6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13 \
     lazy_static                                                             1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                                                               0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libc                                                                  0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
@@ -259,11 +260,11 @@ cargo.crates \
     redox_syscall                                                          0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     ref-cast                                                               1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                                                          1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    referencing                                                            0.46.5  69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2 \
+    referencing                                                           0.46.10  0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d \
     reflink-copy                                                           0.1.28  23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92 \
-    regex                                                                  1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex                                                                  1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
     regex-automata                                                         0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
-    regex-syntax                                                            0.8.8  7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58 \
+    regex-syntax                                                           0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     reqwest                                                                0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     reqwest-middleware                                                      0.5.2  07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58 \
     ring                                                                  0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
@@ -354,14 +355,14 @@ cargo.crates \
     tracing-indicatif                                                      0.3.14  e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e \
     tracing-log                                                             0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                                                     0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
-    tree-sitter                                                            0.26.9  4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3 \
+    tree-sitter                                                           0.26.10  3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55 \
     tree-sitter-bash                                                       0.25.1  9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062 \
     tree-sitter-language                                                    0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
     tree-sitter-powershell                                                 0.26.4  3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022 \
     tree-sitter-yaml                                                        0.7.2  53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97 \
     try-lock                                                                0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typenum                                                                1.19.0  562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb \
-    typomania                                                               0.1.2  38f8c4efb88486b445b83759c6589b97a0fe4cf82bd36be336c164b49af13bef \
+    typomania                                                               0.2.0  d38affe9145e7241f8ae34880cd791b6a63676d30a53d8084db4774dff7e7840 \
     unicode-general-category                                                1.1.0  0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f \
     unicode-ident                                                          1.0.20  462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06 \
     unicode-width                                                          0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.27.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
