### PR TITLE
skaffold: update to 2.24.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.23.0 v
+github.setup        GoogleContainerTools skaffold 2.24.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  f467b8183a21e7f8ac50806d25d6cc0f9e67d196 \
-                    sha256  af16760930e9463139f3228858a9308bb5e1eaa1c595c09768a1e058a1ae0baa \
-                    size    74999439
+checksums           rmd160  12220b407b9e23b6372007215d648a389a47967b \
+                    sha256  a8a5b2f7f291834be1fffff0f2eb1a32245c6279546b2037e0281d62d5607bb5 \
+                    size    75001841
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.24.0.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?