### PR TITLE
openjdk17-sap: update to 17.0.20

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.19
+version      ${feature}.0.20
 revision     0
 
 description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  eaee2ee27e9d461c433db4a5a50451d7883be433 \
-                 sha256  e1da0fa345e11dd12e70b462a7e39abead4be645d96fdeeb1169a69e03f59d24 \
-                 size    189827239
+    checksums    rmd160  118a148b682b2b9eee746d2b1efc08adf42b5877 \
+                 sha256  e7e7d0615056573ebcd60820d138fa2f05e1f1b03d491e5080eaf9d89c2f1b1b \
+                 size    189884660
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  184f7abe0c2f8fb949565fcc7d6b77a27f3ad049 \
-                 sha256  a98bd4b0f2f0e253ef670ac651205afc4a235db470809b6730e990c0e51705d6 \
-                 size    187747466
+    checksums    rmd160  bfb70698cfdefa4a854c861fbbaa0134f9737231 \
+                 sha256  9c84d766eeb257208ccbb852b00ed3a88b5a92cc5ead6796266ba4d60ebbc574 \
+                 size    187830758
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.20 (OpenJDK 17.0.20).

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?