### PR TITLE
openjdk25: update to 25.0.4

### DIFF
--- a/java/openjdk25/Portfile
+++ b/java/openjdk25/Portfile
@@ -11,8 +11,8 @@ name                openjdk${feature}
 set boot_feature 24
 
 # See https://github.com/openjdk/jdk25u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.3
-set build 9
+set openjdk_version ${feature}.0.4
+set build 7
 revision            0
 
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
@@ -29,9 +29,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  4ac991bfdd9b43e78e559b89481b56cf9a5137de \
-                    sha256  33991482d2e08eaa865212239db7815ad627f2449a836e4a4362301fc1893e12 \
-                    size    119520713
+checksums           rmd160  5cd4ecaf14b8ddac4f1641870c1aa8aab9dddda8 \
+                    sha256  7ac9dc76bc201e1a03e8a7bff750fb226cd7373182293bc1860c33317d47b2df \
+                    size    119678926
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 25.0.4.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?