### PR TITLE
opencode: update to 1.18.5

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.18.3
+version             1.18.5
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  f2edeb87f079bcefb2910a21c031528a93835722 \
-                    sha256  102fd1da136b603f4bcc3d74c2c9cf0d6906f44865f2233f3e0612390d2e5ead \
-                    size    3046
+checksums           rmd160  4b3e89aa7c3cfbb444fd409f72e59530451243d6 \
+                    sha256  e86ed5a01d91564b6b02c360a752695b1910def48db28a63454a49b78b5f9c43 \
+                    size    3048


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.5.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?