### PR TITLE
gawk: backport upstream fix for a critical bug

### DIFF
--- a/lang/gawk/Portfile
+++ b/lang/gawk/Portfile
@@ -6,7 +6,7 @@ PortGroup               legacysupport 1.1
 
 name                    gawk
 version                 5.4.1
-revision                0
+revision                1
 
 categories              lang
 license                 GPL-3+
@@ -25,6 +25,8 @@ long_description \
 checksums               rmd160  929ac99cc1bcb8015b7cc0701f29fdf812833c75 \
                         sha256  07f6f7342b7febe4313fc2c2542ad93d64fe20ad8717200109f105a826f5fd37 \
                         size    3838416
+
+patchfiles-append       patch-node_align.diff
 
 depends_build           port:gettext
 

--- a/lang/gawk/files/patch-node_align.diff
+++ b/lang/gawk/files/patch-node_align.diff
@@ -1,0 +1,78 @@
+From ef0e66c42ccb585b8d91b91a76ea7fe39e05363a Mon Sep 17 00:00:00 2001
+From: "Arnold D. Robbins" <arnold@skeeve.com>
+Date: Tue, 14 Jul 2026 10:14:50 +0300
+Subject: [PATCH] Workaround fix for systems without MPFR and GMP.
+
+---
+ ChangeLog | 10 ++++++++++
+ awk.h     | 23 ++++++++++++++---------
+ 2 files changed, 24 insertions(+), 9 deletions(-)
+
+diff --git ChangeLog ChangeLog
+index 1376843b77be..f37d4f2d85c7 100644
+--- ChangeLog
++++ ChangeLog
+@@ -1,3 +1,13 @@
++2026-07-14         Arnold D. Robbins     <arnold@skeeve.com>
++
++	Unrelated: Make things works when built on systems without
++	the GMP and MPFR libraries.  Thanks to Thomas Trepl <ttrepl@yahoo.de>
++	and Bruce Dubbs <bdubbs@linuxfromscratch.org> for the reports.
++
++	* awk.h (struct exp_node): Add alignment padding when we don't
++	have MPFR. This is a hack, pending a total refactoring of
++	the NODE structure.
++
+ 2026-07-08         Arnold D. Robbins     <arnold@skeeve.com>
+ 
+ 	* 5.4.1: Release tar ball made.
+diff --git awk.h awk.h
+index dbad0d810df2..f4a84300f3fc 100644
+--- awk.h
++++ awk.h
+@@ -406,17 +406,24 @@ typedef struct exp_node {
+ 		} nodep;
+ 
+ 		struct {
+-#ifdef HAVE_MPFR
+ 			union {
+ 				AWKNUM fltnum;
++#ifdef HAVE_MPFR
+ 				mpfr_t mpnum;
+ 				mpz_t mpi;
+-			} nm;
+-			int rndmode;
+ #else
+-			AWKNUM fltnum;
+-			int for_alignment_only;	// especially on 32-bit
+-#endif
++				// 7/2026:
++				// This is a workaround for systems that build
++				// gawk without MPFR and GMP.  The NODE struct
++				// desperately needs to be refactored.
++#if SIZEOF_VOID_P == 4
++				char alignment[28];
++#else	// SIZEOF_VOID_P != 4
++				char alignment[48];
++#endif	// SIZEOF_VOID_P != 4
++#endif	// HAVE_MPFR
++			} nm;
++			int rndmode;	// only used for MPFR.
+ 			char *sp;
+ 			size_t slen;
+ 			int idx;
+@@ -561,10 +568,8 @@ typedef struct exp_node {
+ #ifdef HAVE_MPFR
+ #define mpg_numbr	sub.val.nm.mpnum
+ #define mpg_i		sub.val.nm.mpi
+-#define numbr		sub.val.nm.fltnum
+-#else
+-#define numbr		sub.val.fltnum
+ #endif
++#define numbr		sub.val.nm.fltnum
+ #define typed_re	sub.val.typre
+ 
+ /*
+-- 
+2.55.0
+


### PR DESCRIPTION
gawk-5.4.1 contains a critical bug that prevents it from being used to build gcc. The bug also prevents gawk’s own `make check` (`port test gawk`) from succeeding.

As reported in two [bug-gawk](https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00011.html) [threads](https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00013.html), a gcc build will fail when building options.cc:

```
options.cc:22882:2: error: 0Wabsolute-value does not have a
      Var() flag
 22882 | #error 0Wabsolute-value does not have a Var() flag
       |  ^
options.cc:22946:2: error: 0Wexpansion-to-defined does not
      have a Var() flag
 22946 | #error 0Wexpansion-to-defined does not have a Var() flag
       |  ^
[…similar repeated many more times…]
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

As reported in [another bug-gawk thread](https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00026.html), gawk’s own `make check` fails 6 tests:
 - _arraysort2
 - _delarpm2
 - _elemnew2
 - _elemnew4
 - _matchuninitialized
 - _typeof7

This occurs when gawk-5.4.1 is not built with mpfr. MacPorts’ gawk port has a +mpfr variant, but it is not the default.

A patch with a workaround is available upstream, but it has not been incorporated into any release yet. It’s applied here, because of the critical nature of the bug.

A rollback to gawk-5.4.0 is not advisable because it contains its own serious bugs, notably, [MacPorts trac 73940](https://trac.macports.org/ticket/73940).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
