### PR TITLE
openjdk25-openj9: update to 25.0.4

### DIFF
--- a/java/openjdk25-openj9/Portfile
+++ b/java/openjdk25-openj9/Portfile
@@ -20,10 +20,9 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.3
+version      ${feature}.0.4
+set build    7
 revision     0
-
-set build    9
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -33,14 +32,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  adcb7934169547fb5906ccaa6abde91aeb987195 \
-                 sha256  445db356704fdfd735b27c8cb1c539dcb77c02e3b9b1bcb465289c3eebf8b81f \
-                 size    240157426
+    checksums    rmd160  5fe0b89092b15b9c4ccf2e9426a2fb96a6a9545a \
+                 sha256  6a0be956cf61f73cdb2f016c04a9b5d8118d9ebf3b2e58a22703d1fd341e1e42 \
+                 size    240245232
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  1bb7278aa4906610fdc6cf098474eb26033c5fde \
-                 sha256  a69eb48b9c2a3321d44d6bbc3ec26e860e894ee3e96888f0ad114bd65c5fc73a \
-                 size    234306520
+    checksums    rmd160  f885790f66d37c79d799fe1af353e6cbb61341c1 \
+                 sha256  872eef131370704bd498b8f7961917758f980b86b98903d482c48c145f8c1a32 \
+                 size    234146940
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 25.0.4.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?