### PR TITLE
netatalk: update to 4.5.1

### DIFF
--- a/net/netatalk/Portfile
+++ b/net/netatalk/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 PortGroup           legacysupport 1.1
 
 name                netatalk
-version             4.5.0
+version             4.5.1
 revision            0
 categories          net
 description         Netatalk is a freely-available Open Source AFP fileserver.
@@ -15,18 +15,18 @@ long_description    Netatalk is a freely-available Open Source AFP fileserver. \
                     servers for Macintosh computers.
 
 if {${subport} eq ${name}} {
-    github.setup        Netatalk netatalk 4-5-0 netatalk-
-    version             4.5.0
-    revision            1
+    github.setup        Netatalk netatalk 4-5-1 netatalk-
+    version             4.5.1
+    revision            0
     github.tarball_from releases
     distname            netatalk-${version}
     use_xz              yes
 
     compiler.c_standard 2011
 
-    checksums       rmd160  828049d176308bbb3f4e00e27d91992ccba44376 \
-                    sha256  62d77f5a491e69086c1706ff7d9e016912e0e48b43d0c3a7ae60c384b6d625b3 \
-                    size    1303408
+    checksums       rmd160  30986ad34619e6c4cee961296c2507ba44c52057 \
+                    sha256  f091de10b0c40996ebf7d6502cf947cfd87dfe1a7e62f9d96013225573938524 \
+                    size    1305244
     
     license             GPL-2+
     maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
@@ -66,7 +66,7 @@ if {${subport} eq ${name}} {
 subport netatalk4 {
     PortGroup           stub 1.0
 
-    version             4.5.0
+    version             4.5.1
     revision            0
     
     categories          net


### PR DESCRIPTION
#### Description

Update to Netatalk 4.5.1, a bugfix/security release fixing four
CVEs and adding big-endian support in SpotlightRPC.

###### Type(s)

- [x] security fix

###### Tested on

macOS 26.6 25G70 arm64 / Command Line Tools 26.6.0.0.1781586589
macOS 27.0 26A5388g arm64 / Command Line Tools 27.0.0.0.1784267383

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?