### PR TITLE
weechat: update to 4.9.4

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.9.3
+version             4.9.4
 revision            0
-checksums           rmd160  6f831fbb3c6d80d6a9e37a98a0a8ccd6ab770375 \
-                    sha256  5c7d9539fa86c99ea76a551a889a92bac21eab7bb2790dbd346452d00b10c37c \
-                    size    2797720
+checksums           rmd160  d7aeaf65315d3dc4a85bedeb4391b4bf76c873fa \
+                    sha256  3fc50359f3a3b258c9f03148b02f3b9c59194535d1b465c481fb85a76c2ed005 \
+                    size    2799628
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.9.4

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
