### PR TITLE
claude-code: update to 2.1.216

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.215
+version             2.1.216
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  69f6ca8af0a403d8e9c9075368eb2172cbb970a7 \
-                 sha256  1ef5f5e56ede9f7765a9bef654ece6045dba58f48b7f5b699765375953d52b6b \
-                 size    256540048
+    checksums    rmd160  e91b6667481d4f78222d65498738e2dcf8713077 \
+                 sha256  e17cdc51437bd7a80ce0244d25045f568d67b212eea4ff81b83ee90f8666e42f \
+                 size    258670096
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5e351574854fe84ef7889fd7b80bdd6264f76aa6 \
-                 sha256  90608b5c5ab504e96e77365cea6203d046e291d59b2bb42cf28dcb2ccdf9dd58 \
-                 size    247124336
+    checksums    rmd160  54e5ae411db32c9345362c067bc2ff7cf3485a80 \
+                 sha256  d01b49210d72ecbe277a2665d104bacccddf2d22185be99446d2929e0edfc48d \
+                 size    249225584
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.216.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?