### PR TITLE
llama-swap: update to 241

### DIFF
--- a/llm/llama-swap/Portfile
+++ b/llm/llama-swap/Portfile
@@ -3,15 +3,15 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/mostlygeek/llama-swap 240 v
+go.setup                github.com/mostlygeek/llama-swap 241 v
 go.offline_build        no
 revision                0
-set git-commit          6b5320d
+set git-commit          8b61e3d
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  48e2f09219dfad125c5b217303134ef5b3e637a2 \
-                        sha256  153966ad537be92fc0b839d51b02335cffba442bf5410404725bdc06a2b090ad \
-                        size    3687321
+                        rmd160  bc5fcf329484f9fcdeaef8ca4e7f9d735fb1f134 \
+                        sha256  dc6f9fa8d6705c77044ff97f65d3d2e5c409fd478acb367fb5fd893c3af584ff \
+                        size    3704654
 
 categories              llm
 license                 MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
