### PR TITLE
pi-coding-agent: update to 0.80.10

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.80.7
+version             0.80.10
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  0e25cbe0b6d35e8cbe57b394ce83c93991180bd9 \
-                    sha256  c010db218d57d561765651bf42ec13adc22736693880b46cf1919b9bfc260ab3 \
-                    size    4877339
+checksums           rmd160  61d97cc66f57d0924b127ea11c6977abb3178573 \
+                    sha256  9f2771711b8d4ebb8d59e3177026ab417bfc6caf0d4296a58de741b41e4d9c1c \
+                    size    4899008
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
