### PR TITLE
openjdk21-openj9: update to 21.0.12

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -20,10 +20,9 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.11
+version      ${feature}.0.12
+set build    8
 revision     0
-
-set build    10
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -33,14 +32,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  92e6541cb187a13df1efa32b5e9cb10143e96009 \
-                 sha256  801f7731660bdd81a311504c16a2e89541a648f1ac09f74624a82856f2aa60f1 \
-                 size    232047827
+    checksums    rmd160  0faba57df40fdebb7047ebd360bc79d954867922 \
+                 sha256  d83274d852cfddaa6d3c7b703debe9da65b9f37d87ee002a96d530edf99627eb \
+                 size    232702203
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  5904485b848836588628a0493c427ec890748756 \
-                 sha256  3eadaf09b075321c13fc3c494ad50033614b3119810b15f2547ebed678a9d2ef \
-                 size    226270093
+    checksums    rmd160  5146717de46f88577d50d64703f7012b9a8422f4 \
+                 sha256  f1803539466437b13ff057a975685b432464874214f3613e81e6427bea55671c \
+                 size    226692554
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.12.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?