### PR TITLE
opencode2: add new port

### DIFF
--- a/llm/opencode2/Portfile
+++ b/llm/opencode2/Portfile
@@ -40,3 +40,4 @@ livecheck.url       https://registry.npmjs.org/${npm.rootname}/next
 checksums           rmd160  8d0cc149e392352b9e3ff677b9073a578ab55cdf \
                     sha256  19278b62ee09219233d1bbc79a15cf680fc3ef82b14cda6936b85ecf39a9dd47 \
                     size    2381
+# trigger rebuild

--- a/llm/opencode2/Portfile
+++ b/llm/opencode2/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                opencode2
+version             0.0.0-next-16527
+revision            0
+
+categories          llm
+platforms           {darwin any >= 19}
+maintainers         {@oakimov} openmaintainer
+license             MIT
+supported_archs     x86_64 arm64
+
+description         Beta version of OpenCode, the open source agent that helps you write code
+long_description    OpenCode is an open source agent that helps you write code.\
+                    \n\
+                    \nThis is a beta version of OpenCode, which will become OpenCode 2.0. \
+                    The beta is still changing: it may wipe your data, things may break, \
+                    and APIs, configuration, and plugin APIs may change.\
+                    \n\
+                    \nOpenCode 2 installs and runs as opencode2. It does not replace \
+                    OpenCode 1's opencode binary, so you can keep both versions \
+                    installed and run them side by side.\
+                    \n\
+                    \n- LSP Enabled: Automatically loads the right LSPs for the LLM\
+                    \n- Multi-session: Start multiple agents in parallel on the same project\
+                    \n- Share links: Share a link to any session for reference or to debug\
+                    \n- Any model: 75+ LLM providers through Models.dev, including local models\
+                    \n- Any editor: Available as a terminal interface, desktop app, and IDE extension
+
+homepage            https://opencode.ai/v2/docs
+
+npm.rootname        @opencode-ai/cli
+distname            cli-${version}
+
+livecheck.url       https://registry.npmjs.org/${npm.rootname}/next
+
+checksums           rmd160  8d0cc149e392352b9e3ff677b9073a578ab55cdf \
+                    sha256  19278b62ee09219233d1bbc79a15cf680fc3ef82b14cda6936b85ecf39a9dd47 \
+                    size    2381


### PR DESCRIPTION
Add new port for the OpenCode 2 beta.

OpenCode is an open source agent that helps you write code. This is the beta version of OpenCode, which will become OpenCode 2.0.

OpenCode 2 installs and runs as `opencode2` and does not replace OpenCode 1's `opencode` binary, so both versions can be installed side by side.

Uses the npm PortGroup to install from the `@opencode-ai/cli@next` npm package.