### PR TITLE
kubectl subports: update recent releases

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -57,11 +57,11 @@ subport kubectl-1.34 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     9
+    set patchNumber     10
     revision            0
-    checksums           rmd160  6fba79f526d012999014a3bc52389b67f8965ab9 \
-                        sha256  a6949a78bd93f97dd2b0b2abf736eb2907a9b1a9739bf71d340f7aa95a799ce2 \
-                        size    38367952
+    checksums           rmd160  4a0c751345cf877ba4d9bb3b7287f20f5d055044 \
+                        sha256  8e2a678ef653a9c691bd74d6be65c05ccfe9a698f7123b85448032e4424d8ee2 \
+                        size    38370447
 }
 
 subport kubectl-1.33 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -44,11 +44,11 @@ subport kubectl-1.35 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     6
+    set patchNumber     7
     revision            0
-    checksums           rmd160  c75f7097065878aa44dc077be52ff9152abe71f1 \
-                        sha256  2705457cc1a6f9e09f2849e317eb6117d6f0af6dbabefe6f839fbb9df62c6e5f \
-                        size    39185264
+    checksums           rmd160  1f764ed63c3d50e13a16ccb4c073df21fcfbac70 \
+                        sha256  006cf52d6a5a165f91f356c763f4c252af76dc6e18ef029aecf4dcba63bc0a87 \
+                        size    39196444
 }
 
 subport kubectl-1.34 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -31,11 +31,11 @@ subport kubectl-1.36 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     2
+    set patchNumber     3
     revision            0
-    checksums           rmd160  9863dab4aec4cc172283e552abb313944193a77a \
-                        sha256  ffbc46612cf32ad08a3b606de064b63afc350ae1dd1a691e99b5cd127d716c26 \
-                        size    40606064
+    checksums           rmd160  b85285de91361c11d8455a0cfaccdeca5865bf7d \
+                        sha256  950f7dd65b64b18ca065a08ae73dd5f61ff72b48c8778c5bfceacc84eaaf10ed \
+                        size    40619171
 }
 
 subport kubectl-1.35 {
@@ -325,7 +325,7 @@ if {${subport} == ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             1.36.2
+    version             1.36.3
     revision            0
 
 } elseif {${subport} == "kubectl_select"} {


### PR DESCRIPTION
## Summary

- Update `kubectl-1.34` to 1.34.10
- Update `kubectl-1.35` to 1.35.7
- Update `kubectl-1.36` to 1.36.3
- Update the obsolete `kubectl` stub version to 1.36.3
