### PR TITLE
sops: Update to 3.13.3

### DIFF
--- a/security/sops/Portfile
+++ b/security/sops/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mozilla/sops 3.13.2 v
+go.setup            github.com/mozilla/sops 3.13.3 v
 go.package          go.mozilla.org/sops/v3
 go.offline_build    no
 revision            0
@@ -20,9 +20,9 @@ license             MPL-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  1037fc6ef1a9698cfc3cc0bd2788d5bed57a617e \
-                    sha256  79560b53814e20031d094a293d6c169314eaaf97efd6e95a6d765e61e881db2c \
-                    size    271738
+checksums           rmd160  4876396bf90eb861aa3e2d2f3df7a4ca5afd28ca \
+                    sha256  49811c5ed80f6b4d4e98cef98e3f7378406aa692fd773dfb72ad1b4dfb940448 \
+                    size    272777
 
 build.target        ./cmd/sops
 


### PR DESCRIPTION
#### Description

Fixes a regression that caused files with commented entries in lists to no longer open.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
