### PR TITLE
htop: Update to 3.5.2

### DIFF
--- a/sysutils/htop/Portfile
+++ b/sysutils/htop/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        htop-dev htop 3.5.0
+github.setup        htop-dev htop 3.5.2
 github.tarball_from releases
 revision            0
 epoch               1
 use_xz              yes
 
-checksums           rmd160  2e1e62e69cbe63c6474a7a7ebe72fa22d817c425 \
-                    sha256  b6586e405c5223ebe5ac7828df21edad45cbf90288088bd1b18ad8fa700ffa05 \
-                    size    461144
+checksums           rmd160  f198051f0810c86eceb406cbbf6b81ae2084576e \
+                    sha256  225128e697c4a8c8a878fd0078c965ff8bd5fb24913bfc8473b8edbd50f843f8 \
+                    size    474052
 
 categories          sysutils
 maintainers         {cal @neverpanic} openmaintainer
@@ -21,21 +21,14 @@ license             GPL-2
 description         an interactive text-mode process viewer for Unix
 long_description    ${name} is {*}${description} systems. It aims to be a better 'top'.
 
-homepage            https://htop.dev
+homepage            https://htop.dev/
 
 depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:ncurses
 
-pre-configure {
-    system -W ${worksrcpath} "sh autogen.sh"
-}
-
-configure.args      --disable-unwind
+configure.args      --without-libunwind
 
 post-destroot {
     # Delete the .png and .desktop files


### PR DESCRIPTION
#### Description

Update htop to 3.5.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
