### PR TITLE
openjdk11-zulu: update to 11.90.19

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.88.17
+version      ${feature}.90.19
 revision     0
 
-set openjdk_version ${feature}.0.31
+set openjdk_version ${feature}.0.32
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until January 2032)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  56f8a209ca024b7f8005f9d6284d9195899de017 \
-                 sha256  fb7382de640ea36b9c246d0e00293b209b53bd3c0f9f958f6dc1b9713f430007 \
-                 size    194720094
+    checksums    rmd160  2cc45d390e2316626ee8a779038cc17b6053ad00 \
+                 sha256  5ba1b39cc08999645944bcfd54da48dd6c9a0891785d56cff95e92324fa841f6 \
+                 size    193710889
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  4a791593f10a068312ccbc1956b3273a802a8d99 \
-                 sha256  fe756215bc360cab0703c9c851f7e46d4762591dff33011420a710d4950e79b1 \
-                 size    192716379
+    checksums    rmd160  4509b1bfbc069e87826bdff6956ab1eb8bf51702 \
+                 sha256  a552338385fa27026ced01a3c56a3b3a2de048ed4b79907d876e99be80547551 \
+                 size    191717842
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.90.19 (OpenJDK 11.0.32).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?