### PR TITLE
espanso: update to 2.4.0

### DIFF
--- a/aqua/espanso/Portfile
+++ b/aqua/espanso/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo 1.0
 PortGroup           github 1.0
 
-github.setup        espanso espanso 2.3.0 v
+github.setup        espanso espanso 2.4.0 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ long_description    espanso is a privacy-first, cross-platform text \
                     hub.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  177be4a4bf3c3835f91232d25d696f082c55522d \
-                    sha256  32b315a813114b28ef3ee74c5d2ce0bfc2f75a0bd9a4141c7465cd0b00fdf34c \
-                    size    71749236
+                    rmd160  d17da1b2b1f4031011322f5f67b2dcd45cf81afd \
+                    sha256  90895a8a79476f902a6cfc88a67e8e077971be13f728ce1a35866355d60285a7 \
+                    size    73127300
 
 homepage            https://espanso.org
 
@@ -80,7 +80,9 @@ pre-deactivate {
 
 cargo.crates \
     adler                                    1.0.2                f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                                    0.8.12               5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                             0.7.19               b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e \
+    allocator-api2                           0.2.21               683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android-tzdata                           0.1.1                e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties                0.1.5                819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anyhow                                   1.0.38               afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1 \
@@ -118,7 +120,7 @@ cargo.crates \
     calloop                                  0.12.4               fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298 \
     calloop-wayland-source                   0.2.0                0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02 \
     caps                                     0.5.2                c088f2dddef283f86b023ab1ebe2301c653326834996458b2f48d29b804e9540 \
-    cc                                       1.2.30               deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7 \
+    cc                                       1.2.45               35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe \
     cfg-if                                   0.1.10               4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     cfg-if                                   1.0.0                baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                              0.2.1                613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
@@ -151,6 +153,7 @@ cargo.crates \
     cxxbridge-flags                          1.0.97               8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8 \
     cxxbridge-macro                          1.0.97               a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d \
     dashmap                                  5.4.0                907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc \
+    deranged                                 0.5.8                7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     dialoguer                                0.8.0                c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c \
     difference                               2.0.0                524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
     digest                                   0.9.0                d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
@@ -160,7 +163,6 @@ cargo.crates \
     dlib                                     0.5.2                330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412 \
     downcast                                 0.10.0               4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d \
     downcast-rs                              1.2.0                9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650 \
-    dtoa                                     0.4.7                88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e \
     dunce                                    1.0.1                b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4 \
     either                                   1.6.1                e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     encode_unicode                           0.3.6                a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
@@ -176,8 +178,11 @@ cargo.crates \
     errno-dragonfly                          0.1.1                14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067 \
     event-listener                           5.4.0                3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae \
     event-listener-strategy                  0.5.4                8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
+    fallible-iterator                        0.2.0                4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7 \
+    fallible-streaming-iterator              0.1.9                7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a \
     fastrand                                 2.3.0                37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     filetime                                 0.2.14               1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8 \
+    find-msvc-tools                          0.1.4                52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127 \
     flate2                                   1.0.20               cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0 \
     float-cmp                                0.8.0                e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4 \
     fnv                                      1.0.7                3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -208,7 +213,9 @@ cargo.crates \
     glob                                     0.3.0                9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
     h2                                       0.3.26               81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8 \
     hashbrown                                0.12.3               8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                                0.14.5               e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                                0.15.4               5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5 \
+    hashlink                                 0.8.4                e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
     heck                                     0.3.2                87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac \
     heck                                     0.4.1                95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     hermit-abi                               0.1.18               322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
@@ -242,8 +249,8 @@ cargo.crates \
     lazycell                                 1.3.0                830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
     libc                                     0.2.174              1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776 \
     libloading                               0.7.0                6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a \
+    libsqlite3-sys                           0.26.0               afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326 \
     link-cplusplus                           1.0.10               4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212 \
-    linked-hash-map                          0.5.6                0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                            0.4.13               01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
     linux-raw-sys                            0.9.4                cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     lock_api                                 0.4.11               3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
@@ -278,9 +285,9 @@ cargo.crates \
     notify                                   4.0.17               ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257 \
     notify-rust                              4.11.7               6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400 \
     ntapi                                    0.4.1                e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4 \
+    num-conv                                 0.1.0                51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
     num-traits                               0.2.14               9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     num_cpus                                 1.13.0               05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    num_threads                              0.1.7                5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     objc2                                    0.6.1                88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551 \
     objc2-core-foundation                    0.3.1                1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166 \
     objc2-encode                             4.1.0                ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
@@ -288,10 +295,10 @@ cargo.crates \
     once_cell                                1.19.0               3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     opaque-debug                             0.3.0                624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
     opener                                   0.5.0                4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952 \
-    openssl                                  0.10.72              fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da \
+    openssl                                  0.10.80              a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967 \
     openssl-macros                           0.1.1                a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                            0.1.4                28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a \
-    openssl-sys                              0.9.107              8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07 \
+    openssl-sys                              0.9.116              f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4 \
     ordered-float                            2.1.1                766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218 \
     ordered-stream                           0.2.0                9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
     os_str_bytes                             6.6.1                e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
@@ -311,6 +318,7 @@ cargo.crates \
     piper                                    0.2.4                96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
     pkg-config                               0.3.19               3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
     polling                                  3.6.0                e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6 \
+    powerfmt                                 0.2.0                439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                               0.2.10               ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
     precomputed-hash                         0.1.1                925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
     predicates                               1.0.8                f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df \
@@ -326,7 +334,7 @@ cargo.crates \
     quote                                    1.0.40               1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
     rand                                     0.4.6                552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
     rand                                     0.7.3                6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
-    rand                                     0.8.3                0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e \
+    rand                                     0.8.6                5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
     rand_chacha                              0.2.2                f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_chacha                              0.3.0                e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d \
     rand_core                                0.3.1                7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
@@ -334,7 +342,6 @@ cargo.crates \
     rand_core                                0.5.1                90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                                0.6.2                34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7 \
     rand_hc                                  0.2.0                ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-    rand_hc                                  0.3.0                3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73 \
     rand_pcg                                 0.2.1                16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
     rayon                                    1.5.3                bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d \
     rayon-core                               1.9.3                258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f \
@@ -349,6 +356,7 @@ cargo.crates \
     remove_dir_all                           0.5.3                3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
     reqwest                                  0.11.17              13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91 \
     ring                                     0.16.20              3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
+    rusqlite                                 0.29.0               549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2 \
     rust-argon2                              0.8.3                4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb \
     rustix                                   0.38.32              65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89 \
     rustix                                   1.0.8                11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
@@ -367,9 +375,9 @@ cargo.crates \
     serde                                    1.0.219              5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde_derive                             1.0.219              5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_json                               1.0.62               ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486 \
+    serde_norway                             0.9.42               e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c \
     serde_repr                               0.1.20               175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
     serde_urlencoded                         0.7.1                d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_yaml                               0.8.17               15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23 \
     sha2                                     0.9.6                9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3 \
     shlex                                    1.3.0                0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook-registry                     1.4.5                9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410 \
@@ -400,8 +408,8 @@ cargo.crates \
     thiserror                                2.0.12               567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
     thiserror-impl                           1.0.56               fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471 \
     thiserror-impl                           2.0.12               7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
-    time                                     0.1.44               6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
-    time                                     0.3.15               d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c \
+    time                                     0.3.44               91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d \
+    time-core                                0.1.6                40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b \
     tinyvec                                  1.3.1                848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338 \
     tinyvec_macros                           0.1.0                cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
     tokio                                    1.28.2               94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2 \
@@ -428,11 +436,12 @@ cargo.crates \
     unicode-width                            0.2.1                4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
     unicode-xid                              0.2.1                f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
     unindent                                 0.1.7                f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7 \
+    unsafe-libyaml-norway                    0.2.15               b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104 \
     untrusted                                0.7.1                a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
     url                                      2.2.2                a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
     utf-8                                    0.7.6                09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     vcpkg                                    0.2.15               accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    version_check                            0.9.2                b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    version_check                            0.9.5                0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     wait-timeout                             0.2.0                9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     walkdir                                  2.3.1                777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
     want                                     0.3.0                1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
@@ -522,10 +531,11 @@ cargo.crates \
     xkbcommon                                0.7.0                13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e \
     xkeysym                                  0.2.0                054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621 \
     xml5ever                                 0.17.0               4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650 \
-    yaml-rust                                0.4.5                56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
     zbus                                     5.9.0                4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad \
     zbus_macros                              5.9.0                ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659 \
     zbus_names                               4.2.0                7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97 \
+    zerocopy                                 0.8.27               0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c \
+    zerocopy-derive                          0.8.27               88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831 \
     zeroize                                  1.3.0                4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd \
     zip                                      0.5.13               93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815 \
     zvariant                                 5.6.0                d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f \


### PR DESCRIPTION
#### Description
espanso: update to 2.4.0

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?