### PR TITLE
openjdk11-microsoft: update to 11.0.32

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.31
-set build    11
+version      ${feature}.0.32
+set build    9
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  96d0b169dfe96dcd8114277f90fb4f7c65702154 \
-                 sha256  f16583e0fe5ce4274dc4bec49593470d899353b16f5571a2cd980d6438f9f3ef \
-                 size    191132465
+    checksums    rmd160  d540841f58e754bc32a1daaa46f3dae344a25cc4 \
+                 sha256  f4c6d69692e27b33ed39b89d096cfcfb2dae0d5bbce78c5dc3123d507bd7d049 \
+                 size    191105486
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f876a245c17aaf3a2f59821bc07671a309e3d9cd \
-                 sha256  03e7a317bf74e370252a86049d379183628dfb7320e9e74ae0bdcfd8a4506bd9 \
-                 size    185244891
+    checksums    rmd160  966ccb8428bbf74742134d5f331c2a590fa06993 \
+                 sha256  5b56e9658e4f08b0ed5aa9c914213b5214de299c85e8668892d169c37ba134bc \
+                 size    185242316
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 11.0.32.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?