### PR TITLE
libpsl: update to 0.23.0

### DIFF
--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -5,10 +5,7 @@ PortGroup           github 1.0
 PortGroup           clang_dependency 1.0
 
 epoch               1
-github.setup        rockdaboot libpsl 0.22.0
-# When increasing the version or revision please check
-# that psl_data_commit and psl_data_date refer to latest
-# https://github.com/publicsuffix/list git master commit
+github.setup        rockdaboot libpsl 0.23.0
 
 license             MIT
 description         A C library and utility to handle the Public Suffix List
@@ -17,30 +14,10 @@ maintainers         nomaintainer
 categories          net
 
 github.tarball_from releases
-set main_distfile   ${distfiles}
 
-set psl_data_commit     18ecca5d54471f21918798da451dd8d03a18f3c7
-set psl_data_date       20260624
-set psl_data_worksrcdir list-${psl_data_commit}
-set psl_data_distname   publicsuffix-list-[string range ${psl_data_commit} 0 6]
-set psl_data_distfile   ${psl_data_distname}${extract.suffix}
-
-version             ${version}-${psl_data_date}
-
-distfiles           ${main_distfile}:main \
-                    ${psl_data_distfile}:list
-
-master_sites        ${github.master_sites}:main \
-                    https://github.com/publicsuffix/list/archive/${psl_data_commit}:list
-
-checksums           ${main_distfile} \
-                    rmd160  486716c479891ae0446521b3abed3c9ac91f5141 \
-                    sha256  c45c3aa17576b99873e05a9b09a44041b065bbfa390e6d474d06fbfaeb9c7722 \
-                    size    7745227 \
-                    ${psl_data_distfile} \
-                    rmd160  0f7b867ed1f00aba43a30602bb9e654c1e9db0ff \
-                    sha256  5fa1d3f28c224ba2e2470717a44e318d25b24d897d7f7f50cc70a7156dbe4a29 \
-                    size    302617
+checksums           rmd160  19a8f10cbd6ec309aa1bc3b0fda249a2acf43862 \
+                    sha256  f39b9631b3d369a21259ea4654f8875c0ec6995ce9551c0eb5d423e4c011f911 \
+                    size    7822832
 
 # Please note this port is (indirectly, via cmake) a dependency of the
 # various clang-X ports. When updating the port versions
@@ -57,12 +34,6 @@ depends_lib-append  \
                     port:libiconv \
                     port:libidn2 \
                     port:libunistring
-
-post-extract {
-    # Replace older bundled publicsuffix list.
-    delete ${worksrcpath}/list
-    move ${workpath}/${psl_data_worksrcdir} ${worksrcpath}/list
-}
 
 configure.args      --enable-builtin \
                     --enable-runtime=libidn2 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update libpsl to 0.23.0.

This also removes the separate Public Suffix List (`psl_data_*`) bundling. The port only used that list to regenerate the built-in DAFSA (`suffixes_dafsa.h`), which needs python at build time (removed in #70998), and the list itself is never installed. Without python the regeneration cannot run, so the bundled list had no effect on the built package. libpsl already ships a pre-generated `suffixes_dafsa.h` in its release tarball, so the built-in PSL now comes from the release itself.

Recreated from #33582 (closed).


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
