### PR TITLE
container: update to 1.2.0

### DIFF
--- a/devel/container/Portfile
+++ b/devel/container/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        apple container 1.1.0
+github.setup        apple container 1.2.0
 github.tarball_from archive
 
 revision            0
@@ -19,9 +19,9 @@ long_description    container is a tool that you can use to create and run Linux
                     registry. You can push images that you build to those registries \
                     as well, and run the images in any other OCI-compatible application.
 
-checksums           rmd160  5c954dba9d45e62618f13ce0162f25761ae81837 \
-                    sha256  beb7f2536d714de6863a056b677a2b51aa498bb7caec6011cfb01c0c95bcbe8c \
-                    size    1001406
+checksums           rmd160  b24de4341e021db12ee27d5dd5da5dc42a6a0a36 \
+                    sha256  40f2d98cb41a5f688e5b4b6dbe6d66eba7451c78ce6f3afe351da1550adf1591 \
+                    size    1009748
 
 # The version number for macosx is the darwin version number (os.major)
 platforms           {macosx >= 25}
@@ -37,11 +37,12 @@ if {${os.platform} eq "darwin" && (${os.major} < 25 || ${os.arch} ne "arm")} {
 
 use_configure       no
 use_parallel_build  no
+use_xcode           yes
 installs_libs       no
 
 build.target        build
 # Disable the swift sandbox since the port build already runs in a sandbox
-build.pre_args      BUILD_CONFIGURATION=release SWIFT_CONFIGURATION="--disable-sandbox --cache-path ${workpath}/.swiftpm/cache --security-path ${workpath}/.swiftpm/security --config-path ${workpath}/.swiftpm/config" ${build.target}
+build.pre_args      BUILD_CONFIGURATION=release SWIFT_CONFIGURATION="--disable-sandbox --cache-path ${workpath}/.swiftpm/cache --security-path ${workpath}/.swiftpm/security --config-path ${workpath}/.swiftpm/config -Xswiftc -enable-testing" ${build.target}
 
 destroot.target     install
 destroot.pre_args   BUILD_CONFIGURATION=release DEST_DIR="${destroot}${prefix}/" RELEASE_VERSION=${version} SUDO= ${destroot.target}


### PR DESCRIPTION
#### Description

- enable `import testable` for the build, this requires two smaller change:
  - Adding `-Xswiftc -enable-testing` to the Swift configuration, this was also done upstream (see https://github.com/apple/container/pull/1955)
  - Setting `use_xcode yes` to make the `Testing` module available (it is not available in the command line tools `DEVELOPER_DIR`)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
