### PR TITLE
claude-code: update to 2.1.212

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.211
+version             2.1.212
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  3a53ab7d41510230616230f42656e259606b8873 \
-                 sha256  33049eb14cf4702b992b7eda41ec077fc6e76539f7fd046e6d32538757235da4 \
-                 size    251966736
+    checksums    rmd160  73703e247b84efc613bbf24b2ade6cc2c05a02f7 \
+                 sha256  7681a0634c89fa4474e53c0c794e992944aebf3409a7a2b87ea9f9b0194ea341 \
+                 size    254080272
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  568d30d9d3b945193fed48e679343261a6dcab2f \
-                 sha256  5a728a76198b6eca7f3c7cdbff43bab44b77b48c2108f7a3107d889773382629 \
-                 size    242445680
+    checksums    rmd160  9fb7d6fbe39c4e5072e8f990b1dfbe938e6f5d1c \
+                 sha256  09ecba2ab2df9b6ee5b0695e26f65dea60fb3b6af3d3542ee09f466838d1e574 \
+                 size    244530512
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.212.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?