### PR TITLE
openjdk11-corretto: update to 11.0.32.9.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      ${feature}.0.31.11.1
+version      ${feature}.0.32.9.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  b02c2ba6b343f0fc033365e5607ef0f92df5de2a \
-                 sha256  ce278c17516502934179faff7e6d64aac0bab0e48633c792b59b70893b56a0e6 \
-                 size    187827837
+    checksums    rmd160  d926f0fc19a007ee80ec37ce2cd01ab2bd124375 \
+                 sha256  399ff66c80c4f55024c8ba36bfdefbcd4ac180934d147a30b9f66d6970b055e7 \
+                 size    187859804
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f8668f2cde8a1386ecd8db31d587acd07fed0fdf \
-                 sha256  e31cc1fd9b42bf40ec0682a027c024599ac1d84bf2447ab1f32b4caa94c08faa \
-                 size    185315671
+    checksums    rmd160  0652f999174947bed23e7c1ea060e9487b632723 \
+                 sha256  569ef802134a63d026b9a0215c2c61e49a077ce896462334b63668cdd644b1f6 \
+                 size    185351709
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.32.9.1 (OpenJDK 11.0.32).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?