### PR TITLE
docker: update to 29.7.1

### DIFF
--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 29.6.2 v
+go.setup            github.com/docker/cli 29.7.1 v
 revision            0
 name                docker
 categories          devel
@@ -16,9 +16,9 @@ long_description    Docker is an open source project to pack, ship \
                     This port contains command line utilities for interacting \
                     with Docker, but not the core daemon.
 
-checksums           rmd160  d5dff79642c5ab16617bd7cde5b3ce180a6372d4 \
-                    sha256  11aef3484c38d39d291a54a73a4d9dd2bb3c000d9a3fc3862bd03fe899594f2c \
-                    size    6871605
+checksums           rmd160  7281cfcb4ae1c5f7f15c6a5d300500b450d73e74 \
+                    sha256  09c72c14870f9c34029942f4c5cf3169b69dc48ea78e7380b5ebaa316356ba1d \
+                    size    6892126
 
 build.target        github.com/docker/cli/cmd/docker
 

--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/docker/cli 29.7.1 v
+go.toolchain_min    1.25.0
 revision            0
 name                docker
 categories          devel


### PR DESCRIPTION
#### Description

Update to Docker CLI 29.7.1.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?