### PR TITLE
pkgconf: Update to 3.0.4

### DIFF
--- a/devel/pkgconf/Portfile
+++ b/devel/pkgconf/Portfile
@@ -8,7 +8,7 @@ PortGroup                   meson 1.0
 legacysupport.newest_darwin_requires_legacy 13
 
 name                        pkgconf
-version                     3.0.3
+version                     3.0.4
 revision                    0
 categories                  devel
 license                     ISC
@@ -20,9 +20,9 @@ long_description            pkgconf is ${description}. \
 homepage                    https://github.com/pkgconf/pkgconf
 master_sites                https://distfiles.ariadne.space/pkgconf/
 
-checksums                   rmd160  abec61acdf511761ddb294bff1debe1825bee734 \
-                            sha256  f9c5c8bd4185ea140c01fae0c6cae4e4ca2f315c6102d3d47d6d624de8fe382b \
-                            size    609791
+checksums                   rmd160  c8914030bbb8957c6e7b6817afb49b83d91826e2 \
+                            sha256  67dd778366d1a094f26a9bf5ad0cce1b2e25588420c49a4c9fea6452a6eef829 \
+                            size    611767
 
 # both ports install ${prefix}/share/aclocal/pkg.m4
 conflicts                   pkgconfig


### PR DESCRIPTION
#### Description

Update pkgconf to 3.0.4

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
