### PR TITLE
pi-coding-agent: update to 0.82.1

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.81.1
+version             0.82.1
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  9457a1a4fe690abb89300f7bf567d772e860f5a0 \
-                    sha256  420113c0282160e6181656fd16cf18742f76bf9040ee3dfb9cb67e3e6ad5641c \
-                    size    4967228
+checksums           rmd160  f08fd7d64d11605d19e5987997c25ca25fedbdc8 \
+                    sha256  8343ab95cbab5766f2f5d48844df8db13e772ead2e2976166cbb820a29dacb7d \
+                    size    4978133
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
