### PR TITLE
meta-package-manager: new port

### DIFF
--- a/python/py-boltons/Portfile
+++ b/python/py-boltons/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-boltons
-version             23.0.0
+version             26.1.0
 platforms           {darwin any}
 license             BSD
 supported_archs     noarch
@@ -17,8 +17,9 @@ long_description    Boltons is a set of over 230 BSD-licensed, pure-Python utili
 
 homepage            https://boltons.readthedocs.org/
 
-checksums           rmd160  526fb6a2866d2b63549a502ce634926133099c6b \
-                    sha256  8c50a71829525835ca3c849c7ed2511610c972b4dddfcd41a4a5447222beb4b0 \
-                    size    182572
+checksums           rmd160  60fa03be3d9c9037bab930b984aca67f55930fb5 \
+                    sha256  5764468aba493b15995ed17f46a16789023f123ca2a62d491a9ce825c1cbe26c \
+                    size    227393
 
-python.versions     310 311
+python.versions     310 311 312 313 314
+python.pep517_backend flit

--- a/python/py-click-extra/Portfile
+++ b/python/py-click-extra/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-click-extra
+version             8.4.0
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             GPL-2+
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Drop-in replacement for Click to build user-friendly \
+                    and colorful CLIs
+long_description    Click Extra is a collection of helpers and utilities \
+                    for Click, the Python CLI framework. It provides \
+                    colorful help screens, configuration file loading, \
+                    logging management, table rendering and platform \
+                    detection to Click-based tools.
+
+homepage            https://github.com/kdeldycke/click-extra
+
+python.rootname     click_extra
+
+checksums           rmd160  64af88de5df1af7a72a249d33f5367af493b8b7d \
+                    sha256  92e5441824126248c61b05471ecacb6403e45a0b0b743f6babf425abb4c217de \
+                    size    362743
+
+python.versions     311 312 313 314
+python.pep517_backend uv
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-boltons \
+                    port:py${python.version}-click \
+                    port:py${python.version}-cloup \
+                    port:py${python.version}-deepmerge \
+                    port:py${python.version}-extra-platforms \
+                    port:py${python.version}-tabulate \
+                    port:py${python.version}-wcmatch \
+                    port:py${python.version}-wcwidth
+}

--- a/python/py-cloup/Portfile
+++ b/python/py-cloup/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cloup
+version             3.1.0
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Adds option groups, constraints, subcommand sections \
+                    and help themes to Click
+long_description    Cloup extends Click, the Python CLI framework, with \
+                    option groups, constraints for group options, \
+                    subcommand sections in the help screen and themeable \
+                    help formatting.
+
+homepage            https://github.com/janluke/cloup
+
+checksums           rmd160  5026a77b425664f46e216f22e1a165faf793b5fe \
+                    sha256  637c1e628fe98f3f20a5e44da591a72b42bf54d7d4527190bf39ed5f64af7585 \
+                    size    230167
+
+python.versions     311 312 313 314
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+    depends_lib-append \
+                    port:py${python.version}-click
+}

--- a/python/py-deepmerge/Portfile
+++ b/python/py-deepmerge/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-deepmerge
+version             2.1.0
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Toolset for deeply merging Python dictionaries
+long_description    deepmerge provides a toolset to deeply merge nested \
+                    Python data structures, with configurable strategies \
+                    to resolve conflicts between dictionaries, lists and \
+                    sets.
+
+homepage            https://deepmerge.readthedocs.io/
+
+checksums           rmd160  1d597ecb6d361ca568121d3455e1af0f8080054a \
+                    sha256  07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f \
+                    size    21449
+
+python.versions     311 312 313 314
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+}

--- a/python/py-extra-platforms/Portfile
+++ b/python/py-extra-platforms/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-extra-platforms
+version             13.3.1
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             Apache-2
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Detect architectures, platforms, shells, terminals, \
+                    CI systems and agents
+long_description    Extra Platforms detects the environment a Python \
+                    program runs in: operating system, distribution, \
+                    architecture, shell, terminal and CI system, with \
+                    platforms grouped by family.
+
+homepage            https://github.com/kdeldycke/extra-platforms
+
+python.rootname     extra_platforms
+
+checksums           rmd160  725ffc954d75819630e56a9f1bff57fe1fd05f0b \
+                    sha256  1efefa780f0b97dce5d352f7873065988f7f23938af70456182b20474849d1c2 \
+                    size    86205
+
+python.versions     311 312 313 314
+python.pep517_backend uv

--- a/python/py-packageurl-python/Portfile
+++ b/python/py-packageurl-python/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-packageurl-python
+version             0.17.6
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Parser and builder for purl Package URLs
+long_description    packageurl-python is the Python implementation of the \
+                    purl specification. A Package URL identifies a software \
+                    package in a mostly universal and uniform way across \
+                    programming languages, package managers, packaging \
+                    conventions, tools, APIs and databases.
+
+homepage            https://github.com/package-url/packageurl-python
+
+python.rootname     packageurl_python
+
+checksums           rmd160  62b8e5aaca38615e0db899017516e43eebe34cce \
+                    sha256  1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25 \
+                    size    50618
+
+python.versions     311 312 313 314

--- a/sysutils/meta-package-manager/Portfile
+++ b/sysutils/meta-package-manager/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                meta-package-manager
+version             7.3.0
+revision            0
+
+categories          sysutils python
+platforms           {darwin any}
+supported_archs     noarch
+license             GPL-2+
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Wraps all package managers with a unifying CLI
+long_description    mpm is a unifying command line interface on top of the \
+                    70+ package managers it supports (Homebrew, MacPorts, \
+                    pip, npm, cargo, gem and more): list, search, install, \
+                    upgrade, remove, sync, clean up, back up and restore \
+                    packages across all of them at once, with table, JSON, \
+                    CSV and SBOM outputs.
+
+homepage            https://kdeldycke.github.io/meta-package-manager/
+
+python.rootname     meta_package_manager
+
+checksums           rmd160  4bf9c9303adb24aee7c94b5bf1457724a407661b \
+                    sha256  f540a4957ae2d3f702e97aa3217261b808e4b98233707c9f8c5f214c3dbfee91 \
+                    size    325448
+
+python.default_version 314
+python.pep517_backend uv
+
+depends_lib-append  port:py${python.version}-boltons \
+                    port:py${python.version}-click-extra \
+                    port:py${python.version}-extra-platforms \
+                    port:py${python.version}-packageurl-python \
+                    port:py${python.version}-tomli-w \
+                    port:py${python.version}-xmltodict


### PR DESCRIPTION
#### Description

This is a new port for [Meta Package Manager (aka `mpm`)](https://github.com/kdeldycke/meta-package-manager), a CLI that unifies the invocation of 70+ package managers, MacPorts included.

The submission is a stack of 7 commits, one per port, in dependency order:

- `py-boltons: update to 26.1.0`: version update of the existing port (`mpm` requires `boltons >= 25`). Boltons switched its build backend from setuptools to `flit_core`, and `python.versions` extended to support the `312` and `313` interpreters.
- `py-cloup`, `py-deepmerge`, `py-extra-platforms`, `py-packageurl-python`, `py-click-extra`: new ports for `mpm` dependencies that are not yet in the tree. All are pure-Python.
- `meta-package-manager`: the application itself.

I am the upstream author of `meta-package-manager`, `click-extra` and `extra-platforms`, and volunteer as maintainer for every port in this stack except `py-boltons`, which keeps its current maintainer.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

- macOS 26.4 25E246 arm64 (GitHub Actions `macos-26` runner): https://github.com/kdeldycke/meta-package-manager/actions/runs/29634750371/job/88055009701#step:6:5
- macOS 15 x86_64 (GitHub Actions `macos-15-intel` runner): https://github.com/kdeldycke/meta-package-manager/actions/runs/29634750371/job/88055009758#step:6:5
- MacPorts 2.12.5

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? (`port lint --nitpick` on all 7 ports, clean, in the CI job linked above)
- [x] tried a full install with `sudo port -vst install`? (installed in CI with `sudo port -v install` in the CI runs above)
- [x] tested basic functionality of all binary files? (`mpm --version` in the CI runs above)