### PR TITLE
n3-mode.el: migrate to elisp-1.0 portgroup

### DIFF
--- a/editors/n3-mode.el/Portfile
+++ b/editors/n3-mode.el/Portfile
@@ -1,47 +1,26 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-PortSystem 1.0
 
-PortGroup  github 1.0
-github.setup           kurtjx n3-mode-for-emacs f20dfa2684f601e1c46f115980c7f4c7af4c82fb
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           elisp 1.0
+
+github.setup        kurtjx n3-mode-for-emacs f20dfa2684f601e1c46f115980c7f4c7af4c82fb
 # Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from    tarball
+github.tarball_from tarball
+name                n3-mode.el
+version             201410300
+revision            1
+categories          editors
+license             none
+maintainers         {easieste @easye} openmaintainer
 
-name                   n3-mode.el
-categories             editors
-version                201410300
-license                none
-maintainers            {easieste @easye} openmaintainer
-description            An Emacs mode for editing N3 ("Notation 3") and Turtle RDF
-long_description       {*}${description}
-homepage               https://github.com/kurtjx/n3-mode-for-emacs
-platforms              any
-supported_archs        noarch
+description         An Emacs mode for editing N3 ("Notation 3") and Turtle RDF
+long_description    {*}${description}
 
 checksums           rmd160  9b8659daf292ec900f8c81afb56d5a6e1d92d306 \
-                    sha256  9d55d474470175203899ae8757eb4c0d81d787bdf99e43842d57b5c97d62a33d
+                    sha256  9d55d474470175203899ae8757eb4c0d81d787bdf99e43842d57b5c97d62a33d \
+                    size    1477
 
-depends_lib port:emacs
+patchfiles          patch-n3-mode.el.diff
 
-patchfiles patch-n3-mode.el.diff
-
-use_configure no
-build {}
-destroot {
-    file mkdir ${destroot}${prefix}/share/emacs/site-lisp
-    file copy  ${workpath}/${worksrcdir}/n3-mode.el  \
-        ${destroot}${prefix}/share/emacs/site-lisp
-}
-
-notes {
-To use add the following to your ~/.emacs:
-
-(autoload 'n3-mode "n3-mode" "Major mode for OWL or N3 files" t)
-
-(add-hook 'n3-mode-hook 'turn-on-font-lock)
-(setq auto-mode-alist
- (append
-  (list
-  '("\\.n3" . n3-mode)
-  '("\\.owl" . n3-mode))
-    auto-mode-alist))
-}
+elisp.files         n3-mode.el

--- a/editors/n3-mode.el/files/patch-n3-mode.el.diff
+++ b/editors/n3-mode.el/files/patch-n3-mode.el.diff
@@ -1,12 +1,24 @@
 --- n3-mode.el.orig	2010-10-07 19:24:02.000000000 +0200
 +++ n3-mode.el          2014-10-30 15:56:44.000000000 +0100
-@@ -42,7 +42,7 @@
+@@ -42,7 +42,8 @@
  )
  
  ;;(define-generic-mode 'n3-mode
 -(define-derived-mode n3-mode fundamental-mode
++;;;###autoload
 +(define-derived-mode n3-mode fundamental-mode "n3-mode"
    ;; setup tab key not working :/
    ;;(setq c-basic-offset 4)
  
+@@ -57,4 +58,11 @@
  
+   ;; description
+   "Mode for Notation 3 documents."
+ )
++
++;;;###autoload
++(add-to-list 'auto-mode-alist '("\\.n3\\'" . n3-mode))
++;;;###autoload
++(add-to-list 'auto-mode-alist '("\\.owl\\'" . n3-mode))
++
++(provide 'n3-mode)


### PR DESCRIPTION

#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files. This PR migrates n3-mode.el to use this support, replacing the manual build/destroot and notes. Since the existing emacs mode does not provide an autoload cookie, this adds one in the patchfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
