### PR TITLE
katifetch: new port at version 13.1

### DIFF
--- a/sysutils/katifetch/Portfile
+++ b/sysutils/katifetch/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                katifetch
+version             13.1
+categories          sysutils
+platforms           any
+supported_archs     noarch
+license             GPL-3+
+maintainers         {@ximimoments github.com:ximimoments}
+
+description         Lightweight system information fetch tool
+long_description    Katifetch is a lightweight system information fetch utility written in shell.
+
+homepage            https://github.com/ximimoments/katifetch
+master_sites        https://github.com/ximimoments/katifetch/archive/refs/tags/
+
+distname            13.1
+worksrcdir          katifetch-13.1
+
+checksums           rmd160  52f52dcf046cb4a5dc330e7552fc87cdd4df4fcf \
+                    sha256  93ef6bf75ef2eb0e5edc8b4931a5ebfbe8caaf9bc9a685cb48dc10ca1c22cbce \
+                    size    8631
+
+use_configure       no
+
+build {}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/katifetch ${destroot}${prefix}/bin/katifetch
+}


### PR DESCRIPTION
#### Description

Adding katifetch version 13.1, a lightweight system information fetch utility written in shell.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

Linux (Cross-checked Portfile syntax and checksums for macOS compatibility)

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?