### PR TITLE
privoxy: compile with extended-statistics, large-file-support, pcre-host-patterns, zstd

### DIFF
--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                privoxy
 version             4.1.0
-revision            0
+revision            1
 categories          www security net
 license             GPL-2
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -98,7 +98,8 @@ if {${name} eq ${subport}} {
     depends_lib-append \
                     port:brotli \
                     port:pcre2 \
-                    port:zlib
+                    port:zlib \
+                    port:zstd
 
     depends_run-append \
                     port:perl${perl5.major} \
@@ -150,7 +151,11 @@ if {${name} eq ${subport}} {
                     --mandir=${prefix}/share/man \
                     --enable-compression \
                     --enable-dynamic-pcre \
+                    --enable-extended-statistics \
+                    --enable-large-file-support \
+                    --enable-pcre-host-patterns \
                     --enable-zlib \
+                    --enable-zstd \
                     --with-brotli
 
     # work around bug 30345
@@ -527,7 +532,7 @@ TLS_PRIVOXY_ROOT_CA
                     "\t&& \"\${prefix}/sbin/${name}\" \\" \
                     "\t\t--pidfile \"\${pidfile}\" \\" \
                     "\t\t--user ${privoxyUser} \\" \
-                    "\t\t\"${prefix}/etc/${name}/config\" 2>/dev/null" \
+                    "\t\t\"\${prefix}/etc/${name}/config\" 2>/dev/null" \
         ] \
         stop [list  "if \[ -f \"\${pidfile}\" \]; then" \
                     "\tkill \$(cat \"\${pidfile}\") \\" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
