### PR TITLE
sing-box: new port

### DIFF
--- a/net/sing-box/Portfile
+++ b/net/sing-box/Portfile
@@ -1,0 +1,79 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/sagernet/sing-box 1.13.15 v
+revision            0
+name                sing-box
+categories          net security
+homepage            https://sing-box.sagernet.org/
+maintainers         nomaintainer
+license             GPL-3+
+
+description         The universal proxy platform
+
+long_description    sing-box is a universal proxy platform supporting many protocols \
+                    and platforms, including SOCKS, HTTP, Shadowsocks, VMess, VLESS, \
+                    Trojan, WireGuard, QUIC/Hysteria, TUN, and more. It aims to be \
+                    general, stable and high performance.
+
+checksums           rmd160  cbdf8f00a6d4d3196c5da71fd387fa1145a6a07e \
+                    sha256  b43456c0cb2d4d7b81664010b2149a35ed6e3f6c245d78bcc7caf27c46eca816 \
+                    size    953016
+
+go.offline_build    no
+go.toolchain_min    1.24
+
+build.env-append    GOTOOLCHAIN=local
+
+# Build tags and ldflags match the official darwin release (release/DEFAULT_BUILD_TAGS).
+build.args          -o ./${name}
+build.post_args     -trimpath \
+                    -tags with_gvisor,with_quic,with_dhcp,with_wireguard,with_utls,with_acme,with_clash_api,with_tailscale,with_ccm,with_ocm,with_naive_outbound,badlinkname,tfogo_checklinkname0 \
+                    -ldflags='-X github.com/sagernet/sing-box/constant.Version=${version} -X internal/godebug.defaultGODEBUG=multipathtcp=0 -checklinkname=0 -s -w -buildid='
+build.dir           ${worksrcpath}/cmd/sing-box
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/cmd/sing-box/${name} ${destroot}${prefix}/bin/
+    xinstall -d ${destroot}${prefix}/etc/${name}
+    # minimal local-only config: mixed SOCKS/HTTP proxy on 127.0.0.1:2080
+    set config [open "${destroot}${prefix}/etc/${name}/config.json" w]
+    puts $config {{
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "inbounds": [
+    {
+      "type": "mixed",
+      "listen": "127.0.0.1",
+      "listen_port": 2080
+    }
+  ],
+  "outbounds": [
+    {
+      "type": "direct"
+    }
+  ]
+}}
+    close $config
+}
+
+post-destroot {
+    file rename ${destroot}${prefix}/etc/${name}/config.json ${destroot}${prefix}/etc/${name}/config.json.example
+}
+
+post-activate {
+    if {![file exists ${prefix}/etc/${name}/config.json]} {
+        file copy ${prefix}/etc/${name}/config.json.example ${prefix}/etc/${name}/config.json
+    }
+}
+
+startupitem.create          yes
+startupitem.executable      ${prefix}/bin/${name} run -c ${prefix}/etc/${name}/config.json
+
+notes "
+    The default configuration file is copied to ${prefix}/etc/${name}/config.json.\
+    It is used by the startup item (service). You should edit or replace it.
+"


### PR DESCRIPTION
#### Description

New port: sing-box 1.13.15, a universal proxy platform (SOCKS/HTTP, Shadowsocks, VMess, VLESS, Trojan, WireGuard, Hysteria, TUN, ...). Source build via the golang PortGroup with the same tags/ldflags as upstream release binaries.

###### Type(s)
<!-- submission: new Portfile (auto-detected) -->

###### Tested on
macOS 12.5
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
