### PR TITLE
yaml-mode.el: update to v0.0.16, migrate to elisp 1.0 portgroup

### DIFF
--- a/editors/yaml-mode.el/Portfile
+++ b/editors/yaml-mode.el/Portfile
@@ -1,44 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup        github 1.0
+PortSystem          1.0
+PortGroup           elisp 1.0
 
-github.setup     yoshiki yaml-mode 0.0.8 release-
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-name             yaml-mode.el
-categories       editors
-maintainers      gmail.com:michael.dagitses
-platforms        any
-supported_archs  noarch
-license          GPL-2+
+name                yaml-mode.el
+elpa.setup          yaml-mode 0.0.16 nongnu
 
-description      An emacs major mode for editing yaml files.
-long_description This is a major mode for editing files in the YAML \
-                 data serialization format. It was initially developed \
-                 by Yoshiki Kurihara and many features were added by \
-                 Marshall Vandegrift. As YAML and Python share the fact \
-                 that indentation determines structure, this mode \
-                 provides indentation and indentation command behavior \
-                 very similar to that of python-mode. 
+categories          editors
+license             GPL-2+
+maintainers         gmail.com:michael.dagitses
+platforms           any
+supported_archs     noarch
 
-checksums        rmd160  c1e819729e41426eb0c0716b0175b84c0de4358f \
-                 sha256  05494824f259b800004c840ac5b3f4b281e7eb3a9ca6a2634d95876b5cec020e
+description         An Emacs major mode for editing YAML files.
+long_description    This is a major mode for editing files in the YAML \
+                    data serialization format. It provides indentation and \
+                    indentation command behavior similar to that of python-mode.
 
-depends_lib      port:emacs
+checksums           rmd160  532e05ea24efa060ad4b19164a9260975bb97608 \
+                    sha256  a73698067b1a5b515790f4a2456bfbe8f6f9755b09e1a6bdb9e98c0fcaa60e2e \
+                    size    40960
 
-use_configure    no
-
-post-build       { file mkdir ${destroot}${prefix}/share/emacs/site-lisp }
-
-destroot.args    PREFIX=${destroot}${prefix}
-
-notes "
-To use this mode, put the following in your ~/.emacs:
-
-(require 'yaml-mode)
-
-To automatically handle files ending in '.yaml, add something like:
-
-(add-to-list 'auto-mode-alist '(\"\\\\.yaml$\" . yaml-mode))
-"
+elisp.files         yaml-mode.el


### PR DESCRIPTION

#### Description

I recently updated the elisp-1.0 portgroup to add support for automatically byte-compiling elisp files and installing autoload files, along with shortcuts for fetching and installing from ELPA repositories. This PR updates yaml-mode.el to v0.0.16 from nongnu ELPA, and migrates it to use this support, replacing the manual build/destroot and notes. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
