### PR TITLE
openjdk26-zulu: update to 26.32.13

### DIFF
--- a/java/openjdk26-zulu/Portfile
+++ b/java/openjdk26-zulu/Portfile
@@ -19,11 +19,11 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-# https://www.azul.com/downloads/?version=java-25&package=jdk#zulu
-version      ${feature}.30.11
+# https://www.azul.com/downloads/?version=java-26&package=jdk#zulu
+version      ${feature}.32.13
 revision     0
 
-set openjdk_version ${feature}.0.1
+set openjdk_version ${feature}.0.2
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2026)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  285682556e6fe710355933cd8bc2b9e824912e18 \
-                 sha256  192610410dcdfb6edca2429b0d5d2b1cdf322f532218ac00327e1bcf8dfe29b3 \
-                 size    231453738
+    checksums    rmd160  5749cac0c4db53153c1625ac6f2d534e808e33e5 \
+                 sha256  3a96262cd9ac0a606959d246fcdedbc5d96081670325cc44aede3bf5690e386c \
+                 size    231522832
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  661db8886c95062fa6ebb7e8e3940f472020a9fb \
-                 sha256  7f1b123232537a30a6ed4aa87d6a84d426b75abf350ebe2356784a261e9d6076 \
-                 size    228824305
+    checksums    rmd160  7c2d7e7a0957d4bfae4a964d49f024c057e9f188 \
+                 sha256  4e9958fc459d8dd72fc51b21314b20b678132fc542915d9faa88d10a4a137ba2 \
+                 size    228897043
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 26.32.13 (OpenJDK 26.0.2).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?