### PR TITLE
ngspice: update to 46

### DIFF
--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            ngspice
-version         44.2
+version         46
 revision        0
 license         BSD
 categories      science cad
@@ -23,14 +23,14 @@ homepage        http://ngspice.sourceforge.net/
 distname        ${name}-${version}
 master_sites    https://sourceforge.net/projects/ngspice/files/ng-spice-rework/${version}
 
-checksums       rmd160  4194feaa1163de2bad9459d79be0a47ea0b4b4ec \
-                sha256  e7dadfb7bd5474fd22409c1e5a67acdec19f77e597df68e17c5549bc1390d7fd \
-                size    11198335
+checksums       rmd160  69a2a9a95d919bac6f80e0d18d85b2e6f089159c \
+                sha256  a0d1699af1940b06649276dcd6ff5a566c8c0cad01b2f7b5e99dedbb4d64c19b \
+                size    10504768
 
 set docdir      ${prefix}/share/doc/${name}
 
-#this strips the .x from 4.x 
-set major_version [string range ${version} 0 [expr {[string first "." ${version}]-1}]]
+#take the major version (part before the first dot), or the whole version if there is no dot
+set major_version [lindex [split ${version} .] 0]
 
 
 # checking whether C compiler accepts -std=gnu11... no
@@ -91,6 +91,7 @@ if {${name} eq ${subport}} {
             FAQ \
             NEWS \
             README \
+            README_OSDI.md \
             Stuarts_Poly_Notes \
             ${destroot}${docdir}
     }
@@ -126,9 +127,9 @@ subport ngspice-docs {
     extract.suffix
     extract.only
 
-    checksums           rmd160  a6cf586696a6307df9be3d40091b355829b35e90 \
-                        sha256  ab302f45ce5f866279638c8e7a4fb8e6a3b8b67cfbfd76d7951ccc4f636ce83e \
-                        size    2575573
+    checksums           rmd160  7fd3305cf6829a44c13bfd50993d53b937afeeeb \
+                        sha256  b5bc7c4f3aac00e670b01b1d1ab64ec87055a491014af1de828764bf98faf766 \
+                        size    2660636
 
     use_configure       no
 


### PR DESCRIPTION
  #### Description

  Update ngspice from 44.2 to 46.
  - Cleanup for 44.2
  - Bump `version` to 46 
  - Update the `ngspice-docs` subport to the ngspice-46 manual PDF.
  - Install the new `README_OSDI.md` doc file (OSDI / OpenVAF support has been default-on since ngspice 45).

  Both existing patches (`patch-fix-linking.diff`, `patch-ngspice-older-MACH-defines.diff`) still apply

  ###### Type(s)
  
  - [ ] bugfix
  - [x] enhancement
  - [ ] security fix

  ###### Tested on
  macOS 13.7.8 22H730 x86_64
  Xcode 14.3.1 14E300c

  ###### Verification
  Have you

  - [x] followed our [Commit Message 
  Guidelines](https://trac.macports.org/wiki/CommitMessages)?
  - [x] squashed and [minimized your 
  commits](https://guide.macports.org/#project.github)?
  - [x] checked that there aren't other open [pull 
  requests](https://github.com/macports/macports-ports/pulls) for the same 
  change?
  - [ ] referenced existing tickets on 
  [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit 
  message?
  - [x] checked your Portfile with `port lint`?
  - [x] tried existing tests with `sudo port test`?
  - [x] tried a full install with `sudo port -vst install`?
  - [x] tested basic functionality of all binary files?
  - [x] checked that the Portfile's most important 
  [variants](https://trac.macports.org/wiki/Variants) haven't been broken?