### PR TITLE
mp3rgain: update to 2.11.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.10.0 v
+github.setup        M-Igashi mp3rgain 2.11.0 v
 github.tarball_from archive
 revision            0
 
@@ -26,13 +26,13 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  af287651d78c7db5de8d3d2af574873f17742c03 \
-                    sha256  82562f9a15174c4afbf6beb445f680763c967e2961ac6de2ea6d83be4bf98d72 \
-                    size    528616
+                    rmd160  43762c76d5592f8057000e14465184b53b69b68e \
+                    sha256  0e928932d33e76fd83b97b58fe9f18af072996187a09e3f7891e54d44a1f0a53 \
+                    size    529928
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
-    anyhow                       1.0.103          2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
+    anyhow                       1.0.104          330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
     autocfg                      1.5.0            c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     bitflags                     2.11.0           843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
     bumpalo                      3.20.2           5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
@@ -67,10 +67,10 @@ cargo.crates \
     rayon-core                   1.13.0           22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     regex-lite                   0.1.9            cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     rustversion                  1.0.22           b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
-    serde                        1.0.228          9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde_core                   1.0.228          41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                 1.0.228          d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                   1.0.150          e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde                        1.0.229          4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde_core                   1.0.229          67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                 1.0.229          e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                   1.0.151          c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     simd-adler32                 0.3.9            703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     smallvec                     1.15.1           67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     symphonia                    0.6.0            1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a \
@@ -81,8 +81,9 @@ cargo.crates \
     symphonia-format-isomp4      0.6.0            2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e \
     symphonia-metadata           0.6.0            a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681 \
     syn                          2.0.117          e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
-    thiserror                    2.0.18           4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
-    thiserror-impl               2.0.18           ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    syn                          3.0.3            53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
+    thiserror                    2.0.19           09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
+    thiserror-impl               2.0.19           43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
     unicode-ident                1.0.24           e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-width                0.2.2            b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unit-prefix                  0.5.2            81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3 \


### PR DESCRIPTION
#### Description

Update mp3rgain to 2.11.0.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.11.0

Changes: version bump, refreshed distfile checksums, regenerated cargo.crates from the new Cargo.lock (anyhow 1.0.104, serde 1.0.229, serde_json 1.0.151, thiserror 2.0.19, adds syn 3.0.3).

###### Verification

- [x] `port lint --nitpick` passes cleanly (0 errors)
- [x] Builds from the regenerated cargo.crates with `--frozen --offline` dependency set
- [x] Checksums (rmd160/sha256/size) recomputed from the v2.11.0 GitHub archive tarball