### PR TITLE
cloudflare-speed-cli: update to 1.0.8

### DIFF
--- a/net/cloudflare-speed-cli/Portfile
+++ b/net/cloudflare-speed-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo  1.0
 
-github.setup            kavehtehrani cloudflare-speed-cli 1.0.5 v
+github.setup            kavehtehrani cloudflare-speed-cli 1.0.8 v
 github.tarball_from     archive
 
 revision                0
@@ -22,9 +22,9 @@ long_description        {*}${description}. Measures download and upload throughp
                         a specific network interface or source IP if required.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  e4de27e32e3c435b542edc4dd851972ea8c7d914 \
-                        sha256  71b8a1a48b31dd39c648eef649a642f8f7b4e36f7f9a43d6619f9b8f7c0e9255 \
-                        size    697224
+                        rmd160  fdfa48d569ea743db537e6a667350462463a951d \
+                        sha256  a510b28d7b70b5e5ca6e55c64e3342f938990a211f5ed91f4281c15464dfaa24 \
+                        size    710801
 
 # The TUI feature requires the 'tui' cargo feature flag.
 build.args-append       --features tui


### PR DESCRIPTION
#### Description

- Bind to a network interface with dual-stack support
- Small bug fixes
- See upstream project for more information: https://github.com/kavehtehrani/cloudflare-speed-cli/compare/v1.0.5...v1.0.8


###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix


###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? --> see comment below.
- [x] tried a full install with `sudo port -vst install`? --> fails when using the `-t` switch, I think this is a known issue?
- [x] tested basic functionality of all binary files?

`port lint` → 0 errors. Warnings are limited to per-crate `missing recommended checksum type: rmd160 / size`, which is the standard form used by every other Rust port in the tree (e.g. `audio/mp3rgain`, t`extproc/ripgrep`, `sysutils/eza`).
