### PR TITLE
markdown-preview: new port, version 0.0.43

### DIFF
--- a/aqua/markdown-preview/Portfile
+++ b/aqua/markdown-preview/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                markdown-preview
+github.setup        pluk-inc markdown-preview 0.0.43 v
+github.tarball_from releases
+revision            0
+
+categories          aqua textproc
+platforms           {macosx >= 15}
+supported_archs     x86_64 arm64
+license             MIT
+maintainers         {github.com:IANatCAMBIO @IANatCAMBIO} openmaintainer
+
+description         Fast, native macOS app for reading Markdown files
+
+long_description    \
+    Markdown Preview is a fast, native macOS app for reading .md files. \
+    Drop a .md onto the icon (or set it as the default handler) for a clean, \
+    scrollable preview with a real document outline—no Electron, no browser tab. \
+    Features include Mermaid diagram rendering, LaTeX math equations (KaTeX), \
+    an inspector panel, in-document search, Quick Look extension, and optional \
+    command-line tools (mdp, md-preview, markdown-preview).
+
+homepage            http://markdownpreview.app
+
+distname            Markdown-Preview
+use_dmg             yes
+
+checksums           rmd160  38e7b64ca838826615ed66815b19346d32de9747 \
+                    sha256  d70cb544b6a65920dd2b4bf7e86cc619ce1829c0198ef3435713b3df8d5010ee \
+                    size    8240680
+
+use_configure       no
+build               {}
+
+if {${os.major} < 24} {
+    known_fail      yes
+    pre-fetch {
+        return -code error "${name} requires macOS 15 Sequoia or later."
+    }
+}
+
+destroot {
+    copy "${worksrcpath}/Markdown Preview.app" \
+        "${destroot}${applications_dir}/Markdown Preview.app"
+}


### PR DESCRIPTION
#### Description

New port for Markdown Preview, a fast native macOS Markdown viewer. https://markdownpreview.app

###### Type(s)
submission

###### Tested on
macOS 26.5.2 25F84 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] checked your Portfile with `port lint`?
- [ x] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?
- [ x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
