### PR TITLE
ziggity: new port

### DIFF
--- a/devel/ziggity/Portfile
+++ b/devel/ziggity/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        simoarpe ziggity 0.3.0 v
+github.tarball_from archive
+revision            0
+
+description         Fast keyboard-driven terminal UI for Git, written in Zig
+
+long_description    Ziggity is a fast, keyboard-driven terminal UI for Git, \
+                    inspired by lazygit and written in Zig.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  9a7a998e8bf29fd694992ec4aefbe6382ce79f31 \
+                    sha256  8f65d471e05dbf1680a17f605898c64c4aa6f93f83621ef166d8088aa0633149 \
+                    size    4794205
+
+# The Zig 0.16 compiler currently supported by MacPorts requires macOS 13.
+platforms           {darwin >= 22}
+
+depends_build-append \
+                    port:zig \
+                    path:bin/git:git
+depends_run-append  path:bin/git:git
+
+categories          devel
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+use_configure       no
+
+build.cmd           ${prefix}/bin/zig
+build.target        build
+build.args          -Doptimize=ReleaseSafe -j${build.jobs}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/zig-out/bin/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+github.livecheck.regex \
+                    {([0-9.]+)}


### PR DESCRIPTION
#### Description

https://github.com/simoarpe/ziggity

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
