### PR TITLE
claude-code: update to 2.1.219

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.218
+version             2.1.219
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  afbe9066224d3d2df2dc08d74fe5f03ffa0e7bc2 \
-                 sha256  9862b74a083e8a4ed572f99cbd4895185e0dd5a0a601affb0fb8e43d8d1f40e6 \
-                 size    264548368
+    checksums    rmd160  67516eee67b7cd65314e1eb220b676a96e347d56 \
+                 sha256  03be9f988ed88391b4a5f08e4c5dc317ce2fffa4a9dc66c01106326e7698ee76 \
+                 size    266381200
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  64b64a483b464dfb7c1d4fdd69c4e769611e8fe2 \
-                 sha256  71abaff59312c9a9b6a1d818365048b42e4e95cc521a823660eded3e0880d9b7 \
-                 size    255069680
+    checksums    rmd160  17b24756c47a93e99c4fdbfcafa90f6d5d6f420d \
+                 sha256  a8e806faaefac53c7a0f26523d8a45c60dbef3407b14ef990c75765d08febc82 \
+                 size    256908272
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.219.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?