### PR TITLE
beancount.el: update to v0.9.0, migrate to elisp-1.0 portgroup

### DIFF
--- a/lang/beancount.el/Portfile
+++ b/lang/beancount.el/Portfile
@@ -1,52 +1,25 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-
-github.setup        beancount beancount-mode 3c04745fa539c25dc007683ad257239067c24cfe
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-version             20210303
-revision            0
-checksums           rmd160  38ef2dbf7c048fe05c278c9043599521372cd18e \
-                    sha256  128873506d8a8548166fa12b61fefda93b2e1a2a3b1d8f220794f10869db9621 \
-                    size    26602
+PortGroup           elisp 1.0
 
 name                beancount.el
+elpa.setup          beancount 0.9.0 nongnu
+epoch               1
+
 categories          lang editors
-platforms           any
-supported_archs     noarch
 license             GPL-3+
 maintainers         {l2dy @l2dy} openmaintainer
+platforms           any
+supported_archs     noarch
 
 description         Beancount mode for Emacs
-
-long_description    an Emacs major-mode implementing syntax highlighting, \
+long_description    An Emacs major-mode implementing syntax highlighting, \
                     indentation, completion, and other facilities to edit and \
                     work with Beancount ledger files.
 
-# We want emacs from MacPorts since this will install stuff in emacs' site-lisp and we want
-# it to go into ${prefix}'s site-lisp.
-depends_lib         path:bin/emacs:emacs
+checksums           rmd160  d7a6d34ddca97e8c419f457f6ca1e838697fcd9b \
+                    sha256  f11331beba52eadc87049aa533a3346fa96d30f43769bcffe6ab4d8cf836285f \
+                    size    143360
 
-use_configure       no
-
-build {
-    system -W ${worksrcpath} "emacs --batch --eval \
-        '(progn (setq load-path (cons \".\" load-path)) \
-                (byte-compile-file \"beancount.el\"))'"
-}
-
-destroot {
-    set site_lisp ${prefix}/share/emacs/site-lisp
-    xinstall -d ${destroot}${site_lisp}
-    xinstall -W ${worksrcpath} beancount.el beancount.elc ${destroot}${site_lisp}
-}
-
-notes "
-To use this, put the following into your ~/.emacs:
-
-(setq auto-mode-alist
-  (cons '(\"\\\\.beancount\" . beancount-mode) auto-mode-alist))
-(autoload 'beancount-mode \"beancount\" \"Beancount mode.\" t)
-"
+elisp.files         beancount.el flymake-bean-check.el


### PR DESCRIPTION

#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files, along with shortcuts for fetching and installing from ELPA repositories. This PR updates beancount.el to v0.9.0 and migrates it use this support, replacing the manual build/destroot and notes. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
