### PR TITLE
R-Matrix: update to 1.7-5

### DIFF
--- a/R/R-Matrix/Portfile
+++ b/R/R-Matrix/Portfile
@@ -6,7 +6,7 @@ PortGroup           R 1.0
 R.recommended       yes
 
 # This is a recommended package. Keep it CRAN-sourced.
-R.setup             cran r-forge Matrix 1.7-1
+R.setup             cran r-forge Matrix 1.7-5
 revision            0
 categories-append   math
 maintainers         nomaintainer
@@ -14,9 +14,9 @@ license             GPL-2+
 description         Sparse and dense matrix classes and methods
 long_description    {*}${description}. Recommended package.
 homepage-append     https://Matrix.R-forge.R-project.org
-checksums           rmd160  6ea35b2326b1c39a1833ff469013d08a3df7a119 \
-                    sha256  a2cabbf04e4e2cafbd0a04281f130bb58e4f7653a91951368a404ef8682b38a1 \
-                    size    2480082
+checksums           rmd160  9f4710ca4e89f0673ae7d6b9dee5592343008375 \
+                    sha256  308b0edd7bcb023a8bb50cc5cec98e66b3658c94a5badfb1ce6024e595fa8a83 \
+                    size    2529215
 
 # R-Matrix uses bundled parts of SuiteSparse. The version used in 1.7-0
 # has a bug breaking it for < 10.7 (fixed in upstream already).


### PR DESCRIPTION
## Summary

R-Matrix 1.7-1 fails to compile against R 4.6.0: R's `Rinternals.h` now
gates the legacy internal `Rf_findVarInFrame` declaration behind
`ENABLE_LEGACY_NONAPI_FUNS` (undefined by default), and R-Matrix 1.7-1's
bundled `src/cholmod-common.c` uses the remapped `findVarInFrame` macro
unconditionally, so the build fails with:

```
error: use of undeclared identifier 'Rf_findVarInFrame'
```

1.7-5 no longer hits this — upstream replaced the legacy call with its
own `R_getVar` wrapper (`#define findVarInFrame(env, sym) R_getVar(sym, env, FALSE)`
in `cholmod-common.c`).

The existing `patch-pre-10.7-fix-math.diff` (SuiteSparse_config.h
`__NOEXTENSIONS__` fix for pre-10.7 macOS) still applies cleanly and
remains necessary against 1.7-5, so it is unchanged.

## Test plan
- [x] `port lint --nitpick R-Matrix` — 0 errors, 0 warnings
- [x] Built and installed from source against R 4.6.0 on macOS (arm64);
      `library(Matrix)` loads successfully
- [x] Checksums recomputed from the actual CRAN `Matrix_1.7-5.tar.gz`
      (rmd160/sha256/size)