### PR TITLE
aerc: update to 0.22.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile    1.0
 PortGroup           sourcehut   1.0
 
-sourcehut.setup     rjarry aerc 0.21.0
+sourcehut.setup     rjarry aerc 0.22.0
 revision            0
 
 homepage            https://aerc-mail.org
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  270e1cdb69c82e7ae3ed73e4f7df9c3386f33444 \
-                    sha256  3f1469bbaea982fc58352f2682932ecc2fb50c705994d96b2343e771747745a7 \
-                    size    614327
+checksums           rmd160  6566d704a75c0dea24ee842fcefa86a37a87b169 \
+                    sha256  f1cd5e358fd836051d4d88c189ecaa025a108b729281985525b45b13bc49e70f \
+                    size    641634
 
 depends_build-append \
                     port:go \


### PR DESCRIPTION
#### Description
https://lists.sr.ht/~rjarry/aerc-announce/%3C20260728183939.SNBCAYWUFGH7YUJI-robin@jarry.cc%3E

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
