### PR TITLE
claude-code: update to 2.1.218

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.217
+version             2.1.218
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  eb96e0bb5a2c3accd91af33fea35e2b81c59f5ae \
-                 sha256  8387a6fd44edfd40d7e74c5fdc3270a15f5e6b1b58c7c6fee560e70d3d1943da \
-                 size    259908496
+    checksums    rmd160  afbe9066224d3d2df2dc08d74fe5f03ffa0e7bc2 \
+                 sha256  9862b74a083e8a4ed572f99cbd4895185e0dd5a0a601affb0fb8e43d8d1f40e6 \
+                 size    264548368
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  36a67701da887432d166eb6ef22f0b8476320c8c \
-                 sha256  5840c777fd47115e9ca276e165563c6e121e7c7e2b4d86598e0025f8cc37de56 \
-                 size    250456784
+    checksums    rmd160  64b64a483b464dfb7c1d4fdd69c4e769611e8fe2 \
+                 sha256  71abaff59312c9a9b6a1d818365048b42e4e95cc521a823660eded3e0880d9b7 \
+                 size    255069680
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.218.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?