### PR TITLE
micronaut: update to 5.1.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.0.6 v
+github.setup    micronaut-projects micronaut-starter 5.1.0 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  953c1316a4322f70abdd6fa430d866a9f94b9cc7 \
-                 sha256  4596f65e81da7669956fe464b2a1ae90e1480b98a2f72655905941b58cf79de1 \
-                 size    33774236
+    checksums    rmd160  9d41588f50424dc5ebb94b828583c7f0aa9f4e49 \
+                 sha256  cb2569db41a58c3927d56efacc59a409d876c8d4a8dfc990d0ae7a57737d3578 \
+                 size    34082121
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  834df5bdbecb91344e9d3cb8cec0a9043934524a \
-                 sha256  a7d720fd102b5a0c17ab80e88bb1b0ba12c00745d6f8fa5664776c582634faf3 \
-                 size    38794983
+    checksums    rmd160  e70e0168be026e37da4bd988914825686f7866b8 \
+                 sha256  a76fd1185379727bb7e6d8085524911838443e6c6ce8d1d727d439b31154dd61 \
+                 size    39179166
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.1.0.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?