### PR TITLE
libgit2-devel: update to 1.9.6

### DIFF
--- a/devel/libgit2-devel/Portfile
+++ b/devel/libgit2-devel/Portfile
@@ -11,7 +11,7 @@ conflicts           libgit2
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.9.3 v
+github.setup        libgit2 libgit2 1.9.6 v
 github.tarball_from archive
 revision            0
 epoch               0
@@ -30,9 +30,9 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  38abfbd37f86147691c13e4c3c6e6ed1bef16e05 \
-                    sha256  d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64 \
-                    size    7674513
+checksums           rmd160  191dc24c339619b50fd4dfe816784ad00a053a99 \
+                    sha256  a88a42a4ea9bdab7aa8686eead3bf7d9c6dd74529caca16ab22eaa92433d31d9 \
+                    size    7769080
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
