### PR TITLE
muse-image-brief: new port, version 1.0.0

### DIFF
--- a/graphics/muse-image-brief/Portfile
+++ b/graphics/muse-image-brief/Portfile
@@ -1,0 +1,44 @@
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        FosterMartyn735 muse-image-brief 1.0.0 v
+github.tarball_from archive
+revision            0
+
+categories          graphics
+supported_archs     noarch
+license             MIT
+maintainers         {@FosterMartyn735 gmail.com:fostermartyn735} openmaintainer
+
+description         Validate structured JSON image briefs from the command line
+long_description    Muse Image Brief checks that a JSON image brief contains \
+                    a subject, composition, lighting, palette, and output \
+                    purpose before it enters a rendering or review stage. The \
+                    command is dependency-free and does not upload files.
+
+homepage            https://github.com/FosterMartyn735/muse-image-brief
+
+checksums           rmd160  e5bd194efee42120a8ef9754ea72d1bec074d3af \
+                    sha256  9227199efdcbdbd38ccb1fe06e6accd74c79527f6e83d91c5d2dc833dfa896d9 \
+                    size    2984
+
+depends_run         port:python312
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/muse-image-brief.py \
+        ${destroot}${prefix}/bin/muse-image-brief
+    reinplace "s|#!/usr/bin/env python3|#!${prefix}/bin/python3.12|" \
+        ${destroot}${prefix}/bin/muse-image-brief
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} README.md LICENSE \
+        ${destroot}${prefix}/share/doc/${name}
+}
+
+test.run            yes
+test.cmd            ${prefix}/bin/python3.12
+test.args           -m unittest discover -s tests -v
+


### PR DESCRIPTION
#### Description

Add a new port for Muse Image Brief 1.0.0, a dependency-free command-line validator for structured JSON image briefs. The source archive is public at https://github.com/FosterMartyn735/muse-image-brief and contains an MIT license, documentation, and four unit tests.

This is a new Portfile submission. No existing Trac ticket is required.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

No macOS host is available in the current environment. The source command and its four unit tests pass with Python, but port lint, port test, and a full MacPorts install have not been claimed; the official PR CI is requested for those checks.

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there are no other open pull requests for the same change?
- [ ] referenced existing tickets on Trac? (not applicable: new PR submission)
- [ ] checked your Portfile with port lint? (no macOS/MacPorts host available)
- [ ] tried existing tests with sudo port test? (awaiting CI)
- [ ] tried a full install with sudo port -vst install? (awaiting CI)
- [x] tested basic functionality of the command and its unit tests?