### PR TITLE
openjdk17-openj9: update to 17.0.20

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -20,10 +20,9 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.19
+version      ${feature}.0.20
+set build    8
 revision     0
-
-set build    10
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -33,14 +32,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  cba1fbcd6f01d9a97d5b15ce63db80dc139d2086 \
-                 sha256  5db39e34f1ff48bdc6ee0cbd0d81acdbd7e5630866e7330b53e8820d9915dbe4 \
-                 size    219334264
+    checksums    rmd160  b7e4e2dd1a243dcce1729b6fd31f82e16b243b1b \
+                 sha256  04d711f51e00021e4c24d8917cd3a8a79c7564f50c7f57679a962aaeb0f7e911 \
+                 size    219964337
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  b19fc32934635f9ab4ff9c4484319b0df8456ec2 \
-                 sha256  42d79668d1ecda453ff8d7b5de981f00713699152cca649411270fcbfc2f9411 \
-                 size    213601507
+    checksums    rmd160  94fdb464cff1851f90c2e17eaf2f48504d008ad5 \
+                 sha256  811db6bc798cef68fd723e1729584bc05836f15fca739f0fa725d55f2744f13f \
+                 size    213957294
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.20.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?