### PR TITLE
openjdk8-corretto: update to 8.502.07.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.492.09.2
+version      ${feature}.502.07.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  ada72c004118df06ac1071a04cfe4c46f3d06b33 \
-                 sha256  63cf32569fae961497091a77c763b3511b1e1650abc22a7e7a9ee38de8fc3567 \
-                 size    118430001
+    checksums    rmd160  c9dfa011cfd9e14298579f28509e6b732b525b41 \
+                 sha256  ab6c714f54388f67bce204cea9f40b2a5ea8fed3263e425520efbc970e6c1f6f \
+                 size    102825410
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  54aac5547dfdbe9f3405362a79675c97ad3526bb \
-                 sha256  4316bff4922d9799883e68f6b9d78a720663fd8f1664f74b005bb285eda0ca26 \
-                 size    102887969
+    checksums    rmd160  d77abdd5c3ea0b718fbdc8e4c6bd907dfe22ac3d \
+                 sha256  81a172ff2dfb3f408eca5b0a0dfaf84657cb68f9a0cc94818d562e144b3f199f \
+                 size    102923569
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.502.07.1.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?