### PR TITLE
google-cloud-sdk: update to 577.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             576.0.0
+version             577.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  205074cf0245f82989e812b60f02e2f68c8ab135 \
-                    sha256  59bfea027b9a9e614763bba1b154ce7d52720d0c2a7d9cf32245b9a5e7006835 \
-                    size    59631983
+    checksums       rmd160  e009eb5c50ae97ce510198a18c4f47dbd1520a32 \
+                    sha256  4da3cec159ed45d88c1227efe2c34a83e7a794b0df3805bee8a2c227afbb4c78 \
+                    size    59855747
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  75a3ff1ab5af7012a5af8197f2d8aeec11bc0cf8 \
-                    sha256  ce3f37637805f60e24e4648053354af041aac2407e63dd63b4b48193677da681 \
-                    size    61291475
+    checksums       rmd160  3514e67276e47e6c875b13eefcf15fb9512e09a9 \
+                    sha256  7085ec9fe2cb277fc2adf4a5d7d348494b31dbccaa8e3ac3866663600a363d88 \
+                    size    61508241
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  4b25dda6f0c3d3c3580e35aa64d25e280033b32f \
-                    sha256  307d0a7cf3a911d90df01c3d6cb09b79d6be5c4a8cb1590ce3debc7629f5ce2c \
-                    size    61202654
+    checksums       rmd160  f88047f3be90c687c82b3fe2c038a3abcf2d83b2 \
+                    sha256  5791d4f8db12d0d07eada5cdf74a432dcd770bccf32d217e0bc166fb9fe6e0af \
+                    size    61417557
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 577.0.0.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?