### PR TITLE
miniflux: update to 2.3.3

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.3.2
+go.setup            github.com/miniflux/v2 2.3.3
 go.package          miniflux.app/v2
 go.offline_build    no
 name                miniflux
@@ -18,9 +18,9 @@ description         Minimalist and opinionated feed reader
 long_description    {*}${description}
 homepage            https://miniflux.app
 
-checksums           rmd160  64e5419bda764a41ffb653f78decfd546968477d \
-                    sha256  5bcfab4ca5c8d3ab83627d7230129fc616c98e5050f475f2876995441b2fc94e \
-                    size    969503
+checksums           rmd160  4056e96eecb1131df6f90921c984e6afb4d3498f \
+                    sha256  68cd4f16d85faf2045c13990de605cc7b1e2550d7a1d88e3522d2893685b5847 \
+                    size    982597
 
 build.args-append   \
     -ldflags=\"-s -w -X \


### PR DESCRIPTION
#### Description
https://github.com/miniflux/v2/releases/tag/2.3.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
