### PR TITLE
libcbor: update to 0.14.0, fix cmocka dependency

### DIFF
--- a/devel/libcbor/Portfile
+++ b/devel/libcbor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        PJK libcbor 0.13.0 v
+github.setup        PJK libcbor 0.14.0 v
 github.tarball_from archive
 revision            0
 
@@ -15,14 +15,14 @@ license             MIT
 description         library for parsing and generating CBOR
 long_description    {*}${description}, the general-purpose schema-less binary data format.
 
-checksums           rmd160  ad9bb702516b6d055650a1e3f90335f33005e97b \
-                    sha256  95a7f0dd333fd1dce3e4f92691ca8be38227b27887599b21cd3c4f6d6a7abb10 \
-                    size    299917
+checksums           rmd160  e07df18a748864c2da6988d7f3f30bf3a0f8c402 \
+                    sha256  a8c1516e741562cf95aa4479c64916c3d4d2623e24fdc35e414e2320e7300aae \
+                    size    317101
                     
 configure.args-append    -DBUILD_SHARED_LIBS=ON
 
 variant tests description {enable tests} {
-    depends_test-append         port:cmocka
+    depends_build-append        port:cmocka
     configure.args-append       -DWITH_TESTS=ON
     configure.pre_args-replace  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                                 -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF


### PR DESCRIPTION
#### Description

Update to libcbor 0.14.0 and fix the `tests` variant's cmocka
dependency, which was declared as `depends_test` even though
CMake's `find_package(CMocka)` runs during configure — before
the test phase installs it. Moved to `depends_build` so it's
present when needed.

Closes: https://trac.macports.org/ticket/71357

###### Type(s)

- [x] bugfix

###### Tested on

macOS 26.6 25G70 arm64 / Command Line Tools 26.6.0.0.1781586589
macOS 27.0 26A5388g arm64 / Command Line Tools 27.0.0.0.1784267383

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?