### PR TITLE
packwiz: update to 20260211

### DIFF
--- a/games/packwiz/Portfile
+++ b/games/packwiz/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/packwiz/packwiz 52b123018f9e19b49703f76e78ad415642acf5c5
+go.setup            github.com/packwiz/packwiz dfd8b68a4796c763e25bad50265ea1f1233e24f1
 go.offline_build    no
 
-version             20251124
+version             20260211
 maintainers         {johnlindop.com:git @JLindop} openmaintainer
 revision            0
 
@@ -21,9 +21,9 @@ categories          games
 license             MIT
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  9bc23bdd6b604cf52aea12538ac1c686ea5004e1 \
-                        sha256  f800ae8301ed894c80e9b0eb55994791857e5490a27e43828a773afd7c1b6afa \
-                        size    76913
+                        rmd160  6340a970f7110ed2fc5882be7eb6fab314644bc6 \
+                        sha256  6f4df7081d8122c89635eb6946b68d76b38ca4bd948dd3fbb1fc0f3fd08c753c \
+                        size    83329
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Update packwiz
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.8 24G817 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
