### PR TITLE
cloudmonkey, autorestic, amfora: declare the Go they need

### DIFF
--- a/net/amfora/Portfile
+++ b/net/amfora/Portfile
@@ -5,7 +5,8 @@ PortGroup           golang 1.0
 
 go.setup            github.com/makeworld-the-better-one/amfora 1.11.0 v
 go.offline_build    no
-revision            0
+go.toolchain_min    1.24
+revision            1
 
 description         A fancy terminal browser for the Gemini protocol.
 

--- a/sysutils/autorestic/Portfile
+++ b/sysutils/autorestic/Portfile
@@ -5,7 +5,8 @@ PortGroup           golang 1.0
 
 go.setup            github.com/cupcakearmy/autorestic 1.8.3 v
 go.offline_build    no
-revision            0
+go.toolchain_min    1.21
+revision            1
 
 categories          sysutils
 installs_libs       no

--- a/sysutils/cloudmonkey/Portfile
+++ b/sysutils/cloudmonkey/Portfile
@@ -5,8 +5,9 @@ PortGroup           golang 1.0
 
 go.setup            github.com/apache/cloudstack-cloudmonkey 6.5.0
 go.offline_build    no
+go.toolchain_min    1.20
 name                cloudmonkey
-revision            0
+revision            1
 
 description         CloudMonkey is a command line interface for Apache \
                     Cloudstack.


### PR DESCRIPTION
### Summary

Declares `go.toolchain_min` on three more Go ports, so that systems which
cannot build them skip them instead of failing. With `rclone`, already merged,
this covers every band where the gate behaves differently.

None of the four has a version update pending, so the declarations will not go
stale under a bump.

### Coverage

Each port gates one band lower than the next, so every boundary is exercised by
exactly one of them:

| port | go.mod | 10.6 | 10.7–10.12 | 10.13–10.14 | 10.15 | 11 | 12 | 13+ |
|---|---|---|---|---|---|---|---|---|
| cloudmonkey | 1.20 | skip | skip | build | build | build | build | build |
| autorestic | 1.21 | skip | skip | skip | build | build | build | build |
| amfora | 1.24 | skip | skip | skip | skip | build | build | build |
| rclone *(merged)* | 1.25.0 | skip | skip | skip | skip | skip | build | build |

All three build in module mode, so Go reads `go.mod` and enforces the `go`
directive rather than ignoring it.

### What this is meant to find out

`rclone` was the straightforward case. Its directive is three-component, a form
that only became legal in Go 1.21, so an older toolchain cannot parse `go.mod`
at all and the declaration is certainly right. Ten builders went from failing to
skipping.

The other three declare two-component versions, which any toolchain parses. The
build then proceeds and fails only if the source actually reaches for something
newer — or it succeeds.

Two of them have archives of their current version on systems these annotations
now skip: `autorestic` on 10.13 and 10.14, `amfora` on 10.15. Either those
archives predate the current `go.mod`, in which case the annotations are right,
or a module-mode declaration can overstate what the source needs. The second
would mean seeding annotations from `go.mod` alone skips ports that work, and it
is worth knowing on three ports rather than on several hundred.

`cloudmonkey` has no such archives and is the control.

### Testing

Verified for each port at every ceiling that it is gated exactly where intended
and nowhere else. All four lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

See: https://trac.macports.org/ticket/73086
