### PR TITLE
golang: let a port declare the oldest Go it can be built with

### DIFF
--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -3,9 +3,11 @@
 # This PortGroup provides two things:
 #
 #   * The mapping from Go release to the oldest macOS it runs on, and the
-#     queries over it: go_toolchain.ceiling, go_toolchain.satisfies and
-#     go_toolchain.wrapped. Including the PortGroup has no side effects, so a
-#     port or another PortGroup may include it purely to ask.
+#     queries over it: go_toolchain.min_darwin, go_toolchain.ceiling,
+#     go_toolchain.satisfies, go_toolchain.range, go_toolchain.wrapped,
+#     go_toolchain.oldest_packaged and go_toolchain.floor. Including the
+#     PortGroup has no side effects, so a port or another PortGroup may include
+#     it purely to ask.
 #
 #   * The build of a versioned Go toolchain port, via go_toolchain.setup.
 #
@@ -43,6 +45,10 @@
 #      table to decide what each system can run, so a series missing from it
 #      leaves systems that cannot run the new release still reporting that they
 #      can, and ports are then built against a Go that will not start.
+#
+#      This step comes first for a second reason: the golang PortGroup refuses
+#      a go.toolchain_min naming a series newer than anything recorded here, so
+#      no port can declare the new release until it is listed.
 #
 #   2. go_toolchain.packaged: add the series if a go-1.NN port is created for
 #      it. setup refuses a version-named port whose series is absent here.
@@ -111,7 +117,7 @@ set go_toolchain.min_darwin(1.27)   22  ;# 13    Ventura
 # the toolchain's own Portfile.
 set go_toolchain.packaged {1.17 1.20 1.22 1.23 1.24 1.25 1.26}
 
-# The newest and oldest series in go_toolchain.packaged.
+# The newest series MacPorts packages.
 proc go_toolchain._newest_packaged {} {
     global go_toolchain.packaged
 
@@ -124,7 +130,8 @@ proc go_toolchain._newest_packaged {} {
     return ${newest}
 }
 
-proc go_toolchain._oldest_packaged {} {
+# The oldest series MacPorts packages.
+proc go_toolchain.oldest_packaged {} {
     global go_toolchain.packaged
 
     set oldest {}
@@ -134,6 +141,12 @@ proc go_toolchain._oldest_packaged {} {
         }
     }
     return ${oldest}
+}
+
+# The oldest darwin major version on which any packaged Go runs. Below this no
+# Go is available at all, and the `go` port is not offered.
+proc go_toolchain.floor {} {
+    return [go_toolchain.min_darwin [go_toolchain.oldest_packaged]]
 }
 
 # The series the `go` port should provide here, or {} when no packaged release
@@ -249,6 +262,28 @@ proc go_toolchain.ceiling {} {
         return {}
     }
     return ${best}
+}
+
+# Where a version sits relative to the series this table records:
+#
+#   older   below every series recorded, and so below every ceiling
+#   known   within the recorded range
+#   newer   above every series recorded
+#
+# A caller validating a declared minimum should treat "newer" as an error:
+# either the value is wrong, or it names a release whose macOS floor has not
+# been recorded here, and neither can be gated correctly. "older" means the
+# value can never gate anything.
+proc go_toolchain.range {version} {
+    set series [go_toolchain._minor ${version}]
+
+    if {[vercmp ${series} > [go_toolchain._newest]]} {
+        return newer
+    }
+    if {[vercmp ${series} < [go_toolchain._oldest]]} {
+        return older
+    }
+    return known
 }
 
 # Whether a minimum Go version can be satisfied on this platform.

--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -56,6 +56,10 @@
 #   3. lang/go-1.NN/Portfile: call go_toolchain.setup with the full version,
 #      and give the checksums.
 #
+# Steps 2 and 3 belong in the same change. A series listed without a port leaves
+# `go` depending on a toolchain that does not exist on every system that selects
+# it; a port whose series is unlisted is refused outright.
+#
 # Nothing else needs touching. The `go` port follows the newest series each
 # system can run, and every ceiling recomputes from the table.
 #
@@ -149,11 +153,16 @@ proc go_toolchain.floor {} {
     return [go_toolchain.min_darwin [go_toolchain.oldest_packaged]]
 }
 
-# The series the `go` port should provide here, or {} when no packaged release
-# runs on this system at all.
+# The series the `go` port should provide here, or {} when no Go release runs
+# on this system at all.
 #
 # A capped system gets the newest release it can run, an uncapped one the
 # newest packaged. Both are the newest usable Go, which is what `go` means.
+#
+# A system capped at a series that is not packaged is a fault in the two tables
+# rather than a property of the system, so it is an error and not another empty
+# answer: `go` would otherwise be offered here, since the floor is below us,
+# while depending on a toolchain that does not exist.
 proc go_toolchain.wrapped {} {
     global go_toolchain.packaged
 
@@ -165,7 +174,10 @@ proc go_toolchain.wrapped {} {
         return [go_toolchain._newest_packaged]
     }
     if {[lsearch -exact ${go_toolchain.packaged} ${ceiling}] < 0} {
-        return {}
+        return -code error "go_toolchain: this system is capped at Go\
+            ${ceiling}, which go_toolchain.packaged does not list. Package that\
+            series, or drop it from go_toolchain.min_darwin if it should not be\
+            a ceiling."
     }
     return ${ceiling}
 }

--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -170,6 +170,19 @@ proc go_toolchain._newest {} {
     return ${newest}
 }
 
+# The oldest series in go_toolchain.min_darwin.
+proc go_toolchain._oldest {} {
+    global go_toolchain.min_darwin
+
+    set oldest {}
+    foreach minor [array names go_toolchain.min_darwin] {
+        if {${oldest} eq "" || [vercmp ${minor} < ${oldest}]} {
+            set oldest ${minor}
+        }
+    }
+    return ${oldest}
+}
+
 # The oldest darwin major version a release runs on. Accepts either a series
 # ("1.23") or a full version ("1.23.12").
 proc go_toolchain.min_darwin {go_version} {

--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -53,6 +53,7 @@
 
 PortGroup legacysupport    1.1
 PortGroup compiler_wrapper 1.0
+PortGroup go_toolchain     1.0
 
 options go.package go.domain go.author go.project go.version go.tag_prefix go.tag_suffix go.offline_build
 
@@ -139,6 +140,22 @@ proc go._translate_package_id {package_id} {
 
 proc go._strip_gopkg_version {str} {
     return [regsub -- \\..*$ ${str} ""]
+}
+
+# Upstream raises Go's minimum macOS version regularly, and an old enough
+# system is left with no Go release it can run at all. Nothing built with this
+# PortGroup can be built there either, so say so once here rather than letting
+# every port discover it by failing.
+if {[go_toolchain.ceiling] eq "none"} {
+    known_fail yes
+}
+
+pre-fetch {
+    if {[go_toolchain.ceiling] eq "none"} {
+        ui_error "No Go release runs on this version of macOS, so ${subport}\
+                  cannot be built here."
+        return -code error "no Go toolchain is available on this platform"
+    }
 }
 
 options go.bin go.vendors

--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -178,15 +178,15 @@ options go.bin go.vendors go.toolchain_min
 default go.toolchain_min {}
 option_proc go.toolchain_min go._handle_toolchain_min
 
-# Holds the minimum when this system cannot meet it, for the message below.
-set go.toolchain_unmet  {}
-
 # Where no Go release runs at all, nothing built with this PortGroup can be
 # either, whatever it does or does not declare. That needs no annotation to
 # decide, so it is settled here rather than per port.
 if {[go_toolchain.ceiling] eq "none"} {
     known_fail yes
 }
+
+# Holds the minimum when this system cannot meet it, for the message below.
+set go.toolchain_unmet  {}
 
 proc go._handle_toolchain_min {option action args} {
     global go.toolchain_unmet
@@ -197,19 +197,21 @@ proc go._handle_toolchain_min {option action args} {
 
     set minimum [lindex ${args} 0]
 
-    # Reduce to a series and check it against what go_toolchain describes. A
-    # value above the newest series it knows is either a typo, which would
-    # otherwise silently skip the port everywhere, or a real new release whose
-    # macOS floor has not been recorded yet; neither can be gated correctly.
-    set series [go_toolchain._minor ${minimum}]
-    if {[vercmp ${series} > [go_toolchain._newest]]} {
-        return -code error "go.toolchain_min ${minimum}: Go ${series} is newer\
-            than any release go_toolchain knows about. If it is real, add it to\
-            go_toolchain.min_darwin with the oldest darwin it runs on."
-    }
-    if {[vercmp ${series} < [go_toolchain._oldest]]} {
-        ui_warn "go.toolchain_min ${minimum} is older than any release MacPorts\
-                 packages, so it can never gate this port; it may be dropped."
+    # A value above every series go_toolchain records is either a typo, which
+    # would otherwise skip the port everywhere without a word, or a real
+    # release whose macOS floor has not been recorded; neither can be gated
+    # correctly. One below them all can never gate anything.
+    switch [go_toolchain.range ${minimum}] {
+        newer {
+            return -code error "go.toolchain_min ${minimum} is newer than any\
+                Go release go_toolchain records. If it is real, add it to\
+                go_toolchain.min_darwin with the oldest darwin it runs on."
+        }
+        older {
+            ui_warn "go.toolchain_min ${minimum} is older than every Go release\
+                     go_toolchain records, so it is below every ceiling and can\
+                     never gate this port; it may be dropped."
+        }
     }
 
     if {[go_toolchain.satisfies ${minimum}]} {

--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -50,6 +50,32 @@
 # The list of vendors can be found in the go.sum, Gopkg.lock, glide.lock,
 # etc. file in the upstream source code. The go2port tool (install via MacPorts)
 # can be used to generate a skeleton portfile with precomputed go.vendors.
+#
+# A port that cannot be built with an arbitrarily old Go should say so:
+#
+# go.toolchain_min  1.24
+#
+# Upstream raises Go's minimum macOS version regularly, so an older system is
+# capped at an older Go, and a port needing something newer cannot be built
+# there by any means. Declaring the minimum lets such a port be marked
+# known_fail on those systems rather than being fetched, built and failed every
+# time it is tried. A port that does not declare one is never gated.
+#
+# The value may be written however go.mod writes it, "1.24" or "1.24.0"; only
+# the series is compared, since MacPorts ships the newest patch release of each
+# series it packages.
+#
+# Where to get the value depends on how the port builds:
+#
+#   * With go.offline_build no, the build runs in module mode and Go reads
+#     go.mod, so its `go` directive is enforced and is exactly the minimum.
+#     Copy it.
+#
+#   * Otherwise the build runs in GOPATH mode, where go.mod is not consulted at
+#     all. The directive is then only an upper bound on what the source really
+#     needs, and may be well above it. Declare a minimum for such a port only
+#     when it is known to be needed, or the port will be skipped on systems
+#     where it would have built.
 
 PortGroup legacysupport    1.1
 PortGroup compiler_wrapper 1.0
@@ -142,23 +168,75 @@ proc go._strip_gopkg_version {str} {
     return [regsub -- \\..*$ ${str} ""]
 }
 
-# Upstream raises Go's minimum macOS version regularly, and an old enough
-# system is left with no Go release it can run at all. Nothing built with this
-# PortGroup can be built there either, so say so once here rather than letting
-# every port discover it by failing.
+options go.bin go.vendors go.toolchain_min
+
+# The oldest Go this port can be built with. Unset means the port states no
+# minimum and is never gated. See the header for where to get the value.
+#
+# Evaluated as soon as a Portfile sets it, so that known_fail is in place for
+# anything that reads it.
+default go.toolchain_min {}
+option_proc go.toolchain_min go._handle_toolchain_min
+
+# Holds the minimum when this system cannot meet it, for the message below.
+set go.toolchain_unmet  {}
+
+# Where no Go release runs at all, nothing built with this PortGroup can be
+# either, whatever it does or does not declare. That needs no annotation to
+# decide, so it is settled here rather than per port.
 if {[go_toolchain.ceiling] eq "none"} {
     known_fail yes
 }
 
+proc go._handle_toolchain_min {option action args} {
+    global go.toolchain_unmet
+
+    if {${action} ne "set"} {
+        return
+    }
+
+    set minimum [lindex ${args} 0]
+
+    # Reduce to a series and check it against what go_toolchain describes. A
+    # value above the newest series it knows is either a typo, which would
+    # otherwise silently skip the port everywhere, or a real new release whose
+    # macOS floor has not been recorded yet; neither can be gated correctly.
+    set series [go_toolchain._minor ${minimum}]
+    if {[vercmp ${series} > [go_toolchain._newest]]} {
+        return -code error "go.toolchain_min ${minimum}: Go ${series} is newer\
+            than any release go_toolchain knows about. If it is real, add it to\
+            go_toolchain.min_darwin with the oldest darwin it runs on."
+    }
+    if {[vercmp ${series} < [go_toolchain._oldest]]} {
+        ui_warn "go.toolchain_min ${minimum} is older than any release MacPorts\
+                 packages, so it can never gate this port; it may be dropped."
+    }
+
+    if {[go_toolchain.satisfies ${minimum}]} {
+        set go.toolchain_unmet {}
+        return
+    }
+
+    set go.toolchain_unmet ${minimum}
+    known_fail yes
+}
+
 pre-fetch {
-    if {[go_toolchain.ceiling] eq "none"} {
+    global go.toolchain_unmet
+
+    set ceiling [go_toolchain.ceiling]
+
+    if {${ceiling} eq "none"} {
         ui_error "No Go release runs on this version of macOS, so ${subport}\
                   cannot be built here."
         return -code error "no Go toolchain is available on this platform"
     }
+    if {${go.toolchain_unmet} ne ""} {
+        ui_error "${subport} needs Go ${go.toolchain_unmet} or newer, but this\
+                  version of macOS runs nothing newer than Go ${ceiling}."
+        return -code error "Go ${go.toolchain_unmet} is not available on this platform"
+    }
 }
-
-options go.bin go.vendors
 
 default go.bin          {${prefix}/bin/go}
 default go.vendors      {}

--- a/lang/go-1.17/Portfile
+++ b/lang/go-1.17/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 
 PortGroup           legacysupport 1.1
+PortGroup           go_toolchain  1.0
 
 legacysupport.newest_darwin_requires_legacy 16
 
@@ -36,10 +37,10 @@ homepage            https://go.dev
 # 10.7 it cannot be built at all: on 10.6 the system dsymutil aborts on the
 # debug information Go's linker emits, failing the final link. The main `go`
 # port has never produced a 10.6 x86_64 build either.
-platforms           {darwin >= 11 < 17}
+platforms           "darwin >= [go_toolchain.min_darwin 1.17] < 17"
 
-# Go dropped darwin/386 in 1.15; the i386 systems that need an older release
-# than this one continue to be served by the main `go` port.
+# Go dropped darwin/386 in 1.15, so no toolchain here is built for it and no
+# Go is available to an i386 build on any system.
 supported_archs     x86_64
 
 master_sites        ${homepage}/dl/

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -60,7 +60,9 @@ platforms           "darwin >= [go_toolchain.floor]"
 
 depends_lib         port:go-${go_wrapped}
 
-# Only symlinks are installed, so nothing here is architecture specific.
+# Only symlinks are installed, so nothing here is architecture specific. The
+# toolchain behind them is not, though, and none is built for i386, so `go` is
+# in practice unavailable for an i386 build even where this port is offered.
 supported_archs     noarch
 
 use_configure       no

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -44,7 +44,7 @@ set go_wrapped      [go_toolchain.wrapped]
 if {${go_wrapped} eq ""} {
     # Below every floor MacPorts packages. The platforms line excludes these
     # systems; this only keeps the Portfile parseable when it is read there.
-    set go_wrapped  [go_toolchain._oldest_packaged]
+    set go_wrapped  [go_toolchain.oldest_packaged]
 }
 
 # The version is the series, not a patch release. The wrapper's content -- two
@@ -56,7 +56,7 @@ version             ${go_wrapped}
 # Older than this there is no Go release MacPorts can provide. 10.6 in
 # particular cannot build one: its dsymutil aborts on the debug information
 # Go's linker emits. See lang/go-1.17.
-platforms           "darwin >= [go_toolchain.min_darwin [go_toolchain._oldest_packaged]]"
+platforms           "darwin >= [go_toolchain.floor]"
 
 depends_lib         port:go-${go_wrapped}
 

--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -5,7 +5,8 @@ PortGroup           golang 1.0
 
 go.setup            github.com/rclone/rclone 1.75.0 v
 go.offline_build    no
-revision            0
+go.toolchain_min    1.25.0
+revision            1
 
 homepage            https://rclone.org
 


### PR DESCRIPTION
### Summary

Lets a Go port say which Go it needs, so that ports which cannot be built on an
older system are skipped there instead of being fetched, built and failed on
every push. `rclone` is annotated as the first one; nothing else changes.

Upstream raises Go's minimum macOS version regularly, so an older system is
capped at an older Go. A port needing something newer cannot be built there by
any means, and today the buildbots rediscover that every time.

### The gate

The `golang` PortGroup gains `go.toolchain_min`. It defaults unset, so no port
is gated until it opts in:

```tcl
go.toolchain_min    1.25.0
```

The value may be written as `go.mod` writes it; only the series is compared,
because a ceiling names a series and MacPorts ships the newest patch release of
each one it packages. Comparing the two directly would be wrong in exactly the
case that matters, since `vercmp` ranks `1.24.0` above `1.24`.

A declared series is checked against the range `go_toolchain` records. Above it
the value is refused, because it is either a typo — which would otherwise skip
the port everywhere without a word — or a real release whose macOS floor has
not been recorded, and neither can be gated correctly. Below it the value is
kept but flagged, since such a port can never be gated.

Separately, and needing no annotation: where no Go release runs at all, nothing
built with this PortGroup can be either. That is 10.6, where `go` is no longer
offered, and it is settled once rather than by each port failing on an
unsatisfiable dependency.

### Where to get the value

It depends on how the port builds, and the PortGroup says so:

* With `go.offline_build no` the build runs in module mode, Go reads `go.mod`,
  and its `go` directive is enforced. It is exactly the minimum; copy it.

* Otherwise the build runs in GOPATH mode, where `go.mod` is not consulted at
  all. The directive is then only an upper bound on what the source needs, and
  may be well above it. Declaring one there risks skipping a port that would
  have built.

Of the ports using this PortGroup, 353 build in module mode and 234 in GOPATH
mode.

### rclone

`rclone` is module mode and its `go.mod` asks for 1.25.0, so below 12 Monterey
the build fails while parsing it:

```
invalid go version '1.25.0': must match format 1.23
```

That is happening now, on six builders, for every push touching the port.
Upstream documents the same limit and arrives at it the same way: rclone states
no macOS requirement of its own, only the one Go imposes.

It goes up alone so that the first run has exactly one annotation to account
for.

### Also here

`go_toolchain` gains `range`, `floor` and `oldest_packaged`, and a fresh reading
of it closed two gaps: `wrapped` answered `{}` both for a system below every
floor and for one capped at a series we do not package, which would have left
`go` offered while depending on a toolchain that does not exist; and `go-1.17`
restated a floor the table already records.

### Testing

Verified for every macOS version that `go` depends on a toolchain actually
available there, and that `rclone` is gated on 10.6 through 11 and not on 12 and
later. The PortGroup's queries pass under Tcl 8.6 and 9.0. Ports that declare no
minimum are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

See: https://trac.macports.org/ticket/73086
