### PR TITLE
llmfit: update to 1.1.6

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.37 v
+github.setup            AlexsJones llmfit 1.1.6 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  75be0b762f100059a7b460c62e5c52f34206436c \
-                        sha256  bf609447f376e24253cce64ef31e68db865057fa6c0aa6720d0a7532fb78bfa2 \
-                        size    3335708
+                        rmd160  4693f2386aa5fda22aad15fdc367f9ee5f566af2 \
+                        sha256  20464f17882ea45ac4b52708a87da83eadeec4ac31a065807d14b6716078d246 \
+                        size    7817372
 
 categories              llm
 platforms               macosx
@@ -47,7 +47,7 @@ cargo.crates \
     anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arboard                          3.6.1  0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf \
-    assert_cmd                       2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
+    assert_cmd                       2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
     async-nats                      0.49.1  fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a \
     async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atk                             0.18.2  241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b \
@@ -341,6 +341,7 @@ cargo.crates \
     objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
     objc2-io-kit                     0.3.2  33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15 \
     objc2-io-surface                 0.3.2  180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d \
+    objc2-metal                      0.3.2  a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794 \
     objc2-open-directory             0.3.2  bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d \
     objc2-quartz-core                0.3.2  96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f \
     objc2-ui-kit                     0.3.2  d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22 \
@@ -425,13 +426,13 @@ cargo.crates \
     ref-cast                        1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                   1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
     referencing                     0.46.5  69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2 \
-    regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex                           1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
     regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
-    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     reqwest                         0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rmcp                             1.7.0  0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e \
-    rmcp-macros                      1.7.0  6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d \
+    rmcp                             1.8.0  1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59 \
+    rmcp-macros                      1.8.0  1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5 \
     rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
@@ -458,7 +459,7 @@ cargo.crates \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_nanos                      0.1.4  a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985 \
     serde_path_to_error             0.1.20  10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
     serde_repr                      0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
@@ -507,13 +508,13 @@ cargo.crates \
     tao                             0.35.2  a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4 \
     tao-macros                       0.1.3  f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
-    tauri                           2.11.2  437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28 \
-    tauri-build                      2.6.2  4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7 \
-    tauri-codegen                    2.6.2  e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9 \
-    tauri-macros                     2.6.2  ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924 \
-    tauri-runtime                   2.11.2  48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef \
-    tauri-runtime-wry               2.11.2  b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9 \
-    tauri-utils                      2.9.2  092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95 \
+    tauri                           2.11.5  667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5 \
+    tauri-build                      2.6.3  bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632 \
+    tauri-codegen                    2.6.3  08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5 \
+    tauri-macros                     2.6.3  e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45 \
+    tauri-runtime                   2.11.3  b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8 \
+    tauri-runtime-wry               2.11.4  4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f \
+    tauri-utils                      2.9.3  3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887 \
     tauri-winres                     0.3.5  1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0 \
     tendril                          0.5.0  c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24 \
     termina                          0.3.3  9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e \
@@ -554,7 +555,7 @@ cargo.crates \
     tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
     tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
-    tray-icon                       0.23.1  15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773 \
+    tray-icon                       0.24.1  65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     tryhard                          0.5.2  9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5 \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
@@ -567,7 +568,7 @@ cargo.crates \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
     unicode-general-category         1.1.0  0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f \
     unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
-    unicode-segmentation            1.13.2  9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c \
+    unicode-segmentation            1.13.3  c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8 \
     unicode-truncate                 2.0.1  16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5 \
     unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
@@ -619,7 +620,7 @@ cargo.crates \
     wezterm-dynamic                  0.2.1  5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac \
     wezterm-dynamic-derive           0.1.1  46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b \
     wezterm-input-types              0.1.0  7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e \
-    which                            8.0.2  81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459 \
+    which                            8.0.4  48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
