### PR TITLE
openjdk25-corretto: update to 25.0.4.7.1

### DIFF
--- a/java/openjdk25-corretto/Portfile
+++ b/java/openjdk25-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.3.9.1
+version      ${feature}.0.4.7.1
 revision     0
 
 # Support calendar: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  784a388d2da4c98fe5ae2992677b19b59c3dfd96 \
-                 sha256  0cfef7feb0f4d7d352881b08d527c22840b8fb5eaaa7552b25619edb449d6d94 \
-                 size    221430346
+    checksums    rmd160  06130fcfa562c09bd784d717f980ad6e35a84ae7 \
+                 sha256  840b857016f2ab1a60a2aa5a68584b1da55f4ab953c1e2a207bde0a5114f683d \
+                 size    221008402
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  ccc95113a6a23374afff143d1be8d0a882f8a8c4 \
-                 sha256  614107ed76e9fb86d62d8cf2686a9cc4b3a11c019502ca3ba605fc5d51f4d7bb \
-                 size    218752889
+    checksums    rmd160  7a5cb2490219836d645bad071b327011a2e2a713 \
+                 sha256  41e185be6b230cff4e9c85d33f9b092274a32e42113087f26d3b2e4f7909ab78 \
+                 size    218317899
 } else {
     set corretto_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 25.0.4.7.1 (OpenJDK 25.0.4).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?