### PR TITLE
jpeg-xt: Update to 1.72

### DIFF
--- a/graphics/jpeg-xt/Portfile
+++ b/graphics/jpeg-xt/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        thorfdbg libjpeg 25f71280913fde7400801772bbf885bb3e873242
+github.setup        thorfdbg libjpeg 702114c8130ae818ccd2354cc03e879dac69e579
 # https://github.com/macports/macports-ports/pull/28116#issuecomment-2847585194
 name                jpeg-xt
 # https://github.com/thorfdbg/libjpeg/blob/master/README
-version             1.71
+version             1.72
 revision            0
+
 categories          graphics
 license             GPL-3
-maintainers         nomaintainer
+maintainers         {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
 
 description         Complete implementation of 10918-1 (JPEG) from jpeg.org
 
@@ -19,9 +21,9 @@ long_description    A complete implementation of 10918-1 (JPEG) coming \
                     from jpeg.org (the ISO group) with extensions for \
                     HDR standardized as 18477 (JPEG XT).
 
-checksums           rmd160  4ff5a09bf6a3f4689ec618efc07b32fdfbbe82f0 \
-                    sha256  2625a50fbf4751bb145b4704a55de3da77a946d589455acedbab41ddebb19d3a \
-                    size    565066
+checksums           rmd160  3b7e6a743c676d2c87b222b0b482cfa2622853f1 \
+                    sha256  91cc611c6ead4fd34cabdb724b8f2abd86163ed5e3cc444af40fce2a742e8b94 \
+                    size    565303
 
 post-patch {
     reinplace {s|-Wno-shift-negative-value||} \
@@ -53,3 +55,9 @@ post-destroot {
     move            ${destroot}${prefix}/bin/jpeg \
                     ${destroot}${prefix}/bin/jpeg-xt
 }
+
+# Upstream does not use github tags, but keeps version numbers in the README.
+livecheck.type      regex
+livecheck.version   ${version}
+livecheck.url       ${github.homepage}/raw/refs/heads/master/README
+livecheck.regex     {Release +([0-9.]+):}


### PR DESCRIPTION
#### Description

* Update jpeg-xt 1.71 --> 1.72.
* Fix livecheck.
* Add self as maintainer.

###### Type(s)

###### Tested on

CI only.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?