### PR TITLE
vega: update to 6.3.0

### DIFF
--- a/graphics/vega/Portfile
+++ b/graphics/vega/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                vega
-version             6.2.0
+version             6.3.0
 revision            0
 
 npm.rootname        vega-cli
@@ -25,9 +25,9 @@ long_description    Vega is a visualization grammar, a declarative language for 
 
 homepage            https://vega.github.io/vega/
 
-checksums           rmd160  628ebd2ffc088f9eb97cc67b0acbd0bb01087383 \
-                    sha256  b6007efa43e3b8fe8d5ad941a4283affeec3f07770c1dcb4ed50cbe70dbce802 \
-                    size    4080
+checksums           rmd160  ac7e536b8be48a984929225b3a44c629e1f0b22f \
+                    sha256  db42f7bb7f2d3032430eb44a6c01de216c91867db2c67997b95cbdff01127f4f \
+                    size    4154
 
 platform darwin {
     if {${os.major} >= 22} {


### PR DESCRIPTION
Update `vega` from 6.2.0 to 6.3.0.

Upstream release: https://github.com/vega/vega/releases/tag/v6.3.0

Verified locally:
- `port lint --nitpick` passes
- `port test` passes