### PR TITLE
R-mime: fix extract-dir naming with github.tarball_from archive

### DIFF
--- a/R/R-mime/Portfile
+++ b/R/R-mime/Portfile
@@ -4,13 +4,15 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             github yihui mime 0.12 v
-revision            2
+github.tarball_from archive
+dist_subdir         R-mime/tarball-from-archive
+revision            3
 categories-append   devel
 maintainers         nomaintainer
 license             {GPL-2 GPL-3}
 description         Map filenames to MIME types
 long_description    {*}${description}
 homepage            https://yihui.org/mime
-checksums           rmd160  a46bbe898fc63e90bc55ad970e6f4861a426931d \
-                    sha256  9683bf779ad0e888666f4b3c3f32f9e41e4c704d1055b1c3b2c2487a22277d81 \
-                    size    14454
+checksums           rmd160  84f74703a4c0b0ee6a3c7a039dd1d92a82ff2b3e \
+                    sha256  7531d22466cda370f9fe6a5ad0653898e95dccc75c82804acfd34ec4153b80ec \
+                    size    14444


### PR DESCRIPTION
## Summary

R-mime fails to configure: `R CMD build .` reports `checking for file './DESCRIPTION' ... NO`.

`github.setup yihui mime 0.12 v` leaves `github.tarball_from` at the `github-1.0`
PortGroup's default `releases`, which resolves master_sites to
`${homepage}/releases/download/${tag}/mime-0.12.tar.gz`. MacPorts' own
`distfiles.macports.org` mirror serves an existing cached copy of that filename whose
internal top-level directory is `yihui-mime-<shortsha>`, not `mime-0.12`. The PortGroup's
`extract.rename` auto-fix only triggers when `github.tarball_from in {archive, tarball}`
— with `releases` it never fires, so the R-1.0 PortGroup's configure phase looks for
sources at the expected `mime-0.12/` path, finds only the empty directory it creates
itself, and fails.

## Fix

Add `github.tarball_from archive`, switching the fetch to the tag-archive codeload
endpoint (`https://github.com/yihui/mime/archive/v0.12.tar.gz`), which correctly names
its top-level directory `mime-0.12/` — verified directly. Add `dist_subdir` to give this
fetch its own cache path so it doesn't collide with the existing `distfiles.macports.org`
cache entry for the old filename. Checksums recomputed against the archive-endpoint
tarball.

## Test plan
- [x] `port lint --nitpick R-mime` — 0 errors, 0 warnings
- [x] Built and installed from source; configure/build/install all succeed;
      `library(mime)` loads successfully