### PR TITLE
R-rappdirs: fix extract-dir naming with github.tarball_from archive

### DIFF
--- a/R/R-rappdirs/Portfile
+++ b/R/R-rappdirs/Portfile
@@ -4,16 +4,18 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             github r-lib rappdirs 0.3.3 v
-revision            2
+github.tarball_from archive
+dist_subdir         R-rappdirs/tarball-from-archive
+revision            3
 categories-append   devel
 maintainers         nomaintainer
 license             MIT
 description         Application directories: determine where to save data, caches and logs.
 long_description    {*}${description}
 homepage            https://rappdirs.r-lib.org
-checksums           rmd160  d0e773a61e0822e1d51d0499f857db3dfa399527 \
-                    sha256  c5bd00a59d0dc6d9ecc416ce1f6532baf8379644ac0408d6c1dfdec117c57cbe \
-                    size    14168
+checksums           rmd160  a7cf5299d370ddc3ae88ee5169cd5525ebcd5dbb \
+                    sha256  8b845a4a12a403fe8b20bfb0125aef19e8baddd5b1f6664e4d1c013c712ff752 \
+                    size    14153
 
 depends_test-append port:R-covr \
                     port:R-roxygen2 \


### PR DESCRIPTION
## Summary

R-rappdirs fails to configure with the identical defect just fixed in R-mime: `R CMD
build .` reports `checking for file './DESCRIPTION' ... NO`.

`github.setup r-lib rappdirs 0.3.3 v` leaves `github.tarball_from` at the `github-1.0`
PortGroup's default `releases`, resolving master_sites to
`${homepage}/releases/download/${tag}/rappdirs-0.3.3.tar.gz`. MacPorts' own
`distfiles.macports.org` mirror serves an existing cached copy of that filename whose
internal top-level directory is `r-lib-rappdirs-<shortsha>`, not `rappdirs-0.3.3`. The
PortGroup's `extract.rename` auto-fix only triggers when `github.tarball_from in
{archive, tarball}` — with `releases` it never fires, so configure finds no DESCRIPTION
at the expected `rappdirs-0.3.3/` path and fails.

## Fix

Add `github.tarball_from archive` (tag-archive codeload endpoint, correctly named
`rappdirs-0.3.3/` — verified directly) + `dist_subdir` to avoid the
`distfiles.macports.org` cache collision on rebuild. Checksums recomputed against the
archive-endpoint tarball.

## Test plan
- [x] `port lint --nitpick R-rappdirs` — 0 errors, 0 warnings
- [x] Built and installed from source; configure/build/install all succeed;
      `library(rappdirs)` loads successfully