### PR TITLE
sml-mode.el: update to v6.12, simplify with elisp 1.0 elpa.setup

### DIFF
--- a/lang/sml-mode.el/Portfile
+++ b/lang/sml-mode.el/Portfile
@@ -4,51 +4,19 @@ PortSystem          1.0
 PortGroup           elisp 1.0
 
 name                sml-mode.el
-version             6.10
+elpa.setup          sml-mode 6.12
+
 categories          lang editors
 license             GPL-3+
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
-description         An EMACS major mode for editing Standard ML
-long_description    {*}${description}
-homepage            https://elpa.gnu.org/packages/sml-mode.html
 platforms           any
-distname            sml-mode-${version}
-master_sites        https://elpa.gnu.org/packages/
-
-distfiles           ${distname}.el
-
-checksums           rmd160  2140de723fd299a4229c6d5b7e391bee570bdb87 \
-                    sha256  4b9fee50ddb8be6a113b21a272bc2fab3396aca424e8658d843d65728806ce07 \
-                    size    75631
-
-extract.suffix
-extract.mkdir       yes
-extract.cmd         cp
-extract.pre_args
-extract.post_args   ${worksrcpath}/${name}
-
 supported_archs     noarch
 
-depends_lib-append  path:${emacs_binary}:${emacs_binary_provider}
+description         An Emacs major mode for editing Standard ML
+long_description    {*}${description}
 
-use_configure       no
+checksums           rmd160  684da02f265b8eb00ce2e7a9df50973e22924338 \
+                    sha256  f0b72c7a911a19558ee2c0670c7af763265ddba6d3cc64bfec52ae5ce203f783 \
+                    size    143360
 
-build {
-    system -W ${build.dir} "${emacs_binary} -batch -f batch-byte-compile sml-mode.el"
-    system -W ${build.dir} "${emacs_binary} -batch --eval '(update-file-autoloads \"${build.dir}/sml-mode.el\" t \"${build.dir}/sml-mode-autoloads.el\")'"
-}
-
-destroot {
-    set lisp_dir ${destroot}${emacs_lispdir}/sml-mode
-    xinstall -d ${lisp_dir}
-    xinstall -m 0644 -W ${worksrcpath} sml-mode.el           ${lisp_dir}
-    xinstall -m 0644 -W ${worksrcpath} sml-mode.elc          ${lisp_dir}
-    xinstall -m 0644 -W ${worksrcpath} sml-mode-autoloads.el ${lisp_dir}
-}
-
-notes "To use this, put the following into your ~/.emacs:
-(load \"${prefix}/share/emacs/site-lisp/sml-mode/sml-mode-autoloads.el\")"
-
-livecheck.type      regex
-livecheck.regex     sml-mode-(\\d+(?:\\.\\d+)*).el
-livecheck.url       https://elpa.gnu.org/packages/sml-mode.html
+elisp.files         sml-mode.el


### PR DESCRIPTION

#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files, along with shortcuts for fetching and installing from ELPA repositories. This PR updates sml-mode.el to v6.1.2 from ELPA and migrates it to use this support, replacing the manual build/destroot and notes. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
