### PR TITLE
emacs-mac-app: load site-start.d snippets generated by elisp-1.0

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -10,7 +10,7 @@ bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ve
 name                emacs-mac-app
 conflicts           emacs-app emacs-app-devel
 version             ${emacs_mac_ver}
-revision            4
+revision            5
 categories          aqua editors
 maintainers         {amake @amake} openmaintainer
 
@@ -102,7 +102,7 @@ subport ${name}-devel {
     set date            2025-09-20
 
     version         [string map {- {}} ${date}]
-    revision        2
+    revision        3
 
     long_description \
         ${name} is the \"Mac port\" of GNU Emacs ${emacs_version}. \

--- a/aqua/emacs-mac-app/files/site-start.el
+++ b/aqua/emacs-mac-app/files/site-start.el
@@ -10,3 +10,12 @@
 
 ;; Info-directory-list contains ${prefix}/share/info. See #32148.
 (setq Info-default-directory-list (cons "__PREFIX__/share/info" Info-default-directory-list))
+
+;; Load per-package startup snippets that MacPorts elisp ports install into
+;; site-lisp/site-start.d/ (e.g. to register their autoloads).
+(let ((site-start-d "__PREFIX__/share/emacs/site-lisp/site-start.d"))
+  (when (file-directory-p site-start-d)
+    (dolist (f (directory-files site-start-d t "\\.el\\'"))
+      (condition-case err
+          (load f nil t)
+        (error (message "site-start.d: error loading %s: %s" f err))))))


### PR DESCRIPTION
#### Description

I recently added support in the elisp-1.0 portgroup used by elisp-module ports for generating autoload fragments in $prefix/share/emacs/site-lisp/site-start.d. This PR updates emacs-mac-app's site-start.el to load them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
