### PR TITLE
`meta-package-manager`: update to 7.5.0, with dependency updates, two new ports and test phases

### DIFF
--- a/python/py-click-extra/Portfile
+++ b/python/py-click-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-click-extra
-version             8.4.0
+version             8.8.1
 revision            0
 
 categories-append   devel
@@ -25,9 +25,9 @@ homepage            https://github.com/kdeldycke/click-extra
 
 python.rootname     click_extra
 
-checksums           rmd160  64af88de5df1af7a72a249d33f5367af493b8b7d \
-                    sha256  92e5441824126248c61b05471ecacb6403e45a0b0b743f6babf425abb4c217de \
-                    size    362743
+checksums           rmd160  e7013539e104262ee78146043c60e250e95b66b2 \
+                    sha256  fc67535bbc186ac608b04f1da3dd1c442903567f08a12f484af89a894653f796 \
+                    size    1263359
 
 python.versions     311 312 313 314
 python.pep517_backend uv
@@ -42,4 +42,21 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-tabulate \
                     port:py${python.version}-wcmatch \
                     port:py${python.version}-wcwidth
+
+    depends_test-append \
+                    path:bin/git:git \
+                    port:py${python.version}-hjson \
+                    port:py${python.version}-jsonschema \
+                    port:py${python.version}-myst-parser \
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-pytest-httpserver \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-sphinx \
+                    port:py${python.version}-tomlkit \
+                    port:py${python.version}-xmltodict \
+                    port:py${python.version}-yaml
+
+    # Exclude the network tests (marked "network") that reach external services.
+    test.run            yes
+    test.args-append    -o addopts="-m 'not network'"
 }

--- a/python/py-cloup/Portfile
+++ b/python/py-cloup/Portfile
@@ -33,4 +33,6 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools_scm
     depends_lib-append \
                     port:py${python.version}-click
+
+    test.run            yes
 }

--- a/python/py-extra-platforms/Portfile
+++ b/python/py-extra-platforms/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-extra-platforms
-version             13.3.1
+version             13.6.0
 revision            0
 
 categories-append   devel
@@ -24,9 +24,14 @@ homepage            https://github.com/kdeldycke/extra-platforms
 
 python.rootname     extra_platforms
 
-checksums           rmd160  725ffc954d75819630e56a9f1bff57fe1fd05f0b \
-                    sha256  1efefa780f0b97dce5d352f7873065988f7f23938af70456182b20474849d1c2 \
-                    size    86205
+checksums           rmd160  60cf5336ab0b305c72aba5521f1dad811f6dda4c \
+                    sha256  92b5800c0ca9767820ae2cf3d48b7037432c1360055ed1804bc43a8269a2a090 \
+                    size    464011
 
 python.versions     311 312 313 314
 python.pep517_backend uv
+
+if {${name} ne ${subport}} {
+    test.run            yes
+    test.args-append    -o addopts="-m 'not network'"
+}

--- a/python/py-hjson/Portfile
+++ b/python/py-hjson/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  8932f335c23be5f046f62a54219159143c06dfba \
                     sha256  55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75 \
                     size    40541
 
-python.versions     310 311
+python.versions     310 311 312 313 314
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-myst-parser/Portfile
+++ b/python/py-myst-parser/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        executablebooks MyST-Parser 3.0.1 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        executablebooks MyST-Parser 5.0.0 v
+github.tarball_from archive
 revision            0
 name                py-myst-parser
 
@@ -27,11 +26,11 @@ long_description    \
     to write MyST Markdown in Sphinx.
 homepage            https://github.com/executablebooks/MyST-Parser
 
-checksums           rmd160  eb40b9bc147beeb989e7a6286a66d9bcfde786bf \
-                    sha256  82954a85a6a5876a298a8f1567590321d9fa67bcc33f99063511f1fd55591640 \
-                    size    823858
+checksums           rmd160  acbbe5a68327cca8b7a0de3e245d7655c2f90696 \
+                    sha256  358c0f4a5c6a3d65f6878d0ec7dca0e1c79238e63923982bb2a3af6429e78860 \
+                    size    830837
 
-python.versions     310 311 312
+python.versions     311 312 313 314
 python.pep517_backend flit
 
 if {${name} ne ${subport}} {
@@ -44,10 +43,15 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-yaml
 
     depends_test-append \
-                        port:py${python.version}-mdit-py-plugins \
                         port:py${python.version}-beautifulsoup4 \
-                        port:py${python.version}-pytest-regressions
+                        port:py${python.version}-defusedxml \
+                        port:py${python.version}-linkify-it-py \
+                        port:py${python.version}-pytest-param-files \
+                        port:py${python.version}-pytest-regressions \
+                        port:py${python.version}-sphinx-pytest
 
     test.run            yes
-    test.args           -k 'not test_sphinx_builds and not test_fixtures'
+    # Put the unpacked source on PYTHONPATH: the nested tests import myst_parser
+    # from it, which is not installed during the test phase.
+    test.env-append     PYTHONPATH=${worksrcpath}
 }

--- a/python/py-packageurl-python/Portfile
+++ b/python/py-packageurl-python/Portfile
@@ -29,3 +29,8 @@ checksums           rmd160  62b8e5aaca38615e0db899017516e43eebe34cce \
                     size    50618
 
 python.versions     311 312 313 314
+
+if {${name} ne ${subport}} {
+    test.run            yes
+    test.args-append    --ignore tests/test_purl_spec.py
+}

--- a/python/py-pytest-param-files/Portfile
+++ b/python/py-pytest-param-files/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pytest-param-files
+python.rootname     pytest_param_files
+version             0.6.0
+revision            0
+
+categories-append   devel
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Create pytest parametrize decorators from external files.
+long_description    {*}${description}
+
+homepage            https://github.com/chrisjsewell/pytest-param-files
+
+checksums           rmd160  4a2acca3e96c59327e9030c449f374521df76aa7 \
+                    sha256  ab02608d63f7baf14483682ee6213c9330401f2a14d7a63489b872f6830a9848 \
+                    size    9750
+
+python.versions     310 311 312 313 314
+python.pep517_backend flit
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-ruamel-yaml
+}

--- a/python/py-sphinx-pytest/Portfile
+++ b/python/py-sphinx-pytest/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sphinx-pytest
+python.rootname     sphinx_pytest
+version             0.3.0
+revision            0
+
+categories-append   devel textproc
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+maintainers         {deldycke.com:kevin @kdeldycke} openmaintainer
+
+description         Helpful pytest fixtures for Sphinx extensions.
+long_description    {*}${description}
+
+homepage            https://github.com/sphinx-extensions2/sphinx-pytest
+
+checksums           rmd160  102cde5832573e81769808fcd2a541edb9c29855 \
+                    sha256  141a3d6b6cd8616ded72a949a2e7ba8b95e811e58f1118fa1ddeb8c61c3b6364 \
+                    size    8025
+
+python.versions     310 311 312 313 314
+python.pep517_backend flit
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-sphinx
+}

--- a/sysutils/meta-package-manager/Portfile
+++ b/sysutils/meta-package-manager/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                meta-package-manager
-version             7.3.0
+version             7.5.0
 revision            0
 
 categories          sysutils python
@@ -25,9 +25,9 @@ homepage            https://kdeldycke.github.io/meta-package-manager/
 
 python.rootname     meta_package_manager
 
-checksums           rmd160  4bf9c9303adb24aee7c94b5bf1457724a407661b \
-                    sha256  f540a4957ae2d3f702e97aa3217261b808e4b98233707c9f8c5f214c3dbfee91 \
-                    size    325448
+checksums           rmd160  4ebf8cb085ec2d62ab1c5f1b50eca9ecc200f78a \
+                    sha256  78275f2e63c9133484b1d8cb36198eb053955a9c7eeea06994f4b90c0c19c4ea \
+                    size    2058072
 
 python.default_version 314
 python.pep517_backend uv
@@ -38,3 +38,11 @@ depends_lib-append  port:py${python.version}-boltons \
                     port:py${python.version}-packageurl-python \
                     port:py${python.version}-tomli-w \
                     port:py${python.version}-xmltodict
+
+depends_test-append port:py${python.version}-tomlkit \
+                    port:py${python.version}-yaml
+
+# Run the hermetic layer from the unpacked sdist, excluding the integration
+# tests (marked "integration") that drive real package managers.
+test.run            yes
+test.args-append    -o addopts="-m 'not integration'"


### PR DESCRIPTION
#### Description

This is an update for my `meta-package-manager` to its latest releases.

**Updated ports**

- `meta-package-manager`: `7.3.0` → `7.5.0`
- `py-click-extra`: `8.4.0` → `8.8.1`
- `py-extra-platforms`: `13.3.1` → `13.6.0`
- `py-myst-parser`: `3.0.1` → `5.0.0`
- `py-hjson`: add Python 3.12, 3.13 and 3.14 subports

**New ports**

- `py-pytest-param-files` `0.6.0`: test dependency for `py-myst-parser`
- `py-sphinx-pytest` `0.3.0`: test dependency for `py-myst-parser`

It additionally enable the `test` phases, so each runs its test suite under `sudo port test`. This should bring better stability and early warnings in the near future.

This follows up on #33609.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6 25G72 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?