### PR TITLE
libgit2: update to 1.9.6

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -11,7 +11,7 @@ conflicts           libgit2-devel
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.9.4 v
+github.setup        libgit2 libgit2 1.9.6 v
 github.tarball_from archive
 revision            0
 epoch               1
@@ -30,9 +30,9 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  b1595b9bdef074a94f5bad38aff71d68877d2357 \
-                    sha256  824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b \
-                    size    7674814
+checksums           rmd160  191dc24c339619b50fd4dfe816784ad00a053a99 \
+                    sha256  a88a42a4ea9bdab7aa8686eead3bf7d9c6dd74529caca16ab22eaa92433d31d9 \
+                    size    7769080
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig

--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson  1.0
 
 gitlab.instance     https://gitlab.gnome.org
 gitlab.setup        GNOME libgit2-glib 1.2.1 v
-revision            2
+revision            3
 
 categories          gnome devel
 license             LGPL-2+

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        libgit2 pygit2 1.19.2 v
+github.setup        libgit2 pygit2 1.19.3 v
 github.tarball_from archive
 name                py-pygit2
 revision            0
@@ -18,9 +18,9 @@ description         Python bindings for libgit2
 long_description    Pygit2 is a set of Python bindings to the libgit2 shared \
                     library, libgit2 implements the core of Git.
 
-checksums           rmd160  1d9302b6c8b04e1111b88a7293dd121e27821425 \
-                    sha256  596abed18fc2d49d23c27b461d2c3a6bc51714feb3cd36c1ec4a15f33879d639 \
-                    size    834118
+checksums           rmd160  3351d63e9d2d590cd8068b59c7205d73121bc359 \
+                    sha256  35afd3662b0a8b6446b23209cee79979215f604ff1d918dbf74c6f4beb6b78c6 \
+                    size    840302
 
 python.versions     310 311 312 313 314
 


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
