### PR TITLE
hdf5: Fix livecheck

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -166,6 +166,6 @@ Otherwise errors such as "unable to open file" or "HDF5 error" may be\
 encountered.
 }
 
-# Livecheck on GitHub release tags only.  Exclude non-release tags.
+# Livecheck on GitHub release tags only.  Exclude release candidates.
 # Accept matches both with and without "hdf5_" or "hdf5-" prefix.
-livecheck.regex     releases/tag/\[hdf5_-\]*(\[0-9.-\]+)
+livecheck.regex     {releases/tag/[hdf5_-]*([0-9.]+)"}

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -166,6 +166,6 @@ Otherwise errors such as "unable to open file" or "HDF5 error" may be\
 encountered.
 }
 
-# Livecheck on GitHub release tags only.  Exclude release candidates.
+# Livecheck on GitHub release tags only.  Exclude non-release tags.
 # Accept matches both with and without "hdf5_" or "hdf5-" prefix.
 livecheck.regex     {releases/tag/[hdf5_-]*([0-9.]+)"}


### PR DESCRIPTION
#### Description

* Livecheck fix only.  Fix exclusion of release candidates.

###### Type(s)

- [x] enhancement

###### Tested on

* CI only.  No code changes.
* Livecheck fix was tested on macOS 15.7.7.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?