### PR TITLE
openjdk17-microsoft: update to 17.0.20

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.19
-set build    10
+version      ${feature}.0.20
+set build    8
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  cfe4bc5462e6a3e9da7dcc802242a3865718e036 \
-                 sha256  6af364adc0c79a5a8d4ea2edc5ecb8cd7e47360c2944947c70482e18befea046 \
-                 size    188133169
+    checksums    rmd160  1650b236ffcbafb121cd6fd9abaf906c81f3ca2d \
+                 sha256  0ac37641dab2dcfec41cc31f932f0eea28bb773fdab443c2d2cd1614020f6047 \
+                 size    188139000
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  94b1049a8dc7c0a4a16c71b5405806756da65fbf \
-                 sha256  5ce59293b2eb30cb4e9f0c72c1ea27cea2bfaadcf0dbbe87ddd92e031c4210be \
-                 size    186130463
+    checksums    rmd160  a43cf957b79cb8f6996e17cf115f0e8dbcb537c5 \
+                 sha256  13f45a64a3d3a1f2eec490527bf3e42913ac0ca3f95af2c5471446a2da8e5a22 \
+                 size    186155866
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 17.0.20.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?