### PR TITLE
openjdk11-openj9: update to 11.0.32

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -20,10 +20,9 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.31
+version      ${feature}.0.32
+set build    9
 revision     0
-
-set build    11
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -33,14 +32,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  0e844d40fa8b4a992ee53c21fe53524972d59397 \
-                 sha256  dadd7ba7885ae2e6aacbf0197c4cb2e9bf7bb4d71a8fe628ec1952a086b5bd47 \
-                 size    212793598
+    checksums    rmd160  6b9e6b11e9858403c730d0a5467cd07396a0e5c3 \
+                 sha256  3f24cebbfaf947d24bbb0fe194d001876a5c3ea75a9d08d06a34bf61ae51185f \
+                 size    213252378
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  c7144d408b123b9df78af1f5a804d0cc12691afe \
-                 sha256  df773bded292d77de6f2d29aad9577fb9615e03745d76c4dad6069435d8e3950 \
-                 size    207384792
+    checksums    rmd160  78bbe08eed340a65f30f7368f6d8c530ef74b5b7 \
+                 sha256  5dcc5e5fee9ad2399100db51b5a84182e91e27cabd2ea441061a61f83f0e852a \
+                 size    207618648
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.32.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?