### PR TITLE
emacs-app: declare class-based TCC usage descriptions

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -144,7 +144,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         30.2
-    revision        14
+    revision        15
     checksums       rmd160  fefdd3fcd453d733114f609a3e122b2529cc7410 \
                     sha256  1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d \
                     size    83059014
@@ -164,7 +164,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.tarball_from archive
     epoch           5
     version         20260602
-    revision        3
+    revision        4
 
     master_sites    ${github.master_sites}
 
@@ -280,6 +280,12 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 
     universal_variant   no
 
+    # Sets LSEnvironment/PATH, and declares the class-based TCC usage
+    # descriptions (Photos, Camera, Microphone, ...) that upstream omits.  macOS
+    # attributes a privacy check to the "responsible process", which for anything
+    # started from a shell inside Emacs is Emacs.app, so a subprocess touching one
+    # of those frameworks is killed with SIGABRT unless Emacs.app declares the key.
+    # Keys upstream already declares are deliberately not repeated.
     patchfiles-append   patch-Info.plist.in.diff
 
     post-patch {

--- a/editors/emacs/files/patch-Info.plist.in.diff
+++ b/editors/emacs/files/patch-Info.plist.in.diff
@@ -1,6 +1,6 @@
 --- nextstep/templates/Info.plist.in.orig	2025-08-16 16:16:20
 +++ nextstep/templates/Info.plist.in	2025-08-16 16:16:23
-@@ -21,6 +21,11 @@
+@@ -21,6 +21,39 @@
  <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
  <plist version="1.0">
  <dict>
@@ -9,6 +9,34 @@
 +    <key>PATH</key>
 +    <string>@PATH@</string>
 +  </dict>
++	<key>NSBluetoothAlwaysUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to use Bluetooth.</string>
++	<key>NSCalendarsFullAccessUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access your calendars.</string>
++	<key>NSCalendarsUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access your calendars.</string>
++	<key>NSCameraUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to use the camera.</string>
++	<key>NSContactsUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access your contacts.</string>
++	<key>NSLocalNetworkUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access devices on your local network.</string>
++	<key>NSLocationUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to use your location information.</string>
++	<key>NSLocationWhenInUseUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to use your location information while active.</string>
++	<key>NSMicrophoneUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to use the microphone.</string>
++	<key>NSPhotoLibraryAddUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to add to your photo library.</string>
++	<key>NSPhotoLibraryUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access your photo library.</string>
++	<key>NSRemindersFullAccessUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access your reminders.</string>
++	<key>NSRemindersUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires permission to access your reminders.</string>
++	<key>NSSystemAdministrationUsageDescription</key>
++	<string>Emacs, or a program started from within Emacs, requires elevated permission to perform system administration tasks.</string>
  	<key>CFBundleDevelopmentRegion</key>
  	<string>English</string>
  	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
macOS attributes a privacy check to the "responsible process" found by walking up the parent chain, which for a program started from a shell inside Emacs is Emacs.app.  Emacs.app's Info.plist declares usage descriptions only for the file-access TCC services and Apple Events, so any such program that touches Photos, Camera, Microphone, Contacts, Calendars, Reminders, Location or Bluetooth is killed with SIGABRT instead of getting the normal permission dialog -- even when its own bundle declares the key correctly.

Add the 14 missing class-based keys to the existing Info.plist.in patch. Keys upstream already declares are not repeated, since duplicating a key in a plist is undefined: NSAppleEvents, NSDesktopFolder, NSDocumentsFolder, NSDownloadsFolder and NSRemovableVolumes in both trees, plus NSSpeechRecognition, which emacs master has already added.

Declaring a usage description does not grant access; it only lets macOS prompt instead of aborting the process.

Verified to apply with zero fuzz against both the 30.2 tarball and the emacs-master snapshot used by the -devel subports.

fixed https://trac.macports.org/ticket/74272#ticket

Prepared with the assistance of Claude Code. Reviewed and tested by a human being.