### PR TITLE
openjdk17-zulu: update to 17.68.17

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.66.19
+version      ${feature}.68.17
 revision     0
 
-set openjdk_version ${feature}.0.19
+set openjdk_version ${feature}.0.20
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until September 2029)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  1be949678876f00375320deb21246fe422830791 \
-                 sha256  6a7b8b23f2419ea1dde7eeace0d5a4cc5dbe7bbc83a8dda35dc64aa12269d041 \
-                 size    194731967
+    checksums    rmd160  cce7d390570cd77915749141ba429f0c87057920 \
+                 sha256  b5bace4a346a7af0fe4f50904c46770e66d4b465800b038693c35e5d5b9bd52a \
+                 size    193762657
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  2c1b8401bead2198f4cd18ea54b6dedfb0513611 \
-                 sha256  f2bd5afaaaa4c23eb4bf2c78913c7eb7d3d228e44209ffec652fb72388a2f25c \
-                 size    192646028
+    checksums    rmd160  12b42026e5c4f0b05ff8f3f778b23e9f6e849296 \
+                 sha256  0da52534760b74ba8a42660384b2f4e44311a47ae52faa45fcbd829b2797b244 \
+                 size    191676948
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.68.17 (OpenJDK 17.0.20).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?