### PR TITLE
legcord: update to 1.30.0, drop maintainership

### DIFF
--- a/net/Legcord/Portfile
+++ b/net/Legcord/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Legcord Legcord 1.2.4 v
+github.setup        Legcord Legcord 1.3.0 v
 github.tarball_from archive
 
 categories          net
-maintainers         {@akierig fastmail.de:akierig} openmaintainer
+maintainers         nonmaintainer
 revision            0
 
-checksums           rmd160  887d7480d89dc5745a901693dc5bdddc5e0ee52a \
-                    sha256  a33abe315ea4d46a796b9827e8b1b5c29c00ad158101242df51c07712e5fbebe \
-                    size    3312893
+checksums           rmd160  61aa5a44925335ae03af3ac558924d23ff0059b4 \
+                    sha256  bdaccce0f26106d35f0b89df4a1efb7aa4a073ae0514fc252c287ae6fb1df301 \
+                    size    3461522
 
 description         lightweight alternative to the regular Discord application
 long_description    ${name} is a {*}${description}. It wraps the Discord web \


### PR DESCRIPTION
#### Description

legcord: update to 1.30.0, drop maintainership

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?