### PR TITLE
3proxy: Fix build on OSX 10.6

### DIFF
--- a/net/3proxy/Portfile
+++ b/net/3proxy/Portfile
@@ -7,6 +7,7 @@ PortGroup               cmake 1.1
 
 github.setup            3proxy 3proxy 0.9.7
 github.tarball_from     archive
+revision                0
 categories              net
 license                 BSD GPL-2+ LGPL-2.1+ Apache
 maintainers             {mail.ru:nano103 @nano103} openmaintainer
@@ -27,6 +28,8 @@ checksums               rmd160  5a1098da56e5b7d515c17587cd40728db0280aa9 \
 depends_lib-append      port:pcre2
 
 configure.args-append   -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc
+
+patchfiles              0001-define-IPV6_BOUND_IF-if-not-defined-for-legacy-MacOS.patch
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}

--- a/net/3proxy/files/0001-define-IPV6_BOUND_IF-if-not-defined-for-legacy-MacOS.patch
+++ b/net/3proxy/files/0001-define-IPV6_BOUND_IF-if-not-defined-for-legacy-MacOS.patch
@@ -1,0 +1,47 @@
+From f18a751f8956fb4f1696a4ec426846ff0d859852 Mon Sep 17 00:00:00 2001
+From: Vladimir Dubrovin <3proxy@3proxy.ru>
+Date: Fri, 17 Jul 2026 15:07:11 +0300
+Subject: [PATCH] define IPV6_BOUND_IF if not defined (for legacy MacOS
+ 10.x)
+
+See: https://github.com/3proxy/3proxy/issues/1250
+Upstream-Status: Backport [https://github.com/3proxy/3proxy/compare/f18a751f89%5E...afb2ec0696]
+---
+ src/common.c    | 3 +++
+ src/proxymain.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/common.c b/src/common.c
+index 3444dcd..f0eada7 100644
+--- src/common.c.orig
++++ src/common.c
+@@ -659,7 +659,9 @@ int doconnect(struct clientparam * param){
+ 	    if(!idx || (*SAFAMILY(&param->sinsl) == AF_INET && param->srv->so._setsockopt(param->sostate, param->remsock, IPPROTO_IP, IP_BOUND_IF, &idx, sizeof(idx))))
+ 			return 12;
+ #ifndef NOIPV6
++#ifdef IPV6_BOUND_IF
+ 	    if(*SAFAMILY(&param->sinsl) == AF_INET6 && param->srv->so._setsockopt(param->sostate, param->remsock, IPPROTO_IPV6, IPV6_BOUND_IF, &idx, sizeof(idx))) return 12;
++#endif
+ #endif
+ 	}
+ #endif
+
+diff --git a/src/proxymain.c b/src/proxymain.c
+index fe938f8..08eef95 100644
+--- src/proxymain.c.orig
++++ src/proxymain.c
+@@ -772,10 +772,12 @@ int MODULEMAINFUNC (int argc, char** argv){
+ 			return -12;
+ 		    }
+ #ifndef NOIPV6
++#ifdef IPV6_BOUND_IF
+ 	            if((*SAFAMILY(&srv.intsa) == AF_INET6 && srv.so._setsockopt(srv.so.state, sock, IPPROTO_IPV6, IPV6_BOUND_IF, &idx, sizeof(idx)))) {
+ 			dolog(&defparam, (unsigned char *)"failed to bind device");
+ 	        	return -12;
+ 	    	    }
++#endif
+ #endif
+ 		}
+ #endif
+--
+2.55.0


### PR DESCRIPTION
#### Description

Fix 3proxy build on OSX 10.6 and lower. `IPV6_BOUND_IF` is not defined (nor supported as a protocol) by OSX 10.6 and lower.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

[CI only](https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/277991/steps/install-port/logs/stdio)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
