### PR TITLE
nanomq: update to 0.25.5

### DIFF
--- a/net/nanomq/Portfile
+++ b/net/nanomq/Portfile
@@ -4,7 +4,7 @@ PortSystem             1.0
 PortGroup              github 1.0
 PortGroup              cmake 1.1
 
-github.setup           emqx nanomq 0.24.6
+github.setup           nanomq nanomq 0.25.5
 revision               0
 categories             net
 license                MIT


### PR DESCRIPTION
#### Description
https://github.com/nanomq/nanomq/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
