### PR TITLE
xmoto: update to 0.6.3, add nilFinx as maintainer

### DIFF
--- a/games/xmoto/Portfile
+++ b/games/xmoto/Portfile
@@ -1,13 +1,14 @@
-PortSystem 1.0
-PortGroup app 1.0
+PortSystem      1.0
+PortGroup       cmake       1.1
+PortGroup       github      1.0
 
 name            xmoto
-version         0.5.11
-revision        1
+version         0.6.3
+revision        0
 categories      games
 platforms       macosx
 license         GPL-2
-maintainers     nomaintainer
+maintainers     {disroot.org:nulflox @nilFinx} openmaintainer
 
 description     X-Moto is a challenging 2D motocross platform game
 long_description \
@@ -16,20 +17,25 @@ long_description \
                 to control your bike to its limits, if you want to have a \
                 chance to finish the most difficult challenges.
 
-homepage        http://xmoto.tuxfamily.org/
-master_sites    http://download.tuxfamily.org/xmoto/xmoto/${version}/
-distname        ${name}-${version}-src
-worksrcdir      ${name}-${version}
+homepage            https://xmoto.tuxfamily.org/
+github.setup        xmoto xmoto 0.6.3 v
+github.tarball_from archive
+checksums           rmd160  488283e7b51439952f296f96189882354e8523ea \
+                    sha256  64cb29934660456ec82cebdaa0d3d273a862e10760e8ee80443928d317242484 \
+                    size    42113475
 
-checksums       rmd160  4b005c37871489f54c16c9557e6a8556cd2121b4 \
-                sha256  a584a6f9292b184686b72c78f16de4b82d5c5b72ad89e41912ff50d03eca26b2
+depends_build-append \
+                path:bin/pkg-config:pkgconfig
 
 depends_lib     port:libpng \
                 path:include/turbojpeg.h:libjpeg-turbo \
-                port:libsdl \
-                port:libsdl_mixer \
-                port:libsdl_ttf \
-                port:libsdl_net \
+                port:libsdl2 \
+                port:libsdl2_mixer \
+                port:libsdl2_ttf \
+                port:libsdl2_net \
+                port:libxml2 \
+                port:zlib \
+                port:gettext \
                 port:lua \
                 port:ode \
                 port:sqlite3 \
@@ -37,14 +43,16 @@ depends_lib     port:libpng \
                 port:curl \
                 port:libxdg-basedir
 
-configure.args-append --with-apple-opengl-framework --disable-sdltest
+cmake.install_prefix \
+                ${applications_dir}
 
-# xmoto does not pick up flags for ode correctly, so we do this manually
-# http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=521013
-configure.cflags-append  -DdDOUBLE
-configure.cxxflags-append -DdDOUBLE
+configure.args-append \
+                -DBUILD_MACOS_BUNDLE=ON \
+                -DSDL2_TTF_IBRARY=${prefix}/lib/
 
-app.icon ${filespath}/xmoto.png
+patchfiles      build-fix.diff
+
+compiler.cxx_standard   2011
 
 livecheck.type  regex
 livecheck.regex {XMoto ([\d.]+) released}

--- a/games/xmoto/files/build-fix.diff
+++ b/games/xmoto/files/build-fix.diff
@@ -1,0 +1,88 @@
+--- bin/CMakeLists.txt.orig
++++ bin/CMakeLists.txt
+@@ -33,9 +33,15 @@ if(WIN32)
+   install(DIRECTORY Textures/Fonts DESTINATION ./Textures)
+ elseif(BUILD_MACOS_BUNDLE)
+   install(CODE "
++  if(DEFINED ENV{DESTDIR})
++    set(ACTUAL_PREFIX \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
++  else()
++    set(ACTUAL_PREFIX \"\${CMAKE_INSTALL_PREFIX}\")
++  endif()
++
+   set(RESOURCES_DIR_PATH
+     # CPACK_BUNDLE_NAME is set in cpack/macos.cmake
+-    \"\${CMAKE_INSTALL_PREFIX}/${CPACK_BUNDLE_NAME}.app/Contents/Resources\")
++    \"\${ACTUAL_PREFIX}/${CPACK_BUNDLE_NAME}.app/Contents/Resources\")
+
+   execute_process(COMMAND \"\${CMAKE_COMMAND}\"
+     -E copy
+--- cpack/macos.cmake.orig
++++ cpack/macos.cmake
+@@ -27,7 +27,7 @@ if(BUILD_MACOS_BUNDLE)
+
+   install(CODE "
+     include(BundleUtilities)
+-    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${CPACK_BUNDLE_NAME}.app\"  \"\"  \"\")
+-    execute_process(COMMAND codesign --deep --force --sign - \"\${CMAKE_INSTALL_PREFIX}/${CPACK_BUNDLE_NAME}.app\")
++#    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${CPACK_BUNDLE_NAME}.app\"  \"\"  \"\")
++#    execute_process(COMMAND codesign --deep --force --sign - \"\${CMAKE_INSTALL_PREFIX}/${CPACK_BUNDLE_NAME}.app\")
+     " COMPONENT Runtime)
+ endif()
+--- src/CMakeLists.txt.orig
++++ src/CMakeLists.txt
+@@ -518,7 +518,6 @@ target_link_libraries(xmoto PUBLIC
+   ode
+   glad
+   ${CMAKE_DL_LIBS}
+-  ${OPENGL_LIBRARIES}
+   ${PNG_LIBRARIES}
+   ${SDL2_LIBRARIES}
+   ${SDL2_MIXER_LIBRARY}
+@@ -531,6 +530,14 @@ target_link_libraries(xmoto PUBLIC
+   $<$<PLATFORM_ID:Darwin>:${COREFOUNDATION_LIBRARY}>
+ )
+
++# Fixes an on-boot issue on OS X 10.9, at least.
++if(APPLE)
++  set(OPENGL_LIBRARIES "-framework OpenGL")
++  target_link_libraries(xmoto PUBLIC ${OPENGL_LIBRARIES})
++else()
++  target_link_libraries(xmoto PUBLIC OpenGL::GL)
++endif()
++
+ set_property(TARGET xmoto PROPERTY CXX_STANDARD 11)
+ # strip release builds
+ set_target_properties(xmoto PROPERTIES LINK_FLAGS_RELEASE -s)
+--- src/xmoto/UserConfig.cpp.orig
++++ src/xmoto/UserConfig.cpp
+@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ #include "common/VXml.h"
+ #include "helpers/Log.h"
+ #include "helpers/VExcept.h"
++#include <stdlib.h>
+
+ /*===========================================================================
+ Load from XML
+--- src/xmoto/input/Joystick.cpp.orig
++++ src/xmoto/input/Joystick.cpp
+@@ -86,7 +86,7 @@ bool JoystickInput::joyAxisRepeat(JoyAxisEvent event) {
+   }
+
+   JoyDir dir = getJoyAxisDir(event.axisValue);
+-  bool dirSame = dir != 0 && std::abs(dir) == std::abs(axis.lastDir);
++  bool dirSame = dir != 0 && std::abs((double)dir) == std::abs((double)axis.lastDir);
+
+   if (!dirSame && axis.isHeld)
+     return false;
+--- src/xmscene/PhysicsSettings.cpp.orig
++++ src/xmscene/PhysicsSettings.cpp
+@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ #include "PhysicsSettings.h"
+ #include "common/VXml.h"
+ #include "helpers/VExcept.h"
++#include <stdlib.h>
+
+ PhysicsSettings::PhysicsSettings(const std::string &i_filename) {
+   load(FDT_DATA, i_filename);
+


### PR DESCRIPTION
#### Description

Updates the xmoto port to v0.6.3, and add nilFinx (myself) as maintainer, replacing nomaintainer with that and openmaintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
