### PR TITLE
openjdk25-graalvm: update to 25.2.4

### DIFF
--- a/java/openjdk25-graalvm/Portfile
+++ b/java/openjdk25-graalvm/Portfile
@@ -20,11 +20,12 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  arm64
 
-version          ${feature}.1.3
-set build        9
+set innovation   2
+version          ${feature}.${innovation}.4
+set build        7
 revision         0
 
-set jdk_version  ${feature}.0.3
+set jdk_version  ${feature}.0.4
 
 description GraalVM Community Edition based on OpenJDK ${feature} (Long Term Support)
 long_description {*}${description} \
@@ -32,11 +33,11 @@ long_description {*}${description} \
 
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${version}/
 
-checksums    rmd160  ab24742c988bf12f126c32aedda38b8d769fd382 \
-             sha256  b41cdde27691a0e04a1f2b0660624bc37e59c738e536888860c4c9f65a4a9a3b \
-             size    336020050
+checksums    rmd160  c64d3a6ca9d0f2b6a13f748d8f66b17aaacdb274 \
+             sha256  507330fff8907de51b8621c95a21a491fa9b0d8c240de184594f40f83add3bfa \
+             size    331502567
 
-distname     graalvm-community-jdk-${feature}i1-${jdk_version}_macos-aarch64_bin
+distname     graalvm-community-jdk-${feature}i${innovation}-${jdk_version}_macos-aarch64_bin
 
 worksrcdir   graalvm-community-${version}+${build}.1
 


### PR DESCRIPTION
#### Description

Update to GraalVM Community 25 innovation 2 (graal 25.2.4, jdk 25.0.4).

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
