### PR TITLE
dav1d: Update to 1.5.4

### DIFF
--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -11,12 +11,12 @@ legacysupport.newest_darwin_requires_legacy 9
 name                dav1d
 # Please increase the revision of libheif, ffmpeg and ffmpeg-devel whenever
 # dav1d's version is updated.
-version             1.5.3
+version             1.5.4
 revision            0
 
-checksums           rmd160  ecd0104e3a844b2457a53fbff6ec4436c0c37c5e \
-                    sha256  f92b3895acc508d44a3941276420371c8829ce8c1f62b076ab347650a4699bf3 \
-                    size    1214666
+checksums           rmd160  d695873234ac145285bfb9785a813888fd3af4bc \
+                    sha256  686616b7c69eb88d44459391ab25cac13b6647a3b288835c5784e71c1514a5c5 \
+                    size    1038852
 
 categories          multimedia
 license             BSD
@@ -27,14 +27,8 @@ long_description    dav1d is an AV1 decoder that is open-source, cross-platform 
                     focused on speed, size and correctness.
 
 homepage            https://www.videolan.org/projects/dav1d.html
-master_sites        https://code.videolan.org/videolan/dav1d/-/archive/${version}/
-distname            ${name}_${version}
-# extracted directory contains a hash
-if {[exists extract.rename]} {
-extract.rename      yes
-}
-
-use_bzip2           yes
+master_sites        https://downloads.videolan.org/pub/videolan/dav1d/${version}/
+use_xz              yes
 
 # nasm is not needed on arm64 platforms
 if { ${build_arch} in "i386 x86_64" || [variant_isset universal] } {

--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -27,7 +27,8 @@ long_description    dav1d is an AV1 decoder that is open-source, cross-platform 
                     focused on speed, size and correctness.
 
 homepage            https://www.videolan.org/projects/dav1d.html
-master_sites        https://downloads.videolan.org/pub/videolan/dav1d/${version}/
+set download_site   https://downloads.videolan.org/pub/videolan/${name}
+master_sites        ${download_site}/${version}/
 use_xz              yes
 
 # nasm is not needed on arm64 platforms
@@ -73,5 +74,5 @@ post-destroot {
         ${destroot}${docdir}
 }
 
-livecheck.url       https://download.videolan.org/pub/videolan/${name}/
+livecheck.url       ${download_site}
 livecheck.regex     {>([0-9.]+)/<}

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -17,7 +17,7 @@ set my_name         ffmpeg
 conflicts           ffmpeg
 
 version             8.1.1
-revision            1
+revision            2
 epoch               2
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -18,7 +18,7 @@ conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             8.1.2
-revision            0
+revision            1
 epoch               1
 
 license             LGPL-2.1+

--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -30,7 +30,7 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
 
 if {${which_version} eq "latest"} {
     github.setup            strukturag libheif 1.23.1 v
-    revision                0
+    revision                1
 
     checksums               rmd160  52f1ade573cd8c3137d06e09a0019462d4481193 \
                             sha256  0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a \
@@ -39,7 +39,7 @@ if {${which_version} eq "latest"} {
     compiler.cxx_standard   2020
 } else {
     github.setup            strukturag libheif 1.18.2 v
-    revision                5
+    revision                6
 
     checksums               rmd160  fb41f7c4d109883a214b8db5db1039809a3fb8eb \
                             sha256  c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf \


### PR DESCRIPTION
#### Description

* Update dav1d 1.5.3 --> 1.5.4.
* Rev bump dependents as indicated in portfile comment.
* Switch distfile source from code repo, to intended upstream archive site.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
