### PR TITLE
javascript-lint: fix build failure due to missing unistd.h

### DIFF
--- a/lang/javascript-lint/Portfile
+++ b/lang/javascript-lint/Portfile
@@ -6,7 +6,6 @@ name                javascript-lint
 version             0.3.0
 categories          lang devel
 license             {MPL-1.1 LGPL-2.1}
-platforms           darwin
 maintainers         nomaintainer
 
 description         Lint program for JavaScript
@@ -17,7 +16,9 @@ homepage            http://www.javascriptlint.com
 
 master_sites        http://www.javascriptlint.com/download
 distname            jsl-${version}-src
-checksums           md5 2b94ffa4fab07acabe0c5e73cd49bcdf
+checksums           md5 2b94ffa4fab07acabe0c5e73cd49bcdf \
+                    rmd160 8527738a1ae1dea7626c40da01dc94f502fa3fcb \
+                    sha256 86f16792d71fc59b96f65eca65b1b7466dc046efe6d5ac04c6632f1315e83cfa
 
 patchfiles          find-va_copy.patch \
                     add-unistd-include.patch

--- a/lang/javascript-lint/Portfile
+++ b/lang/javascript-lint/Portfile
@@ -19,7 +19,8 @@ master_sites        http://www.javascriptlint.com/download
 distname            jsl-${version}-src
 checksums           md5 2b94ffa4fab07acabe0c5e73cd49bcdf
 
-patchfiles          find-va_copy.patch
+patchfiles          find-va_copy.patch \
+                    add-unistd-include.patch
 
 use_configure       no
 worksrcdir          jsl-${version}/src

--- a/lang/javascript-lint/files/add-unistd-include.patch
+++ b/lang/javascript-lint/files/add-unistd-include.patch
@@ -1,0 +1,21 @@
+--- editline/editline.c.orig	2006-10-25 06:00:00.000000000 +1000
++++ editline/editline.c
+@@ -63,6 +63,7 @@
+ #include "editline.h"
+ #include <signal.h>
+ #include <ctype.h>
++#include <unistd.h>
+ 
+ /*
+ **  Manifest constants.
+@@ -155,8 +156,10 @@
+ **  Declarations.
+ */
+ STATIC CHAR	*editinput();
++#ifndef _UNISTD_H_
+ extern int	read();
+ extern int	write();
++#endif /* _UNISTD_H_ */
+ #if	defined(USE_TERMCAP)
+ extern char	*getenv();
+ extern char	*tgetstr();


### PR DESCRIPTION
The editline.c source calls `getpid()` without including `<unistd.h>`, which declares it. Modern Xcode/CLT compilers treat implicit function declarations as errors, so the build fails on current macOS.

Add a new patch that:
1. Includes `<unistd.h>` for `getpid()` and other POSIX declarations
2. Guards the old-style `extern int read()`/`extern int write()` declarations with `#ifndef _UNISTD_H_` to avoid conflicting prototypes from the new include

Also fixes pre-existing `port lint` warnings:
- Added missing `rmd160` and `sha256` checksums
- Removed redundant `platforms darwin` (darwin is the default)