### PR TITLE
mediawiki.el: migrate to elisp-1.0 portgroup

### DIFF
--- a/editors/mediawiki.el/Portfile
+++ b/editors/mediawiki.el/Portfile
@@ -1,46 +1,36 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               github 1.0
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           elisp 1.0
 
-github.setup            hexmode mediawiki-el 2.3.1
+github.setup        hexmode mediawiki-el 2.3.1
 # Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from     tarball
-name                    mediawiki.el
-categories              editors
-license                 GPL-3
-maintainers             {easieste @easye} openmaintainer
-description             An Emacs mode for editing MediaWiki content
-long_description        {*}${description}
-homepage                http://www.emacswiki.org/emacs/MediaWikiMode
-platforms               any
-supported_archs         noarch
+github.tarball_from tarball
+name                mediawiki.el
+revision            1
+categories          editors
+license             GPL-3
+maintainers         {easieste @easye} openmaintainer
+description         An Emacs mode for editing MediaWiki content
+long_description    {*}${description}
+homepage            http://www.emacswiki.org/emacs/MediaWikiMode
 
-checksums               rmd160  4f011a2efac2f406958361ef8063d703658a9f57 \
-                        sha256  80fb1d3ba5d1f66388b0758cee70e2a27299f4a5244b6d13fd29466851c020ab \
-                        size    36627
+checksums           rmd160  4f011a2efac2f406958361ef8063d703658a9f57 \
+                    sha256  80fb1d3ba5d1f66388b0758cee70e2a27299f4a5244b6d13fd29466851c020ab \
+                    size    36627
 
-use_configure           no
+elisp.files         mediawiki.el
 
-depends_lib             port:emacs
-
-build {}
-destroot {
-    file mkdir ${destroot}${prefix}/share/emacs/site-lisp
-    file copy ${workpath}/${worksrcdir}/${name} \
-        ${destroot}${prefix}/share/emacs/site-lisp
-    set docdir ${destroot}${prefix}/share/docs/${name}
-    file mkdir ${docdir}
-    xinstall -m 644 ${worksrcpath}/ChangeLog ${docdir}
-    file copy ${worksrcpath}/LICENSE ${docdir}
-    file copy ${worksrcpath}/README.mediawiki ${docdir}
+post-destroot {
+    set docdir ${destroot}${prefix}/share/doc/${subport}
+    xinstall -d ${docdir}
+    xinstall -m 0644 ${worksrcpath}/ChangeLog \
+                     ${worksrcpath}/LICENSE \
+                     ${worksrcpath}/README.mediawiki ${docdir}
 }
 
-notes "To use ${name}, add the following to your ~/.emacs:\n\
-\n\
-    (require 'mediawiki)\n\
-\n\
-Once the mediawiki mode is loaded, one can customize the variable\n\
-mediawiki-site-alist to set up information by issuing:\n\
+notes "To set up the sites ${name} connects to, customize the variable\n\
+mediawiki-site-alist by issuing:\n\
 \n\
    M-x customize-variable RET mediawiki-site-alist RET"


### PR DESCRIPTION


#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files. This PR migrates mediawiki.el to use this support, replacing the manual build/destroot and notes. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
