### PR TITLE
php-phalcon5: update to 5.18.0

### DIFF
--- a/php/php-phalcon/Portfile
+++ b/php/php-phalcon/Portfile
@@ -8,34 +8,34 @@ PortGroup               obsolete 1.0
 # keep it updated and don't delete it.
 
 name                    php-phalcon
-version                 5.16.0
+version                 5.18.0
 revision                0
 maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license                 BSD
 
 # https://docs.phalcon.io/5.9/releases/
 subport php85-phalcon {
-    version             5.16.0
+    version             5.18.0
     revision            0
 }
 
 subport php84-phalcon {
-    version             5.16.0
+    version             5.18.0
     revision            0
 }
 
 subport php83-phalcon {
-    version             5.16.0
+    version             5.18.0
     revision            0
 }
 
 subport php82-phalcon {
-    version             5.16.0
+    version             5.18.0
     revision            0
 }
 
 subport php81-phalcon {
-    version             5.16.0
+    version             5.18.0
     revision            0
 }
 

--- a/php/php-phalcon5/Portfile
+++ b/php/php-phalcon5/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
 PortGroup               php 1.1
 
 name                    php-phalcon5
@@ -8,35 +9,29 @@ maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @Bjar
 license                 BSD
 
 php.branches            7.4 8.0 8.1 8.2 8.3 8.4 8.5
-php.pecl                yes
-php.pecl.name           phalcon
-set pecl_homepage       https://pecl.php.net/package/${php.pecl.name}
 
 if {[vercmp ${php.branch} <= 7.4]} {
     conflicts-append    ${php}-phalcon4
 }
 
 if {[vercmp ${php.branch} >= 8.1]} {
-    version             5.16.0
-    distname            ${php.pecl.name}-${version}
+    github.setup        phalcon cphalcon 5.18.0 v
     revision            0
-    checksums           rmd160  678932f2517050c54329a5c56d5416f5e8f5b1c6 \
-                        sha256  33db2df75a81224f710a2435f7f81c5fe1486ea1fb11579f66c4875a28b4d607 \
-                        size    1364235
+    checksums           rmd160  c716d5d77d41d66ccd0de7218af29df0f82a1bd1 \
+                        sha256  1eee4eeb8c8a9ce635bd85a29cd4179a6100557f6d0a231d16560e4b9dfc9789 \
+                        size    1608864
 } elseif {[vercmp ${php.branch} >= 8.0]} {
-    version             5.8.0
-    distname            ${php.pecl.name}-${version}
+    github.setup        phalcon cphalcon 5.8.0 v
     revision            0
-    checksums           rmd160  7431f619589c60426892ba9deff7eb7d1c78018b \
-                        sha256  d80b137763b790854c36555600a23b1aa054747efd0f29d8e1a0f0c5fa77f476 \
-                        size    967103
+    checksums           rmd160  cac79b26b1d8cc6b9408ddcbbd5038f1c0857d3d \
+                        sha256  c49cfc301209f4719de9d02979add21b906248b5a5b50376dbb831e711d6ec48 \
+                        size    6151691
 } elseif {[vercmp ${php.branch} >= 7.4]} {
-    version             5.4.0
-    distname            ${php.pecl.name}-${version}
+    github.setup        phalcon cphalcon 5.4.0 v
     revision            0
-    checksums           rmd160  17e92cc6a21138081a6bdc84a8e2ab53756be7af \
-                        sha256  47810a0aaa20c1a3cf0a2d7babccfa1870fa0fc78d30cefd45ed808f89d47619 \
-                        size    966058
+    checksums           rmd160  065bee36a48f88f7e171248ad42520816214d55e \
+                        sha256  bd6c3ee8b3a98a82828773e48b56c3029d4127087b12f0d051db0e7b1ed0b5c6 \
+                        size    6133723
 }
 
 if {[vercmp ${php.branch} <= 8.0]} {
@@ -55,11 +50,13 @@ long_description        Phalcon is an open source full stack framework for \
                         PHP frameworks employ.
 
 homepage                https://phalcon.io
+github.tarball_from     archive
 dist_subdir             php-phalcon
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:${php}-psr \
                         port:pcre
 
+    php.build_dirs      [list "${worksrcpath}/build/phalcon"]
     configure.args      --enable-phalcon
 }

--- a/php/php-phalcon5/files/patch_phalcon.zep.c.diff
+++ b/php/php-phalcon5/files/patch_phalcon.zep.c.diff
@@ -1,8 +1,8 @@
 [BUG]: Fails to compile on php 8.5
 https://github.com/phalcon/cphalcon/issues/16808
 
---- a/phalcon.zep.c	2026-02-27 14:16:05
-+++ b/phalcon.zep.c	2026-02-27 14:17:35
+--- a/build/phalcon/phalcon.zep.c	2026-02-27 14:16:05
++++ b/build/phalcon/phalcon.zep.c	2026-02-27 14:17:35
 @@ -58,7 +58,7 @@
  #include <main/php_ini.h>
  #include <main/SAPI.h>


### PR DESCRIPTION
#### Description
Update & gone from PECL to GitHub due to the deprecation of PECL in favour of PIE
Developers have announced, that future major versions won't be published on PECL
###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix
