### PR TITLE
openjdk26-corretto: update to 26.0.2.10.1

### DIFF
--- a/java/openjdk26-corretto/Portfile
+++ b/java/openjdk26-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.1.8.1
+version      ${feature}.0.2.10.1
 revision     0
 
 # Support calendar: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  82371b94edf8a9cf525a579e97e199b8619d4f96 \
-                 sha256  7da780f1176119fb81d84839f7d0faa825c5aead799e116f37b278899ff55fe3 \
-                 size    226160588
+    checksums    rmd160  fe263397774c809f2455c66d09b289ce2a2ff58a \
+                 sha256  3c136216dac0b9d1616ae4d6fa2faa317d9af7843be0853dbe7a93154fbd99a9 \
+                 size    226273685
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  9bdfd9fb749a21d05e811878e826198ac61100a4 \
-                 sha256  b385a8d73b53f0b2ee25fe8b0836adae9554f9284aa43fc3bc516ff527097338 \
-                 size    223380962
+    checksums    rmd160  ed55c17eafb6172233e471bfcf2068ed5b0f13af \
+                 sha256  005e867168437be5c12ce704b5310e1ad40e122bef0108634cac70790b5bd6f8 \
+                 size    223486567
 } else {
     set corretto_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 26.0.2.10.1 (OpenJDK 26.0.2).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?