### PR TITLE
openjdk21-microsoft: update to 21.0.12

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.11
-set build    10
+version      ${feature}.0.12
+set build    8
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  170b0322de55c4f02021990f21a44f6d91b97e1d \
-                 sha256  c0c2db2d9ec201ffec96cfa7a39b5e1ad486b6acf421a153651789da6a565fa3 \
-                 size    202440895
+    checksums    rmd160  15f90671cb1ca7bddfe42ff289b78bb27804e52b \
+                 sha256  9b06efd99de047f2aba42ea0804854e51b69ed633e995730aef049adac62cb98 \
+                 size    202450530
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  c72982f5cd6ecb5579109a19ee479aa75a7a3e59 \
-                 sha256  22eac07819b9fe6670cb026fd3fd7bddd31938ea3adad7b722ac0631d76d9667 \
-                 size    200065878
+    checksums    rmd160  4c8c26b0a8a54fd4ec901d9094c348922651ed68 \
+                 sha256  56f338a3c6af071649047e78f2d31a2ca97c57be6c1b2c213823acb016463ee1 \
+                 size    200091378
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 21.0.12.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?