### PR TITLE
ollama: update to 0.32.5

### DIFF
--- a/llm/ollama/Portfile
+++ b/llm/ollama/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ollama/ollama 0.32.4 v
+go.setup            github.com/ollama/ollama 0.32.5 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ description         ${name} runs and manages LLMs
 long_description    Get up and running with large language models easily
 homepage            https://ollama.com
 
-checksums           rmd160  0705d702c28d299405103932968b384c5eafb4aa \
-                    sha256  c20ff44d18453311f0d724e9215336add75a7c01efed2434a409b5b6715e49f3 \
-                    size    28994048
+checksums           rmd160  e64e486218b9c3df13765cc3608973941f0f8e46 \
+                    sha256  41cd7d9204540223a53371443f7dad2ffadae56475375945d465ad898e60c27a \
+                    size    28993850
 
 depends_run-append  port:llama.cpp
 


### PR DESCRIPTION
#### Description

Update to Ollama 0.32.5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?