### PR TITLE
libkrun: Update to 1.19.4, remove the EFI build, krunkit: Update to 1.3.2

### DIFF
--- a/emulators/krunkit/Portfile
+++ b/emulators/krunkit/Portfile
@@ -6,7 +6,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo_fetch 1.0
 
-github.setup        containers krunkit 1.1.1 v
+github.setup        containers krunkit 1.3.2 v
 github.tarball_from archive
 
 revision            0
@@ -22,22 +22,27 @@ long_description    {*}${description}.
 supported_archs     arm64
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9b908aae100804c9659df44e0cb73b2b0b067589 \
-                    sha256  d8162e620dc96329db449ede9ee69edb0f4c70ab1ef9c664ce8b251f6310e16c \
-                    size    26982
+                    rmd160  425f1963f24c2a606867c1fc5a402c36b2b300f1 \
+                    sha256  ce714476e62db927cc872e4d2f066f5f756f6f54fef2f0cc4fc82329be75c86d \
+                    size    757735
 
 depends_lib         port:libkrun
 
 use_configure       no
 
-build.env-append    LIBKRUN_EFI=${prefix}/lib
+build.args-append   PREFIX=${prefix}
+destroot.args-append \
+                    PREFIX=${prefix}
 
 # Patch upstream's Makefile to respect CARGO_BUILD_TARGET as that is automatically set by MacPorts and also to set binary rpath and entitlements.
 patchfiles-append \
                 patch-makefile.diff
 
-post-patch {
-    reinplace "s|@@DEFAULT_PREFIX@@|${prefix}|g" ${worksrcpath}/Makefile
+post-destroot {
+    xinstall -d -m 755 ${destroot}${prefix}/share/${name}
+    xinstall -m 644 \
+        ${worksrcpath}/edk2/KRUN_EFI.silent.fd \
+        ${destroot}${prefix}/share/${name}/
 }
 
 # cargo2port Cargo.lock | pbcopy
@@ -51,6 +56,8 @@ cargo.crates \
     anyhow                          1.0.79  080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                        2.10.0  812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3 \
+    block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
     cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     clap                             4.5.0  80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f \
@@ -58,14 +65,18 @@ cargo.crates \
     clap_derive                      4.5.0  307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47 \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    dispatch2                        0.3.0  89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec \
     either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
     env_filter                       0.1.3  186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0 \
     env_logger                      0.11.8  13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     jiff                            0.2.10  5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6 \
     jiff-static                     0.2.10  199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254 \
     libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
@@ -75,6 +86,10 @@ cargo.crates \
     memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
     nix                             0.23.2  8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c \
     ntapi                            0.4.1  e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4 \
+    objc2                            0.6.3  b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05 \
+    objc2-core-foundation            0.3.2  2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536 \
+    objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
+    objc2-io-kit                     0.3.2  33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15 \
     portable-atomic                 1.11.0  350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e \
     portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
     proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
@@ -84,8 +99,10 @@ cargo.crates \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
-    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
+    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     strsim                          0.11.0  5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01 \
     syn                            2.0.101  8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf \
     sysinfo                         0.31.4  355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be \
@@ -108,4 +125,5 @@ cargo.crates \
     windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa

--- a/emulators/krunkit/files/patch-makefile.diff
+++ b/emulators/krunkit/files/patch-makefile.diff
@@ -1,23 +1,12 @@
---- Makefile	2025-11-04 17:58:08
-+++ Makefile.new	2025-11-17 13:40:45
-@@ -1,9 +1,9 @@
+--- Makefile.orig	2026-07-31 11:02:37
++++ Makefile	2026-07-31 11:02:52
+@@ -1,7 +1,7 @@
  OS = $(shell uname -s)
 -KRUNKIT_RELEASE = target/release/krunkit
 -KRUNKIT_DEBUG = target/debug/krunkit
 +KRUNKIT_RELEASE = target/$(CARGO_BUILD_TARGET)/release/krunkit
 +KRUNKIT_DEBUG = target/$(CARGO_BUILD_TARGET)/debug/krunkit
+ LIBKRUN = libkrun.1.dylib
  
- ifeq ($(PREFIX),)
--    PREFIX := /usr/local
-+    PREFIX := @@DEFAULT_PREFIX@@
- endif
- 
- .PHONY: install clean $(KRUNKIT_RELEASE) $(KRUNKIT_DEBUG)
-@@ -15,6 +15,7 @@
- $(KRUNKIT_RELEASE):
- 	cargo build --release
- ifeq ($(OS),Darwin)
-+	install_name_tool -add_rpath $(PREFIX)/lib $@
- 	codesign --entitlements krunkit.entitlements --force -s - $@
- endif
- 
+ PREFIX ?= /usr/local
+ export PREFIX

--- a/emulators/libkrun/Portfile
+++ b/emulators/libkrun/Portfile
@@ -8,7 +8,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo_fetch 1.0
 
-github.setup        containers libkrun 1.16.0 v
+github.setup        containers libkrun 1.19.4 v
 github.tarball_from archive
 
 revision            0
@@ -26,25 +26,22 @@ long_description    Dynamic library that allows programs to easily acquire the \
 supported_archs     arm64
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fe8e95ae313bc9d7b1f0fc31fe74e4d6ccf59bb5 \
-                    sha256  04b6f01f44e263d168757ebcd9bc037d7c5836c1987a547c6b2fa5837abe1ab1 \
-                    size    8790910
+                    rmd160  ed7f975ba657bbdd06deba87bd7660c186c7055b \
+                    sha256  e8775fab2b460972a67ca6cd936296bb79cdb078d852d712a283cb290dd0b284 \
+                    size    1764913
 
-depends_build       port:pkgconfig
-                    # port:zig    # TODO: When EFI deprecated we'll need Zig to cross compile init.
+# Need clang-22 for ld.lld-mp-22
+depends_build       port:pkgconfig \
+                    port:clang-22
 depends_run         port:dtc
 depends_lib         port:libepoxy \
                     port:virglrenderer
 
 use_configure       no
 
-# TODO 2025/11/17: the EFI variant is deprecated, see bottom of Portfile for staged changes since
-#                  we cannot fully move to non-EFI yet (krunkit build problems explained).
-
 # Build and installation options per upstream's docs are passed as environment variables.
-# EFI sets both BLK and NET too.
-build.env-append    EFI=1 GPU=1
-destroot.env-append EFI=1 GPU=1
+build.env-append    GPU=1 BLK=1 NET=1
+destroot.env-append GPU=1 BLK=1 NET=1
 
 # Patch upstream's Makefile to respect CARGO_BUILD_TARGET as that is automatically set by MacPorts and also to set correct install_name.
 patchfiles-append \
@@ -52,12 +49,6 @@ patchfiles-append \
 
 post-patch {
     reinplace "s|@@DEFAULT_PREFIX@@|${prefix}|g" ${worksrcpath}/Makefile
-}
-
-# Until deprecated EFI changes added we must (and can safely) stub an empty file so that Rust's
-# `include_bytes!` macro succeeds, otherwise we cannot build at all.
-pre-build {
-    system "touch ${worksrcpath}/init/init"
 }
 
 # Makefile patched for PREFIX should alleviate any rpath problems, but as a guard against future
@@ -69,239 +60,190 @@ post-destroot {
 
 # cargo2port Cargo.lock | pbcopy
 cargo.crates \
-    addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
-    adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
-    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
-    annotate-snippets                0.9.2  ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e \
-    anstream                        0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
-    anstyle                         1.0.11  862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd \
+    annotate-snippets               0.11.5  710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4 \
+    anstream                        0.6.21  43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
     anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
-    anstyle-query                    1.1.3  6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9 \
-    anstyle-wincon                   3.0.9  403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882 \
-    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
-    async-trait                     0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
-    autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
-    backtrace                       0.3.75  6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002 \
+    anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
+    anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
+    anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
-    bindgen                         0.69.5  271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088 \
-    bindgen                         0.72.0  4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f \
-    bitfield                        0.19.1  db1bcd90f88eabbf0cadbfb87a45bceeaebcd3b4bc9e43da379cd2ef0162590d \
-    bitfield-macros                 0.19.1  3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c \
+    bincode                          2.0.1  36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740 \
+    bincode_derive                   2.0.1  bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09 \
+    bindgen                         0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
+    bitfield                        0.19.4  21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419 \
+    bitfield-macros                 0.19.4  f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.9.1  1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967 \
+    bitflags                        2.11.0  843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    bumpalo                         3.18.1  793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee \
-    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bumpalo                         3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
     bzip2                            0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2-sys                     0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
-    caps                             0.5.5  190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b \
-    cc                              1.2.26  956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac \
+    caps                             0.5.6  fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0 \
+    cc                              1.2.57  7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423 \
     cexpr                            0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
-    cfg-expr                        0.15.8  d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02 \
-    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cfg-expr                        0.20.7  3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368 \
+    cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     clang-sys                        1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    codicon                          3.0.0  12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61 \
-    colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
-    convert_case                     0.6.0  ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca \
+    colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
+    convert_case                     0.8.0  baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f \
     cookie-factory                   0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
-    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-channel               0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
-    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
-    dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
-    dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
-    env_filter                       0.1.3  186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0 \
-    env_logger                      0.11.8  13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f \
+    env_filter                       1.0.0  7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f \
+    env_logger                      0.11.9  b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
-    flate2                           1.1.1  7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece \
-    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
-    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
-    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
-    futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
-    futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
-    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
-    futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
-    futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
-    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
-    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
-    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
+    filetime                        0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
+    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
-    getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
-    gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
-    glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
-    hashbrown                       0.15.3  84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3 \
+    getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
+    glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
+    hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
-    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    imago                            0.1.5  6a94a5babb4a05f462d7736c7263ddd7e721ec0c5e5f26b02d888e9edf75b549 \
-    indexmap                         2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
+    imago                            0.2.3  ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c \
+    indexmap                        2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
     iocuddle                         0.1.1  d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007 \
-    is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
-    itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
-    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-    jiff                            0.2.14  a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93 \
-    jiff-static                     0.2.14  6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442 \
-    jobserver                       0.1.33  38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a \
-    js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
+    is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+    jiff                            0.2.23  1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359 \
+    jiff-static                     0.2.23  2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4 \
+    jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
+    js-sys                          0.3.91  b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c \
     kbs-types                       0.13.0  d2119e8aaa1382675e879f0cbc95fc948d28284d134896f57676b8ef2c90212e \
-    kvm-bindings                    0.12.0  d4b153a59bb3ca930ff8148655b2ef68c34259a623ae08cf2fb9b570b2e45363 \
-    kvm-ioctls                      0.22.0  b702df98508cb63ad89dd9beb9f6409761b30edca10d48e57941d3f11513a006 \
-    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.172  d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa \
-    libloading                       0.8.8  07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667 \
-    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libspa                           0.8.0  65f3a4b81b2a2d8c7f300643676202debd1b7c929dbf5c9bb89402ea11d19810 \
-    libspa-sys                       0.8.0  bf0d9716420364790e85cbb9d3ac2c950bde16a7dd36f3209b7dfdfc4a24d01f \
-    linux-loader                    0.13.0  870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638 \
-    log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
-    lru                             0.14.0  9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198 \
-    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    kvm-bindings                    0.12.1  9a537873e15e8daabb416667e606d9b0abc2a8fb9a45bd5853b888ae0ead82f9 \
+    kvm-ioctls                      0.22.1  0c8f7370330b4f57981e300fa39b02088f2f2a5c2d0f1f994e8090589619c56d \
+    libc                           0.2.183  b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d \
+    libloading                       0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
+    libredox                        0.1.14  1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a \
+    libspa                           0.9.2  b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4 \
+    libspa-sys                       0.9.2  901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0 \
+    linux-loader                    0.13.2  de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6 \
+    linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
+    log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    lru                             0.16.3  a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593 \
+    memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
     memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                      0.8.8  3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a \
-    nitro-enclaves                   0.3.0  8e263b205723b7e69812658f42eebbf790531e902ed0a4d77b8219f2006d5187 \
+    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    nitro-enclaves                   0.5.0  2b5b539a76e3f555fb143c3e67d5e05fa1d5fece02a515f6ecf41b3f1a081f58 \
+    nitro-enclaves                   0.6.1  c6436c562bcdb6f192e0e59f627bff5b0b88f2e1c48264079f4f1d6da42bec2d \
     nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
-    nix                             0.27.1  2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053 \
-    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nix                             0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
+    nix                             0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
-    object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
-    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
-    once_cell_polyfill              1.70.1  a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad \
-    openssl                        0.10.73  8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8 \
-    openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
-    openssl-src                   300.5.0+3.5.0  e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f \
-    openssl-sys                    0.9.109  90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571 \
-    option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    nom                              8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
+    once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     page_size                        0.6.0  30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da \
-    pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pipewire                         0.8.0  08e645ba5c45109106d56610b3ee60eb13a6f2beb8b74f8dc8186cf261788dda \
-    pipewire-sys                     0.8.0  849e188f90b1dda88fe2bfe1ad31fe5f158af2c98f80fb5d13726c44f3f01112 \
+    pipewire                         0.9.2  9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44 \
+    pipewire-sys                     0.9.2  cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36 \
     pkg-config                      0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
-    portable-atomic                 1.11.1  f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
-    portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
+    plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
+    portable-atomic                 1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
+    portable-atomic-util             0.2.6  091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
-    proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
-    quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
-    r-efi                            5.2.0  74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5 \
+    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
-    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
-    rdrand                           0.8.3  d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655 \
-    redox_users                      0.5.0  dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b \
-    regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
-    regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
-    regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    redox_syscall                    0.7.3  6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16 \
+    regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
     remain                          0.2.15  d7ef12e84481ab4006cb942f8682bba28ece7270743e649442027c5db87df126 \
-    rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
-    rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustversion                     1.0.21  8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
-    ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
-    semver                          1.0.26  56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0 \
-    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
-    serde-big-array                  0.5.1  11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f \
-    serde_bytes                    0.11.17  8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96 \
-    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
-    serde_spanned                    0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
-    sev                              6.2.1  1750ba11a6a6bba3c220da714caa0226aa34e417dce3975d2953062240717dea \
+    rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
+    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    semver                          1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
+    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
-    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
+    signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
+    simd-adler32                     0.3.8  e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2 \
     sm3                              0.4.2  ebb9a3b702d0a7e33bc4d85a14456633d2b165c2ad839c5fd9a8417c1ab15860 \
-    smallvec                        1.15.0  8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9 \
+    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strum                           0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
     strum_macros                    0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
-    syn                            2.0.101  8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf \
-    system-deps                      6.2.2  a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349 \
-    target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
+    syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    system-deps                      7.0.8  396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7 \
+    tar                             0.4.45  22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973 \
+    target-lexicon                  0.13.3  df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c \
     tdx                              0.1.0  ad59e5bf374211a1fdd8e7439a07d5a5e617fe97f5cf21d03bcd1bf8c82b73af \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
+    thiserror                       2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
-    tokio                           1.45.1  75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779 \
-    toml                            0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
-    toml_datetime                   0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
-    toml_edit                      0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
-    tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
-    tracing-attributes              0.1.29  1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662 \
-    tracing-core                    0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
-    typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
-    unicode-ident                   1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
+    thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    tokio                           1.50.0  27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d \
+    toml                          1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    toml_datetime                 1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
+    toml_parser                   1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_writer                   1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
+    tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
+    tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
+    tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
+    typenum                         1.19.0  562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb \
+    unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
-    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
+    unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
+    unty                             0.0.4  6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.17.0  3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d \
-    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    version-compare                  0.2.0  852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b \
+    uuid                            1.22.0  a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37 \
+    version-compare                  0.2.1  03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
-    virtio-bindings                  0.2.6  804f498a26d5a63be7bbb8bdcd3869c3f286c4c4a17108905276454da0caf8cb \
+    virtio-bindings                  0.2.7  091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868 \
+    virtue                          0.0.18  051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1 \
     vm-fdt                           0.3.0  7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23 \
-    vm-memory                       0.16.2  1fd5e56d48353c5f54ef50bd158a0452fc82f5383da840f7b8efc31695dd3b9d \
+    vm-memory                       0.17.1  f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380 \
     vmm-sys-util                    0.12.1  1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede \
     vmm-sys-util                    0.14.0  d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789 \
-    vsock                            0.5.1  4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688 \
-    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasi                          0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
-    wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
-    wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
-    wasm-bindgen-macro             0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
-    wasm-bindgen-macro-support     0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
-    wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
+    vmm-sys-util                    0.15.0  506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f \
+    vsock                            0.5.3  b82aeb12ad864eb8cd26a6c21175d0bdc66d398584ee6c93c76964c3bcfc78ff \
+    wasip2                        1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
+    wasm-bindgen                   0.2.114  6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e \
+    wasm-bindgen-macro             0.2.114  18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6 \
+    wasm-bindgen-macro-support     0.2.114  03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3 \
+    wasm-bindgen-shared            0.2.114  75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
-    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
-    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
-    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
-    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
-    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
-    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
-    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.7.10  c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec \
-    wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
-    yansi-term                       0.1.2  fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1 \
-    zerocopy                        0.8.26  1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f \
-    zerocopy-derive                 0.8.26  9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181 \
+    windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-sys                     0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
+    winnow                           1.0.2  2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0 \
+    wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
+    xattr                            1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
+    zerocopy                        0.8.47  efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87 \
+    zerocopy-derive                 0.8.47  0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89 \
+    zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
     zstd-safe                        7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \
-    zstd-sys                      2.0.15+zstd.1.5.7  eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237
+    zstd-sys                      2.0.16+zstd.1.5.7  91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748
 
-# TODO: Technically this is specifically the EFI variant. Make this Portfile normal (if appropriate) and then add an equivalent +efi variant for this.
 # TODO: Tests from upstream build source.
 # TODO: Possible to get memory ballooning working? This is not trivial and not hyper specific to libkrun but one to watch out for any progress on.
-
-# TODO 2025/11/17: the EFI variant has been deprecated, so the `init/init` binary built by
-#                  BUILD_INIT=1 is now required. This binary must be Linux ELF. The easiest way
-#                  to have this built is by using Zig, but _for now_ this is too hard to test
-#                  when you have an existing Podman machine created with krunkit which used EFI
-#                  so, as it's not yet _removed_, and because krunkit still expects literal `-efi`
-#                  libraries to link against the changes for libkrun to build (apparently correctly)
-#                  with EFI deprecations in mind are commented out. As and when krunkit is sorted
-#                  out these can then be uncommented.
-# build.env-append    EFI=0 GPU=1 BLK=1 NET=1
-# TODO 2025/11/12: We keep EFI=1 on destroot since the Makefile requires it to run install_name_tool
-#                  should pribably just add that to the patch we're already running
-# destroot.env-append EFI=0 GPU=1 BLK=1 NET=1
-# The target here can safely be hardcoded since this port itself only supports arm64 macOS.
-# pre-build {
-#     system "zig cc ${worksrcpath}/init/init.c -o ${worksrcpath}/init/init -target aarch64-linux-gnu"
-# }

--- a/emulators/libkrun/files/check-rpath.sh
+++ b/emulators/libkrun/files/check-rpath.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
+set -x
+
 # Expects to be run with PWD as the destroot for libkrun
 
 # TODO: The `1` here is from the compatibility version and when libkrun 2 is released this will
 #       need to be templated from the Portfile depending on the version being installed.
-target_dylib="${MP_PREFIX}/lib/libkrun-efi.1.dylib"
-# target_dylib="${MP_PREFIX}/lib/libkrun.1.dylib"
+target_dylib="${MP_PREFIX}/lib/libkrun.1.dylib"
 
 # So we can print all errors before exiting.
 exit_status=0

--- a/emulators/libkrun/files/patch-makefile.diff
+++ b/emulators/libkrun/files/patch-makefile.diff
@@ -1,6 +1,6 @@
---- Makefile	2025-10-28 19:40:51
-+++ Makefile.new	2025-11-12 03:02:36
-@@ -84,14 +84,14 @@
+--- Makefile.orig	2026-07-31 11:12:15
++++ Makefile	2026-07-31 11:12:48
+@@ -80,14 +80,14 @@
  
  LIBRARY_RELEASE_Linux = target/release/$(KRUN_BINARY_Linux)
  LIBRARY_DEBUG_Linux = target/debug/$(KRUN_BINARY_Linux)
@@ -16,20 +16,38 @@
 +    PREFIX := @@DEFAULT_PREFIX@@
  endif
  
- .PHONY: install clean test test-prefix $(LIBRARY_RELEASE_$(OS)) $(LIBRARY_DEBUG_$(OS)) libkrun.pc
-@@ -118,12 +118,12 @@
+ .PHONY: install clean test test-prefix $(LIBRARY_RELEASE_$(OS)) $(LIBRARY_DEBUG_$(OS)) libkrun.pc clean-sysroot clean-all
+@@ -110,7 +110,7 @@
+     GCC_TRIPLET = $(subst arm64,aarch64,$(ARCH))-linux-gnu
+     GCC_LIB_DIR = $(abspath $(SYSROOT_LINUX))/usr/lib/gcc/$(GCC_TRIPLET)/$(GCC_VERSION)
+     # Cross-compile on macOS with the LLVM linker (brew install lld)
+-    CC_LINUX=$(CLANG) -target $(GCC_TRIPLET) -fuse-ld=lld -Wl,-strip-debug --sysroot $(abspath $(SYSROOT_LINUX)) -B$(GCC_LIB_DIR) -L$(GCC_LIB_DIR) -Wno-c23-extensions
++    CC_LINUX=$(CLANG) -target $(GCC_TRIPLET) -fuse-ld=lld-mp-22 -Wl,-strip-debug --sysroot $(abspath $(SYSROOT_LINUX)) -B$(GCC_LIB_DIR) -L$(GCC_LIB_DIR) -Wno-c23-extensions
+ else
+     # Build on Linux host
+     CC_LINUX=$(CC)
+@@ -133,7 +133,7 @@
+     SYSROOT_BSD_TARGET =
+ endif
+     # Cross-compile on macOS with the LLVM linker (brew install lld)
+-    CC_BSD=$(CLANG) -target $(ARCH)-unknown-freebsd -fuse-ld=lld -stdlib=libc++ -Wl,-strip-debug --sysroot $(SYSROOT_BSD)
++    CC_BSD=$(CLANG) -target $(ARCH)-unknown-freebsd -fuse-ld=lld-mp-22 -stdlib=libc++ -Wl,-strip-debug --sysroot $(SYSROOT_BSD)
+ else ifeq ($(OS),Linux)
+ # Linux -> FreeBSD cross-compilation
+ ifeq ($(SYSROOT_BSD),)
+@@ -218,12 +218,10 @@
  	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
  endif
  ifeq ($(OS),Darwin)
- ifeq ($(EFI),1)
+-ifeq ($(EFI),1)
 -	install_name_tool -id $(PREFIX)/$(LIBDIR_$(OS))/$(KRUN_SONAME_$(OS)) target/release/libkrun.dylib
 +	install_name_tool -id $(PREFIX)/$(LIBDIR_$(OS))/$(KRUN_SONAME_$(OS)) target/$(CARGO_BUILD_TARGET)/release/libkrun.dylib
- endif
--	mv target/release/libkrun.dylib target/release/$(KRUN_BASE_$(OS))
 +	mv target/$(CARGO_BUILD_TARGET)/release/libkrun.dylib target/$(CARGO_BUILD_TARGET)/release/$(KRUN_BASE_$(OS))
  endif
+-	mv target/release/libkrun.dylib target/release/$(KRUN_BASE_$(OS))
+-endif
 -	cp target/release/$(KRUN_BASE_$(OS)) $(LIBRARY_RELEASE_$(OS))
 +	cp target/$(CARGO_BUILD_TARGET)/release/$(KRUN_BASE_$(OS)) $(LIBRARY_RELEASE_$(OS))
  
- $(LIBRARY_DEBUG_$(OS)): $(INIT_BINARY)
+ $(LIBRARY_DEBUG_$(OS)): $(SYSROOT_TARGET) $(INIT_BINARY_BSD)
  	cargo build $(FEATURE_FLAGS)


### PR DESCRIPTION
#### Description

This fixes krunkit use with podman again, since podman now requires the `--timesync` parameter, which the previous version of `krunkit` did not support.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
