### PR TITLE
wine-devel,staging: Update to 11.14

### DIFF
--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -6,12 +6,12 @@ PortGroup                   muniversal 1.1
 
 # Keep the wine-stable, wine-devel and wine-crossover portfiles as similar as possible.
 
-github.setup                wine-mirror wine 11.13 wine-
+github.setup                wine-mirror wine 11.14 wine-
 github.tarball_from         archive
 name                        wine-devel
 conflicts                   wine-stable wine-staging wine-crossover
 revision                    0
-platforms                   {darwin >= 16}
+platforms                   {darwin >= 17}
 set branch                  [lindex [split ${version} .] 0].x
 license                     LGPL-2.1+
 categories                  emulators
@@ -35,9 +35,9 @@ long_description \
 
 checksums \
     ${distname}${extract.suffix} \
-    rmd160  65bb75e6bff8ecad3092ac4abecdbc129f1ce103 \
-    sha256  dce1e93faba5896346e783384c879fe9856091637e59bb619626e2743a648d27 \
-    size    75308629
+    rmd160  03565cdf9ffda23bfdcf1dc4a6f70cddd3196826 \
+    sha256  8565706de64b516c1b0a1abacbcd5835b72f88befebbc548df4e4e0ec77f73a5 \
+    size    75337673
 
 depends_build \
     port:bison \
@@ -135,12 +135,13 @@ subport wine-staging {
 
     checksums-append \
         ${wine_staging_distfile} \
-        rmd160  65ab34473411718097cf9a9c3d44cb8e930489bd \
-        sha256  59738ad7f2ca72f4b21a34a1a0edbfb7e60f2d8fd50e337391cf5fdb1cc8d4f0 \
-        size    9317536
+        rmd160  eb048ccc90289705291068618ef6742e39bdb46c \
+        sha256  751d3f75edb2449e15fcbb79dc82103cb2026e45d2f842d89f2c5b3a579c877d \
+        size    9334253
 
     depends_patch-append    port:autoconf
 
+    # https://trac.macports.org/wiki/Python
     set py_ver              3.14
     set py_ver_nodot        [string map {. {}} ${py_ver}]
     depends_patch-append    port:python${py_ver_nodot}
@@ -186,16 +187,6 @@ variant kerberos description "Build ${subport} with Kerberos, for network authen
 }
 
 if {${os.major} < 19} {
-    if {${os.major} == 16} {
-        # Using the 10.13 SDK as that's what CodeWeavers tests against for i386
-        configure.sdk_version   10.13
-        if {${configure.sdkroot} eq ""} {
-            pre-fetch {
-                error "Building ${subport} @${version} requires the MacOSX10.13.sdk to be present in ${developer_dir}/SDKs/"
-            }
-        }
-    }
-
     default_variants            +universal
 
     if {${universal_possible} && [variant_isset universal]} {


### PR DESCRIPTION
Also drop macOS 10.12 support

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.2 25F84 x86_64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
