### PR TITLE
markdown-mode.el: migrate to elisp-1.0 portgroup

### DIFF
--- a/editors/markdown-mode.el/Portfile
+++ b/editors/markdown-mode.el/Portfile
@@ -4,11 +4,8 @@ PortSystem             1.0
 PortGroup              github 1.0
 PortGroup              elisp 1.0
 
-
 categories             editors
 license                GPL-3+
-platforms              any
-supported_archs        noarch
 maintainers            {easieste @easye} openmaintainer
 description            An Emacs mode for editing Markdown files
 long_description       {*}${description}
@@ -18,30 +15,9 @@ github.setup           jrblevin markdown-mode 2.6 v
 github.tarball_from    tarball
 name                   markdown-mode.el
 epoch                  1
+revision               1
 checksums              rmd160  1f58ac332cad0a58ed1221fbe0f318a6322a8a8c \
                        sha256  887e479d9aeb4813e7f6b12630079b0590a5b305c9d7118c06b4ca89d7e7ac58 \
                        size    222217
 
-depends_lib-append     path:${emacs_binary}:${emacs_binary_provider}
-
-use_configure          no
-
-# if the following line is commented out, the build system
-# generates a compiled version markdown-mode.elc
-# the destroot block needs to be updated in that case
-build {}
-
-destroot {
-    xinstall -d ${destroot}${emacs_lispdir}
-    copy        ${workpath}/${worksrcdir}/markdown-mode.el  \
-                ${destroot}${emacs_lispdir}
-}
-
-notes {
-To use add the following to your ~/.emacs:
-
-(autoload 'markdown-mode "markdown-mode"
-  "Major mode for editing Markdown files" t)
-(add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
-(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
-}
+elisp.files            markdown-mode.el


### PR DESCRIPTION


#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files. This PR migrates markdown-model.el to use this support, replacing the manual build/destroot and notes. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
