### PR TITLE
cyclonedds: update to 11.0.1

### DIFF
--- a/devel/cyclonedds/Portfile
+++ b/devel/cyclonedds/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # _strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        eclipse-cyclonedds cyclonedds 0.10.5
+github.setup        eclipse-cyclonedds cyclonedds 11.0.1
 github.tarball_from archive
 revision            0
 categories          devel
@@ -20,9 +20,9 @@ description         Eclipse Cyclone DDS project
 long_description    {*}${description}
 homepage            https://cyclonedds.io/
 
-checksums           rmd160  f8ae32da57f51de102662bf77efcd161b1474f98 \
-                    sha256  ec3ec898c52b02f939a969cd1a276e219420e5e8419b21cea276db35b4821848 \
-                    size    6982715
+checksums           rmd160  b53ecd39394ce59fb230070c70a6744cd7e3b49c \
+                    sha256  c25d46075ad6b5cee564bda9e5f49509e9a6dbb1a8b858e708eb360d335cf973 \
+                    size    7972646
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 


### PR DESCRIPTION
#### Description
https://github.com/eclipse-cyclonedds/cyclonedds/releases/tag/11.0.0
https://github.com/eclipse-cyclonedds/cyclonedds/releases/tag/11.0.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
