### PR TITLE
mise: Update to 2026.7.14

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.7.8 v
+github.setup        jdx mise 2026.7.14 v
 github.tarball_from archive
 revision            0
 
@@ -26,12 +26,12 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  93b8ad4ec245eb931fa9a6dd469c33bd103fd4cf \
-                    sha256  e4b2c02406c55bd0fca9544dc45960532ec8d462777135e392dec981d8396cbd \
-                    size    12495180
+                    rmd160  66a5180f2b1b94471bf63fc74a9989809bbf90fa \
+                    sha256  75fd7c1b43c2d2af5b8cf3716aaf809f92f20919ee65f7febef1e0659e1ccf74 \
+                    size    12696744
 
-build.args-prepend  --no-default-features \
-                    --features native-tls,vfox/vendored-lua
+depends_build-append \
+                    port:bin/cmake:cmake
 
 post-build {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -74,6 +74,16 @@ destroot {
     }
 }
 
+post-destroot {
+  file delete ${destroot}${prefix}/lib/mise-self-update-instructions.toml
+  set toml [open ${destroot}${prefix}/lib/mise-self-update-instructions.toml w 644]
+  puts $toml "message = \"\"\""
+  puts $toml "To update the mise MacPorts package, run:"
+  puts $toml "  sudo port sync && sudo port update mise"
+  puts $toml "\"\"\""
+  close $toml
+}
+
 notes {
   Shell completions for mise have been installed. These completions require
   an additional program, 'usage', which should be managed with mise.
@@ -90,10 +100,15 @@ cargo.crates \
     aes                                  0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
     aes                                  0.9.1  f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138 \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
-    age                                 0.11.3  a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5 \
+    aes-kw                               0.2.1  69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c \
+    age                                 0.11.5  047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43 \
+    age                                 0.12.1  fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26 \
     age-core                            0.11.0  e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99 \
+    age-core                            0.12.0  01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656 \
     ahash                               0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                         1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    alloc-no-stdlib                      2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
+    alloc-stdlib                         0.2.4  0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195 \
     allocator-api2                      0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     ambient-id                          0.0.11  c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e \
     android_system_properties            0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
@@ -104,31 +119,45 @@ cargo.crates \
     anstyle-parse                        1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                        1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                      3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
-    anyhow                             1.0.103  2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
+    anyhow                             1.0.104  330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
     arbitrary                            1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
     arc-swap                             1.9.2  c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b \
     archspec                             0.2.0  3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33 \
+    argon2                               0.5.3  3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072 \
     arrayref                             0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                             0.7.8  d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     astral-reqwest-middleware            0.5.1  98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9 \
-    astral-tokio-tar                     0.6.3  08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd \
+    astral-tokio-tar                     0.6.4  b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463 \
     astral_async_http_range_reader      0.11.0  4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f \
-    astral_async_zip                    0.0.18  c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb \
+    astral_async_zip                    0.0.20  bd939d79959c3f49a648a1d7857d63cc62548725a6b060b8dbf0ea5c92470b63 \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes           0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
     async-compression                   0.4.42  e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac \
     async-fd-lock                        0.2.0  7569377d7062165f6f7834d9cb3051974a2d141433cc201c2f94c149e993cccf \
     async-once-cell                      0.5.4  4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
-    async-trait                         0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    async-trait                         0.1.91  ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
+    aube                                1.33.1  551ab991fd7d877da9f94099163cc278336b52a5a27f6d0d53bf2a99119e1e75 \
+    aube-codes                          1.33.1  142d0a70354e58d16a4550c49ea9c7b8b6e4c608d00c66fbfbe63a26f4e19456 \
+    aube-linker                         1.33.1  a64288c1754206e9c02f6de7c1c2a07925b5ddccda04652885c2873c7818cca6 \
+    aube-lockfile                       1.33.1  5b8766aa34b4f27b87399ca95ececb29b28754f11245cda65e41af49e9ff7515 \
+    aube-manifest                       1.33.1  5d874c3b77ef64260d3ffc0004238d921a4ea2bde7e942f4d3ad9d880f389a45 \
+    aube-registry                       1.33.1  c5c823bd9dc7f4fafc73143fc245f736daa4221385d566cf0a77277216b219c4 \
+    aube-resolver                       1.33.1  26e64a34e8de78be4e274bebcd83e7b5bbcfaefe20b9a083429a1afad7bff4af \
+    aube-runtime                        1.33.1  e81cd711e9a73565f51b61ab0f37866a3bc57dd7aa3825a4553af63a7f0b1018 \
+    aube-scripts                        1.33.1  fa129c5b70bf7d6e3a609de1e2bc14ed6f425974b99023123371a19b5edfd6f4 \
+    aube-settings                       1.33.1  377fcdc8fe07f4b30f11588efcefb41328f6a9d9f1e3dc0e2ce8da2a92fd892d \
+    aube-store                          1.33.1  712a6f0483e4207eecc50caf814465d43e634d04467ddac3a491c4462c23714a \
+    aube-util                           1.33.1  08b729c64f4ad8143c1da960561d14014fa0b9069609a23c4f58c5b74b5443eb \
+    aube-workspace                      1.33.1  d543ba7b5ee964f9f0a021398f68ab8f6fea938ea17bb3ffed1530660d5f48c5 \
     autocfg                              1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
     aws-credential-types                1.2.13  6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0 \
-    aws-lc-fips-sys                    0.13.15  6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1 \
-    aws-lc-rs                           1.17.1  4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad \
-    aws-lc-sys                          0.42.0  6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444 \
+    aws-lc-fips-sys                    0.13.16  37b00953a69b2cfb471d13d72538d2e66930832340b0f31deadd404b48c573c5 \
+    aws-lc-rs                           1.17.3  00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1 \
+    aws-lc-sys                          0.43.0  43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c \
     aws-runtime                          1.7.1  ede2ddc593e6c8acc6ce3358c28d6677a6dc49b65ba4b37a2befe14a11297e75 \
     aws-sdk-s3                         1.119.0  1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c \
     aws-sdk-sso                         1.95.0  00c5ff27c6ba2cbd95e6e26e2e736676fdf6bcf96495b187733f521cfe4ce448 \
@@ -152,6 +181,7 @@ cargo.crates \
     aws-types                           1.3.13  0470cc047657c6e286346bdf10a8719d26efd6a91626992e0e64481e44323e96 \
     backtrace                           0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
     backtrace-ext                        0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
+    base16ct                             0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
     base64                              0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                              0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     base64-simd                          0.8.0  339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195 \
@@ -159,29 +189,36 @@ cargo.crates \
     basic-toml                          0.1.10  ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a \
     bcrypt-pbkdf                        0.10.0  6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2 \
     bech32                               0.9.1  d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445 \
+    bech32                              0.11.1  32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f \
     beef                                 0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                             0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
+    bitfields                            1.0.3  ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195 \
+    bitfields-impl                       1.0.3  f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555 \
     bitflags                             1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                            2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
+    bitflags                            2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
     bitvec                               1.1.1  ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837 \
+    blake2                              0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     blake2                         0.11.0-rc.6  061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690 \
     blake3                               1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-buffer                        0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     block-padding                        0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     blowfish                             0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
+    brotli                               8.0.4  5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3 \
+    brotli-decompressor                  5.0.3  3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583 \
     bs58                                 0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
-    bstr                                1.12.3  5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79 \
+    bstr                                1.13.0  1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530 \
+    buffer-redux                         1.1.0  431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54 \
     built                                0.8.1  5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9 \
     bumpalo                             3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     bytecheck                            0.8.2  0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b \
     bytecheck_derive                     0.8.2  89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9 \
     bytecount                            0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                               1.12.0  8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593 \
+    bytes                               1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
     bytes-utils                          0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
     bytesize                             2.4.2  3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e \
     bzip2                                0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
@@ -190,11 +227,14 @@ cargo.crates \
     cache_control                        0.2.0  1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
+    camellia                             0.1.0  3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30 \
+    cast5                               0.11.1  26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.66  f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996 \
+    cc                                   1.3.0  c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8 \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
+    cfb-mode                             0.8.2  738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
-    cfg_aliases                          0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    cfg_aliases                          0.2.2  f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
     chacha20                             0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
     chacha20                            0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
     chacha20poly1305                    0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
@@ -206,18 +246,20 @@ cargo.crates \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     cipher                               0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
     clang-sys                            1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                                 4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
+    clap                                 4.6.3  0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776 \
     clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
-    clap_builder                         4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_derive                          4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
+    clap_builder                         4.6.2  f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b \
+    clap_derive                          4.6.3  32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077 \
     clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    clap_usage                           2.0.3  7179a7bcab80d71e4524ae4a384cb9180b6ca3eb30d8e398add707541989ce4a \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
-    clx                                  2.1.0  20daab9df9e49b0478215055d38362d5973043b7a4af836a58968760755e9a9f \
+    clx                                  3.0.0  58ae514e7ddc9e3b7b6d5fd3efe8428ad45273cb0cd69f3d4f6c6fc78b6389de \
+    cmac                                 0.7.2  8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa \
     cmake                               0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
     cmov                                 0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     cmpv2                                0.2.0  961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39 \
     cms                                  0.2.3  7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730 \
-    coalesced_map                        0.1.3  b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de \
+    coalesced_map                        0.1.4  dae1159673deb7e62cf1be84e4cda5dfc584fac013123096a2e720d777694ecd \
     color-eyre                           0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
     color-print                          0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
     color-print-proc-macro               0.3.7  692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22 \
@@ -252,6 +294,7 @@ cargo.crates \
     crc                                  3.4.0  5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
     crc-catalog                          2.5.0  217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
     crc-fast                             1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
+    crc24                                0.1.6  fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0 \
     crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crmf                                 0.2.0  36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92 \
     crossbeam-channel                   0.5.16  d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
@@ -260,33 +303,47 @@ cargo.crates \
     crossbeam-utils                     0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
     crossterm                           0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
+    crypto-bigint                        0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    ctor                                 1.0.8  fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb \
+    ctor                                 1.0.9  a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3 \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive              0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
+    cx448                                0.1.1  b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa \
+    darling                            0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
     darling                             0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
+    darling_core                       0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
     darling_core                        0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
+    darling_macro                      0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
     darling_macro                       0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
     dashmap                              5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                              6.2.1  e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c \
+    dbl                                  0.3.2  bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9 \
     deadpool                            0.12.3  0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b \
     deadpool-runtime                     0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
+    decmpfs                              0.1.0  651715809b4119e14ba1ba88650756d8a7012686473a32ec14c0e602e90fc47f \
     deflate64                           0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
     defmt                                1.1.1  e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1 \
     defmt-macros                         1.1.1  bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8 \
     defmt-parser                         1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
-    demand                               2.0.3  c96e17936c1a2340dde9999f89a2f749020a3dd3f8bcf5c321741047b15ca024 \
+    demand                               2.0.4  5439b2dab1b826af399f3b21a84538f52102a4b32f0dd59b0c69b40725e20fdd \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
+    der                                  0.8.1  a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
+    der_derive                           0.8.0  59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903 \
     deranged                             0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     derive_arbitrary                     1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
+    derive_builder                      0.20.2  507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947 \
+    derive_builder_core                 0.20.2  2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8 \
+    derive_builder_macro                0.20.2  ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c \
     derive_more                          2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                     2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
+    des                                  0.8.1  ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e \
     deunicode                            1.6.2  abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04 \
     diff                                0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+    diffy                                0.5.1  10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914 \
     digest                              0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     digest                              0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
     directories                          6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
@@ -295,12 +352,16 @@ cargo.crates \
     displaydoc                           0.2.6  1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
     document-features                   0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                             0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
+    dsa                                  0.6.3  48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689 \
     duct                                 1.1.1  7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684 \
     dunce                                1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                           1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
+    eax                                  0.5.0  9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28 \
+    ecdsa                               0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
     ed25519                              2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                        2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     either                              1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
+    elliptic-curve                      0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     elsa                                1.11.2  9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e \
     encode_unicode                       1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                         0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
@@ -322,9 +383,11 @@ cargo.crates \
     eyre                                0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
     fancy-regex                         0.18.0  e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277 \
     faster-hex                          0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
-    fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
+    fastrand                             2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
+    faststr                             0.2.34  1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113 \
+    ff                                  0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
-    file_url                             0.3.1  f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747 \
+    file_url                             0.3.2  5e68d9ad067554ef18d79494f0e0bcddaf263f41b0126eb7a937f9e942fcbbd8 \
     filetime                            0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
     find-msvc-tools                      0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
@@ -333,9 +396,12 @@ cargo.crates \
     flate2                               1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
     float-cmp                           0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     fluent                              0.16.1  bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a \
+    fluent                              0.17.0  8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477 \
     fluent-bundle                       0.15.3  7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493 \
+    fluent-bundle                       0.16.0  01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4 \
     fluent-langneg                      0.13.1  7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0 \
     fluent-syntax                       0.11.1  2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d \
+    fluent-syntax                       0.12.0  54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198 \
     fnv                                  1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                             0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     foldhash                             0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
@@ -344,21 +410,21 @@ cargo.crates \
     form_urlencoded                      1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     formatx                              0.3.0  c40f9ee993b100102723f778c82d3daf1808c494ce2fd6e9a06d58d6e8e59748 \
     fs-err                               3.3.1  b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a \
-    fs4                                 0.13.1  8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4 \
+    fs4                                  1.1.0  7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5 \
     fs_extra                             1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsio                                 0.4.1  f4944f16eb6a05b4b2b79986b4786867bb275f52882adea798f17cc2588f25b2 \
     fslock                               0.2.1  04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb \
     funty                                2.0.0  e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c \
-    futures                             0.3.32  8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d \
-    futures-channel                     0.3.32  07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
-    futures-core                        0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
-    futures-executor                    0.3.32  baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d \
-    futures-io                          0.3.32  cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718 \
+    futures                             0.3.33  a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218 \
+    futures-channel                     0.3.33  262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae \
+    futures-core                        0.3.33  2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7 \
+    futures-executor                    0.3.33  6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458 \
+    futures-io                          0.3.33  4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a \
     futures-lite                         2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
-    futures-macro                       0.3.32  e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b \
-    futures-sink                        0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
-    futures-task                        0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
-    futures-util                        0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    futures-macro                       0.3.33  2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b \
+    futures-sink                        0.3.33  e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307 \
+    futures-task                        0.3.33  b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109 \
+    futures-util                        0.3.33  a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa \
     fuzzy-matcher                        0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
     generator                            0.7.5  5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e \
     generic-array                       0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
@@ -378,12 +444,12 @@ cargo.crates \
     gix-commitgraph                     0.37.1  7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb \
     gix-config                          0.58.0  a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583 \
     gix-config-value                    0.18.1  ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab \
-    gix-credentials                     0.38.1  f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d \
-    gix-date                            0.15.5  3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0 \
+    gix-credentials                     0.38.2  e8a0fcfcd73229d1a9c34e04edd05dbcb80364ec6f3788d24c546de2916671eb \
+    gix-date                            0.15.6  7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567 \
     gix-diff                            0.65.0  92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3 \
     gix-dir                             0.27.0  20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f \
     gix-discover                        0.53.0  d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722 \
-    gix-error                            0.2.4  e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b \
+    gix-error                            0.2.5  4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329 \
     gix-features                        0.48.1  1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc \
     gix-filter                          0.32.0  6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c \
     gix-fs                              0.21.2  6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe \
@@ -400,7 +466,7 @@ cargo.crates \
     gix-odb                             0.82.0  7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a \
     gix-pack                            0.72.0  ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b \
     gix-packetline                      0.21.5  b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7 \
-    gix-path                            0.12.1  afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6 \
+    gix-path                            0.12.2  cbbecb0f8dc5cdf6cbde69133f7072064dfc9da4cf0046913afb6857b07300fa \
     gix-pathspec                        0.18.1  3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f \
     gix-prompt                          0.15.1  3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8 \
     gix-protocol                        0.63.0  978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2 \
@@ -417,15 +483,16 @@ cargo.crates \
     gix-trace                           0.1.20  44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678 \
     gix-transport                       0.57.2  186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3 \
     gix-traverse                        0.59.0  5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1 \
-    gix-url                             0.36.1  65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2 \
-    gix-utils                            0.3.3  66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771 \
+    gix-url                             0.36.2  57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29 \
+    gix-utils                            0.3.4  d773a906e39472c2b00aaf1993cd120d40198c1ff6db07c0ee9a44d4431b66c1 \
     gix-validate                        0.11.2  7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3 \
     gix-worktree                        0.54.0  92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036 \
     gix-worktree-state                  0.32.0  c0f926b6a249bdb0086b307c704b7abd9d643e08f98040efe6467f00bb6d2ef5 \
     gix-worktree-stream                 0.34.0  55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f \
     glob                                 0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
-    globset                             0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
+    globset                             0.4.19  e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
+    group                               0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
     h2                                  0.4.15  6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155 \
     halfbrown                            0.4.0  0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09 \
     hash32                               0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
@@ -442,12 +509,13 @@ cargo.crates \
     hmac                                0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     hmac                                0.13.0  6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
     homedir                              0.3.6  68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527 \
+    hpke                                0.12.0  4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11 \
     http                                0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                                 1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
     http-auth                           0.1.10  150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822 \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
-    http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
-    http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
+    http-body                            1.1.0  ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
+    http-body-util                       0.1.4  e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2 \
     http-cache-semantics                 3.0.0  0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7 \
     http-content-range                   0.2.5  0298eab7a8b2346aa6e6b3502dfddf643735e45864cbe4ce9c73606cecb8b53f \
     http-serde                           2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
@@ -456,14 +524,17 @@ cargo.crates \
     human_format                         1.2.1  eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b \
     humansize                            2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                            2.4.0  15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
+    hybrid-array                         0.2.3  f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9 \
     hybrid-array                        0.4.13  818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c \
-    hyper                               1.10.1  55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
+    hyper                               1.11.0  d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72 \
     hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                          0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
     i18n-config                          0.4.8  3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef \
     i18n-embed                          0.15.4  669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4 \
+    i18n-embed                          0.16.0  a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305 \
     i18n-embed-fl                        0.9.4  04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d \
+    i18n-embed-fl                       0.10.1  602e6bd30c3db2749e13e38b363a3d98d9d41de1d8de7a79c31bb69e45b47cda \
     i18n-embed-impl                      0.8.4  0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2 \
     iana-time-zone                      0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku                 0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
@@ -474,10 +545,11 @@ cargo.crates \
     icu_properties                       2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
     icu_properties_data                  2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
     icu_provider                         2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
+    idea                                 0.5.1  075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477 \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                         1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
-    ignore                              0.4.27  fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f \
+    ignore                              0.4.31  7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83 \
     impl-tools                          0.11.4  0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208 \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
@@ -490,6 +562,7 @@ cargo.crates \
     insta                               1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
     intl-memoizer                        0.5.3  310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f \
     intl_pluralrules                     7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
+    inventory                           0.3.24  a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b \
     io-close                             0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
     io_tee                               0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
     ipnet                               2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
@@ -501,9 +574,10 @@ cargo.crates \
     itertools                           0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     jdx-tar                              1.1.0  ea172082e0f86db95eb1eb387cf802b02749322e79219378e59ca390dd0cd284 \
-    jiff                                0.2.31  ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634 \
-    jiff-static                         0.2.31  e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2 \
-    jiff-tzdb                            0.1.7  6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590 \
+    jiff                                0.2.34  e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16 \
+    jiff-core                            0.1.0  7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09 \
+    jiff-static                         0.2.34  323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de \
+    jiff-tzdb                            0.1.8  142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
     jni-macros                          0.22.4  a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
@@ -514,7 +588,10 @@ cargo.crates \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
+    k256                                0.13.4  f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b \
     kdl                                  6.5.0  81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e \
+    keccak                               0.1.6  cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653 \
+    kem                            0.3.0-pre.0  2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
     kstring                              2.0.2  558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1 \
     landlock                             0.4.5  635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d \
@@ -527,6 +604,9 @@ cargo.crates \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
     libredox                            0.1.18  c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652 \
+    libyaml-rs                           0.3.0  2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777 \
+    libz-ng-sys                         1.1.29  879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469 \
+    line-index                           0.1.2  3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2 \
     link-section                        0.19.0  e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9 \
     linktime-proc-macro                  0.2.0  8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
@@ -540,8 +620,8 @@ cargo.crates \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
     lru                                 0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
     lru-slab                             0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
-    lua-src                            550.0.0  e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb \
-    luajit-src                 210.6.6+707c12b  a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295 \
+    lua-src                            550.1.1  75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949 \
+    luajit-src                 210.7.2+b925b3e  920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6 \
     lzma-rs                              0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     lzma-rust2                          0.16.5  ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
@@ -549,19 +629,21 @@ cargo.crates \
     maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
-    memchr                               2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
+    memchr                               2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     memmap2                             0.9.11  d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0 \
     memoffset                            0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                               7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
     miette-derive                        7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
     mime                                0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    mime_guess                           2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
     minimal-lexical                      0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                      0.2.5  22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e \
     miniz_oxide                          0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                                  1.2.1  02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
-    mlua                                0.11.6  ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab \
-    mlua-sys                            0.10.0  0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8 \
-    mlua_derive                         0.11.0  465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2 \
+    mio                                  1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
+    ml-kem                               0.2.3  8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f \
+    mlua                                0.12.0  ad72ffa037cf5970c9860674f32f703fda25d86cf217475fe7a79c5f9961bcaa \
+    mlua-sys                            0.11.0  92136787b906d4e55cfe96cd6c62e010bb1a56889d0d6cf83eb016dbad07576b \
+    mlua_derive                         0.12.0  0232231813b214d44b57c7678e7dbbcfaac35bd1a01acef0dad7c5dfdc1b1973 \
     mockito                              1.7.2  90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0 \
     munge                                0.4.7  5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c \
     munge_macro                          0.4.7  4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931 \
@@ -569,7 +651,9 @@ cargo.crates \
     netrc-rs                             0.1.2  ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836 \
     nix                                 0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
     nix                                 0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
+    node-semver                          2.2.0  3b1a233ea5dc37d2cfba31cfc87a5a56cc2a9c04e3672c15d179ca118dae40a7 \
     nodejs-semver                        5.0.0  364dd919c4d6feef8c3a3f3e2b64af729187902156e17481618622cbbf1353a1 \
+    nohash-hasher                        0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
     nom                                  7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nom                                  8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
     nom-language                         0.1.0  2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29 \
@@ -582,11 +666,14 @@ cargo.crates \
     num-complex                          0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                             0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
     num-integer                         0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
-    num-iter                            0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
+    num-iter                            0.1.46  c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b \
     num-rational                         0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                            1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
+    num_enum                             0.7.6  5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26 \
+    num_enum_derive                      0.7.6  680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8 \
     object                              0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
+    ocb3                                 0.1.0  c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb \
     once_cell                           1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
@@ -599,25 +686,32 @@ cargo.crates \
     os_pipe                              1.2.3  7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967 \
     outref                               0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     owo-colors                           4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
+    p256                                0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
+    p384                                0.13.1  fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6 \
+    p521                                0.13.3  0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2 \
     papergrid                           0.18.0  d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e \
     parking                              2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                         0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                    0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     parse-zoneinfo                       0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
+    password-hash                        0.5.0  346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166 \
     pastey                               0.2.3  2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4 \
-    path-absolutize                      3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
-    path-dedot                           3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
-    path_resolver                       0.2.11  83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660 \
+    path-absolutize                      4.0.1  f808742975794703469f67a28dd14b1d1009a1743c18b0353b4b951dbb0068ad \
+    path-dedot                           4.0.1  03351d0f1c066c114015408dc6a3e101f080fc03ef9d8d799aa58ec760cac5a6 \
+    path_resolver                       0.2.12  87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb \
+    pathdiff                             0.2.3  df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3 \
     pbkdf2                              0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     pbkdf2                              0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
     pem                                  3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
     pem-rfc7468                          0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
+    pem-rfc7468                          1.0.0  a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9 \
     percent-encoding                     2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
     pest                                 2.8.7  47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9 \
     pest_derive                          2.8.7  4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58 \
     pest_generator                       2.8.7  6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7 \
     pest_meta                            2.8.7  f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210 \
     petgraph                             0.8.3  8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455 \
+    pgp                                 0.20.0  1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1 \
     phf                                 0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
     phf                                 0.14.0  010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6 \
     phf_codegen                         0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
@@ -635,10 +729,11 @@ cargo.crates \
     pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
     platforms                           3.12.0  9245c6e7c5a6bcdd7977fdf6d1e1c67f4cc2d0d58c041df0ea5940953033e6ca \
     plist                               1.10.0  7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85 \
+    pluralizer                           0.5.0  4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     poly1305                             0.9.1  6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c \
     polyval                              0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
-    portable-atomic                     1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
+    portable-atomic                     1.14.0  3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3 \
     portable-atomic-util                 0.2.7  c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618 \
     potential_utf                        0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     powerfmt                             0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
@@ -646,28 +741,30 @@ cargo.crates \
     ppv-lite86                          0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     pretty_assertions                    1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     prettyplease                        0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
+    primeorder                          0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
     proc-macro-error-attr2               2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
+    proc-macro-error-attr3               3.0.3  be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1 \
     proc-macro-error2                    2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro2                        1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    proc-macro-error3                    3.0.3  dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c \
+    proc-macro2                        1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     prodash                             31.0.0  962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c \
     proptest                            1.11.0  4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744 \
     ptr_meta                             0.3.1  0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79 \
     ptr_meta_derive                      0.3.1  7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1 \
     purl                                 0.1.6  60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad \
     quick-error                          1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
-    quick-xml                           0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quick-xml                           0.38.4  b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c \
     quick-xml                           0.41.0  e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1 \
     quinn                              0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
     quinn-proto                        0.11.16  2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560 \
     quinn-udp                           0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
-    quote                               1.0.46  dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
+    quote                               1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                                5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
     rancor                               0.1.2  daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c \
-    rand                                 0.8.6  5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
-    rand                                 0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
+    rand                                 0.8.7  22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a \
+    rand                                 0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
     rand                                0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                          0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
@@ -676,67 +773,71 @@ cargo.crates \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_pcg                            0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.46.0  67961cc1ccb170208f10169542752dbe730353a874a13cb0749c13b960d72d5b \
-    rattler_cache                       0.10.1  24205a6af611e71f346e5e170c32f00ce1a9b49077f699f18d8404e711dc2209 \
-    rattler_conda_types                 0.47.2  385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd \
-    rattler_digest                       1.3.1  2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69 \
-    rattler_macros                       1.1.1  ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff \
-    rattler_menuinst                    0.2.68  957dbd0e8fb9ed66dce0bd6922914fb8bf795a4334d92e2190f34314a0b1f170 \
-    rattler_networking                  0.30.0  5014e4f5aedcbe01a83a5be0e8669b305adc82cc10985fc83f51c5fe07e0d198 \
-    rattler_package_streaming           0.26.6  2b4440ad7368a66ddd370a8160d8fb2a4d0a825b7a050f9c421dac350b37bed2 \
-    rattler_pty                         0.2.14  d19145200e8c578be6dca325fbacf375a57f86d4a7ccf85d2d8ee193ddfb10dd \
-    rattler_redaction                    0.2.1  2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b \
-    rattler_repodata_gateway            0.29.7  dbd05b4c6fbad5fae62d1d67c22c2bb411a7d21a026aeb079893df1d6d157a61 \
-    rattler_shell                       0.27.8  9794276d154c19579fe7982ab2c1e9a960f0d51e5e56cd8d9fafe36373a71dd3 \
-    rattler_solve                        7.2.0  0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6 \
-    rattler_virtual_packages             3.0.2  312c7e886ca90e83d562cadfb3d88af9dcef42f7c2489dae569df84c4bd07890 \
+    rattler                             0.47.1  417e0f429d4c0f849d8e862c6d522efb35c6cb48cb6fb9e34a9a26fb6b70850f \
+    rattler_cache                       0.10.3  1e608aa1824f88fbdf0839ed2e5d5a762692cad6aa864a725b44844d79e28c8e \
+    rattler_conda_types                 0.48.1  f38273db000680207c48aa39ae1bcca9babf430c0f4dfb80b7dea9376592ddad \
+    rattler_digest                       1.3.2  56538779701395adba456293b22fda6598b079f30c24d9a22c2bb15271bd67f3 \
+    rattler_macros                       1.1.2  bc1bde42798a908a8a2609836a062f01117b83a3fba6f8f6be3eb8c1d07bfdf2 \
+    rattler_menuinst                    0.2.70  b99d32612f64644cbcaf39caf83fb89409477b579985735930996fe1f71b0cf2 \
+    rattler_networking                  0.30.2  a79426b2af3db171d23fba74bfa9abf832367af610bbee76f979d47f9a094f2a \
+    rattler_package_streaming           0.26.8  4db3af7641d6c40af2f8f2be0a494ad4d04c3825dc5ed1e7957d3c019637b5b2 \
+    rattler_pty                         0.2.15  ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328 \
+    rattler_redaction                    0.2.2  068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177 \
+    rattler_repodata_gateway            0.30.1  7b18c19b2e44e3c29840a73cb76bf741bd844b777f5a9d19dabb522ea99bcbb8 \
+    rattler_shell                      0.27.10  40e36d0927ce8ee7cc7648be7060f8d1bbda9ac0afeb24e280af644d21d6ba28 \
+    rattler_solve                        7.2.2  766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3 \
+    rattler_virtual_packages             3.0.4  af8a387e540318781c3805871c02f4652da75c5440a8b6adea63a2de63dffec6 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     redox_users                          0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    ref-cast                            1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
-    ref-cast-impl                       1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
+    ref-cast                            1.0.26  216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d \
+    ref-cast-impl                       1.0.26  2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c \
     reflink-copy                        0.1.30  d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b \
-    regex                               1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
-    regex-automata                      0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex                               1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                      0.4.16  8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad \
     regex-lite                           0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     regex-syntax                        0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     rend                                 0.5.4  663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240 \
+    replace_with                         0.1.8  51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     resolvo                             0.11.1  cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
+    rfc6979                              0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
+    ripemd                               0.1.3  bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f \
     rkyv                                0.8.17  815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874 \
     rkyv_derive                         0.8.17  c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c \
     rmcp                                 2.2.0  14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af \
     rmcp-macros                          2.2.0  783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
+    roff                                 0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
     rops                                 0.1.7  b4beb52a5d008a707436d388c05e9fee9ae81039cce62813ee750918a13c0aaf \
     rowan                              0.15.19  a2441aaccb50f4267d4f0f58b21e0138e96a449f361ed57a2673a83c9bca0772 \
     rsa                                 0.9.10  b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
-    rust-embed                          8.11.0  04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27 \
-    rust-embed-impl                     8.11.0  da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa \
-    rust-embed-utils                    8.11.0  5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1 \
-    rustc-demangle                      0.1.27  b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d \
+    rust-embed                          8.12.0  e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9 \
+    rust-embed-impl                     8.12.0  3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097 \
+    rust-embed-utils                    8.12.0  42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0 \
+    rustc-demangle                      0.1.28  b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb \
     rustc-hash                           1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                           2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                        0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                             0.23.41  6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f \
+    rustls                             0.23.42  3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138 \
     rustls-native-certs                  0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
     rustls-pki-types                    1.15.0  764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
-    rustversion                         1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    rustversion                         1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     ryu                                 1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
-    ryu-js                               1.0.2  dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15 \
+    ryu-js                               1.0.3  04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714 \
     salsa20                             0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                            1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                            0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
@@ -746,41 +847,45 @@ cargo.crates \
     scoped-tls                           1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                           1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                              0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
+    sec1                                 0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     seccompiler                          0.5.0  a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884 \
     secrecy                             0.10.3  e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a \
     security-framework                   3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys              2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
     self-replace                         1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_cell                           0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
-    self_cell                            1.2.2  b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89 \
+    self_cell                            1.3.0  2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813 \
     self_update                         0.44.0  2e79722b5a505d4ddc77527455a97244e9e8c4c07533ff44cf4421cce7bb6d17 \
     semver                              1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
-    serde                              1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde                              1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
     serde-untagged                       0.1.9  f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058 \
     serde-value                          0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
     serde_bytes                        0.11.19  a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8 \
-    serde_core                         1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                       1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_core                         1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                       1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
     serde_derive_internals              0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_ignored                       0.1.14  115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798 \
-    serde_json                         1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde_json                         1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     serde_json_canonicalizer             0.3.2  fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2 \
     serde_regex                          1.2.0  bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012 \
-    serde_repr                          0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
+    serde_repr                          0.1.21  8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906 \
     serde_spanned                        0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
     serde_spanned                        1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                     0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_with                          3.21.0  76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c \
     serde_with_macros                   3.21.0  84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660 \
     serde_yaml               0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
+    serdect                              0.2.0  a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177 \
+    serdect                              0.3.0  f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53 \
     serial_test                          3.5.0  699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
     serial_test_derive                   3.5.0  94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
     sevenz-rust2                        0.20.2  29225600349ef74beda5a9fffb36ac660a24613c0bde9315d0c49be1d51e9c24 \
-    sha1                                0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha1                                0.10.7  a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8 \
     sha1                                0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha1-checked                        0.10.0  89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423 \
     sha2                                0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sha2                                0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
+    sha3                                0.10.9  77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874 \
     sharded-slab                         0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shared_child                         1.1.1  1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7 \
     shared_thread                        0.2.0  52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0 \
@@ -793,45 +898,54 @@ cargo.crates \
     signal-hook                          0.4.4  b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d \
     signal-hook-registry                 1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
     signature                            2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
-    sigstore-bundle                     0.10.0  18b51b097b7e9d898efad51e1031c855ce4008b4866d0c38ac8b0fac5745a84c \
-    sigstore-crypto                     0.10.0  1210ea5dd0dd07b1466449a6c5c79000f8ca10ac30b4e8f64031c3bed4c5c662 \
-    sigstore-merkle                     0.10.0  9ae98f8a270885497dbe84e6dae10fa29066df0388f62980923728e38d844716 \
-    sigstore-rekor                      0.10.0  4e1c153f4f89f7570d0f625f660cadcb1b2fba72583f378d2d2b308c752ac45f \
-    sigstore-trust-root                 0.10.0  ded6afc37295a10dba6569e033dd15f85f04f00980bfcf2c64009bc8ed279985 \
-    sigstore-tsa                        0.10.0  a88505b71600a791e52bed3777ed9cfeefd4b03dee6575d38c5542ae80e2bbdc \
-    sigstore-tuf                        0.10.0  dfc7cced094bd306ef561312cfffa3ea05ac7eea4a62cfa81680c07a10addbc0 \
-    sigstore-types                      0.10.0  56f034e86c3b8d91b32608c83f4a18939eed32c6ca08d17d2f52b88be365aac6 \
-    sigstore-verify                     0.10.0  f4720f300d093ecac6dcd75d4498fd1b2d9133600e679837bb9d944a4229eda7 \
-    simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
-    simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
-    simd_cesu8                           1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
+    sigstore-bundle                     0.11.0  5948e95f63e900fa92936ecf72c7f2251f83d27560a35a4aae560cc745f8b687 \
+    sigstore-crypto                     0.11.0  22f27364b37bec104a904f10a675c8cdf05d5e48a980569368f0cd0c119b2652 \
+    sigstore-merkle                     0.11.0  0ee85fd9fb550efd7c8a59447cb0ef4eb02f1258f3ffa80c88d38427c3930af3 \
+    sigstore-rekor                      0.11.0  9b97c5a866f849a9445ae657bef0caa2db053a82827e6dae3a2b3de9c15a6a1a \
+    sigstore-trust-root                 0.11.0  389b54d1b8ace20ba86fdf90e5e655495f65f1abbc7d5d0eb7494defa9ad32f0 \
+    sigstore-tsa                        0.11.0  b58fe92d4d8cf4b7215b927b70bc1245b6e0d70d801febdfe0cd265ad97ebf8b \
+    sigstore-tuf                        0.11.0  eedac50883a917b7b434db22e2e6e853ace8c00f4a9c27f53e1e9c87e6d89fe4 \
+    sigstore-types                      0.11.0  236474c535a3157839926a0ae18f9c0c22b151e49634da6e5b18ad7cac8a3b69 \
+    sigstore-verify                     0.11.0  558f71aad0e1c5925d29ae2024f55f0f8898a7ad450c93668f99086624c421e0 \
+    simd-adler32                        0.3.10  3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea \
+    simd-json                           0.17.3  e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c \
+    simd_cesu8                           1.2.0  11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520 \
     simdutf8                             0.1.5  e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
     similar                              2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
-    simple_spawn_blocking                1.1.0  55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2 \
+    simple_spawn_blocking                1.1.1  83a7b2679ee03cca581f57e5a4fecac405aa6b5d5174abe65b4b41fa181d8438 \
     siphasher                            1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     slab                                0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slug                                 0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                            1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
-    snap                                 1.1.1  1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b \
-    socket2                              0.6.4  52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
+    snafu                                0.9.1  d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522 \
+    snafu-derive                         0.9.1  5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda \
+    snap                                 1.1.2  199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886 \
+    socket2                              0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
     socks                                0.3.4  f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b \
-    spin                                 0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    sonic-number                         0.1.2  3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32 \
+    sonic-rs                             0.5.8  d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f \
+    sonic-simd                           0.1.4  f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4 \
+    spin                                 0.9.9  3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e \
     spki                                 0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
+    spki                                 0.8.0  1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f \
     stable_deref_trait                   1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                    1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    streaming-iterator                   0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strip-ansi-escapes                   0.2.1  2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025 \
     strsim                              0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                               0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
     strum                               0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                        0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     strum_macros                        0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
+    subfeature                          1.27.0  bae27fccb1615a3b3ae930cf93c0c4d32b7daffb57477ca0406f07fc0e68ea57 \
     subtle                               2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     superslice                           1.0.0  ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f \
     supports-color                       3.0.2  c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6 \
     supports-hyperlinks                  3.2.0  e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91 \
     supports-unicode                     3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
     syn                                1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                                2.0.118  1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
+    syn                                2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
+    syn                                  3.0.2  a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3 \
     sync_wrapper                         1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                        0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     sysctl                               0.5.5  ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea \
@@ -855,34 +969,34 @@ cargo.crates \
     text-size                            1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     textwrap                            0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                           1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                           2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror                           2.0.19  09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
     thiserror-impl                      1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                      2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
-    thread_local                         1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    time                                0.3.53  18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50 \
+    thiserror-impl                      2.0.19  43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
+    thread_local                        1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
+    time                                0.3.54  3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244 \
     time-core                            0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
-    time-macros                         0.2.31  c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f \
+    time-macros                         0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
     tinystr                              0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
-    tinyvec                             1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
+    tinyvec                             1.12.0  bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tls_codec                            0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
     tls_codec_derive                     0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
-    tokio                               1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
-    tokio-macros                         2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
+    tokio                               1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
+    tokio-macros                         2.7.1  6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba \
     tokio-native-tls                     0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                        0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                        0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
     tokio-util                          0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
     toml                                0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                                0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
-    toml                      1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    toml                      1.1.3+spec-1.1.0  53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c \
     toml_datetime                       0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
     toml_datetime             1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
     toml_edit                          0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
-    toml_edit               0.25.12+spec-1.1.0  d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7 \
+    toml_edit               0.25.13+spec-1.1.0  6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b \
     toml_parser               1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
     toml_write                           0.1.2  5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801 \
-    toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
+    toml_writer               1.1.2+spec-1.1.0  7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                          0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
     tower-layer                          0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -892,8 +1006,14 @@ cargo.crates \
     tracing-core                        0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
     tracing-error                        0.2.1  8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db \
     tracing-log                          0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
+    tracing-serde                        0.2.0  704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1 \
     tracing-subscriber                  0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
+    tree-sitter                        0.26.11  af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df \
+    tree-sitter-iter                    1.27.0  0cbef0ee83b87916292355e78f4fdee268d719ececa729be8914882428ca86b0 \
+    tree-sitter-language                 0.1.7  009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782 \
+    tree-sitter-yaml                     0.7.2  53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97 \
     try-lock                             0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    twofish                              0.7.1  a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013 \
     type-map                             0.5.1  cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90 \
     typed-path                          0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typeid                               1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
@@ -904,6 +1024,7 @@ cargo.crates \
     unarray                              0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
     unic-langid                          0.9.6  a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05 \
     unic-langid-impl                     0.9.6  dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658 \
+    unicase                              2.9.0  dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142 \
     unicode-bom                          2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
     unicode-ident                       1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-linebreak                    0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
@@ -922,13 +1043,14 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.5.4  80738ec537e63ca00453a217231683a2cc52e8c07a802ff96c1bf28ec42eac99 \
+    usage-lib                           2.18.2  1851c9ddbc3a428af152852227363e7f66b73ca2ce732c8db3c2d4ab37eb63d2 \
+    usage-lib                            4.0.0  b60d4043943b220cc7269576a383ff2d62ab00f208f10d94b2496791729f8b02 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                                1.23.4  bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53 \
+    uuid                                1.24.0  bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239 \
     valuable                             0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
-    value-trait                         0.12.1  8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59 \
+    value-trait                         0.12.2  f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc \
     vcpkg                               0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                        0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                             7.0.0  80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f \
@@ -948,9 +1070,9 @@ cargo.crates \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
     web-sys                            0.3.103  8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-root-certs                    1.0.8  0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267 \
-    webpki-roots                         1.0.8  bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf \
-    which                                8.0.4  48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248 \
+    webpki-root-certs                    1.0.9  b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b \
+    webpki-roots                         1.0.9  7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
+    which                                8.0.5  8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c \
     widestring                           1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                               0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu           0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -971,7 +1093,7 @@ cargo.crates \
     windows-link                         0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
     windows-numerics                     0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-numerics                     0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
-    windows-registry                     0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
+    windows-registry                     0.6.1  02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
     windows-result                       0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                       0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                      0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
@@ -1010,7 +1132,7 @@ cargo.crates \
     windows_x86_64_msvc                 0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
     winnow                              0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
     winnow                              0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
-    winnow                               1.0.3  0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
+    winnow                               1.0.4  23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81 \
     winver                               1.0.0  9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33 \
     wiremock                             0.6.5  08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031 \
     wit-bindgen                         0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
@@ -1018,16 +1140,20 @@ cargo.crates \
     wyz                                  0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     x25519-dalek                         2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     x509-cert                            0.2.5  1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94 \
+    x509-cert                            0.3.0  105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b \
     x509-tsp                             0.1.0  f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1 \
     xattr                                1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xmlparser                           0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     xx                                   2.6.1  f8aff208388ac09afbb2bd20c3db8f7d253c9fbed7076e3618d598bb3deef2c5 \
     xz2                                  0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
+    yaml_serde                          0.10.4  08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975 \
+    yamlpatch                           1.26.1  919764173d845c2b685a44ca9a028534ef1127bcf713edc6b69787430f18b030 \
+    yamlpath                            1.27.0  1362068e6e34bf985c39ee42ee8d410fcc398fedbd5f9303602616db26f542b5 \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                 0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                            0.8.53  75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1 \
-    zerocopy-derive                     0.8.53  4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71 \
+    zerocopy                            0.8.55  b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb \
+    zerocopy-derive                     0.8.55  0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb \
     zerofrom                             0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                      0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                              1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
@@ -1041,8 +1167,8 @@ cargo.crates \
     zip                                  8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zipsign-api                          0.2.1  32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99 \
-    zlib-rs                              0.6.5  5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5 \
-    zmij                                1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
+    zlib-rs                              0.6.6  b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5 \
+    zmij                                1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
     zopfli                               0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249 \
     zstd                                0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
     zstd-safe                            7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \


### PR DESCRIPTION
#### Description
2026.7.12 (skipped) upgraded a dependency (libz-ng-sys) that now requires cmake to build. This port has been updated to use that.

While at it, I modified the "no-self-update" to use the "native" mise tombstone file with a better message than "self-update was disabled at build time".


###### Tested on

macOS 26.5.2 25F84 arm64\
Xcode 26.6 17F113

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?