### PR TITLE
openjdk8-openj9: update to 8.0.502.0

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -3,7 +3,6 @@
 PortSystem       1.0
 
 set feature 8
-set patch 492
 name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun @breun} openmaintainer
@@ -21,10 +20,10 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
+set patch    502
 version      ${feature}.0.${patch}.0
+set build    07
 revision     0
-
-set build    09
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -35,9 +34,9 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 distname     ibm-semeru-open-jdk_x64_mac_${version}
 worksrcdir   jdk${feature}u${patch}-b${build}
 
-checksums    rmd160  46ed8c40d9ede45fd4c6f7860f3654be9518a9fb \
-             sha256  ec8c84dee17104ad43f189c9be6e2d3e121a4cfd09bf3c17681a4fee65e4b2d9 \
-             size    129735157
+checksums    rmd160  9ee71876b28ab3ba06b913c9fa64d2e71dd11a24 \
+             sha256  62fbb02e49c44c9c447f75108480b4900b3f2583f197e22bb986a731b938e700 \
+             size    129980760
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8.0.502.0.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?