### PR TITLE
openjdk25-microsoft: update to 25.0.4

### DIFF
--- a/java/openjdk25-microsoft/Portfile
+++ b/java/openjdk25-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-25
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.3
-set build    9
+version      ${feature}.0.4
+set build    7
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  e25e810da2f5f82124d65bc2339232780d64f16a \
-                 sha256  bb590b1e3bee59120bad3ef79b8de82f2f56f6394b60179c5a7caef820bbdd2f \
-                 size    220403004
+    checksums    rmd160  6f62468aa1f76d83172616ec9241a423d7d51dd8 \
+                 sha256  f1a4ecae13d1f026c2cd1664419afdcb81b56cb21938eec60cfaaf712aaa8199 \
+                 size    219895951
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  53daf4beb0469edadebd1634ef8a0ad6dab38f3e \
-                 sha256  9f0091f4ffd6a4c314cd41c6e42e4a68fd50e17e6d281681c48796139deecab3 \
-                 size    217727186
+    checksums    rmd160  fe1d4999e6abe1a788faf89778b2305d8a504c8b \
+                 sha256  f5aba38dfda6f912eb539458ed089300d82b2a6b25963f714e9bb12b7db842f9 \
+                 size    217213645
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 25.0.4.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?