### PR TITLE
php: integrate openssl in SAPI

### DIFF
--- a/_resources/port1.0/group/php-1.1.tcl
+++ b/_resources/port1.0/group/php-1.1.tcl
@@ -6,7 +6,7 @@
 
 default categories              {php lang}
 
-set phpknownfails               {5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3}
+set phpknownfails               {5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0}
 
 # php.branches: the list of PHP branches for which the extension(s) will be
 # built. For unified extension ports (name begins with "php-") setting

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               php 1.1
 PortGroup               openssl 1.0
+PortGroup               conflicts_build 1.0
 
 # Disable by default adding openssl support.
 # Specific sub-ports below enable as required.
@@ -303,10 +304,12 @@ if {[is_sapi_subport]} {
         depends_lib     port:${php}
     }
 
-    depends_lib-append  path:bin/gsed:gsed \
+    depends_lib-append  port:bzip2 \
+                        path:bin/gsed:gsed \
+                        port:kerberos5 \
+                        port:libcomerr \
                         port:libiconv \
                         port:libxml2 \
-                        port:bzip2 \
                         port:mhash \
                         port:zlib
 
@@ -399,6 +402,7 @@ if {[is_sapi_subport]} {
                         --enable-xmlreader \
                         --enable-xmlwriter \
                         --with-bz2=${prefix} \
+                        --with-kerberos=${prefix} \
                         --with-mhash=${prefix} \
                         --with-zlib=${prefix} \
                         --disable-cgi \
@@ -410,15 +414,33 @@ if {[is_sapi_subport]} {
         configure.args-append   --enable-json
     }
 
+    # Look in OpenSSL directories before the main include directory.
+    configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
+    if {[vercmp ${branch} <= 8.3]} {
+        patchfiles-append       patch-${php}-openssl.diff
+    }
+
+    if {[vercmp ${branch} <= 5.6]} {
+        openssl.branch          1.0
+    } elseif {[vercmp ${branch} <= 8.0]} {
+        openssl.branch          1.1
+        conflicts_build         openssl3
+    } else {
+        openssl.branch          3
+    }
+
     if {[vercmp ${branch} < 7.4]} {
         configure.args-append   --enable-hash \
                                 --enable-libxml \
                                 --with-libxml-dir=${prefix} \
                                 --with-pcre-regex=${prefix} \
-                                --without-pear
+                                --without-pear \
+                                --with-openssl=[openssl::install_area]
     } else {
         configure.args-append   --with-libxml \
-                                --with-external-pcre=${prefix}
+                                --with-external-pcre=${prefix} \
+                                --with-openssl
+        depends_build-append    path:bin/pkg-config:pkgconfig
     }
 
     # Ensure we don't regenerate the parsers even if flex/re2c/bison are installed.
@@ -518,6 +540,13 @@ if {[is_sapi_subport]} {
         notes-append "If this is your first install, you need to enable ${subport} in your web server."
     }
 
+    pre-activate {
+        set php_ssl "${php}-openssl"
+        if {![catch {lindex [registry_active ${php_ssl}] 0} installed]} {
+            registry_deactivate_composite ${php_ssl} "" [list ports_nodepcheck 1]
+        }
+    }
+
 }
 
 }
@@ -529,18 +558,18 @@ subport ${php} {
     PortGroup               select 1.0
 
     switch -- ${version} {
-        5.2.17              {revision 18}
-        5.3.29              {revision 9}
-        5.4.45              {revision 8}
-        5.5.38              {revision 9}
-        5.6.40              {revision 7}
-        7.0.33              {revision 7}
-        7.1.33              {revision 5}
-        7.2.34              {revision 6}
-        7.3.33              {revision 4}
-        7.4.33              {revision 3}
-        8.0.30              {revision 2}
-        8.1.34              {revision 1}
+        5.2.17              {revision 19}
+        5.3.29              {revision 10}
+        5.4.45              {revision 9}
+        5.5.38              {revision 10}
+        5.6.40              {revision 8}
+        7.0.33              {revision 8}
+        7.1.33              {revision 6}
+        7.2.34              {revision 7}
+        7.3.33              {revision 5}
+        7.4.33              {revision 4}
+        8.0.30              {revision 3}
+        8.1.34              {revision 2}
         8.2.33              {revision 0}
         8.3.33              {revision 0}
         8.4.24              {revision 0}
@@ -696,18 +725,18 @@ subport ${php}-apache2handler {
     PortGroup               active_variants 1.1
 
     switch -- ${version} {
-        5.2.17              {revision 4}
-        5.3.29              {revision 4}
-        5.4.45              {revision 4}
-        5.5.38              {revision 4}
-        5.6.40              {revision 2}
-        7.0.33              {revision 2}
-        7.1.33              {revision 2}
+        5.2.17              {revision 5}
+        5.3.29              {revision 5}
+        5.4.45              {revision 5}
+        5.5.38              {revision 5}
+        5.6.40              {revision 3}
+        7.0.33              {revision 3}
+        7.1.33              {revision 3}
         7.2.34              {revision 3}
-        7.3.33              {revision 2}
-        7.4.33              {revision 2}
-        8.0.30              {revision 2}
-        8.1.34              {revision 1}
+        7.3.33              {revision 3}
+        7.4.33              {revision 3}
+        8.0.30              {revision 3}
+        8.1.34              {revision 2}
         8.2.33              {revision 0}
         8.3.33              {revision 0}
         8.4.24              {revision 0}
@@ -768,18 +797,18 @@ To enable ${subport}, run:
 
 subport ${php}-cgi {
     switch -- ${version} {
-        5.2.17              {revision 1}
-        5.3.29              {revision 1}
-        5.4.45              {revision 1}
-        5.5.38              {revision 1}
-        5.6.40              {revision 1}
-        7.0.33              {revision 1}
-        7.1.33              {revision 1}
-        7.2.34              {revision 3}
-        7.3.33              {revision 2}
-        7.4.33              {revision 2}
-        8.0.30              {revision 2}
-        8.1.34              {revision 1}
+        5.2.17              {revision 2}
+        5.3.29              {revision 2}
+        5.4.45              {revision 2}
+        5.5.38              {revision 2}
+        5.6.40              {revision 2}
+        7.0.33              {revision 2}
+        7.1.33              {revision 2}
+        7.2.34              {revision 4}
+        7.3.33              {revision 3}
+        7.4.33              {revision 3}
+        8.0.30              {revision 3}
+        8.1.34              {revision 2}
         8.2.33              {revision 0}
         8.3.33              {revision 0}
         8.4.24              {revision 0}
@@ -816,17 +845,17 @@ subport ${php}-cgi {
 if {[vercmp ${branch} >= 5.3]} {
 subport ${php}-fpm {
     switch -- ${version} {
-        5.3.29              {revision 2}
-        5.4.45              {revision 2}
-        5.5.38              {revision 2}
-        5.6.40              {revision 2}
-        7.0.33              {revision 2}
-        7.1.33              {revision 2}
-        7.2.34              {revision 3}
-        7.3.33              {revision 2}
-        7.4.33              {revision 2}
-        8.0.30              {revision 2}
-        8.1.34              {revision 1}
+        5.3.29              {revision 3}
+        5.4.45              {revision 3}
+        5.5.38              {revision 3}
+        5.6.40              {revision 3}
+        7.0.33              {revision 3}
+        7.1.33              {revision 3}
+        7.2.34              {revision 4}
+        7.3.33              {revision 3}
+        7.4.33              {revision 3}
+        8.0.30              {revision 3}
+        8.1.34              {revision 2}
         8.2.33              {revision 0}
         8.3.33              {revision 0}
         8.4.24              {revision 0}
@@ -1916,60 +1945,28 @@ subport ${php}-opcache {
 
 subport ${php}-openssl {
     switch -- ${version} {
-        5.2.17              {revision 3}
-        5.3.29              {revision 3}
-        5.4.45              {revision 3}
-        5.5.38              {revision 3}
-        5.6.40              {revision 3}
-        7.0.33              {revision 2}
-        7.1.33              {revision 1}
-        7.2.34              {revision 1}
-        7.3.33              {revision 0}
-        7.4.33              {revision 0}
-        8.0.30              {revision 0}
-        8.1.34              {revision 0}
+        5.2.17              {revision 4}
+        5.3.29              {revision 4}
+        5.4.45              {revision 4}
+        5.5.38              {revision 4}
+        5.6.40              {revision 4}
+        7.0.33              {revision 3}
+        7.1.33              {revision 2}
+        7.2.34              {revision 2}
+        7.3.33              {revision 1}
+        7.4.33              {revision 1}
+        8.0.30              {revision 1}
+        8.1.34              {revision 1}
         8.2.33              {revision 0}
         8.3.33              {revision 0}
         8.4.24              {revision 0}
         8.5.9               {revision 0}
         8.6.0beta1          {revision 0}
     }
-
+    PortGroup               obsolete 1.0
+    # This subport can be removed on Aug 1, 2027. 
+    replaced_by             ${php}
     categories-append       devel security
-
-    description             a PHP interface to OpenSSL signature-generation \
-                            and -verification and data-encryption and \
-                            -decryption functions
-
-    long_description        {*}${description}
-
-    depends_lib-append      port:kerberos5 \
-                            port:libcomerr
-
-    post-extract {
-        move ${php.build_dirs}/config0.m4 ${php.build_dirs}/config.m4
-    }
-
-    configure.args-append   --with-kerberos=${prefix}
-
-    # Look in OpenSSL directories before the main include directory.
-    configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
-
-    if {[vercmp ${branch} <= 5.6]} {
-        openssl.branch          1.0
-    } elseif {[vercmp ${branch} <= 8.0]} {
-        openssl.branch          1.1
-    } else {
-        openssl.branch          3
-    }
-
-    if {[vercmp ${branch} <= 5.6]} {
-        configure.args-append   --with-openssl=shared
-    } elseif {[vercmp ${branch} < 7.4]} {
-        configure.args-append   --with-openssl=[openssl::install_area]
-    } else {
-        configure.args-append   --with-openssl
-    }
 }
 
 if {[vercmp ${branch} < 8.3]} {

--- a/lang/php/files/patch-php74-openssl.diff
+++ b/lang/php/files/patch-php74-openssl.diff
@@ -1,0 +1,15 @@
+--- a/configure.ac	2026-08-07 13:35:39
++++ b/configure.ac	2026-08-07 13:51:20
+@@ -1091,12 +1091,6 @@
+ esac
+ 
+ EXTRA_LIBS="$EXTRA_LIBS $DLIBS $LIBS"
+-
+-dnl This has to be here to prevent the openssl crypt() from overriding the
+-dnl system provided crypt().
+-if test "$ac_cv_lib_crypt_crypt" = "yes"; then
+-  EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
+-fi
+ 
+ unset LIBS LDFLAGS
+ 

--- a/lang/php/files/patch-php80-openssl.diff
+++ b/lang/php/files/patch-php80-openssl.diff
@@ -1,0 +1,15 @@
+--- a/configure.ac	2026-08-07 13:35:39
++++ b/configure.ac	2026-08-07 13:51:20
+@@ -1091,12 +1091,6 @@
+ esac
+ 
+ EXTRA_LIBS="$EXTRA_LIBS $DLIBS $LIBS"
+-
+-dnl This has to be here to prevent the openssl crypt() from overriding the
+-dnl system provided crypt().
+-if test "$ac_cv_lib_crypt_crypt" = "yes"; then
+-  EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
+-fi
+ 
+ unset LIBS LDFLAGS
+ 

--- a/lang/php/files/patch-php81-openssl.diff
+++ b/lang/php/files/patch-php81-openssl.diff
@@ -1,0 +1,15 @@
+--- a/configure.ac	2026-08-07 13:35:39
++++ b/configure.ac	2026-08-07 13:51:20
+@@ -1091,12 +1091,6 @@
+ esac
+ 
+ EXTRA_LIBS="$EXTRA_LIBS $DLIBS $LIBS"
+-
+-dnl This has to be here to prevent the openssl crypt() from overriding the
+-dnl system provided crypt().
+-if test "$ac_cv_lib_crypt_crypt" = "yes"; then
+-  EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
+-fi
+ 
+ unset LIBS LDFLAGS
+ 

--- a/lang/php/files/patch-php82-openssl.diff
+++ b/lang/php/files/patch-php82-openssl.diff
@@ -1,0 +1,15 @@
+--- a/configure.ac	2026-08-07 13:35:39
++++ b/configure.ac	2026-08-07 13:51:20
+@@ -1091,12 +1091,6 @@
+ esac
+ 
+ EXTRA_LIBS="$EXTRA_LIBS $DLIBS $LIBS"
+-
+-dnl This has to be here to prevent the openssl crypt() from overriding the
+-dnl system provided crypt().
+-if test "$ac_cv_lib_crypt_crypt" = "yes"; then
+-  EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
+-fi
+ 
+ unset LIBS LDFLAGS
+ 

--- a/lang/php/files/patch-php83-openssl.diff
+++ b/lang/php/files/patch-php83-openssl.diff
@@ -1,0 +1,15 @@
+--- a/configure.ac	2026-08-07 13:35:39
++++ b/configure.ac	2026-08-07 13:51:20
+@@ -1091,12 +1091,6 @@
+ esac
+ 
+ EXTRA_LIBS="$EXTRA_LIBS $DLIBS $LIBS"
+-
+-dnl This has to be here to prevent the openssl crypt() from overriding the
+-dnl system provided crypt().
+-if test "$ac_cv_lib_crypt_crypt" = "yes"; then
+-  EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
+-fi
+ 
+ unset LIBS LDFLAGS
+ 


### PR DESCRIPTION
see: https://trac.macports.org/ticket/69930

#### Description
drop the `php??-openssl` subports and move `openssl` into the SAPI subports in order for `php??-mysql` to be able to use the newest `mysql8` authorisation mechanisms

It works out-of-the-box for `php{81..86}`, but `php{74,80}` fails because they incorrectly link to the wrong libraries.

I'm releasing this for `php{81..86}` and disabling/knownfails `php{74,80}` while working on a solution for those.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
```
Model Identifier: MacPro5,1                 Model Identifier: Macmini6,1
macOS 15.7.7 24G720 x86_64                  macOS 10.15.8 19H2036 x86_64
Xcode 26.3 17C529                           Xcode 12.4 12D4e
Command Line Tools 26.3.0.0.1.1771626560    Command Line Tools 12.4.0.0.1.1610135815
```
