### PR TITLE
micronaut: update to 5.0.6

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.0.5 v
+github.setup    micronaut-projects micronaut-starter 5.0.6 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  4102b5a479dc2905e3b6ab38d6d0484d39e54939 \
-                 sha256  ea640a2794e0c6eb17e8ad96ccf963c96a9fc490b27fbfc95fbee165ca8e67ee \
-                 size    33756005
+    checksums    rmd160  953c1316a4322f70abdd6fa430d866a9f94b9cc7 \
+                 sha256  4596f65e81da7669956fe464b2a1ae90e1480b98a2f72655905941b58cf79de1 \
+                 size    33774236
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  37a3fa60e45a6a1eef946673c82d850a7ea0060b \
-                 sha256  88af16e2f4e77e9d39e46cd46c4335860f263cef93dbe40b8375b33b0ec6977f \
-                 size    38772844
+    checksums    rmd160  834df5bdbecb91344e9d3cb8cec0a9043934524a \
+                 sha256  a7d720fd102b5a0c17ab80e88bb1b0ba12c00745d6f8fa5664776c582634faf3 \
+                 size    38794983
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.0.6.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?