### PR TITLE
opencode: update to 1.18.11

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.18.10
+version             1.18.11
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  17a4e8f154766a1dad6d968104ede978ed221eba \
-                    sha256  c135d5cb88407888f7d67ddb4a2e30f27109a8b9e8922282674b8abb34226bd8 \
-                    size    3048
+checksums           rmd160  e7de102f245321560e44cd6bd53e562bb601f285 \
+                    sha256  c068cf8596484588f308a4ad5e914ec78f5c5da9a7c3383d254d57d4a0bf202c \
+                    size    3047


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.11.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?