### PR TITLE
openjdk8-zulu: update to 8.96.0.19

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      ${feature}.94.0.17
+version      ${feature}.96.0.19
 revision     0
 
-set openjdk_version ${feature}.0.492
+set openjdk_version ${feature}.0.502
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until December 2030)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  1907d6923b042624d160ddd32ca19e1ce02d1f27 \
-                 sha256  5114b269b88e3d89b0d6b2c28af0c96b5489f340fbaded8fa17613b2adca180c \
-                 size    106725768
+    checksums    rmd160  abf681716daf7f0113dd3415a3f86e3811e055e4 \
+                 sha256  b29088ddb00f81db1e01d6d5bfddd44a58e46ef44b50c372cff3eb1bf5b23173 \
+                 size    106163060
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  9ba4941a1b275c52166bf72168514c7e01965c56 \
-                 sha256  73b84abff0ca4a1b648b6cd12381194496bcf31ee01f2bdd1ed0914c9ee5a159 \
-                 size    104292873
+    checksums    rmd160  c923c58d8366fd6548e4eb71a93305cafa9c4e6e \
+                 sha256  9f9e5038c638e415e507e8b5118a774822f553a56e76bdf4b042c3fbe7b69083 \
+                 size    103713081
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.96.0.19 (OpenJDK 8u502b07).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?