### PR TITLE
llama.cpp: update to 10199

### DIFF
--- a/llm/llama.cpp/Portfile
+++ b/llm/llama.cpp/Portfile
@@ -5,9 +5,9 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 
-github.setup            ggerganov llama.cpp 10103 b
+github.setup            ggerganov llama.cpp 10199 b
 github.tarball_from     archive
-set git-commit          c588c4f
+set git-commit          b4ca032
 # This line is for displaying commit in CLI only
 revision                0
 categories              llm
@@ -19,9 +19,9 @@ long_description        The main goal of ${name} is to enable LLM inference with
                         setup and state-of-the-art performance on a wide variety of hardware\
                          - locally and in the cloud.
 
-checksums               rmd160  90e0361d0371cb0b0505ad46ac088c83d2799409 \
-                        sha256  5ebd4bb0c5cb52e502d2611a5f3ac66f954b2f4d48e655701f8fd8046e77dd1b \
-                        size    36321972
+checksums               rmd160  644f57423e77893eb745fac9d9b5bf699f7c5163 \
+                        sha256  a304d65824cb994faef6df546f1dae8ab43f903e121fa3126252492d511b9732 \
+                        size    36453939
 
 # error: 'filesystem' file not found on 10.14
 legacysupport.newest_darwin_requires_legacy \


### PR DESCRIPTION
#### Description

Update to llama.cpp 10199.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?