### PR TITLE
openjdk21: update to 21.0.12

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -8,8 +8,8 @@ set feature 21
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk21u/tags for the latest '*-ga' tag and its corresponding build number
-set openjdk_version ${feature}.0.11
-set build 10
+set openjdk_version ${feature}.0.12
+set build 8
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
 github.tarball_from archive
 version             ${openjdk_version}
@@ -29,9 +29,9 @@ long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementa
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  9ce2dc7b847efd823831229dbafa141baf7b1242 \
-                    sha256  18edf62aa95c99325725475c0ad5621d8de61f4c84fdb8d2b7efd015a6de8e42 \
-                    size    114063214
+checksums           rmd160  45247f59edfdde19422dbdf52c264eb337fe8720 \
+                    sha256  4061da54ee3b69a7b95a5403f3b170e1f6a08b192bde995a5cf607626c839626 \
+                    size    114155298
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.12.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?