### PR TITLE
rsync: Fix build on <10.10

### DIFF
--- a/net/rsync/Portfile
+++ b/net/rsync/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# "at" calls (rsync's mechanism to avoid them doesn't work)
+legacysupport.newest_darwin_requires_legacy 13
 
 name                rsync
 version             3.4.4
@@ -57,13 +61,6 @@ if {${subport} eq ${name}} {
     compiler.blacklist  {clang >= 1100 < 1103}
 
     configure.args      --with-rsyncd-conf=${prefix}/etc/rsyncd.conf
-
-    if {${os.platform} eq "darwin" && ${os.major} < 11} {
-        # macOS 10.6 defines AT_FDCWD but lacks several *at() system calls.
-        # Disable their use so rsync falls back to the compatible code paths.
-        # https://github.com/RsyncProject/rsync/issues/1025
-        configure.cppflags-append -DRSYNC_NO_AT_SYSCALLS
-    }
 
     test.run            yes
     test.target         check


### PR DESCRIPTION
Although rsync has an option to do without the "at" calls, it doesn't work properly.  Legacy-support provides an implementation, thereby avoiding the problem.

Since this change only affects broken builds, no revbump is necessary.

Closes: https://trac.macports.org/ticket/74236

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-26.x arm64.  Included all variants compatible with available dependencies on the respective platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.7 23J520, arm64, Xcode 16.2 16C5032a
macOS 15.7.7 24G720, arm64, Xcode 26.3 17C529
macOS 26.5.2 25F84, arm64, Xcode 26.6 17F113
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The tests fail on almost all platforms, including ones unaffected by this change.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
