### PR TITLE
openjdk21-sap: update to 21.0.12

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      ${feature}.0.11
+version      ${feature}.0.12
 revision     0
 
 description  SAP Machine ${feature}
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  543088f706335b158aab9c8115c90958cab49928 \
-                 sha256  dbbffaa9ccacee3589315deee46e0a9db0be0ee204e1830414fa3ba2fa9073ee \
-                 size    204031098
+    checksums    rmd160  eeeb8f8c93f9df32eb70f611eb8b2b2d5e069bef \
+                 sha256  16ee0108ba14f7d36609fd8cc0677286ed566ef95f708256ce11ff4dbd2a42b3 \
+                 size    204091618
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  3ea65af22bd6cf04b4cc0352a58f30deb5ef865f \
-                 sha256  a2e8c57e87dd09b75efe5e7573b16f894f84f20319b67f1f1bb80562c84926c2 \
-                 size    201725449
+    checksums    rmd160  221769aea685ceb0b52454882eea56415b675588 \
+                 sha256  3102ea90b1c6e7ded54d48eb1b56f18f36d02c5b3b54ea9ec6106685036fdb63 \
+                 size    201791590
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.12 (OpenJDK 21.0.12).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?