### PR TITLE
openjdk26: update to 26.0.2

### DIFF
--- a/java/openjdk26/Portfile
+++ b/java/openjdk26/Portfile
@@ -11,8 +11,8 @@ name                openjdk${feature}
 set boot_feature 25
 
 # See https://github.com/openjdk/jdk26u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set build 8
-github.setup        openjdk jdk${feature}u ${feature}.0.1 jdk- +${build}
+set build 10
+github.setup        openjdk jdk${feature}u ${feature}.0.2 jdk- +${build}
 revision            0
 github.tarball_from archive
 
@@ -26,9 +26,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  72c45f7bebdf84a13cc5edde9207d55038fe2d5a \
-                    sha256  f5d5496a2f9a81605681209d93fc99726313e5d9a9a2af059f1adaa3914b862d \
-                    size    121612462
+checksums           rmd160  560ba09160c8141066d2daa11d1b057eccef32a8 \
+                    sha256  dc7301511e010b22b28f2953c005b1e5bd7845c025440396f940c5c73d4b73d0 \
+                    size    121699515
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 26.0.2.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?