### PR TITLE
mcp-inspector: update to 1.0.0

### DIFF
--- a/llm/mcp-inspector/Portfile
+++ b/llm/mcp-inspector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                mcp-inspector
-version             0.22.0
+version             1.0.0
 revision            0
 
 categories          llm
@@ -20,9 +20,9 @@ homepage            https://modelcontextprotocol.io/docs/tools/inspector
 npm.rootname        @modelcontextprotocol/inspector
 distname            inspector-${version}
 
-checksums           rmd160  be35594f0a12531d3d718664af5e3d8c02276a16 \
-                    sha256  32fa820fde3c75357a206bb8409adaa5d9b110efb2cfec2cd4f9c7af1f1d53ae \
-                    size    570638
+checksums           rmd160  85cf95f0fe200be72e6adfb239578e0f6a31b9e3 \
+                    sha256  02684b5238eba62bf64cdd5cf3e9feb5d04a2feabf557c423a8298eb76ba66ea \
+                    size    571566
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to MCP Inspector 1.0.0.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?