### PR TITLE
minizip-ng: Update to 4.2.2

### DIFF
--- a/archivers/minizip-ng/Portfile
+++ b/archivers/minizip-ng/Portfile
@@ -3,12 +3,13 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
-github.setup        zlib-ng minizip-ng 4.2.1
+github.setup        zlib-ng minizip-ng 4.2.2
 revision            0
-checksums           rmd160  75262e2c3f217f8e75a1758a3ce57960515b1b0a \
-                    sha256  3cc35c2cb925dbe67cc801e3234b31b0f30197812a99377352fa1b551ab3d011 \
-                    size    610659
+checksums           rmd160  41561c2aa39a12ca68e088c305e2f1251fef0654 \
+                    sha256  71af7b9799856d8b03619df3949e9c1be9703f8de0795af71399ba283cb27aac \
+                    size    611941
 
 categories          archivers
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -23,9 +24,8 @@ github.tarball_from archive
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
 
-depends_lib         port:bzip2 \
+depends_lib-append  port:bzip2 \
                     port:libiconv \
-                    path:lib/libssl.dylib:openssl \
                     port:xz \
                     port:zstd
 


### PR DESCRIPTION
#### Description

Update minizip-ng to 4.2.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
