### PR TITLE
openjdk17-corretto: update to 17.0.20.8.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.19.10.1
+version      ${feature}.0.20.8.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6dcec2f5020d0811c0a7b1a6f4a1f8b6d4e5799e \
-                 sha256  6d3b3e367e1a77b9867bc1b5aa925b1f05d76a0ec62b075e375fa91fdcea0e93 \
-                 size    188646524
+    checksums    rmd160  4186fa6ae6b57dfab53a49b0318e386e70fc8fdd \
+                 sha256  36b2e4f270e8b70aafe8c1ec8c254cc323675fd911d1d3f49981e3f18f73e638 \
+                 size    188738226
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  2377a82a08b2d9d680df4078885c83f4db5be2ec \
-                 sha256  3ba2ab957f60e33c6164d7330b1f6c9f48b5ffd60e4cc9bbcc67def319c29a29 \
-                 size    186597310
+    checksums    rmd160  10ff16eaa128d2f21c86bb3abb759afbdeb4ee7c \
+                 sha256  786a9bbb94d2d077ca5618a80eec4c1a909595fbe24b617d57f50d360f96990e \
+                 size    186696102
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.20.8.1 (OpenJDK 17.0.20).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?