### PR TITLE
enblend: fix build

### DIFF
--- a/graphics/enblend/Portfile
+++ b/graphics/enblend/Portfile
@@ -3,9 +3,11 @@
 PortSystem      1.0
 PortGroup       boost 1.0
 
+boost.version   1.88
+
 name            enblend
 version         4.2
-revision        8
+revision        9
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      graphics
 maintainers     nomaintainer
@@ -24,19 +26,16 @@ checksums       rmd160  997a849a39da3f367b666c6d0d344059d97738d7 \
                 size    777747
 
 depends_build   port:pkgconfig \
-                port:texlive-latex \
                 port:help2man
 
-depends_lib     port:glew \
-                port:gnuplot \
-                port:gsl \
+depends_lib     port:gsl \
                 path:include/turbojpeg.h:libjpeg-turbo \
                 port:lcms2 \
                 port:libpng \
-                port:libxmi \
-                port:mesa \
                 port:openexr2 \
-                port:vigra
+                port:tiff \
+                port:vigra \
+                port:zlib
 
 configure.args  --with-openexr
 configure.pkg_config_path-append \
@@ -51,9 +50,26 @@ configure.cxxflags-append -std=c++11
 compiler.blacklist-append \
                 {clang < 1000}
 
+set perl_branch  5.34
+
+# bold-extra sets OT1 bold small caps in cmbcsc10, which TeX Live ships as
+# METAFONT sources only.  pdfTeX renders it as a bitmap font, and microtype's
+# automatic font expansion fails outright on those.  Turn the expansion off.
+set tex_preamble {\def\finishdynamicpreamble{\ifpdf\microtypesetup{expansion=false}\fi}}
+
 post-patch {
     # avoid c++17 header collision
     move ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt
+
+    # fix a boost path for the BOOST_FALLTHROUGH check
+    reinplace "s|boost/config/suffix\\.hpp|boost/config.hpp|" \
+        ${worksrcpath}/configure
+
+    if {[variant_isset docs]} {
+        reinplace -W ${worksrcpath}/doc \
+            "s|^#! /usr/bin/env perl|#!${prefix}/bin/perl${perl_branch}|" \
+            cleantex config2tex docstrings updated-on
+    }
 }
 
 post-destroot {
@@ -62,5 +78,61 @@ post-destroot {
         AUTHORS COPYING NEWS README \
         ${destroot}${prefix}/share/doc/${name}
 }
+
+variant docs description {Build HTML and PDF docs} {
+    depends_build-append \
+                port:ghostscript \
+                port:gnuplot \
+                port:graphviz \
+                port:hevea \
+                port:ImageMagick \
+                port:librsvg \
+                port:m4 \
+                port:p${perl_branch}-readonly \
+                port:perl${perl_branch} \
+                port:texlive-fonts-extra \
+                port:texlive-fonts-recommended \
+                port:texlive-fontutils \
+                port:texlive-latex-extra
+
+    configure.args-append \
+                M4=${prefix}/bin/gm4
+
+    build.args-append \
+                DYNAMIC_TEX_PREAMBLE=[shellescape ${tex_preamble}]
+
+    # pdf is not built in make all
+    post-build {
+        system -W ${worksrcpath} \
+            "${build.cmd} pdf DYNAMIC_TEX_PREAMBLE=[shellescape ${tex_preamble}]"
+    }
+
+    destroot.target-append \
+                install-html install-pdf
+    destroot.args-append \
+                htmldir=${destroot}${prefix}/share/doc/${name}/html \
+                pdfdir=${destroot}${prefix}/share/doc/${name} \
+                DYNAMIC_TEX_PREAMBLE=[shellescape ${tex_preamble}]
+}
+
+if {![variant_isset docs]} {
+    # force configure to skip docs even if we happen
+    # to have latex etc installed
+    configure.args-append \
+                ac_cv_prog_latex=false \
+                ac_cv_path_CONVERT=false \
+                ac_cv_path_DOT=false \
+                ac_cv_path_DVIPS=false \
+                ac_cv_path_GNUPLOT=false \
+                ac_cv_path_MAKEINDEX=false \
+                ac_cv_path_SVGCONVERT=false
+}
+
+variant openmp description {Use OpenMP} {
+    compiler.openmp_version 2.5
+    configure.args-append   --enable-openmp
+}
+
+default_variants +openmp
 
 livecheck.regex   /enblend-enfuse-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
Split docs into a +doc variant and make it work. Also enable OpenMP by default.

Closes: https://trac.macports.org/ticket/70173

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
