### PR TITLE
gemini-cli: update to 0.53.1

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                gemini-cli
-version             0.53.0
+version             0.53.1
 revision            0
 
 categories          llm
@@ -21,9 +21,9 @@ homepage            https://geminicli.com
 npm.rootname        @google/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  61d60a9307ad7ef2fd1a05adb6b6cd4eeb0bddba \
-                    sha256  13bcdb2b3b5f36fbb9407b38145f1798466db8bbf384553e116642fc49c7208a \
-                    size    20678169
+checksums           rmd160  85e28f0a9e240f5f3857e4d565eb96d8e2ea119c \
+                    sha256  9d9f3ab9c7c6a0d6048f150372d5f11015e5c6420ec9c257c6b68a652a4f75ce \
+                    size    24773390
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to Gemini CLI 0.53.1.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?