### PR TITLE
claude-code: update to 2.1.220

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.219
+version             2.1.220
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  67516eee67b7cd65314e1eb220b676a96e347d56 \
-                 sha256  03be9f988ed88391b4a5f08e4c5dc317ce2fffa4a9dc66c01106326e7698ee76 \
-                 size    266381200
+    checksums    rmd160  4ccaa67d9b958d75f2ea828c415d50f9447c16d6 \
+                 sha256  dca7be0aa7d3d924836d440e0c6d8e3d47ef3c8e61fa5809b54b9017170ce2f3 \
+                 size    266397712
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  17b24756c47a93e99c4fdbfcafa90f6d5d6f420d \
-                 sha256  a8e806faaefac53c7a0f26523d8a45c60dbef3407b14ef990c75765d08febc82 \
+    checksums    rmd160  5a5ee9ab82877ecd82dab4e7ae6dcc9512044a7d \
+                 sha256  8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081 \
                  size    256908272
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.220.

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?