### PR TITLE
php-mode.el: migrate to elisp 1.0 portgroup

### DIFF
--- a/lang/php-mode.el/Portfile
+++ b/lang/php-mode.el/Portfile
@@ -1,54 +1,26 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               github 1.0
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           elisp 1.0
 
-github.setup            emacs-php php-mode 1.27.0 v
-revision                0
-checksums               rmd160  0b17317b2052fb0c286a63c30154d0d9d312b51c \
-                        sha256  2ac03fe0e553d2df630b267f51069a815e430e3b73bf14f6844244ccfbb4778f \
-                        size    133871
+github.setup        emacs-php php-mode 1.27.0 v
+revision            1
+checksums           rmd160  0b17317b2052fb0c286a63c30154d0d9d312b51c \
+                    sha256  2ac03fe0e553d2df630b267f51069a815e430e3b73bf14f6844244ccfbb4778f \
+                    size    133871
 
-name                    php-mode.el
-categories              lang editors
-platforms               any
-supported_archs         noarch
-license                 GPL-3+
-maintainers             {ryandesign @ryandesign} openmaintainer
-github.tarball_from     archive
+name                php-mode.el
+categories          lang editors
+license             GPL-3+
+maintainers         {ryandesign @ryandesign} openmaintainer
+github.tarball_from archive
 
-description             PHP mode for Emacs
+description         PHP mode for Emacs
+long_description    An Emacs major mode for editing PHP code. \
+                    Features: Syntax coloring and indenting\; \
+                    Documentation browse and search functions\; \
+                    Support for Imenu and SpeedBar\; \
+                    Customization options
 
-long_description        An Emacs major mode for editing PHP code. \
-                        Features: Syntax coloring and indenting\; \
-                        Documentation browse and search functions\; \
-                        Support for Imenu and SpeedBar\; \
-                        Customization options
-
-# We want emacs from MacPorts since this will install stuff in emacs' site-lisp and we want
-# it to go into ${prefix}'s site-lisp.
-depends_lib             path:bin/emacs:emacs
-
-use_configure           no
-
-build.dir               ${worksrcpath}/lisp
-
-build {
-    system -W ${build.dir} "emacs --batch --eval \
-        '(progn (setq load-path (cons \".\" load-path)) \
-                (byte-compile-file \"php-mode.el\"))'"
-}
-
-destroot {
-    set site_lisp ${prefix}/share/emacs/site-lisp
-    xinstall -d ${destroot}${site_lisp}
-    xinstall -W ${build.dir} php-mode.el php-mode.elc ${destroot}${site_lisp}
-}
-
-notes "
-To use this, put the following into your ~/.emacs:
-
-(setq auto-mode-alist
-  (cons '(\"\\\\.php\\\\w?\" . php-mode) auto-mode-alist))
-(autoload 'php-mode \"php-mode\" \"PHP mode.\" t)
-"
+elisp.source_dir    ${worksrcpath}/lisp


### PR DESCRIPTION

#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files. This PR migrates php-mode.el to use this support, replacing the manual build/destroot and notes, and simplifying the portfile a lot. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
