### PR TITLE
go: install the newest Go release each system can run

### DIFF
--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -317,6 +317,13 @@ proc go_toolchain.setup {go_version {label ""}} {
                 xinstall -m 0644 -W ${worksrcpath} ${f} ${docdir}
             }
         }
+
+        # The release's own doc/ tree, which carries the language spec among
+        # other things. Its contents vary by release, so copy whatever is
+        # there.
+        if {[file exists ${worksrcpath}/doc]} {
+            copy {*}[glob -directory ${worksrcpath}/doc *] ${docdir}
+        }
     }
 
     notes "

--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -83,6 +83,56 @@ set go_toolchain.min_darwin(1.27)   22  ;# 13    Ventura
 # on 10.7 through 10.12, and fail on 10.6, whose dsymutil aborts on the debug
 # information Go's linker emits. See lang/go-1.17.
 
+# The Go series MacPorts packages as go-1.NN ports. This cannot be derived from
+# the table above, which lists the releases that exist rather than the ones
+# shipped. A list of series and not of versions, so that a patch update to a
+# toolchain touches only that port's own Portfile.
+set go_toolchain.packaged {1.17 1.20 1.22 1.23 1.24 1.25 1.26}
+
+# The newest and oldest series in go_toolchain.packaged.
+proc go_toolchain._newest_packaged {} {
+    global go_toolchain.packaged
+
+    set newest {}
+    foreach series ${go_toolchain.packaged} {
+        if {${newest} eq "" || [vercmp ${series} > ${newest}]} {
+            set newest ${series}
+        }
+    }
+    return ${newest}
+}
+
+proc go_toolchain._oldest_packaged {} {
+    global go_toolchain.packaged
+
+    set oldest {}
+    foreach series ${go_toolchain.packaged} {
+        if {${oldest} eq "" || [vercmp ${series} < ${oldest}]} {
+            set oldest ${series}
+        }
+    }
+    return ${oldest}
+}
+
+# The series the `go` port should provide here, or {} when no packaged release
+# runs on this system at all. A capped system gets the newest release it can
+# run, an uncapped one the newest packaged.
+proc go_toolchain.wrapped {} {
+    global go_toolchain.packaged
+
+    set ceiling [go_toolchain.ceiling]
+    if {${ceiling} eq "none"} {
+        return {}
+    }
+    if {${ceiling} eq ""} {
+        return [go_toolchain._newest_packaged]
+    }
+    if {[lsearch -exact ${go_toolchain.packaged} ${ceiling}] < 0} {
+        return {}
+    }
+    return ${ceiling}
+}
+
 # The newest Go minor release this table knows about. A system that can run it
 # is not capped at all.
 proc go_toolchain._newest {} {
@@ -133,7 +183,14 @@ proc go_toolchain._minor {go_version} {
 # "1.2", which then fails to match anything. Compare it with vercmp and
 # interpolate it directly into strings.
 proc go_toolchain.ceiling {} {
-    global os.platform os.major go_toolchain.min_darwin
+    global os.platform os.major go_toolchain.min_darwin \
+           go_toolchain.ceiling_override
+
+    # Set to simulate a capped system when testing on one that is not.
+    if {[info exists go_toolchain.ceiling_override]
+            && ${go_toolchain.ceiling_override} ne ""} {
+        return ${go_toolchain.ceiling_override}
+    }
 
     if {${os.platform} ne "darwin"} {
         return {}
@@ -200,6 +257,7 @@ proc go_toolchain.setup {go_version {label ""}} {
     global prefix workpath worksrcpath configure.build_arch os.platform \
            extract.suffix extract.cmd extract.pre_args extract.post_args \
            distpath subport \
+           go_toolchain.packaged \
            go_toolchain.version go_toolchain.minor go_toolchain.label \
            go_toolchain.goroot_final go_toolchain.suffix \
            go_toolchain.bootstrap_path
@@ -207,6 +265,15 @@ proc go_toolchain.setup {go_version {label ""}} {
     set minor [go_toolchain._minor ${go_version}]
     if {${label} eq ""} {
         set label ${minor}
+    }
+
+    # A port named after its version must appear in go_toolchain.packaged, so
+    # that a toolchain cannot be added or removed in only one of the two
+    # places. A labelled port, such as the prerelease, is exempt.
+    if {${label} eq ${minor}
+            && [lsearch -exact ${go_toolchain.packaged} ${minor}] < 0} {
+        return -code error "go_toolchain: ${minor} is not in\
+            go_toolchain.packaged; add it there as well"
     }
 
     set go_toolchain.version        ${go_version}

--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -412,9 +412,8 @@ proc go_toolchain.setup {go_version {label ""}} {
     }
 
     notes "
-        This port installs Go ${go_version} as go-${label} and gofmt-${label},
-        so it does not interfere with the main `go` port. Use it directly, or
-        point a build at ${prefix}/lib/go-${label} as GOROOT.
+        Installed as go-${label} and gofmt-${label}, with GOROOT at
+        ${prefix}/lib/go-${label}.
     "
 
     livecheck.type      regex

--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -1,67 +1,88 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 #
-# This PortGroup does two things:
+# This PortGroup provides two things:
 #
-#   1. It records which Go releases are usable on which versions of macOS, and
-#      answers questions about that (go_toolchain.ceiling,
-#      go_toolchain.satisfies). Including the PortGroup on its own has no side
-#      effects, so other PortGroups and ports may include it just to ask.
+#   * The mapping from Go release to the oldest macOS it runs on, and the
+#     queries over it: go_toolchain.ceiling, go_toolchain.satisfies and
+#     go_toolchain.wrapped. Including the PortGroup has no side effects, so a
+#     port or another PortGroup may include it purely to ask.
 #
-#   2. It builds a versioned Go toolchain port, when a Portfile calls
-#      go_toolchain.setup. See "Building a versioned toolchain" below.
+#   * The build of a versioned Go toolchain port, via go_toolchain.setup.
 #
-# Upstream's requirements, from https://go.dev/wiki/MinimumRequirements and the
-# per-release notes:
 #
-#   Go 1.17  requires macOS 10.13 High Sierra  (darwin 17)
-#   Go 1.21  requires macOS 10.15 Catalina     (darwin 19)
-#   Go 1.23  requires macOS 11  Big Sur        (darwin 20)
-#   Go 1.25  requires macOS 12  Monterey       (darwin 21)
-#   Go 1.27  requires macOS 13  Ventura        (darwin 22)
+# Building a toolchain port
+# -------------------------
 #
-# These are hard runtime limits, not merely build limits. From Go 1.25 the
-# darwin runtime resolves Security.framework symbols such as
-# _SecTrustCopyCertificateChain via //go:cgo_import_dynamic even when CGO is
-# disabled, so a too-new Go aborts under dyld on an older system no matter how
-# it was produced. The 1.25 binaries are the first to carry that undefined
-# symbol, and the first built with a minimum of macOS 12.
+#   PortGroup             go_toolchain 1.0
+#
+#   go_toolchain.setup    1.23.12
+#
+#   checksums             ...
+#
+# setup derives the port name, the platforms it is allowed on, the bootstrap
+# and the whole build. go-1.23 installs its GOROOT at ${prefix}/lib/go-1.23 and
+# its commands as ${prefix}/bin/go-1.23 and ${prefix}/bin/gofmt-1.23, so
+# toolchains never collide with each other or with the `go` port.
+#
+# Checksums are needed for the source tarball and for both darwin binaries,
+# which are used to bootstrap.
+#
+# An optional second argument names a port that should not be named after its
+# version:
+#
+#   go_toolchain.setup    1.27rc2 devel     ->  go-devel, bin/go-devel
+#
+#
+# Adding a new Go series
+# ----------------------
+#
+#   1. go_toolchain.min_darwin: add the series with the oldest darwin major
+#      version upstream supports it on.
+#
+#      Required even when no port is added. go_toolchain.ceiling reads this
+#      table to decide what each system can run, so a series missing from it
+#      leaves systems that cannot run the new release still reporting that they
+#      can, and ports are then built against a Go that will not start.
+#
+#   2. go_toolchain.packaged: add the series if a go-1.NN port is created for
+#      it. setup refuses a version-named port whose series is absent here.
+#
+#   3. lang/go-1.NN/Portfile: call go_toolchain.setup with the full version,
+#      and give the checksums.
+#
+# Nothing else needs touching. The `go` port follows the newest series each
+# system can run, and every ceiling recomputes from the table.
+#
+# Retiring a series is the reverse: drop it from go_toolchain.packaged and
+# delete the port. Its go_toolchain.min_darwin entry can stay, since that table
+# records what upstream requires rather than what is shipped.
+#
+# A patch update, say 1.26.5 to 1.26.6, is a change to that port's own Portfile
+# and nothing here.
+#
+#
+# Upstream's macOS requirements
+# -----------------------------
+#
+# From https://go.dev/wiki/MinimumRequirements and the per-release notes:
+#
+#   Go 1.17   macOS 10.13 High Sierra   (darwin 17)
+#   Go 1.21   macOS 10.15 Catalina      (darwin 19)
+#   Go 1.23   macOS 11    Big Sur       (darwin 20)
+#   Go 1.25   macOS 12    Monterey      (darwin 21)
+#   Go 1.27   macOS 13    Ventura       (darwin 22)
+#
+# These are runtime limits rather than build limits. From Go 1.25 the darwin
+# runtime resolves Security.framework symbols such as
+# _SecTrustCopyCertificateChain through //go:cgo_import_dynamic even when CGO
+# is disabled, so a too-new Go aborts under dyld however it was produced.
 # See https://trac.macports.org/ticket/73086.
-#
-# Building a versioned toolchain
-# ------------------------------
-#
-# PortGroup             go_toolchain 1.0
-#
-# go_toolchain.setup    1.23.12
-#
-# checksums             ...
-#
-# go_toolchain.setup derives the port name (go-1.23), the platform the port is
-# allowed on, and the whole build. A second argument names the port when it
-# should not be named after its version; see go_toolchain.setup below. It
-# installs GOROOT into
-# ${prefix}/lib/go-1.23 and the commands as ${prefix}/bin/go-1.23 and
-# ${prefix}/bin/gofmt-1.23, so versioned toolchains never collide with each
-# other or with the main `go` port.
 
-# The minimum darwin major version each Go minor release is usable on. This is
-# the single source of truth; everything else here is derived from it.
+# The oldest darwin major version each Go series runs on.
 #
-# The values are upstream's requirements, except where MacPorts extends a
-# release below them with legacysupport; see the 1.17 note below. This is not a
-# list of the toolchains MacPorts packages: an entry is needed here when
-# either
-#
-#   * a versioned port exists for it, since go_toolchain.setup looks up the
-#     release to decide which platforms the port is allowed on, or
-#   * it is the newest release usable on some macOS version, since that is what
-#     go_toolchain.ceiling reports for that system.
-#
-# Those are independent: 1.23 and 1.25 have ports but decide no ceiling, since
-# 11 Big Sur can run 1.24 and 12 Monterey can run 1.26. The remaining entries
-# (1.18, 1.19, 1.21) do neither; they are kept only so this table stays a
-# complete record of the releases in range, and so that adding a port for one
-# later needs no new data.
+# The values are upstream's requirements, with the exception of 1.17 noted
+# below. An entry is needed for any series that has a port, and for any series
+# that is the newest runnable on some version of macOS.
 set go_toolchain.min_darwin(1.17)   11  ;# 10.7  Lion          (see below)
 set go_toolchain.min_darwin(1.18)   17  ;# 10.13 High Sierra
 set go_toolchain.min_darwin(1.19)   17  ;# 10.13 High Sierra
@@ -74,19 +95,20 @@ set go_toolchain.min_darwin(1.25)   21  ;# 12    Monterey
 set go_toolchain.min_darwin(1.26)   21  ;# 12    Monterey
 set go_toolchain.min_darwin(1.27)   22  ;# 13    Ventura
 
-# The 1.17 entry is the one value here that is not upstream's. Upstream
-# requires 10.13 for Go 1.17, but MacPorts builds it from source below that
-# with legacysupport, which is what makes a Go toolchain available at all on
-# those systems.
-#
-# 11 is where that actually reaches, not a guess: the buildbots build 1.17.13
-# on 10.7 through 10.12, and fail on 10.6, whose dsymutil aborts on the debug
-# information Go's linker emits. See lang/go-1.17.
+# 1.17 is the one value above that is not upstream's. Upstream requires 10.13;
+# MacPorts builds 1.17.13 from source below that with legacysupport, which is
+# what makes any Go available on those systems. 10.7 is the limit of that:
+# 10.6 cannot build it, because its dsymutil aborts on the debug information
+# Go's linker emits. See lang/go-1.17.
 
-# The Go series MacPorts packages as go-1.NN ports. This cannot be derived from
-# the table above, which lists the releases that exist rather than the ones
-# shipped. A list of series and not of versions, so that a patch update to a
-# toolchain touches only that port's own Portfile.
+# The series MacPorts packages as go-1.NN ports.
+#
+# This cannot be derived from the table above, which records the releases that
+# exist rather than the ones shipped: 1.18, 1.19 and 1.21 have no port, and
+# 1.27 exists only as the prerelease.
+#
+# A list of series rather than of versions, so that a patch update touches only
+# the toolchain's own Portfile.
 set go_toolchain.packaged {1.17 1.20 1.22 1.23 1.24 1.25 1.26}
 
 # The newest and oldest series in go_toolchain.packaged.
@@ -115,8 +137,10 @@ proc go_toolchain._oldest_packaged {} {
 }
 
 # The series the `go` port should provide here, or {} when no packaged release
-# runs on this system at all. A capped system gets the newest release it can
-# run, an uncapped one the newest packaged.
+# runs on this system at all.
+#
+# A capped system gets the newest release it can run, an uncapped one the
+# newest packaged. Both are the newest usable Go, which is what `go` means.
 proc go_toolchain.wrapped {} {
     global go_toolchain.packaged
 
@@ -133,8 +157,7 @@ proc go_toolchain.wrapped {} {
     return ${ceiling}
 }
 
-# The newest Go minor release this table knows about. A system that can run it
-# is not capped at all.
+# The newest series in go_toolchain.min_darwin.
 proc go_toolchain._newest {} {
     global go_toolchain.min_darwin
 
@@ -147,8 +170,8 @@ proc go_toolchain._newest {} {
     return ${newest}
 }
 
-# Return the minimum darwin major version for a Go release, given either a
-# minor version ("1.23") or a full version ("1.23.12").
+# The oldest darwin major version a release runs on. Accepts either a series
+# ("1.23") or a full version ("1.23.12").
 proc go_toolchain.min_darwin {go_version} {
     global go_toolchain.min_darwin
 
@@ -159,8 +182,8 @@ proc go_toolchain.min_darwin {go_version} {
     return [set go_toolchain.min_darwin(${minor})]
 }
 
-# Reduce a version to its "1.NN" release series. Prereleases carry a suffix on
-# the minor component (1.27rc2), so this cannot simply split on ".".
+# The release series of a version. Prereleases carry a suffix on the minor
+# component (1.27rc2), so this cannot simply split on ".".
 proc go_toolchain._minor {go_version} {
     if {![regexp {^([0-9]+\.[0-9]+)} ${go_version} -> series]} {
         return -code error "go_toolchain: cannot read a release series from ${go_version}"
@@ -168,25 +191,26 @@ proc go_toolchain._minor {go_version} {
     return ${series}
 }
 
-# Return the newest Go minor version supported on this platform:
+# The newest Go series usable on this platform:
 #
-#   {}      no cap; this platform can run the newest release in the table
-#   none    no release in the table runs here at all
-#   1.NN    the newest release that runs here
+#   1.NN    the newest series that runs here
+#   {}      no cap; the newest series in the table runs here
+#   none    no series in the table runs here
 #
-# The first two are not the same thing and must not be conflated: a system
-# below every floor can run no Go at all, which is the opposite of uncapped.
-# Non-darwin platforms are never capped.
+# {} and none are distinct and must not be conflated: a system below every
+# floor runs no Go at all, which is the opposite of uncapped. Non-darwin
+# platforms are never capped.
 #
-# Careful: the result is a version string, not a number. Do not pass it through
-# expr (including an expr ternary), because Tcl will renormalise "1.20" to
-# "1.2", which then fails to match anything. Compare it with vercmp and
-# interpolate it directly into strings.
+# Setting go_toolchain.ceiling_override replaces the computed answer, which
+# allows a capped system to be simulated for testing.
+#
+# The result is a version string, not a number. Never pass it through expr,
+# including an expr ternary: Tcl renormalises "1.20" to "1.2", which then
+# matches nothing. Compare it with vercmp and interpolate it directly.
 proc go_toolchain.ceiling {} {
     global os.platform os.major go_toolchain.min_darwin \
            go_toolchain.ceiling_override
 
-    # Set to simulate a capped system when testing on one that is not.
     if {[info exists go_toolchain.ceiling_override]
             && ${go_toolchain.ceiling_override} ne ""} {
         return ${go_toolchain.ceiling_override}
@@ -214,17 +238,15 @@ proc go_toolchain.ceiling {} {
     return ${best}
 }
 
-# Return 1 when the given minimum Go version can be satisfied on this platform.
+# Whether a minimum Go version can be satisfied on this platform.
 #
-# The comparison is by release series, because that is what a ceiling names. A
-# go.mod may ask for a patch release, and roughly half of them do ("go 1.24.0"),
-# but MacPorts ships the newest patch of every series it packages, so 1.24.3 is
-# satisfied wherever the 1.24 series is. Comparing the two directly would be
-# wrong in exactly the boundary case that matters: vercmp ranks 1.24.3, and
-# even 1.24.0, above 1.24, so a port asking for the very series a system is
-# capped at would be judged unsatisfiable.
+# The comparison is by series, since that is what a ceiling names. A go.mod may
+# ask for a patch release, and MacPorts ships the newest patch of every series
+# it packages, so 1.24.3 is satisfied wherever the 1.24 series is. Comparing
+# the two directly would fail at the boundary that matters, because vercmp
+# ranks 1.24.3, and even 1.24.0, above 1.24.
 #
-# An empty minimum is satisfiable wherever any Go runs at all, and nothing is
+# An empty minimum is satisfiable wherever any Go runs, and nothing is
 # satisfiable where none does.
 proc go_toolchain.satisfies {minimum} {
     set ceiling [go_toolchain.ceiling]
@@ -245,14 +267,10 @@ options go_toolchain.version go_toolchain.minor go_toolchain.label \
 
 # Configure this Portfile as a versioned Go toolchain port.
 #
-# The label names the port and its commands, and defaults to the release
-# series, giving go-1.23 with bin/go-1.23. Pass one explicitly for a toolchain
-# that is not named after its version, such as the prerelease port:
-#
-#   go_toolchain.setup  1.27rc2 devel   -> go-devel, bin/go-devel
-#
-# Everything else is derived from the version either way, so a labelled port
-# still gets the platform floor, bootstrap and build of the release it tracks.
+# label names the port and its commands and defaults to the release series,
+# giving go-1.23 with bin/go-1.23. Everything else is derived from the version
+# either way, so a labelled port still gets the platform floor, bootstrap and
+# build of the release it tracks.
 proc go_toolchain.setup {go_version {label ""}} {
     global prefix workpath worksrcpath configure.build_arch os.platform \
            extract.suffix extract.cmd extract.pre_args extract.post_args \
@@ -305,7 +323,7 @@ proc go_toolchain.setup {go_version {label ""}} {
     # The oldest macOS this release is supported on.
     platforms           "darwin >= [go_toolchain.min_darwin ${go_version}]"
 
-    # Go dropped darwin/386 well before any release packaged here.
+    # Go dropped darwin/386 in 1.15, before any release packaged here.
     supported_archs     arm64 x86_64
 
     master_sites        [option homepage]/dl/
@@ -329,9 +347,9 @@ proc go_toolchain.setup {go_version {label ""}} {
         default { set goarch {} }
     }
 
-    # Bootstrap from the official prebuilt toolchain of the same release. That
-    # binary's own minimum macOS version is never newer than the release's
-    # stated floor, so it runs anywhere this port is allowed to build.
+    # Bootstrap from the official prebuilt toolchain of the same release. Its
+    # own minimum macOS version is never newer than that release's floor, so it
+    # runs anywhere this port is allowed to build.
     switch ${configure.build_arch} {
         arm64   { set bootstrap_dist go${go_version}.darwin-arm64${extract.suffix} }
         default { set bootstrap_dist go${go_version}.darwin-amd64${extract.suffix} }
@@ -357,7 +375,7 @@ proc go_toolchain.setup {go_version {label ""}} {
     }
 
     destroot {
-        # Contains a deliberately malformed Mach-O file that upsets destroot.
+        # A deliberately malformed Mach-O test fixture that upsets destroot.
         delete ${worksrcpath}/src/cmd/vendor/github.com/google/pprof/internal/binutils/testdata/malformed_macho
 
         set grfdir ${destroot}${go_toolchain.goroot_final}
@@ -366,8 +384,8 @@ proc go_toolchain.setup {go_version {label ""}} {
         xinstall -d ${grfdir}
         xinstall -d ${docdir}
 
-        # go.env only exists from Go 1.21 onwards, and the layout has varied
-        # in other ways between releases, so only copy what this one ships.
+        # go.env exists only from Go 1.21, and the layout varies between
+        # releases in other ways, so copy only what this one ships.
         foreach f {api bin lib misc pkg src test VERSION go.env} {
             if {[file exists ${worksrcpath}/${f}]} {
                 copy ${worksrcpath}/${f} ${grfdir}
@@ -402,20 +420,19 @@ proc go_toolchain.setup {go_version {label ""}} {
     livecheck.type      regex
     livecheck.url       [option homepage]/dl/
     if {[regexp {^[0-9.]+$} ${go_version}]} {
-        # Match only this branch, so a versioned toolchain is not reported as
-        # outdated against whatever the current Go release happens to be.
+        # Match only this series, so a toolchain is not reported as outdated
+        # against a newer one.
         livecheck.regex [go_toolchain._livecheck_regex ${minor}]
     } else {
-        # A prerelease port tracks the newest prerelease, in whatever series
-        # it happens to be. It must not match a stable release: those sort
-        # above a prerelease of the same series, so a plain version pattern
-        # would pull the port onto a stable release the moment one shipped.
+        # A prerelease port tracks the newest prerelease in any series, and
+        # must not match a stable release: those sort above a prerelease of
+        # the same series.
         livecheck.regex {go([0-9.]+(?:beta|rc)[0-9]+)\.src\.tar\.gz}
     }
 }
 
-# The bootstrap distfile for this build, recomputed at phase time so the
-# post-extract block does not need a captured local.
+# The bootstrap distfile for this build, recomputed at phase time so that the
+# post-extract block needs no captured local.
 proc go_toolchain._bootstrap_dist {} {
     global configure.build_arch extract.suffix go_toolchain.version
 
@@ -426,8 +443,7 @@ proc go_toolchain._bootstrap_dist {} {
     return go[option go_toolchain.version].${arch}${extract.suffix}
 }
 
-# Match only patch releases of this port's own branch, so that a versioned port
-# is not reported as outdated against a newer branch.
+# A livecheck pattern matching only the patch releases of one series.
 proc go_toolchain._livecheck_regex {minor} {
     set esc [string map {. {\.}} ${minor}]
     return [subst -nocommands -nobackslashes {go(${esc}\.[0-9.]+)\.src\.tar\.gz}]

--- a/lang/go-1.17/Portfile
+++ b/lang/go-1.17/Portfile
@@ -174,8 +174,7 @@ destroot {
 }
 
 notes-append "
-    This port installs Go ${version} as go-1.17 and gofmt-1.17, so it does not
-    interfere with the main `go` port.
+    Installed as go-1.17 and gofmt-1.17, with GOROOT at ${prefix}/lib/go-1.17.
 "
 
 # Match only this branch, so this port is not reported as outdated against

--- a/lang/go-1.20/Portfile
+++ b/lang/go-1.20/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.20.14
-revision            1
+revision            2
 
 checksums           \
                     go1.20.14.src.tar.gz \

--- a/lang/go-1.22/Portfile
+++ b/lang/go-1.22/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.22.12
-revision            1
+revision            2
 
 checksums           \
                     go1.22.12.src.tar.gz \

--- a/lang/go-1.23/Portfile
+++ b/lang/go-1.23/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.23.12
-revision            1
+revision            2
 
 checksums           \
                     go1.23.12.src.tar.gz \

--- a/lang/go-1.24/Portfile
+++ b/lang/go-1.24/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.24.13
-revision            1
+revision            2
 
 checksums           \
                     go1.24.13.src.tar.gz \

--- a/lang/go-1.25/Portfile
+++ b/lang/go-1.25/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.25.12
-revision            1
+revision            2
 
 checksums           \
                     go1.25.12.src.tar.gz \

--- a/lang/go-1.26/Portfile
+++ b/lang/go-1.26/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.26.5
-revision            1
+revision            2
 
 checksums           \
                     go1.26.5.src.tar.gz \

--- a/lang/go-devel/Portfile
+++ b/lang/go-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
 go_toolchain.setup  1.27rc2 devel
-revision            2
+revision            3
 epoch               3
 
 checksums           go1.27rc2.src.tar.gz \

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -1,73 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-
-PortGroup           legacysupport 1.1
-
-legacysupport.newest_darwin_requires_legacy 16
+PortGroup           go_toolchain 1.0
 
 name                go
+epoch               5
+revision            0
+categories          lang
+license             BSD
 
-# IMPORTANT:
-#
-# When updating major versions, please ensure that you have committed and
-# tested the candidate version using the `go-devel` port, to verify how it
-# builds against current and older versions of macOS.
-
-if {$subport eq $name} {
-# Go 1.22 does not build on macOS 10.12 and older.
-# 1.14.x is the last branch to support i386 on macOS.
-# However past 1.11.x everything is broken.
-# FIXME: consider implementing support for PowerPC.
-if {${os.platform} eq "darwin" && ${os.major} < 17} {
-
-    epoch 3
-
-    if {${build_arch} eq "i386"} {
-        version     1.11.13
-        revision    0
-        set unsupported_macos_386 true
-        set unsupported_macos false
-    } else {
-        version     1.17.13
-        revision    0
-        set unsupported_macos true
-        set unsupported_macos_386 false
-    }
-} else {
-
-    # macOS 10.13 - 10.15, 11's most recently supported major version is 1.24
-    if {${os.platform} eq "darwin" && ${os.major} <= 20} {
-        version         1.24.8
-        set unsupported_macos false
-        set unsupported_macos_386 false
-        revision        0
-        epoch           4
-
-    # macOS 12 and up - latest version
-    } else {
-        version         1.26.5
-        set unsupported_macos false
-        set unsupported_macos_386 false
-        revision        0
-        epoch           3
-    }
-}
-
-platforms           {darwin >= 10} freebsd linux
-}
-
-if {${os.platform} eq "darwin" \
-    && (${os.major} < 11 || ${configure.build_arch} eq "i386")} {
-    set legacy_build    true
-} else {
-    set legacy_build    false
-}
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 homepage            https://go.dev
 
-categories          lang
-license             BSD
 description         compiled, garbage-collected, concurrent programming \
                     language developed by Google Inc.
 
@@ -82,263 +28,72 @@ long_description    \
     language that feels like a dynamically typed, interpreted language. Go \
     is developed by Google Inc.
 
-set go_src_dist     go${version}.src${extract.suffix}
-set go_armbin_dist  go${version}.darwin-arm64${extract.suffix}
-set go_amdbin_dist  go${version}.darwin-amd64${extract.suffix}
+# This port builds nothing. It provides `go` and `gofmt` for the newest Go
+# release this system can actually run, by depending on the versioned toolchain
+# that holds it and linking to its commands.
+#
+# Upstream has raised Go's minimum macOS version repeatedly, so which release
+# that is depends on the system: 10.15 Catalina cannot run anything newer than
+# 1.22, while 13 Ventura and later run the current release. The go_toolchain
+# PortGroup owns that mapping; this port asks it rather than restating it, so
+# `go` cannot come to disagree with the toolchains it is built from.
+#
+# See https://trac.macports.org/ticket/73086.
+set go_wrapped      [go_toolchain.wrapped]
 
-livecheck.type      regex
-livecheck.url       ${homepage}/dl/
-
-if {${unsupported_macos_386}} {
-    # 1.11
-    checksums   ${go_src_dist} \
-                rmd160  19d71fb4c196bd5bb03cab40cc99b35f312aaefc \
-                sha256  5032095fd3f641cafcce164f551e5ae873785ce7b07ca7c143aecd18f7ba4076 \
-                size    21114296
-
-    notes-append "
-        Please note: Go 1.22 does not build on macOS 10.6 and older, so Go ${version} has been installed.
-    "
-} elseif {${unsupported_macos}} {
-    # 1.17
-    checksums   ${go_src_dist} \
-                rmd160  6d8a13da5112ee67bb886eca0fec77ffaab27a5f \
-                sha256  a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd \
-                size    22206518 \
-                ${go_armbin_dist} \
-                rmd160  1e2b1b394f912d92c3afde177f657733692ff593 \
-                sha256  e4ccc9c082d91eaa0b866078b591fc97d24b91495f12deb3dd2d8eda4e55a6ea \
-                size    130528194 \
-                ${go_amdbin_dist} \
-                rmd160  5ff00c1089ca3143c2f8e489f82c659f1066a17a \
-                sha256  c101beaa232e0f448fab692dc036cd6b4677091ff89c4889cc8754b1b29c6608 \
-                size    137060546
-
-    notes-append "
-        Please note: Go 1.22 does not build on macOS 10.12 and older, so Go ${version} has been installed.
-    "
-} else {
-
-    # GO RELEASE - macOS 10.13 - 10.15, 11 - Go 1.24
-    if {${os.platform} eq "darwin" && ${os.major} <= 20} {
-        checksums   ${go_src_dist} \
-                    rmd160  f0b0a7fe7867dc9ea9c7f662332dcaf954728625 \
-                    sha256  b1ff32c5c4a50ddfa1a1cb78b60dd5a362aeb2184bb78f008b425b62095755fb \
-                    size    30797581 \
-                    ${go_armbin_dist} \
-                    rmd160  2d1d9eb6decfa110168acbda9ccf3962a704bf5d \
-                    sha256  0db27ff8c3e35fd93ccf9d31dd88a0f9c6454e8d9b30c28bd88a70b930cc4240 \
-                    size    76429684 \
-                    ${go_amdbin_dist} \
-                    rmd160  86fdbaddbb31cfc967f8cb60adb918689e94700a \
-                    sha256  ecb3cecb1e0bcfb24e50039701f9505b09744cc4730a8b9fc512b0a3b47cf232 \
-                    size    80113551
-
-    # GO RELEASE - macOS 12+ - Latest version
-    } else {
-
-        checksums   ${go_src_dist} \
-                    rmd160  37919c04f4a80d411d21e8244b455359ddfc38ec \
-                    sha256  495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42 \
-                    size    34140216 \
-                    ${go_armbin_dist} \
-                    rmd160  67ab77955564e690647cdff5fdbfc4222acf84b4 \
-                    sha256  efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a \
-                    size    64738542 \
-                    ${go_amdbin_dist} \
-                    rmd160  d71b04c25734257bd78ee97f4ad017ba43741c4a \
-                    sha256  6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725 \
-                    size    67836304
-    }
+if {${go_wrapped} eq ""} {
+    # Below every floor MacPorts packages. The platforms line excludes these
+    # systems; this only keeps the Portfile parseable when it is read there.
+    set go_wrapped  [go_toolchain._oldest_packaged]
 }
 
-livecheck.regex     {go([0-9.]+)\.src\.tar\.gz}
+# The version is the series, not a patch release. The wrapper's content -- two
+# symlinks -- does not change when the toolchain it points at gets a patch
+# update, so there is nothing to re-version, and nothing here to fall out of
+# step with the toolchain Portfiles.
+version             ${go_wrapped}
 
-master_sites        ${homepage}/dl/
-distfiles           ${go_src_dist}
-worksrcdir          ${name}
+# Older than this there is no Go release MacPorts can provide. 10.6 in
+# particular cannot build one: its dsymutil aborts on the debug information
+# Go's linker emits. See lang/go-1.17.
+platforms           "darwin >= [go_toolchain.min_darwin [go_toolchain._oldest_packaged]]"
 
-maintainers         {ciserlohn @ci42} \
-                    {gmail.com:herby.gillot @herbygillot} \
-                    openmaintainer
+depends_lib         port:go-${go_wrapped}
 
-extract.only        ${go_src_dist}
-
-set GOROOT          ${worksrcpath}
-set GOROOT_FINAL    ${prefix}/lib/${subport}
-
-supported_archs     arm64 i386 x86_64
-
-switch ${configure.build_arch} {
-    arm64 {
-        set GOARCH arm64
-    }
-    i386 {
-        set GOARCH 386
-    }
-    x86_64 {
-        set GOARCH amd64
-    }
-    default {
-        set GOARCH {}
-    }
-}
+# Only symlinks are installed, so nothing here is architecture specific.
+supported_archs     noarch
 
 use_configure       no
-
-build.dir           ${worksrcpath}/src
-build.cmd           ./make.bash
-build.target
-build.env           GOROOT=${GOROOT} \
-                    GOARCH=${GOARCH} \
-                    GOOS=darwin \
-                    GOROOT_FINAL=${GOROOT_FINAL} \
-                    CC=${configure.cc}
-
-# Set build.jobs to -1 to disable MacPorts from adding the -j flag for
-# parallel builds, since the build.cmd contains "make".
-build.jobs          -1
-
-if {${os.platform} eq "darwin" && ${os.major} <= ${legacysupport.newest_darwin_requires_legacy}} {
-    # The legacy support PG will not actually change anything in this port directly,
-    # since go doesn't use the standard CFLAGS/CXXFLAGS.
-    # We need to patch the build system and set up env variables manually.
-
-    if {[vercmp ${version} < 1.19] && !${legacy_build}} {
-        # Older compilers don't support the -Wno-nullability-completeness flag and if
-        # that's the case, they won't need it anyway, so just patch it out.
-        # Upstream no longer uses the flag as of 1.19beta1.
-        # https://github.com/golang/go/commit/bf19163a545c3117ab3c309a691f32a42cf29efd
-        patchfiles-append   patch-cgo-drop-no-nullability-completeness.diff
-    }
-
-    # Fix building with the -x flag ("show all commands as they are executed"),
-    # useful for debugging of the bootstrapping process.
-    # Only needed for debugging the build/bootstrapping process.
-    # FIXME: report this as a bug and have it or a better version of it upstreamed.
-    #patchfiles-append   patch-go-internal-buildid-and-gc-fix-debug.diff
-
-    # Show all commands while building packages and only build one package at a time in
-    # the last bootstrapping step.
-    # Only needed for debugging the build/bootstrapping process.
-    #patchfiles-append   patch-build-show-commands.diff
-
-    build.env-append    "GO_EXTLINK_ENABLED=1" \
-                        "GO_LDFLAGS=\"-extldflags=${configure.ldflags}\"" \
-                        "BOOT_GO_LDFLAGS=-extldflags=${configure.ldflags}" \
-                        "CGO_LDFLAGS=-g -O2 ${configure.ldflags}"
-
-    # Might be useful while debugging issues.
-    build.args-append   "-v=3"
-
-    notes-append [subst {
-                    go had to be specially patched and built to work on your platform.
-
-                    It likely won't work out of the box when building other projects,\
-                    so make sure change your environment to use the following variables:
-                      * GO_EXTLINK_ENABLED="1"
-                    to always force go to use the external gcc or clang linker and
-                      * GO_LDFLAGS="\\\"-extldflags=\${configure.ldflags}\\\""
-                      * CGO_LDFLAGS="-g -O2 \${configure.ldflags}"
-                    to force-link any binary against the legacy support library.\
-                    Use exactly the quoting provided here, even if it may look odd,\
-                    or compilation will fail.
-
-                    Failure to do so will leave you unable to create binaries that use\
-                    features not natively available on your system, either directly\
-                    or through a go core dependency.
-    }]
-}
-
-if {${os.platform} eq "darwin" && ${os.major} == 10} {
-    if {${configure.build_arch} eq "x86_64"} {
-        # The branch https://github.com/catap/go/tree/macos-10.6
-        patchfiles-append   patch-macOS-10.6.diff
-    } elseif {${configure.build_arch} eq "i386"} {
-        patchfiles-append   patch-1.11.13-for-10.6-i386.diff
-    }
-}
-
-use_parallel_build  no
-
-if {${configure.build_arch} eq "arm64"} {
-
-    # Use a temporary installation of the binary ARM64 Go distribution to
-    # build Go for ARM64
-    set go_bin_path         ${workpath}/${subport}_prebuilt
-
-    build.env-append        GOROOT_BOOTSTRAP=${go_bin_path}/go
-
-    distfiles-append        ${go_armbin_dist}
-
-    post-extract {
-        xinstall -d ${go_bin_path}
-        system -W ${go_bin_path} \
-            "${extract.cmd} ${extract.pre_args} ${distpath}/${go_armbin_dist} ${extract.post_args}"
-    }
-
-} elseif {${configure.build_arch} eq "x86_64" && (${os.major} >= 21 || !${legacy_build})} {
-
-    # Use a temporary installation of the binary AMD64 Go distribution to
-    # build Go for AMD64 on macOS 12 since go-1.4 fails to build
-    set go_bin_path         ${workpath}/${subport}_prebuilt
-
-    build.env-append        GOROOT_BOOTSTRAP=${go_bin_path}/go
-
-    distfiles-append        ${go_amdbin_dist}
-
-    post-extract {
-        xinstall -d ${go_bin_path}
-        system -W ${go_bin_path} \
-            "${extract.cmd} ${extract.pre_args} ${distpath}/${go_amdbin_dist} ${extract.post_args}"
-    }
-
-} else {
-
-    # https://trac.macports.org/ticket/69160
-    build.env-append        GOROOT_BOOTSTRAP=${prefix}/lib/go-1.4 \
-                            GOHOSTARCH=${GOARCH}
-
-    depends_build-append    port:go-1.4
-}
-
-post-build {
-    system "find ${worksrcpath} -type d -name .hg* -print0 | xargs -0 rm -rf"
-    delete ${worksrcpath}/pkg/bootstrap
-}
+distfiles
+fetch               {}
+extract             {}
+build               {}
 
 destroot {
-
-    delete ${worksrcpath}/src/cmd/vendor/github.com/google/pprof/internal/binutils/testdata/malformed_macho
-
-    set grfdir ${destroot}${GOROOT_FINAL}
-    set docdir ${destroot}${prefix}/share/doc/${subport}
-
-    xinstall -d ${grfdir}
-    xinstall -d ${docdir}
-
-    foreach f {api bin lib misc pkg src test VERSION} {
-        copy ${worksrcpath}/${f} ${grfdir}
-    }
+    xinstall -d ${destroot}${prefix}/bin
 
     foreach f {go gofmt} {
-        system -W ${destroot}${prefix}/bin/ "ln -s ../lib/${subport}/bin/$f ./${f}"
+        ln -s ../lib/go-${go_wrapped}/bin/${f} ${destroot}${prefix}/bin/${f}
     }
 
-    xinstall -m 0644 -W ${worksrcpath} \
-        CONTRIBUTING.md \
-        LICENSE \
-        PATENTS \
-        VERSION \
-        ${docdir}
+    # ${prefix}/lib/go was this port's own GOROOT before it became a wrapper,
+    # and is referenced by anything that has GOROOT set by hand. The toolchain
+    # does not need it -- its GOROOT is compiled in -- so this is purely so
+    # that the path keeps working.
+    xinstall -d ${destroot}${prefix}/lib
+    ln -s go-${go_wrapped} ${destroot}${prefix}/lib/go
 
-    if {!${legacy_build}} {
-        xinstall -m 0644 -W ${worksrcpath} SECURITY.md ${docdir}
-    }
-
-    copy {*}[glob -directory ${worksrcpath}/doc *] ${docdir}
-
-    if { [ file exists ${worksrcpath}/go.env ] } {
-        copy ${worksrcpath}/go.env ${grfdir}/
-    }
+    xinstall -d ${destroot}${prefix}/share/doc
+    ln -s go-${go_wrapped} ${destroot}${prefix}/share/doc/go
 }
+
+notes "
+    This provides the Go ${go_wrapped} series, the newest this version of macOS
+    can run. The toolchain itself comes from the go-${go_wrapped} port, whose
+    GOROOT is ${prefix}/lib/go-${go_wrapped}; run `go version` for its exact
+    release.
+"
+
+# Nothing to check here: this port has no upstream of its own and follows
+# whichever versioned toolchain applies. Those carry their own livechecks.
+livecheck.type      none

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -88,10 +88,9 @@ destroot {
 }
 
 notes "
-    This provides the Go ${go_wrapped} series, the newest this version of macOS
-    can run. The toolchain itself comes from the go-${go_wrapped} port, whose
-    GOROOT is ${prefix}/lib/go-${go_wrapped}; run `go version` for its exact
-    release.
+    This provides the Go ${go_wrapped} series, the newest release this version
+    of macOS can run, from the go-${go_wrapped} port. Run `go version` for the
+    exact release.
 "
 
 # Nothing to check here: this port has no upstream of its own and follows


### PR DESCRIPTION
### Summary

`go` stops building a toolchain of its own and instead provides whichever
versioned toolchain the running system can actually use.

Upstream has raised Go's minimum macOS version repeatedly and this port did not
follow: on 10.13 through 10.15 it installed a Go built for macOS 11 or 12,
which aborts under dyld before it can run, taking every port that builds with
Go down with it.

The versioned toolchains added earlier already know how to build each release
and where each one runs. `go` now depends on the right one and links to its
commands:

| macOS | `go` provides |
|---|---|
| 10.7 – 10.12 | 1.17 |
| 10.13 – 10.14 | 1.20 |
| 10.15 Catalina | 1.22 |
| 11 Big Sur | 1.24 |
| 12 Monterey | 1.26 |
| 13 Ventura and later | current |

Ports that depend on `go` need no changes to benefit.

### What is in the port now

Nothing is built, so the version is the release series rather than a patch
release: the wrapper does not change when the toolchain it points at gets a
patch update. `go version` reports the exact release.

`${prefix}/lib/go` and `${prefix}/share/doc/go` are kept as symlinks to the
toolchain's own, since both were this port's paths before and anything with
GOROOT set by hand refers to the first.

The port is no longer offered below 10.7, where no Go release can be built at
all, nor on freebsd and linux: that support was nominal, since the build
hardcoded `GOOS=darwin` and fetched darwin-only bootstrap tarballs.

### PortGroup changes

`go_toolchain` gains the two things the wrapper needs: `go_toolchain.packaged`,
the series that exist as `go-1.NN` ports, and `go_toolchain.wrapped`, the one
`go` should provide here. The list holds series rather than versions so that a
patch update to a toolchain touches only that port's own Portfile, and `setup`
refuses a version-named port whose series is absent from it.

Separately, the destroot was copying the top-level markdown files but not
`doc/`, so the toolchains shipped without the language specification and the
rest of it. Fixed, with a revision bump for the ports whose contents change.

### What this does not do

A port whose `go.mod` asks for a newer release than its system can run still
cannot be built there, and nothing yet lets it say so, so those keep being
retried on every push. That needs a declared minimum on the `golang` PortGroup,
which is separate work — hence `See:` rather than `Closes:` on the ticket.

### Testing

All nine ports lint clean and resolve to the expected version, revision and
platforms. The resolution table above was verified for every macOS version, and
the PortGroup's queries pass under both Tcl 8.6 and Tcl 9.0, the latter for
MacPorts' coming switch. `port upgrade go` was exercised in a test prefix and
upgrades the toolchain first, then the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

See: https://trac.macports.org/ticket/73086
