### PR TITLE
ralphex: update to 1.6.1

### DIFF
--- a/llm/ralphex/Portfile
+++ b/llm/ralphex/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/umputun/ralphex 1.6.0 v
+go.setup            github.com/umputun/ralphex 1.6.1 v
 revision            0
 categories          llm
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -19,9 +19,9 @@ build.pre_args-append \
                     TAG=v${version}
 build.args          build
 
-checksums           rmd160  8c2ac73c00311fb7b496e1dc4851a49b06547bf8 \
-                    sha256  55daac7de46183e16ee57a22e9527d342ac2c5a2ed6284a749d5a11f25aec6b8 \
-                    size    8239037
+checksums           rmd160  16337580c7fe38866ca04c083cadf81760f12969 \
+                    sha256  634fd66449b340400464cd8e29269da1e4d4344baa5a01d3a70cb595e444603b \
+                    size    8257016
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/.bin/ralphex.v${version} ${destroot}${prefix}/bin/ralphex


### PR DESCRIPTION
#### Description
https://github.com/umputun/ralphex/blob/v1.6.1/CHANGELOG.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
