### PR TITLE
IraVoice: new port, version 0.7.2

### DIFF
--- a/aqua/IraVoice/Portfile
+++ b/aqua/IraVoice/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                IraVoice
+version             0.7.2
+revision            0
+
+categories          aqua
+platforms           {darwin >= 25}
+supported_archs     arm64
+installs_libs       no
+license             Restrictive NoMirror
+maintainers         {iravoice.com:hello @deepmehta11}
+
+description         Menubar dictation app for macOS
+long_description    IraVoice is a menubar dictation app for macOS that uses \
+                    on-device speech recognition.
+
+homepage            https://iravoice.com/
+master_sites        ${homepage}downloads/
+distfiles           ${name}-${version}.dmg
+extract.suffix      .dmg
+extract.mkdir       yes
+
+checksums           rmd160  5d57568bc710d888ff29e2fa87e6071ee618c413 \
+                    sha256  64e4fe4fa9a2c753605306def0ef6eb6cd1b6d12f530c93becc1af3dc29234dd \
+                    size    1791569
+
+use_configure       no
+build               {}
+
+extract {
+    set mountpoint ${workpath}/mnt
+    xinstall -d ${worksrcpath} ${mountpoint}
+    system -W ${workpath} "hdiutil attach [shellescape ${distpath}/${distfiles}] -nobrowse -readonly -mountpoint [shellescape ${mountpoint}]"
+    copy ${mountpoint}/${name}.app ${worksrcpath}
+    system -W ${workpath} "hdiutil detach [shellescape ${mountpoint}]"
+}
+
+destroot {
+    copy ${worksrcpath}/${name}.app ${destroot}${applications_dir}
+}
+
+livecheck.type      none


### PR DESCRIPTION
#### Description

Adds IraVoice 0.7.2, a private on-device dictation app for Apple-silicon Macs.

The port downloads the stable signed and notarized upstream DMG, extracts the unchanged app bundle, and installs it under MacPorts Applications. `Restrictive NoMirror` is intentional: MacPorts should publish the Portfile but must not mirror the DMG or distribute a repackaged binary archive. Users fetch and install the original upstream artifact locally.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.6 17F113

###### Verification

- [x] followed the Commit Message Guidelines
- [x] squashed and minimized commits
- [x] checked for other open pull requests for IraVoice
- [x] checked the Portfile with `port lint --nitpick` (0 errors, 0 warnings)
- [ ] tried existing tests with `sudo port test` (the port has no test phase)
- [x] completed checksum, extract, destroot, install/activate, and rev-upgrade
- [x] verified the installed app with `codesign --verify --deep --strict` and Gatekeeper (`accepted`, Notarized Developer ID)
- [x] verified the original Developer ID signature and stapled ticket remain intact
- [x] checked the only supported platform: Apple silicon on macOS 26 or later

Upstream download: https://iravoice.com/downloads/IraVoice-0.7.2.dmg
Upstream PAD/redistribution terms: https://iravoice.com/pad/iravoice.xml