### PR TITLE
snowemu: update to 1.5.0, package as app bundle

### DIFF
--- a/emulators/snowemu/Portfile
+++ b/emulators/snowemu/Portfile
@@ -3,12 +3,21 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
+PortGroup           app 1.1
 
-github.setup        twvd snow 1.4.1 v
+github.setup        twvd snow 1.5.0 v
 name                snowemu
 github.tarball_from archive
 homepage            https://snowemu.com
 revision            0
+
+app.name            Snow
+app.icon            assets/Snow.icns
+app.identifier      dev.thomasw.snow
+app.retina          yes
+app.sign            yes
+app.signing_args    --force
+app.executable      ${worksrcpath}/target/[cargo.rust_platform]/release/snowemu
 
 categories          emulators
 installs_libs       no
@@ -24,9 +33,9 @@ long_description    Snow emulates classic (Motorola 68k-based) Macintosh \
                     audio, and networking.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b3ddd1fda1417e4472afba61119bf224a1a8a634 \
-                    sha256  c980c9ac4d952ddc21da63fe28a411852ff49463a6e62c647502b541e3d0b229 \
-                    size    11931222
+                    rmd160  8cbf102d9ce6948c27484b95e65f0809160b0dfc \
+                    sha256  00ee7515a8ed5e977e46b5f87a02ce964049613a5b909203b77b2feb277193a0 \
+                    size    11987701
 
 post-patch {
     file delete ${worksrcpath}/rust-toolchain.toml
@@ -34,11 +43,7 @@ post-patch {
 
 cargo.offline_cmd
 
-destroot {
-    xinstall -m 0755 \
-        ${worksrcpath}/target/[cargo.rust_platform]/release/snowemu \
-        ${destroot}${prefix}/bin/
-}
+destroot {}
 
 cargo.crates \
     ab_glyph                              0.2.32                          01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2 \
@@ -197,6 +202,8 @@ cargo.crates \
     either                                1.15.0                          48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     embedded-io                           0.4.0                           ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced \
     embedded-io                           0.6.1                           edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d \
+    encoding_rs                           0.8.35                          75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
+    encoding_rs_rw                        0.4.3                           c5aab15dedf14ff0b6f0a599b40d73a514016d4419e7c270d06549170be7a217 \
     endi                                  1.1.1                           66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099 \
     enum-map                              2.7.3                           6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9 \
     enum-map-derive                       0.17.0                          f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb \
@@ -210,6 +217,7 @@ cargo.crates \
     error-code                            3.3.2                           dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59 \
     event-listener                        5.4.1                           e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab \
     event-listener-strategy               0.5.4                           8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
+    extended                              0.1.0                           af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365 \
     fastrand                              2.4.1                           9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     fax                                   0.2.6                           f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab \
     fax_derive                            0.2.0                           a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d \
@@ -262,7 +270,7 @@ cargo.crates \
     hashbrown                             0.16.1                          841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
     hashbrown                             0.17.0                          4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heapless                              0.7.17                          cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f \
-    heapless                              0.8.0                           0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad \
+    heapless                              0.9.3                           25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4 \
     heck                                  0.5.0                           2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                            0.5.2                           fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                                   0.4.3                           7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
@@ -480,7 +488,7 @@ cargo.crates \
     rustls                                0.23.38                         69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21 \
     rustls-native-certs                   0.8.3                           612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
     rustls-pki-types                      1.14.0                          be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd \
-    rustls-webpki                         0.103.12                        8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06 \
+    rustls-webpki                         0.103.13                        61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
     rustversion                           1.0.22                          b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     rusty_pool                            0.7.0                           4ed36cdb20de66d89a17ea04b8883fc7a386f2cf877aaedca5005583ce4876ff \
     same-file                             1.0.6                           93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
@@ -515,7 +523,7 @@ cargo.crates \
     smithay-client-toolkit                0.20.0                          0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0 \
     smithay-clipboard                     0.7.3                           71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226 \
     smol_str                              0.2.2                           dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead \
-    smoltcp                               0.11.0                          5a1a996951e50b5971a2c8c0fa05a381480d70a933064245c4a223ddc87ccc97 \
+    smoltcp                               0.13.1                          5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e \
     socket2                               0.6.3                           3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
     spin                                  0.9.8                           6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spirv                                 0.3.0+sdk-1.3.268.0             eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844 \
@@ -528,11 +536,16 @@ cargo.crates \
     strum_macros                          0.26.4                          4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     strum_macros                          0.27.2                          7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     subtle                                2.6.1                           13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
+    symphonia                             0.5.5                           5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039 \
+    symphonia-codec-pcm                   0.5.5                           4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95 \
+    symphonia-core                        0.5.5                           ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af \
+    symphonia-format-riff                 0.5.5                           c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f \
+    symphonia-metadata                    0.5.5                           36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16 \
     syn                                   1.0.109                         72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                                   2.0.117                         e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     synstructure                          0.13.2                          728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     sysinfo                               0.37.2                          16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f \
-    tar                                   0.4.45                          22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973 \
+    tar                                   0.4.46                          3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                              3.27.0                          32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                             1.4.1                           06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     termtree                              0.5.1                           8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \


### PR DESCRIPTION
#### Description

Update to Snow 1.5.0 and package it as a proper macOS app bundle
via the `app` PortGroup, matching upstream's own release process
which now distributes Snow exclusively as a signed `.app` rather
than a bare CLI binary.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 26.6 25G70 arm64 / Command Line Tools 26.6.0.0.1781586589
macOS 27.0 26A5388g arm64 / Command Line Tools 27.0.0.0.1784267383

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?