### PR TITLE
jdk21: update to 21.0.12

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      ${feature}.0.11
+version      ${feature}.0.12
 revision     0
 
 description  Oracle Java SE Development Kit ${feature}
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  b7c4fdaf4e7015eef2992409afeb0850f44b310a \
-                 sha256  0c7490310b37f250fa9bfc1e8bd0674ec47f3ce0abbef1468fa87825ae2fcd01 \
-                 size    193957422
+    checksums    rmd160  07289a4700d691c4e9f3d6dafc034ca67fba87e5 \
+                 sha256  73943c130e0e064a7d4674f81e397b097f1a6bf2f35b5db6a4123d6d1f17b703 \
+                 size    194032563
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  c2de39e938e62d2d070297e903bc4ade41f5a25d \
-                 sha256  95debdf373d9b44df554a8dd0b1ace48adc02515139e041325347e372825eeaf \
-                 size    191654769
+    checksums    rmd160  e7031e4d9a9fffda35a7873611b960e9d6969339 \
+                 sha256  64377c2dab9b5df4be5648d84ba54174b46add6ca2bec86aa2716e5b3bddac62 \
+                 size    191716493
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 21.0.12.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?