### PR TITLE
openjdk25-temurin: update to 25.0.4

### DIFF
--- a/java/openjdk25-temurin/Portfile
+++ b/java/openjdk25-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=25&os=mac
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.3
-set build    9
+version      ${feature}.0.4
+set build    7
 revision     0
 
 # End of availability: https://adoptium.net/support
@@ -33,14 +33,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  fa2d496babb96dea3e152a0a93214f6881e7d114 \
-                 sha256  4c539a18b4d656960ff6766727e9ca546fc17f7a29714dba9e7b47bdcb37c447 \
-                 size    120533867
+    checksums    rmd160  e697b25f62fd814caa3d3b9c10fe47bbb00ec1bf \
+                 sha256  a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7 \
+                 size    120249038
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  1ebb3ee20f09b6ac49d3db141e2a4baf1b778fa8 \
-                 sha256  7baab4d69a15554e119b86ff78d40e3fdc28819b5b322955c913cebfe3f6a37c \
-                 size    136601548
+    checksums    rmd160  7b7babfad7762c3233d8f212896238741eb7a4d2 \
+                 sha256  5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd \
+                 size    136352956
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 25.0.4.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?