### PR TITLE
go_toolchain: new PortGroup and versioned go-1.NN toolchain ports

### DIFF
--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -1,0 +1,307 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# This PortGroup does two things:
+#
+#   1. It records which Go releases upstream supports on which versions of
+#      macOS, and answers questions about that (go_toolchain.ceiling,
+#      go_toolchain.satisfies). Including the PortGroup on its own has no side
+#      effects, so other PortGroups and ports may include it just to ask.
+#
+#   2. It builds a versioned Go toolchain port, when a Portfile calls
+#      go_toolchain.setup. See "Building a versioned toolchain" below.
+#
+# Upstream's requirements, from https://go.dev/wiki/MinimumRequirements and the
+# per-release notes:
+#
+#   Go 1.17  requires macOS 10.13 High Sierra  (darwin 17)
+#   Go 1.21  requires macOS 10.15 Catalina     (darwin 19)
+#   Go 1.23  requires macOS 11  Big Sur        (darwin 20)
+#   Go 1.25  requires macOS 12  Monterey       (darwin 21)
+#   Go 1.27  requires macOS 13  Ventura        (darwin 22)
+#
+# These are hard runtime limits, not merely build limits. From Go 1.25 the
+# darwin runtime resolves Security.framework symbols such as
+# _SecTrustCopyCertificateChain via //go:cgo_import_dynamic even when CGO is
+# disabled, so a too-new Go aborts under dyld on an older system no matter how
+# it was produced. The 1.25 binaries are the first to carry that undefined
+# symbol, and the first built with a minimum of macOS 12.
+# See https://trac.macports.org/ticket/73086.
+#
+# Building a versioned toolchain
+# ------------------------------
+#
+# PortGroup             go_toolchain 1.0
+#
+# go_toolchain.setup    1.23.12
+#
+# checksums             ...
+#
+# go_toolchain.setup derives the port name (go-1.23), the platform the port is
+# allowed on, and the whole build. It installs GOROOT into
+# ${prefix}/lib/go-1.23 and the commands as ${prefix}/bin/go-1.23 and
+# ${prefix}/bin/gofmt-1.23, so versioned toolchains never collide with each
+# other or with the main `go` port.
+
+# The minimum darwin major version each Go minor release runs on. This is the
+# single source of truth; everything else here is derived from it.
+#
+# This is a record of upstream's requirements, not a list of the toolchains
+# MacPorts packages. An entry is needed here when either
+#
+#   * a versioned port exists for it, since go_toolchain.setup looks up the
+#     release to decide which platforms the port is allowed on, or
+#   * it is the newest release usable on some macOS version, since that is what
+#     go_toolchain.ceiling reports for that system.
+#
+# Those are independent: 1.23 and 1.25 have ports but decide no ceiling, since
+# 11 Big Sur can run 1.24 and 12 Monterey can run 1.26. The remaining entries (1.18, 1.19, 1.21) do neither;
+# they are kept only so this table stays a complete record of the releases in
+# range, and so that adding a port for one later needs no new data.
+set go_toolchain.min_darwin(1.17)   8   ;# 10.4  Tiger         (see below)
+set go_toolchain.min_darwin(1.18)   17  ;# 10.13 High Sierra
+set go_toolchain.min_darwin(1.19)   17  ;# 10.13 High Sierra
+set go_toolchain.min_darwin(1.20)   17  ;# 10.13 High Sierra
+set go_toolchain.min_darwin(1.21)   19  ;# 10.15 Catalina
+set go_toolchain.min_darwin(1.22)   19  ;# 10.15 Catalina
+set go_toolchain.min_darwin(1.23)   20  ;# 11    Big Sur
+set go_toolchain.min_darwin(1.24)   20  ;# 11    Big Sur
+set go_toolchain.min_darwin(1.25)   21  ;# 12    Monterey
+set go_toolchain.min_darwin(1.26)   21  ;# 12    Monterey
+set go_toolchain.min_darwin(1.27)   22  ;# 13    Ventura
+
+# The 1.17 entry is the one value here that is not upstream's. Upstream also
+# requires 10.13 for Go 1.17, but MacPorts has long built 1.17.13 from source
+# down to 10.6 with legacysupport, and the main `go` port still ships it there.
+# The 8 keeps this table agreeing with that existing behaviour rather than
+# describing an upstream guarantee.
+
+# The newest Go minor release this table knows about. A system that can run it
+# is not capped at all.
+proc go_toolchain._newest {} {
+    global go_toolchain.min_darwin
+
+    set newest {}
+    foreach minor [array names go_toolchain.min_darwin] {
+        if {${newest} eq "" || [vercmp ${minor} > ${newest}]} {
+            set newest ${minor}
+        }
+    }
+    return ${newest}
+}
+
+# Return the minimum darwin major version for a Go release, given either a
+# minor version ("1.23") or a full version ("1.23.12").
+proc go_toolchain.min_darwin {go_version} {
+    global go_toolchain.min_darwin
+
+    set minor [go_toolchain._minor ${go_version}]
+    if {![info exists go_toolchain.min_darwin(${minor})]} {
+        return -code error "go_toolchain: unknown Go release ${go_version}"
+    }
+    return [set go_toolchain.min_darwin(${minor})]
+}
+
+# Reduce a version to its "1.NN" minor form.
+proc go_toolchain._minor {go_version} {
+    return [join [lrange [split ${go_version} .] 0 1] .]
+}
+
+# Return the newest Go minor version supported on this platform, or {} when
+# this platform can run the newest release. Non-darwin platforms are never
+# capped.
+#
+# Careful: the result is a version string, not a number. Do not pass it through
+# expr (including an expr ternary), because Tcl will renormalise "1.20" to
+# "1.2", which then fails to match anything. Compare it with vercmp and
+# interpolate it directly into strings.
+proc go_toolchain.ceiling {} {
+    global os.platform os.major go_toolchain.min_darwin
+
+    if {${os.platform} ne "darwin"} {
+        return {}
+    }
+
+    set best {}
+    foreach {minor min_darwin} [array get go_toolchain.min_darwin] {
+        if {${os.major} >= ${min_darwin}} {
+            if {${best} eq "" || [vercmp ${minor} > ${best}]} {
+                set best ${minor}
+            }
+        }
+    }
+
+    if {${best} eq "" || [vercmp ${best} >= [go_toolchain._newest]]} {
+        return {}
+    }
+    return ${best}
+}
+
+# Return 1 when the given minimum Go version can be satisfied on this platform.
+# An empty minimum is always satisfiable.
+proc go_toolchain.satisfies {minimum} {
+    if {${minimum} eq ""} {
+        return 1
+    }
+
+    set ceiling [go_toolchain.ceiling]
+    if {${ceiling} eq ""} {
+        return 1
+    }
+
+    return [vercmp ${minimum} <= ${ceiling}]
+}
+
+options go_toolchain.version go_toolchain.minor go_toolchain.goroot_final \
+        go_toolchain.suffix go_toolchain.bootstrap_path
+
+# Configure this Portfile as a versioned Go toolchain port.
+proc go_toolchain.setup {go_version} {
+    global prefix workpath worksrcpath configure.build_arch os.platform \
+           extract.suffix extract.cmd extract.pre_args extract.post_args \
+           distpath subport \
+           go_toolchain.version go_toolchain.minor go_toolchain.goroot_final \
+           go_toolchain.suffix go_toolchain.bootstrap_path
+
+    set minor [go_toolchain._minor ${go_version}]
+
+    set go_toolchain.version        ${go_version}
+    set go_toolchain.minor          ${minor}
+    set go_toolchain.suffix         -${minor}
+    set go_toolchain.goroot_final   ${prefix}/lib/go-${minor}
+    set go_toolchain.bootstrap_path ${workpath}/go_prebuilt
+
+    name                go-${minor}
+    version             ${go_version}
+    categories          lang
+    license             BSD
+    homepage            https://go.dev
+
+    maintainers         {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+    description         compiled, garbage-collected, concurrent programming \
+                        language developed by Google Inc.
+
+    long_description    \
+        The Go programming language is an open source project to make \
+        programmers more productive. This port provides Go ${minor} \
+        specifically, installed alongside any other Go toolchain, as \
+        go-${minor} and gofmt-${minor}. It is intended for building software \
+        that requires this particular release, and for systems that cannot run \
+        a newer one.
+
+    # The oldest macOS this release is supported on.
+    platforms           "darwin >= [go_toolchain.min_darwin ${go_version}]"
+
+    # Go dropped darwin/386 well before any release packaged here.
+    supported_archs     arm64 x86_64
+
+    master_sites        [option homepage]/dl/
+    distfiles           go${go_version}.src${extract.suffix}
+    extract.only        go${go_version}.src${extract.suffix}
+    worksrcdir          go
+
+    use_configure       no
+    use_parallel_build  no
+
+    # build.cmd is a shell script that runs make itself, so stop the port
+    # system adding a -j flag.
+    build.jobs          -1
+    build.dir           ${worksrcpath}/src
+    build.cmd           ./make.bash
+    build.target
+
+    switch ${configure.build_arch} {
+        arm64   { set goarch arm64 }
+        x86_64  { set goarch amd64 }
+        default { set goarch {} }
+    }
+
+    # Bootstrap from the official prebuilt toolchain of the same release. That
+    # binary's own minimum macOS version is never newer than the release's
+    # stated floor, so it runs anywhere this port is allowed to build.
+    switch ${configure.build_arch} {
+        arm64   { set bootstrap_dist go${go_version}.darwin-arm64${extract.suffix} }
+        default { set bootstrap_dist go${go_version}.darwin-amd64${extract.suffix} }
+    }
+    distfiles-append    ${bootstrap_dist}
+
+    build.env           GOROOT=${worksrcpath} \
+                        GOARCH=${goarch} \
+                        GOOS=darwin \
+                        GOROOT_FINAL=${go_toolchain.goroot_final} \
+                        GOROOT_BOOTSTRAP=${go_toolchain.bootstrap_path}/go \
+                        CC=[option configure.cc]
+
+    post-extract {
+        xinstall -d ${go_toolchain.bootstrap_path}
+        system -W ${go_toolchain.bootstrap_path} \
+            "${extract.cmd} ${extract.pre_args} ${distpath}/[go_toolchain._bootstrap_dist] ${extract.post_args}"
+    }
+
+    post-build {
+        system "find ${worksrcpath} -type d -name .hg* -print0 | xargs -0 rm -rf"
+        delete ${worksrcpath}/pkg/bootstrap
+    }
+
+    destroot {
+        # Contains a deliberately malformed Mach-O file that upsets destroot.
+        delete ${worksrcpath}/src/cmd/vendor/github.com/google/pprof/internal/binutils/testdata/malformed_macho
+
+        set grfdir ${destroot}${go_toolchain.goroot_final}
+        set docdir ${destroot}${prefix}/share/doc/${subport}
+
+        xinstall -d ${grfdir}
+        xinstall -d ${docdir}
+
+        # go.env only exists from Go 1.21 onwards, and the layout has varied
+        # in other ways between releases, so only copy what this one ships.
+        foreach f {api bin lib misc pkg src test VERSION go.env} {
+            if {[file exists ${worksrcpath}/${f}]} {
+                copy ${worksrcpath}/${f} ${grfdir}
+            }
+        }
+
+        foreach f {go gofmt} {
+            ln -s ../lib/go-${go_toolchain.minor}/bin/${f} \
+                ${destroot}${prefix}/bin/${f}${go_toolchain.suffix}
+        }
+
+        foreach f {CONTRIBUTING.md LICENSE PATENTS SECURITY.md VERSION} {
+            if {[file exists ${worksrcpath}/${f}]} {
+                xinstall -m 0644 -W ${worksrcpath} ${f} ${docdir}
+            }
+        }
+    }
+
+    notes "
+        This port installs Go ${minor} as go-${minor} and gofmt-${minor}, so it
+        does not interfere with the main `go` port. Use it directly, or point a
+        build at ${prefix}/lib/go-${minor} as GOROOT.
+    "
+
+    # Match only this branch, so a versioned toolchain is not reported as
+    # outdated against whatever the current Go release happens to be.
+    livecheck.type      regex
+    livecheck.url       [option homepage]/dl/
+    livecheck.regex     [go_toolchain._livecheck_regex ${minor}]
+}
+
+# The bootstrap distfile for this build, recomputed at phase time so the
+# post-extract block does not need a captured local.
+proc go_toolchain._bootstrap_dist {} {
+    global configure.build_arch extract.suffix go_toolchain.version
+
+    switch ${configure.build_arch} {
+        arm64   { set arch darwin-arm64 }
+        default { set arch darwin-amd64 }
+    }
+    return go[option go_toolchain.version].${arch}${extract.suffix}
+}
+
+# Match only patch releases of this port's own branch, so that a versioned port
+# is not reported as outdated against a newer branch.
+proc go_toolchain._livecheck_regex {minor} {
+    set esc [string map {. {\.}} ${minor}]
+    return [subst -nocommands -nobackslashes {go(${esc}\.[0-9.]+)\.src\.tar\.gz}]
+}

--- a/lang/go-1.17/Portfile
+++ b/lang/go-1.17/Portfile
@@ -1,0 +1,181 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 16
+
+name                go-1.17
+version             1.17.13
+revision            0
+categories          lang
+license             BSD
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         compiled, garbage-collected, concurrent programming \
+                    language developed by Google Inc.
+
+long_description    \
+    The Go programming language is an open source project to make programmers \
+    more productive. This port provides Go ${version}, the newest release that \
+    can be built for versions of macOS older than 10.13 High Sierra. It is \
+    installed alongside any other Go toolchain as go-1.17 and gofmt-1.17.
+
+homepage            https://go.dev
+
+# Upstream discontinued support for macOS older than 10.13 in Go 1.17, so the
+# official binaries for this release will not run on the systems this port
+# targets. MacPorts has nonetheless built 1.17.13 from source down to 10.6
+# using legacysupport and the patches below, and this port carries that
+# forward. Newer systems are deliberately excluded: from 10.13 onwards a newer
+# Go is available, and a modern toolchain building this release is untested.
+platforms           {darwin < 17}
+
+# Go dropped darwin/386 in 1.15; the i386 systems that need an older release
+# than this one continue to be served by the main `go` port.
+supported_archs     x86_64
+
+master_sites        ${homepage}/dl/
+distfiles           go${version}.src${extract.suffix}
+worksrcdir          go
+
+checksums           rmd160  6d8a13da5112ee67bb886eca0fec77ffaab27a5f \
+                    sha256  a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd \
+                    size    22206518
+
+set GOROOT          ${worksrcpath}
+set GOROOT_FINAL    ${prefix}/lib/${name}
+set GOARCH          amd64
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    set legacy_build    true
+} else {
+    set legacy_build    false
+}
+
+use_configure       no
+use_parallel_build  no
+
+# build.cmd is a shell script that runs make itself, so stop the port system
+# adding a -j flag.
+build.jobs          -1
+build.dir           ${worksrcpath}/src
+build.cmd           ./make.bash
+build.target
+build.env           GOROOT=${GOROOT} \
+                    GOARCH=${GOARCH} \
+                    GOOS=darwin \
+                    GOROOT_FINAL=${GOROOT_FINAL} \
+                    CC=${configure.cc}
+
+# Bootstrap from go-1.4, the last release written in C, rather than from the
+# official prebuilt 1.17.13 toolchain. The prebuilt binaries for this release
+# are built for 10.13 and will not run on any system this port supports, which
+# is the same trap that broke the main `go` port on newer systems
+# (https://trac.macports.org/ticket/73086).
+depends_build       port:go-1.4
+
+build.env-append    GOROOT_BOOTSTRAP=${prefix}/lib/go-1.4 \
+                    GOHOSTARCH=${GOARCH}
+
+if {${os.platform} eq "darwin" \
+    && ${os.major} <= ${legacysupport.newest_darwin_requires_legacy}} {
+    # The legacy support PG will not actually change anything in this port
+    # directly, since go doesn't use the standard CFLAGS/CXXFLAGS. We need to
+    # patch the build system and set up env variables manually.
+
+    if {!${legacy_build}} {
+        # Older compilers don't support the -Wno-nullability-completeness flag
+        # and if that's the case, they won't need it anyway, so just patch it
+        # out. Upstream no longer uses the flag as of 1.19beta1.
+        # https://github.com/golang/go/commit/bf19163a545c3117ab3c309a691f32a42cf29efd
+        patchfiles-append   patch-cgo-drop-no-nullability-completeness.diff
+    }
+
+    build.env-append    "GO_EXTLINK_ENABLED=1" \
+                        "GO_LDFLAGS=\"-extldflags=${configure.ldflags}\"" \
+                        "BOOT_GO_LDFLAGS=-extldflags=${configure.ldflags}" \
+                        "CGO_LDFLAGS=-g -O2 ${configure.ldflags}"
+
+    notes-append [subst {
+                    go-1.17 had to be specially patched and built to work on\
+                    your platform.
+
+                    It likely won't work out of the box when building other\
+                    projects, so make sure change your environment to use the\
+                    following variables:
+                      * GO_EXTLINK_ENABLED="1"
+                    to always force go to use the external gcc or clang linker\
+                    and
+                      * GO_LDFLAGS="\\\"-extldflags=\${configure.ldflags}\\\""
+                      * CGO_LDFLAGS="-g -O2 \${configure.ldflags}"
+                    to force-link any binary against the legacy support\
+                    library. Use exactly the quoting provided here, even if it\
+                    may look odd, or compilation will fail.
+
+                    Failure to do so will leave you unable to create binaries\
+                    that use features not natively available on your system,\
+                    either directly or through a go core dependency.
+    }]
+}
+
+if {${os.platform} eq "darwin" && ${os.major} == 10} {
+    # The branch https://github.com/catap/go/tree/macos-10.6
+    patchfiles-append   patch-macOS-10.6.diff
+}
+
+post-build {
+    system "find ${worksrcpath} -type d -name .hg* -print0 | xargs -0 rm -rf"
+
+    if {[file exists ${worksrcpath}/pkg/bootstrap]} {
+        delete ${worksrcpath}/pkg/bootstrap
+    }
+}
+
+destroot {
+    # A deliberately malformed Mach-O test fixture that upsets destroot.
+    set malformed ${worksrcpath}/src/cmd/vendor/github.com/google/pprof/internal/binutils/testdata/malformed_macho
+    if {[file exists ${malformed}]} {
+        delete ${malformed}
+    }
+
+    set grfdir ${destroot}${GOROOT_FINAL}
+    set docdir ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d ${grfdir}
+    xinstall -d ${docdir}
+
+    foreach f {api bin lib misc pkg src test VERSION} {
+        if {[file exists ${worksrcpath}/${f}]} {
+            copy ${worksrcpath}/${f} ${grfdir}
+        }
+    }
+
+    foreach f {go gofmt} {
+        ln -s ../lib/${name}/bin/${f} ${destroot}${prefix}/bin/${f}-1.17
+    }
+
+    foreach f {CONTRIBUTING.md LICENSE PATENTS SECURITY.md VERSION} {
+        if {[file exists ${worksrcpath}/${f}]} {
+            xinstall -m 0644 -W ${worksrcpath} ${f} ${docdir}
+        }
+    }
+
+    if {[file exists ${worksrcpath}/doc]} {
+        copy {*}[glob -directory ${worksrcpath}/doc *] ${docdir}
+    }
+}
+
+notes-append "
+    This port installs Go ${version} as go-1.17 and gofmt-1.17, so it does not
+    interfere with the main `go` port.
+"
+
+# Match only this branch, so this port is not reported as outdated against
+# whatever the current Go release happens to be.
+livecheck.type      regex
+livecheck.url       ${homepage}/dl/
+livecheck.regex     {go(1\.17\.[0-9.]+)\.src\.tar\.gz}

--- a/lang/go-1.17/files/patch-cgo-drop-no-nullability-completeness.diff
+++ b/lang/go-1.17/files/patch-cgo-drop-no-nullability-completeness.diff
@@ -1,0 +1,12 @@
+--- src/runtime/cgo/cgo.go.orig	2022-07-29 11:11:09.000000000 -0500
++++ src/runtime/cgo/cgo.go	2023-02-27 23:43:56.000000000 -0600
+@@ -23,9 +23,6 @@
+ #cgo solaris LDFLAGS: -lxnet
+ #cgo illumos LDFLAGS: -lsocket
+ 
+-// Issue 35247.
+-#cgo darwin CFLAGS: -Wno-nullability-completeness
+-
+ #cgo CFLAGS: -Wall -Werror
+ 
+ #cgo solaris CPPFLAGS: -D_POSIX_PTHREAD_SEMANTICS

--- a/lang/go-1.17/files/patch-macOS-10.6.diff
+++ b/lang/go-1.17/files/patch-macOS-10.6.diff
@@ -1,0 +1,120 @@
+diff --git src/crypto/x509/internal/macos/security.go src/crypto/x509/internal/macos/security.go
+index 0f6fa42b7b..90719b4cfe 100644
+--- src/crypto/x509/internal/macos/security.go
++++ src/crypto/x509/internal/macos/security.go
+@@ -81,18 +81,6 @@ func x509_SecTrustSettingsCopyCertificates_trampoline()
+ 
+ const kSecFormatX509Cert int32 = 9
+ 
+-//go:cgo_import_dynamic x509_SecItemExport SecItemExport "/System/Library/Frameworks/Security.framework/Versions/A/Security"
+-
+-func SecItemExport(cert CFRef) (data CFRef, err error) {
+-	ret := syscall(abi.FuncPCABI0(x509_SecItemExport_trampoline), uintptr(cert), uintptr(kSecFormatX509Cert),
+-		0 /* flags */, 0 /* keyParams */, uintptr(unsafe.Pointer(&data)), 0)
+-	if ret != 0 {
+-		return 0, OSStatus{"SecItemExport", int32(ret)}
+-	}
+-	return data, nil
+-}
+-func x509_SecItemExport_trampoline()
+-
+ const errSecItemNotFound = -25300
+ 
+ //go:cgo_import_dynamic x509_SecTrustSettingsCopyTrustSettings SecTrustSettingsCopyTrustSettings "/System/Library/Frameworks/Security.framework/Versions/A/Security"
+@@ -109,10 +97,15 @@ func SecTrustSettingsCopyTrustSettings(cert CFRef, domain SecTrustSettingsDomain
+ }
+ func x509_SecTrustSettingsCopyTrustSettings_trampoline()
+ 
+-//go:cgo_import_dynamic x509_SecPolicyCopyProperties SecPolicyCopyProperties "/System/Library/Frameworks/Security.framework/Versions/A/Security"
++//go:cgo_import_dynamic x509_SecCertificateCopyData SecCertificateCopyData "/System/Library/Frameworks/Security.framework/Versions/A/Security"
+ 
+-func SecPolicyCopyProperties(policy CFRef) CFRef {
+-	ret := syscall(abi.FuncPCABI0(x509_SecPolicyCopyProperties_trampoline), uintptr(policy), 0, 0, 0, 0, 0)
+-	return CFRef(ret)
++func SecCertificateCopyData(cert CFRef) ([]byte, error) {
++	ret := syscall(abi.FuncPCABI0(x509_SecCertificateCopyData_trampoline), uintptr(cert), 0, 0, 0, 0, 0)
++	if ret == 0 {
++		return nil, errors.New("x509: invalid certificate object")
++	}
++	b := CFDataToSlice(CFRef(ret))
++	CFRelease(CFRef(ret))
++	return b, nil
+ }
+-func x509_SecPolicyCopyProperties_trampoline()
++func x509_SecCertificateCopyData_trampoline()
+diff --git src/crypto/x509/internal/macos/security.s src/crypto/x509/internal/macos/security.s
+index 0038f25b27..03a389b9cf 100644
+--- src/crypto/x509/internal/macos/security.s
++++ src/crypto/x509/internal/macos/security.s
+@@ -12,9 +12,7 @@
+ 
+ TEXT ·x509_SecTrustSettingsCopyCertificates_trampoline(SB),NOSPLIT,$0-0
+ 	JMP	x509_SecTrustSettingsCopyCertificates(SB)
+-TEXT ·x509_SecItemExport_trampoline(SB),NOSPLIT,$0-0
+-	JMP	x509_SecItemExport(SB)
+ TEXT ·x509_SecTrustSettingsCopyTrustSettings_trampoline(SB),NOSPLIT,$0-0
+ 	JMP	x509_SecTrustSettingsCopyTrustSettings(SB)
+-TEXT ·x509_SecPolicyCopyProperties_trampoline(SB),NOSPLIT,$0-0
+-	JMP	x509_SecPolicyCopyProperties(SB)
++TEXT ·x509_SecCertificateCopyData_trampoline(SB),NOSPLIT,$0-0
++ 	JMP x509_SecCertificateCopyData(SB)
+diff --git src/crypto/x509/root_darwin.go src/crypto/x509/root_darwin.go
+index 05593bb105..c4cfc3358a 100644
+--- src/crypto/x509/root_darwin.go
++++ src/crypto/x509/root_darwin.go
+@@ -115,14 +115,11 @@ func loadSystemRoots() (*CertPool, error) {
+ 
+ // exportCertificate returns a *Certificate for a SecCertificateRef.
+ func exportCertificate(cert macOS.CFRef) (*Certificate, error) {
+-	data, err := macOS.SecItemExport(cert)
++	data, err := macOS.SecCertificateCopyData(cert)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	defer macOS.CFRelease(data)
+-	der := macOS.CFDataToSlice(data)
+-
+-	return ParseCertificate(der)
++    return ParseCertificate(data)
+ }
+ 
+ // isRootCertificate reports whether Subject and Issuer match.
+@@ -181,23 +178,12 @@ func sslTrustSettingsResult(cert macOS.CFRef) (macOS.SecTrustSettingsResult, err
+ 		return macOS.SecTrustSettingsResultTrustRoot, nil
+ 	}
+ 
+-	isSSLPolicy := func(policyRef macOS.CFRef) bool {
+-		properties := macOS.SecPolicyCopyProperties(policyRef)
+-		defer macOS.CFRelease(properties)
+-		if v, ok := macOS.CFDictionaryGetValueIfPresent(properties, macOS.SecPolicyOid); ok {
+-			return macOS.CFEqual(v, macOS.CFRef(macOS.SecPolicyAppleSSL))
+-		}
+-		return false
+-	}
+-
+ 	for i := 0; i < macOS.CFArrayGetCount(trustSettings); i++ {
+ 		tSetting := macOS.CFArrayGetValueAtIndex(trustSettings, i)
+ 
+ 		// First, check if this trust setting is constrained to a non-SSL policy.
+-		if policyRef, ok := macOS.CFDictionaryGetValueIfPresent(tSetting, macOS.SecTrustSettingsPolicy); ok {
+-			if !isSSLPolicy(policyRef) {
+-				continue
+-			}
++		if _, ok := macOS.CFDictionaryGetValueIfPresent(tSetting, macOS.SecTrustSettingsPolicy); ok {
++			continue
+ 		}
+ 
+ 		// Then check if it is restricted to a hostname, so not a root.
+diff --git src/syscall/zerrors_darwin_amd64.go src/syscall/zerrors_darwin_amd64.go
+index 0b9897284c..c35e07622d 100644
+--- src/syscall/zerrors_darwin_amd64.go
++++ src/syscall/zerrors_darwin_amd64.go
+@@ -233,7 +233,7 @@ const (
+ 	F_ALLOCATECONTIG                  = 0x2
+ 	F_CHKCLEAN                        = 0x29
+ 	F_DUPFD                           = 0x0
+-	F_DUPFD_CLOEXEC                   = 0x43
++	F_DUPFD_CLOEXEC                   = 0x0
+ 	F_FLUSH_DATA                      = 0x28
+ 	F_FREEZE_FS                       = 0x35
+ 	F_FULLFSYNC                       = 0x33

--- a/lang/go-1.20/Portfile
+++ b/lang/go-1.20/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           go_toolchain 1.0
+
+go_toolchain.setup  1.20.14
+revision            0
+
+checksums           \
+                    go1.20.14.src.tar.gz \
+                    rmd160  f8a9337b5bafc8150b17e490b4a08673ed914046 \
+                    sha256  1aef321a0e3e38b7e91d2d7eb64040666cabdcc77d383de3c9522d0d69b67f4e \
+                    size    26202564 \
+                    go1.20.14.darwin-arm64.tar.gz \
+                    rmd160  6cc5ab8ff337b819650bce0db20247026d96a677 \
+                    sha256  6da3f76164b215053daf730a9b8f1d673dbbaa4c61031374a6744b75cb728641 \
+                    size    96842753 \
+                    go1.20.14.darwin-amd64.tar.gz \
+                    rmd160  91365ecd8e709517fa62c349b1d3543d5ed5d262 \
+                    sha256  754363489e2244e72cb49b4ec6ddfd6a2c60b0700f8c4876e11befb1913b11c5 \
+                    size    100099341

--- a/lang/go-1.22/Portfile
+++ b/lang/go-1.22/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           go_toolchain 1.0
+
+go_toolchain.setup  1.22.12
+revision            0
+
+checksums           \
+                    go1.22.12.src.tar.gz \
+                    rmd160  f82caa31483b224cb04959ed5fdd35dbcacbadcc \
+                    sha256  012a7e1f37f362c0918c1dfa3334458ac2da1628c4b9cf4d9ca02db986e17d71 \
+                    size    27566409 \
+                    go1.22.12.darwin-arm64.tar.gz \
+                    rmd160  026f82bb54b1d6ed016723538a49e15adaf8d5af \
+                    sha256  416c35218edb9d20990b5d8fc87be655d8b39926f15524ea35c66ee70273050d \
+                    size    67315985 \
+                    go1.22.12.darwin-amd64.tar.gz \
+                    rmd160  d9fab5f29364f309b2494cbc9c5945950ab64d2c \
+                    sha256  e7bbe07e96f0bd3df04225090fe1e7852ed33af37c43a23e16edbbb3b90a5b7c \
+                    size    70358300

--- a/lang/go-1.23/Portfile
+++ b/lang/go-1.23/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           go_toolchain 1.0
+
+go_toolchain.setup  1.23.12
+revision            0
+
+checksums           \
+                    go1.23.12.src.tar.gz \
+                    rmd160  87ded7a7475012d8a65936f05cab05ace6ba56f2 \
+                    sha256  e1cce9379a24e895714a412c7ddd157d2614d9edbe83a84449b6e1840b4f1226 \
+                    size    28185486 \
+                    go1.23.12.darwin-arm64.tar.gz \
+                    rmd160  f68cf530ffd280d8a965a0623c261d09f4df7c36 \
+                    sha256  5bfa117e401ae64e7ffb960243c448b535fe007e682a13ff6c7371f4a6f0ccaa \
+                    size    71669468 \
+                    go1.23.12.darwin-amd64.tar.gz \
+                    rmd160  0f524abed104a72443762fdb5417cd5581d5bbd8 \
+                    sha256  0f6efdc3ffc6f03b230016acca0aef43c229de022d0ff401e7aa4ad4862eca8e \
+                    size    75005215

--- a/lang/go-1.24/Portfile
+++ b/lang/go-1.24/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           go_toolchain 1.0
+
+go_toolchain.setup  1.24.13
+revision            0
+
+checksums           \
+                    go1.24.13.src.tar.gz \
+                    rmd160  58bf09c700493823192e64de767158f284c6c9a3 \
+                    sha256  639a6204c2486b137df1eb6e78ee3ed038f9877d0e4b5a465e796a2153f858d7 \
+                    size    30802752 \
+                    go1.24.13.darwin-arm64.tar.gz \
+                    rmd160  c35cec97b7f5cccf90e9d63f6c962fe0264a5718 \
+                    sha256  f282d882c3353485e2fc6c634606d85caf36e855167d59b996dbeae19fa7629a \
+                    size    76442495 \
+                    go1.24.13.darwin-amd64.tar.gz \
+                    rmd160  a65c5593bb244b6f71ac3ac4b899ab3ba5672650 \
+                    sha256  6cc6549b06725220b342b740497ffd24e0ebdcef75781a77931ca199f46ad781 \
+                    size    80145725

--- a/lang/go-1.25/Portfile
+++ b/lang/go-1.25/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           go_toolchain 1.0
+
+go_toolchain.setup  1.25.12
+revision            0
+
+checksums           \
+                    go1.25.12.src.tar.gz \
+                    rmd160  25fa8850c2264cf7dff1c56b66b501ec1932da8b \
+                    sha256  f90dcee4bd023fa376374ea0a5a6ebe553537b39c426ffd8c689469b45519932 \
+                    size    32013699 \
+                    go1.25.12.darwin-arm64.tar.gz \
+                    rmd160  19c5bb66bbb7b43444d5778c3e04a03f73e0106d \
+                    sha256  fa2c88bbcf64bd3b2aef355f026cfec6d3a4a01c132f999c8f8c964eb767164f \
+                    size    58121109 \
+                    go1.25.12.darwin-amd64.tar.gz \
+                    rmd160  509e1916781165250d0bc85cf66d6b1c4145e446 \
+                    sha256  00a2e743b82bccec03c51c4b0f7e46d5fec52184075fd6c5183c3bb39ae9fb00 \
+                    size    60594502

--- a/lang/go-1.26/Portfile
+++ b/lang/go-1.26/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           go_toolchain 1.0
+
+go_toolchain.setup  1.26.5
+revision            0
+
+checksums           \
+                    go1.26.5.src.tar.gz \
+                    rmd160  37919c04f4a80d411d21e8244b455359ddfc38ec \
+                    sha256  495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42 \
+                    size    34140216 \
+                    go1.26.5.darwin-arm64.tar.gz \
+                    rmd160  67ab77955564e690647cdff5fdbfc4222acf84b4 \
+                    sha256  efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a \
+                    size    64738542 \
+                    go1.26.5.darwin-amd64.tar.gz \
+                    rmd160  d71b04c25734257bd78ee97f4ad017ba43741c4a \
+                    sha256  6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725 \
+                    size    67836304


### PR DESCRIPTION
### Summary

Adds a `go_toolchain` PortGroup and seven versioned Go toolchain ports:
`go-1.17`, `go-1.20`, `go-1.22`, `go-1.23`, `go-1.24`, `go-1.25`, `go-1.26`.

Upstream has repeatedly raised Go's minimum macOS version, and the `go` port's
current split no longer matches it — on 10.13–10.15 it installs Go 1.24, whose
binaries are built for macOS 11 and abort under dyld there.

This is the first step and is **purely additive**: `lang/go/Portfile` and the
`golang` PortGroup are untouched, and no existing port changes behaviour.

### What's here

The PortGroup records upstream's minimum macOS per Go release. Both the newest
usable release for a given system and each port's `platforms` line are derived
from that one table, so they cannot drift apart:

| macOS | newest usable Go |
|---|---|
| 10.6–10.12 | 1.17 |
| 10.13–10.14 | 1.20 |
| 10.15 | 1.22 |
| 11 | 1.24 |
| 12 | 1.26 |
| 13+ | current |

Ports install as `go-1.NN` / `gofmt-1.NN` with GOROOT under
`${prefix}/lib/go-1.NN`. Nothing claims `${prefix}/bin/go`, so they coexist
with `go` and with each other. 1.23 and 1.25 decide no ceiling; they're there
for ports needing to pin a specific toolchain.

`go-1.17` is standalone rather than being built via the `go_toolchain`
portgroup, since it needs legacysupport and the 10.6 patches. It bootstraps
from `go-1.4` rather than the prebuilt 1.17.13, which targets 10.13 and cannot
run on the systems it serves.

### Going forward

1. **This PR** — the toolchains exist; nothing consumes them yet.
2. `golang` PortGroup depends on the newest toolchain the running system
   supports instead of `port:go`. Restores Go software builds on 10.13–10.15,
   and keeps 11 and 12 on a toolchain they can run as upstream's floor keeps
   rising, with no changes needed in dependent ports.
3. `go.toolchain_min` in the `golang` PortGroup, taken from each port's
   `go.mod`, marking ports `known_fail` where the OS cannot provide their
   minimum — stops buildbots retrying guaranteed failures.
4. `lang/go` bands corrected, closing the ticket.

### Testing

CI builds and installs all six PortGroup-built ports on macOS 14, 15 and 26;
`go-1.20` and `go-1.26` were additionally built and run by hand. All ports lint
clean, and every checksum is verified against go.dev.

Per-release macOS floors were checked against the official binaries
(`LC_BUILD_VERSION` and the undefined symbol list), not just the release notes:
1.23 and 1.24 are built for macOS 11, while 1.25 is the first built for macOS
12 and the first to reference `_SecTrustCopyCertificateChain`.

Not covered: the amd64 bootstrap, since every CI runner is arm64; and
`go-1.17`, which targets 10.6–10.12 and is excluded from CI as known to fail
there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

See: https://trac.macports.org/ticket/73086
