### PR TITLE
opencode: update to 1.18.9

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.18.7
+version             1.18.9
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  54d0f6f22ab352cc5442989a5d3fa047d8f6ce90 \
-                    sha256  22119806655ab4fbc657ad7862124cadb7704dae7429aa140f62446a4e499c4d \
-                    size    3041
+checksums           rmd160  077f89986e6a3db68e39d4a7323619acee4ab0ce \
+                    sha256  d60025d789fd56501a372bdc788afd9af79a2c9b71e43a7ea83611fa3b51f329 \
+                    size    3044


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.9.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?