### PR TITLE
R-rpart: update to 4.1.27

### DIFF
--- a/R/R-rpart/Portfile
+++ b/R/R-rpart/Portfile
@@ -6,16 +6,16 @@ PortGroup           R 1.0
 R.recommended       yes
 
 # This is a recommended package. Keep it CRAN-sourced.
-R.setup             cran bethatkinson rpart 4.1.23
-revision            1
+R.setup             cran bethatkinson rpart 4.1.27
+revision            0
 maintainers         nomaintainer
 license             {GPL-2 GPL-3}
 description         Recursive partitioning and regression trees
 long_description    {*}${description}. Recommended package.
 homepage-append     https://github.com/bethatkinson/rpart
-checksums           rmd160  7ca4e1b2f9a29a6a3aefd90ff4aa89c707fcd686 \
-                    sha256  f9b89aed6aa6cea656a2dcb271574e969ce2b1c98beb07bd91e17339f6daabaf \
-                    size    618016
+checksums           rmd160  b5732f55760685a5e5369be3f6a7e2181062ff62 \
+                    sha256  3183552d74f02749a70e2b989591c561ca0f7c146034f415748acc8480ca4050 \
+                    size    623943
 
 depends_test-append port:R-survival
 


### PR DESCRIPTION
## Summary

R-rpart 4.1.23 fails to compile against R 4.6.0: R's `Rinternals.h` now
gates the legacy internal `Rf_findVarInFrame` declaration behind
`ENABLE_LEGACY_NONAPI_FUNS` (undefined by default), and
`src/rpart_callback.c` uses the remapped `findVarInFrame` macro
unconditionally, so the build fails with:

```
error: use of undeclared identifier 'Rf_findVarInFrame'
```

4.1.27 no longer hits this — upstream added a `compat_getVar`/`R_getVar`
shim in `rpart_callback.c` that only falls back to the legacy
`findVar`/`findVarInFrame` calls when `R_VERSION < R_Version(4, 5, 0)`.

## Test plan
- [x] `port lint --nitpick R-rpart` — 0 errors, 0 warnings
- [x] Built and installed from source against R 4.6.0 on macOS (arm64);
      `library(rpart)` loads successfully
- [x] Checksums recomputed from the actual CRAN `rpart_4.1.27.tar.gz`
      (rmd160/sha256/size)