### PR TITLE
flint: Fix Sonoma builds, use macports m4

### DIFF
--- a/math/flint/Portfile
+++ b/math/flint/Portfile
@@ -8,7 +8,7 @@ github.setup                flintlib flint 3.6.0 v
 revision                    0
 categories                  math devel
 license                     LGPL-2.1+
-maintainers                 {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+maintainers                 nomaintainer
 description                 Fast Library for Number Theory
 long_description            FLINT is a C library for doing number theory
 
@@ -34,6 +34,12 @@ use_autoreconf              yes
 
 compiler.cxx_standard           2011
 compiler.thread_local_storage   yes
+
+# Fix "configure: error: No usable m4 in $PATH or /usr/5bin" on Sonoma.
+# Use MacPorts M4.
+if {${os.major} < 24} {
+    depends_build-append    port:m4
+}
 
 depends_lib-append          port:gmp \
                             port:mpfr \

--- a/math/flint/Portfile
+++ b/math/flint/Portfile
@@ -30,27 +30,21 @@ use_xz                      yes
 # https://github.com/flintlib/flint/pull/1906
 # https://github.com/flintlib/flint/issues/1907
 
-use_autoreconf              yes
-
 compiler.cxx_standard           2011
 compiler.thread_local_storage   yes
-
-# Fix "configure: error: No usable m4 in $PATH or /usr/5bin" on Sonoma.
-# Use MacPorts M4.
-if {${os.major} < 24} {
-    depends_build-append    port:m4
-}
 
 depends_lib-append          port:gmp \
                             port:mpfr \
                             port:ntl
 
-# We do not want pre-built ports with -march.
-configure.args-append       --disable-arch
-
 configure.args-append       --with-ntl
 # NTL requires C++11
 configure.cxxflags-append   -std=c++11
+
+# Fix "configure: error: No usable m4 in $PATH or /usr/5bin" on Sonoma.
+platform darwin 24 {
+    configure.env-append    M4=/usr/bin/m4
+}
 
 test.run                    yes
 test.target                 check


### PR DESCRIPTION
#### Description

* Sonoma (only) builds were failing on MacPorts builders, but not on Github CI.
* Fixes "configure: error: No usable m4 in $PATH or /usr/5bin" on Sonoma.
* No rev bump.  Build fix only.
* Remove inactive maintainer, switch to nomaintainer.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.
* Wait for merge to check results on MacPorts builders.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?