### PR TITLE
google-cloud-sdk: update to 578.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             577.0.0
+version             578.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  e009eb5c50ae97ce510198a18c4f47dbd1520a32 \
-                    sha256  4da3cec159ed45d88c1227efe2c34a83e7a794b0df3805bee8a2c227afbb4c78 \
-                    size    59855747
+    checksums       rmd160  848704b6b9d7de6309cd8237e5422c240d579ed7 \
+                    sha256  aaa96575fdaf76676e088443869dd2419b48f8bdaf4c8d67553cb9e2483d02fe \
+                    size    59928640
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  3514e67276e47e6c875b13eefcf15fb9512e09a9 \
-                    sha256  7085ec9fe2cb277fc2adf4a5d7d348494b31dbccaa8e3ac3866663600a363d88 \
-                    size    61508241
+    checksums       rmd160  877d19f0c6ddc188d9768d832efa95fa97f5c61e \
+                    sha256  e91d1f8077450afe2dd23a8f549f1d62a1a426f27259fac2e16364a09fbde607 \
+                    size    61586379
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  f88047f3be90c687c82b3fe2c038a3abcf2d83b2 \
-                    sha256  5791d4f8db12d0d07eada5cdf74a432dcd770bccf32d217e0bc166fb9fe6e0af \
-                    size    61417557
+    checksums       rmd160  f1f4d0d7aaf4739a3bd574edfe790779cb2f2dbe \
+                    sha256  d02e61d44bfee07eb6baf56923337d8f656e538bc853dd648b3f970ce1ec821e \
+                    size    61495460
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 578.0.0.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?