### PR TITLE
espanso: new port, version 2.3.0

### DIFF
--- a/aqua/espanso/Portfile
+++ b/aqua/espanso/Portfile
@@ -1,0 +1,533 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo 1.0
+PortGroup           github 1.0
+
+github.setup        espanso espanso 2.3.0 v
+github.tarball_from archive
+revision            0
+
+categories          aqua sysutils
+installs_libs       no
+license             GPL-3+
+maintainers         {acm.org:cardi @cardi} \
+                    openmaintainer
+
+description         Privacy-first text expander written in Rust
+long_description    espanso is a privacy-first, cross-platform text \
+                    expander. It detects when you type a keyword and \
+                    replaces it while you are typing, with support for \
+                    custom scripts, shell commands, forms, emoji, \
+                    images, and installable packages from the espanso \
+                    hub.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  177be4a4bf3c3835f91232d25d696f082c55522d \
+                    sha256  32b315a813114b28ef3ee74c5d2ce0bfc2f75a0bd9a4141c7465cd0b00fdf34c \
+                    size    71749236
+
+homepage            https://espanso.org
+
+# espanso-modulo builds a vendored copy of wxWidgets
+# (espanso-modulo/vendor/wxWidgets-*.zip) during the cargo build.
+
+set app_name        Espanso.app
+set app_contents    ${applications_dir}/${app_name}/Contents
+set app_resources   ${worksrcpath}/espanso/src/res/macos
+set target_dir      target/[cargo.rust_platform]/release
+
+destroot {
+    set contents ${destroot}${app_contents}
+    xinstall -d ${contents}/MacOS ${contents}/Resources
+
+    xinstall -m 0755 ${worksrcpath}/${target_dir}/${name} ${contents}/MacOS/${name}
+
+    xinstall -m 0644 ${app_resources}/Info.plist ${contents}/Info.plist
+    reinplace "s|VERSION|${version}|g" ${contents}/Info.plist
+
+    xinstall -m 0644 ${app_resources}/icon.icns ${contents}/Resources/icon.icns
+
+    set fd [open ${contents}/PkgInfo w]
+    puts -nonewline ${fd} "APPL????"
+    close ${fd}
+
+    ln -s ${app_contents}/MacOS/${name} ${destroot}${prefix}/bin/${name}
+}
+
+notes "
+To start using ${name}:
+
+  1. Register the launchd service:  ${name} service register
+  2. Start it:                      ${name} start
+  3. Grant Accessibility permissions to ${app_name} when prompted
+    (System Settings -> Privacy & Security -> Accessibility)
+
+Before uninstalling ${name}, stop and unregister the launchd service:
+
+  ${name} stop
+  ${name} service unregister
+"
+
+# `espanso service register` installs a per-user LaunchAgent that MacPorts
+# cannot remove, so warn on deactivation.
+pre-deactivate {
+    ui_warn "If you registered the ${name} service, unregister it with\
+        '${name} service unregister' before deactivating, or remove\
+        ~/Library/LaunchAgents/com.federicoterzi.espanso.plist afterwards\
+        (repeat for every user that ran '${name} service register')."
+}
+
+cargo.crates \
+    adler                                    1.0.2                f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    aho-corasick                             0.7.19               b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e \
+    android-tzdata                           0.1.1                e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
+    android_system_properties                0.1.5                819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    anyhow                                   1.0.38               afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1 \
+    arrayref                                 0.3.6                a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                                 0.5.2                23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    async-broadcast                          0.7.2                435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532 \
+    async-channel                            2.5.0                924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2 \
+    async-executor                           1.11.0               b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a \
+    async-io                                 2.5.0                19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca \
+    async-lock                               3.4.0                ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
+    async-process                            2.4.0                65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00 \
+    async-recursion                          1.1.1                3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
+    async-signal                             0.2.12               f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1 \
+    async-task                               4.7.1                8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
+    async-trait                              0.1.88               e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
+    atomic-waker                             1.1.2                1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
+    atty                                     0.2.14               d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                                  1.1.0                d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    base64                                   0.13.0               904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
+    base64                                   0.21.0               a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a \
+    bitflags                                 1.2.1                cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bitflags                                 2.9.1                1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967 \
+    blake2b_simd                             0.5.11               afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587 \
+    block-buffer                             0.9.0                4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
+    block2                                   0.6.1                340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2 \
+    blocking                                 1.6.2                e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21 \
+    bstr                                     0.2.15               a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d \
+    bumpalo                                  3.16.0               79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    bytemuck                                 1.15.0               5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15 \
+    bytemuck_derive                          1.6.0                4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60 \
+    byteorder                                1.4.3                14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    bytes                                    1.1.0                c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8 \
+    bzip2                                    0.4.4                bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
+    bzip2-sys                                0.1.11+1.0.8         736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
+    calloop                                  0.12.4               fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298 \
+    calloop-wayland-source                   0.2.0                0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02 \
+    caps                                     0.5.2                c088f2dddef283f86b023ab1ebe2301c653326834996458b2f48d29b804e9540 \
+    cc                                       1.2.30               deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7 \
+    cfg-if                                   0.1.10               4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                                   1.0.0                baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cfg_aliases                              0.2.1                613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    chrono                                   0.4.41               c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d \
+    chrono-tz                                0.10.4               a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3 \
+    clap                                     3.2.25               4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123 \
+    clap_lex                                 0.2.4                2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5 \
+    codespan-reporting                       0.11.1               3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
+    colored                                  2.1.0                cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
+    concurrent-queue                         2.5.0                4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
+    console                                  0.14.1               3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45 \
+    const_format                             0.2.14               c75ea7d6aeb2ebd1ee24f7b7e1b23242ef5a56b3a693733b99bfbe5ef31d0306 \
+    const_format_proc_macros                 0.2.14               29c36c619c422113552db4eb28cddba8faa757e33f758cc3415bd2885977b591 \
+    constant_time_eq                         0.1.5                245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    core-foundation                          0.9.1                0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62 \
+    core-foundation-sys                      0.8.7                773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    cpufeatures                              0.2.1                95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469 \
+    crc32fast                                1.2.1                81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
+    crossbeam                                0.8.1                4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845 \
+    crossbeam-channel                        0.5.0                dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775 \
+    crossbeam-deque                          0.8.1                6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
+    crossbeam-epoch                          0.9.8                1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c \
+    crossbeam-queue                          0.3.5                1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2 \
+    crossbeam-utils                          0.8.19               248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
+    cstr_core                                0.2.5                644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08 \
+    cty                                      0.2.2                b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35 \
+    cursor-icon                              1.1.0                96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991 \
+    cxx                                      1.0.97               e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8 \
+    cxx-build                                1.0.97               5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb \
+    cxxbridge-flags                          1.0.97               8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8 \
+    cxxbridge-macro                          1.0.97               a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d \
+    dashmap                                  5.4.0                907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc \
+    dialoguer                                0.8.0                c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c \
+    difference                               2.0.0                524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    digest                                   0.9.0                d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
+    dirs                                     3.0.1                142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff \
+    dirs-sys                                 0.3.5                8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
+    dispatch2                                0.3.0                89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec \
+    dlib                                     0.5.2                330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412 \
+    downcast                                 0.10.0               4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d \
+    downcast-rs                              1.2.0                9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650 \
+    dtoa                                     0.4.7                88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e \
+    dunce                                    1.0.1                b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4 \
+    either                                   1.6.1                e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    encode_unicode                           0.3.6                a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    encoding_rs                              0.8.28               80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065 \
+    endi                                     1.1.0                a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf \
+    enum-as-inner                            0.3.3                7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595 \
+    enum-as-inner                            0.6.0                5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a \
+    enumflags2                               0.7.12               1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef \
+    enumflags2_derive                        0.7.12               67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827 \
+    equivalent                               1.0.1                5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                                    0.2.7                fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe \
+    errno                                    0.3.13               778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad \
+    errno-dragonfly                          0.1.1                14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067 \
+    event-listener                           5.4.0                3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae \
+    event-listener-strategy                  0.5.4                8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
+    fastrand                                 2.3.0                37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
+    filetime                                 0.2.14               1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8 \
+    flate2                                   1.0.20               cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0 \
+    float-cmp                                0.8.0                e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4 \
+    fnv                                      1.0.7                3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foreign-types                            0.3.2                f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+    foreign-types-shared                     0.1.1                00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    form_urlencoded                          1.0.1                5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
+    fragile                                  1.0.0                69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2 \
+    fs2                                      0.4.3                9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
+    fs_extra                                 1.3.0                42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
+    fsevent                                  0.4.0                5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6 \
+    fsevent-sys                              2.0.1                f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0 \
+    fuchsia-cprng                            0.1.1                a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    fuchsia-zircon                           0.3.3                2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys                       0.3.3                3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futf                                     0.1.4                7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b \
+    futures-channel                          0.3.17               5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888 \
+    futures-core                             0.3.31               05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
+    futures-io                               0.3.31               9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
+    futures-lite                             2.6.0                f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532 \
+    futures-sink                             0.3.17               36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11 \
+    futures-task                             0.3.17               1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99 \
+    futures-util                             0.3.17               36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481 \
+    gcc                                      0.3.55               8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2 \
+    generic-array                            0.14.4               501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
+    getopts                                  0.2.24               cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df \
+    getrandom                                0.1.16               8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
+    getrandom                                0.2.2                c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8 \
+    glob                                     0.3.0                9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    h2                                       0.3.26               81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8 \
+    hashbrown                                0.12.3               8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                                0.15.4               5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5 \
+    heck                                     0.3.2                87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac \
+    heck                                     0.4.1                95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                               0.1.18               322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
+    hermit-abi                               0.3.9                d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
+    hex                                      0.4.3                7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    html2text                                0.12.0               22f0de8bd2c9fe69eb3fa29e41ae1396c9d2e1b807735acaecafb4c86888674f \
+    html5ever                                0.26.0               bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7 \
+    http                                     0.2.4                527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11 \
+    http-body                                0.4.3                399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5 \
+    httparse                                 1.8.0                d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
+    httpdate                                 1.0.1                6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440 \
+    hyper                                    0.14.26              ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4 \
+    hyper-rustls                             0.23.2               1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c \
+    hyper-tls                                0.5.0                d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
+    iana-time-zone                           0.1.63               b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8 \
+    iana-time-zone-haiku                     0.1.1                0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca \
+    idna                                     0.2.3                418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
+    indexmap                                 1.9.3                bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    indexmap                                 2.10.0               fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
+    indoc                                    1.0.3                e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136 \
+    inotify                                  0.7.1                4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f \
+    inotify-sys                              0.1.5                e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
+    iovec                                    0.1.4                b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    ipnet                                    2.3.1                68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9 \
+    itertools                                0.10.0               37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319 \
+    itoa                                     0.4.7                dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
+    itoa                                     1.0.6                453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
+    js-sys                                   0.3.77               1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
+    kernel32-sys                             0.2.2                7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                              1.5.0                bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    lazycell                                 1.3.0                830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
+    libc                                     0.2.174              1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776 \
+    libloading                               0.7.0                6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a \
+    link-cplusplus                           1.0.10               4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212 \
+    linked-hash-map                          0.5.6                0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
+    linux-raw-sys                            0.4.13               01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
+    linux-raw-sys                            0.9.4                cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
+    lock_api                                 0.4.11               3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
+    log                                      0.4.14               51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    log-panics                               2.0.0                ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef \
+    mac                                      0.1.1                c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4 \
+    mac-notification-sys                     0.6.6                119c8490084af61b44c9eda9d626475847a186737c0378c85e32d77c33a01cd4 \
+    markup5ever                              0.11.0               7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016 \
+    matches                                  0.1.9                a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f \
+    memchr                                   2.5.0                2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
+    memmap2                                  0.8.0                43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed \
+    memmap2                                  0.9.4                fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
+    memoffset                                0.6.5                5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
+    memoffset                                0.9.1                488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
+    mime                                     0.3.16               2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
+    miniz_oxide                              0.4.4                a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
+    mio                                      0.6.23               4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4 \
+    mio                                      0.8.6                5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9 \
+    mio-extras                               2.0.6                52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
+    miow                                     0.2.2                ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d \
+    mockall                                  0.9.1                18d614ad23f9bb59119b8b5670a85c7ba92c5e9adf4385c81ea00c51c8be33d5 \
+    mockall_derive                           0.9.1                5dd4234635bca06fc96c7368d038061e0aae1b00a764dc817e900dc974e3deea \
+    named_pipe                               0.4.1                ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b \
+    native-tls                               0.2.11               07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e \
+    natord                                   1.0.9                308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
+    net2                                     0.2.37               391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae \
+    new_debug_unreachable                    1.0.4                e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54 \
+    nix                                      0.29.0               71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
+    nix                                      0.30.1               74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
+    nom                                      6.1.2                e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2 \
+    normalize-line-endings                   0.3.0                61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
+    notify                                   4.0.17               ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257 \
+    notify-rust                              4.11.7               6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400 \
+    ntapi                                    0.4.1                e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4 \
+    num-traits                               0.2.14               9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_cpus                                 1.13.0               05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    num_threads                              0.1.7                5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
+    objc2                                    0.6.1                88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551 \
+    objc2-core-foundation                    0.3.1                1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166 \
+    objc2-encode                             4.1.0                ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
+    objc2-foundation                         0.3.1                900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c \
+    once_cell                                1.19.0               3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    opaque-debug                             0.3.0                624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    opener                                   0.5.0                4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952 \
+    openssl                                  0.10.72              fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da \
+    openssl-macros                           0.1.1                a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
+    openssl-probe                            0.1.4                28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a \
+    openssl-sys                              0.9.107              8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07 \
+    ordered-float                            2.1.1                766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218 \
+    ordered-stream                           0.2.0                9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
+    os_str_bytes                             6.6.1                e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
+    parking                                  2.2.1                f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
+    parking_lot_core                         0.9.9                4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    percent-encoding                         2.1.0                d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    phf                                      0.10.1               fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259 \
+    phf                                      0.12.1               913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7 \
+    phf_codegen                              0.10.0               4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd \
+    phf_generator                            0.8.0                17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
+    phf_generator                            0.10.0               5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6 \
+    phf_shared                               0.8.0                c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
+    phf_shared                               0.10.0               b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096 \
+    phf_shared                               0.12.1               06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981 \
+    pin-project-lite                         0.2.14               bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
+    pin-utils                                0.1.0                8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    piper                                    0.2.4                96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
+    pkg-config                               0.3.19               3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    polling                                  3.6.0                e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6 \
+    ppv-lite86                               0.2.10               ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    precomputed-hash                         0.1.1                925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
+    predicates                               1.0.8                f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df \
+    predicates-core                          1.0.2                57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451 \
+    predicates-tree                          1.0.2                15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2 \
+    proc-macro-crate                         3.3.0                edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35 \
+    proc-macro2                              1.0.94               a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
+    pulldown-cmark                           0.13.0               1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0 \
+    pulldown-cmark-escape                    0.11.0               007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae \
+    pure-rust-locales                        0.8.1                1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a \
+    quick-xml                                0.36.2               f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe \
+    quick-xml                                0.37.5               331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
+    quote                                    1.0.40               1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
+    rand                                     0.4.6                552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand                                     0.7.3                6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand                                     0.8.3                0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e \
+    rand_chacha                              0.2.2                f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_chacha                              0.3.0                e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d \
+    rand_core                                0.3.1                7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                                0.4.2                9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                                0.5.1                90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                                0.6.2                34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7 \
+    rand_hc                                  0.2.0                ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_hc                                  0.3.0                3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73 \
+    rand_pcg                                 0.2.1                16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
+    rayon                                    1.5.3                bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d \
+    rayon-core                               1.9.3                258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f \
+    rdrand                                   0.4.0                678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                            0.1.57               41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_syscall                            0.2.5                94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9 \
+    redox_syscall                            0.4.1                4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    redox_users                              0.3.5                de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d \
+    regex                                    1.5.5                1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286 \
+    regex-automata                           0.1.10               6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex-syntax                             0.6.27               a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244 \
+    remove_dir_all                           0.5.3                3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    reqwest                                  0.11.17              13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91 \
+    ring                                     0.16.20              3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
+    rust-argon2                              0.8.3                4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb \
+    rustix                                   0.38.32              65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89 \
+    rustix                                   1.0.8                11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
+    rustls                                   0.20.8               fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f \
+    rustls-pemfile                           1.0.2                d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b \
+    rustversion                              1.0.21               8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
+    ryu                                      1.0.5                71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    same-file                                1.0.6                93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schannel                                 0.1.19               8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
+    scoped-tls                               1.0.0                ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2 \
+    scopeguard                               1.1.0                d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    scratch                                  1.0.8                9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52 \
+    sct                                      0.7.0                d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4 \
+    security-framework                       2.3.1                23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467 \
+    security-framework-sys                   2.3.0                7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284 \
+    serde                                    1.0.219              5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
+    serde_derive                             1.0.219              5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
+    serde_json                               1.0.62               ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486 \
+    serde_repr                               0.1.20               175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
+    serde_urlencoded                         0.7.1                d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    serde_yaml                               0.8.17               15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23 \
+    sha2                                     0.9.6                9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3 \
+    shlex                                    1.3.0                0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    signal-hook-registry                     1.4.5                9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410 \
+    simplelog                                0.9.0                4bc0ffd69814a9b251d43afcabf96dad1b29f5028378056257be9e3fecc9f720 \
+    siphasher                                0.3.6                729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1 \
+    siphasher                                1.0.1                56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
+    slab                                     0.4.9                8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                                 1.13.2               3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    smithay-client-toolkit                   0.18.1               922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a \
+    socket2                                  0.4.9                64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662 \
+    spin                                     0.5.2                6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    static_assertions                        1.1.0                a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    string_cache                             0.8.1                8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a \
+    string_cache_codegen                     0.5.1                f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97 \
+    strsim                                   0.10.0               73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    syn                                      1.0.67               6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702 \
+    syn                                      2.0.100              b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0 \
+    sys-locale                               0.1.0                91f89ebb59fa30d4f65fafc2d68e94f6975256fd87e812dd99cb6e020c8563df \
+    sysinfo                                  0.28.4               b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b \
+    tauri-winrt-notification                 0.7.2                0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9 \
+    tempdir                                  0.3.7                15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
+    tempfile                                 3.2.0                dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
+    tendril                                  0.4.2                a9ef557cb397a4f0a5a3a628f06515f78563f2209e64d47055d9dc6052bf5e33 \
+    termcolor                                1.1.2                2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
+    terminal_size                            0.1.17               633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df \
+    textwrap                                 0.16.1               23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
+    thiserror                                1.0.56               d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad \
+    thiserror                                2.0.12               567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
+    thiserror-impl                           1.0.56               fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471 \
+    thiserror-impl                           2.0.12               7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
+    time                                     0.1.44               6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    time                                     0.3.15               d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c \
+    tinyvec                                  1.3.1                848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338 \
+    tinyvec_macros                           0.1.0                cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
+    tokio                                    1.28.2               94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2 \
+    tokio-native-tls                         0.3.0                f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b \
+    tokio-rustls                             0.23.4               c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59 \
+    tokio-util                               0.7.3                cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45 \
+    toml                                     0.5.8                a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa \
+    toml_datetime                            0.6.11               22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
+    toml_edit                                0.22.27              41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
+    tower-service                            0.3.1                360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6 \
+    tracing                                  0.1.40               c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing-attributes                       0.1.30               81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903 \
+    tracing-core                             0.1.32               c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
+    treeline                                 0.1.0                a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41 \
+    try-lock                                 0.2.3                59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642 \
+    typenum                                  1.14.0               b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec \
+    uds_windows                              1.1.0                89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9 \
+    unicase                                  2.6.0                50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                             0.3.6                246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085 \
+    unicode-ident                            1.0.12               3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    unicode-normalization                    0.1.19               d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9 \
+    unicode-segmentation                     1.12.0               f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
+    unicode-width                            0.1.8                9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-width                            0.2.1                4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
+    unicode-xid                              0.2.1                f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    unindent                                 0.1.7                f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7 \
+    untrusted                                0.7.1                a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
+    url                                      2.2.2                a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
+    utf-8                                    0.7.6                09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    vcpkg                                    0.2.15               accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
+    version_check                            0.9.2                b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    wait-timeout                             0.2.0                9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    walkdir                                  2.3.1                777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    want                                     0.3.0                1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
+    wasi                                     0.9.0+wasi-snapshot-preview1   cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi                                     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    wasi                                     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                             0.2.100              1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
+    wasm-bindgen-backend                     0.2.100              2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
+    wasm-bindgen-futures                     0.4.26               95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972 \
+    wasm-bindgen-macro                       0.2.100              7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
+    wasm-bindgen-macro-support               0.2.100              8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
+    wasm-bindgen-shared                      0.2.100              1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
+    wayland-backend                          0.3.7                056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6 \
+    wayland-client                           0.31.6               e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d \
+    wayland-csd-frame                        0.3.0                625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e \
+    wayland-cursor                           0.31.1               71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba \
+    wayland-protocols                        0.31.2               8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4 \
+    wayland-protocols-wlr                    0.2.0                ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6 \
+    wayland-scanner                          0.31.5               597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3 \
+    wayland-sys                              0.31.5               efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09 \
+    web-sys                                  0.3.53               224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c \
+    webpki                                   0.22.2               07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f \
+    webpki-roots                             0.22.6               b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87 \
+    widestring                               0.4.3                c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
+    winapi                                   0.2.8                167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                                   0.3.9                5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                             0.1.1                2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu               0.4.0                ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                              0.1.5                70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu             0.4.0                712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                                  0.61.1               c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419 \
+    windows-collections                      0.2.0                3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8 \
+    windows-core                             0.61.0               4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980 \
+    windows-future                           0.2.0                7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32 \
+    windows-implement                        0.60.0               a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
+    windows-interface                        0.59.1               bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
+    windows-link                             0.1.1                76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
+    windows-numerics                         0.2.0                9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
+    windows-result                           0.3.2                c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252 \
+    windows-strings                          0.4.0                7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
+    windows-sys                              0.45.0               75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-sys                              0.48.0               677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-sys                              0.52.0               282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                              0.59.0               1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-sys                              0.60.2               f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
+    windows-targets                          0.42.2               8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+    windows-targets                          0.48.5               9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                          0.52.6               9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                          0.53.2               c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef \
+    windows-version                          0.1.4                e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c \
+    windows_aarch64_gnullvm                  0.42.2               597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm                  0.48.5               2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm                  0.52.6               32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm                  0.53.0               86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
+    windows_aarch64_msvc                     0.42.2               e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc                     0.48.5               dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc                     0.52.6               09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc                     0.53.0               c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
+    windows_i686_gnu                         0.42.2               c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                         0.48.5               a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                         0.52.6               8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                         0.53.0               c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
+    windows_i686_gnullvm                     0.52.6               0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm                     0.53.0               9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
+    windows_i686_msvc                        0.42.2               44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc                        0.48.5               8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc                        0.52.6               240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc                        0.53.0               581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
+    windows_x86_64_gnu                       0.42.2               8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu                       0.48.5               53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu                       0.52.6               147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu                       0.53.0               2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
+    windows_x86_64_gnullvm                   0.42.2               26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm                   0.48.5               0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm                   0.52.6               24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm                   0.53.0               0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
+    windows_x86_64_msvc                      0.42.2               9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc                      0.48.5               ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc                      0.52.6               589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc                      0.53.0               271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
+    winnow                                   0.7.12               f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95 \
+    winreg                                   0.9.0                16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597 \
+    winreg                                   0.10.1               80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d \
+    winres                                   0.1.11               ff4fb510bbfe5b8992ff15f77a2e6fe6cf062878f0eda00c0f44963a807ca5dc \
+    ws2_32-sys                               0.2.1                d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    xcursor                                  0.3.3                3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08 \
+    xkbcommon                                0.7.0                13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e \
+    xkeysym                                  0.2.0                054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621 \
+    xml5ever                                 0.17.0               4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650 \
+    yaml-rust                                0.4.5                56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
+    zbus                                     5.9.0                4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad \
+    zbus_macros                              5.9.0                ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659 \
+    zbus_names                               4.2.0                7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97 \
+    zeroize                                  1.3.0                4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd \
+    zip                                      0.5.13               93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815 \
+    zvariant                                 5.6.0                d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f \
+    zvariant_derive                          5.6.0                3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208 \
+    zvariant_utils                           3.2.0                e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34


### PR DESCRIPTION
#### Description
espanso: new port, version 2.3.0

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?