### PR TITLE
gdal: Fix livecheck

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -638,9 +638,13 @@ if {$subport eq $name} {
         }
     }
 
+# 2026 July 25: For livecheck, stick with the master download directory.
+# Do not use https://download.osgeo.org/gdal/CURRENT.
+# The master directory is more reliable than the CURRENT subdirectory.
+
     livecheck.type  regex
-    livecheck.url   https://download.osgeo.org/gdal/CURRENT
-    livecheck.regex ${name}-(\\d+(?:\\.\\d+)*)\\.tar
+    livecheck.url   https://download.osgeo.org/gdal/
+    livecheck.regex {title="([0-9.]+)"}
 }
 
 proc set_gdal_variants {} {


### PR DESCRIPTION
#### Description

* Fix livecheck only.
* Use upstream master "download" URL, not "CURRENT".
* As of last upstream release, "CURRENT" is not getting updated reliably.
* No code changes, therefore no rev bumps needed.

###### Type(s)

- [x] enhancement

###### Tested on

* Builds: CI only.
* Livecheck was tested on macOS 15.7.7, on command line.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
