### PR TITLE
py-mitogen: Update to 0.3.51

### DIFF
--- a/python/py-mitogen/Portfile
+++ b/python/py-mitogen/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-mitogen
-version             0.3.45
+version             0.3.51
 revision            0
-checksums           rmd160  55caba439d020119f84137d316b0b29c300c3d85 \
-                    sha256  ee41b1595778903948b94c34ecee853f4ec67c6c5ac3239caa3bc6b4c34e61e8 \
-                    size    241033
+checksums           rmd160  dc12fdc490f1a667b824059927ec4c7693b2f1e6 \
+                    sha256  3c53a276d8c68de36f55c299394fee8739feb891e3a44b988ef4faac2b0c3a2a \
+                    size    242262
 
 categories-append   sysutils
 supported_archs     noarch


### PR DESCRIPTION
#### Description

Includes a fix for the 'dnf5' module not working,
mitogen-hq/mitogen#1077.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
