### PR TITLE
libtool: update to 2.6.2

### DIFF
--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           clang_dependency 1.0
 
 name                libtool
-version             2.5.4
+version             2.6.2
 categories          devel sysutils
 platforms           darwin freebsd
 # Scripts are GPL-2+, libltdl is LGPL-2+, but all parts that tend to be
@@ -21,9 +21,9 @@ homepage            https://www.gnu.org/software/libtool
 
 master_sites        gnu
 use_xz              yes
-checksums           rmd160 8dcde730274c8ac3d0bce43f58bb9ba18d0b9a1e \
-                    sha256 f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675 \
-                    size   1056924
+checksums           rmd160 f09a66e561b0b6a58c03b3a35b74318a23ca9a45 \
+                    sha256 2ef1067c16c97db930fd740cc9bc3d3ba9a583804ae5ac42cc3e8719e49e191e \
+                    size   1093564
 
 # hardcode the M4 executable, similar to other executables such as SED, GREP, LN ...
 patchfiles          hardcode-m4.patch


### PR DESCRIPTION
## Summary
- Update libtool from 2.5.4 to 2.6.2 — the first stable release of the 2.6 line, superseding the 2.5.x development series
- `hardcode-m4.patch` applies unchanged (exact apply, no fuzz/offset)

## Compatibility
Reviewed NEWS across 2.6.0/2.6.1/2.6.2: **no "Important incompatible changes" section** in any of them — every such section in NEWS predates 2.5.4 and is already in effect. The one behaviorally-significant new feature, `--enable-cxx-stdlib` (controls `-nostdlib` for C++ shared libs), defaults to the prior `-nostdlib` behavior and is not enabled here.

## Test plan
- [x] Verified `hardcode-m4.patch` applies exactly against 2.6.2 (M4 hardcoding lands in Makefile.in, configure, libtoolize.in)
- [x] Builds successfully to destroot

🤖 Generated with [Claude Code](https://claude.com/claude-code)