### PR TITLE
weechat: update to 4.9.5

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.9.4
+version             4.9.5
 revision            0
-checksums           rmd160  d7aeaf65315d3dc4a85bedeb4391b4bf76c873fa \
-                    sha256  3fc50359f3a3b258c9f03148b02f3b9c59194535d1b465c481fb85a76c2ed005 \
-                    size    2799628
+checksums           rmd160  3f341d82ca9a2aa759487ff0c13e37e2e3770956 \
+                    sha256  3b3946104e64536d0602370a30e55dd5a301cc8ff420184ff0a101926dad1d16 \
+                    size    2801244
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.9.5

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
