### PR TITLE
libpsl: update to 0.23.1

### DIFF
--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           clang_dependency 1.0
 
 epoch               1
-github.setup        rockdaboot libpsl 0.23.0
+github.setup        rockdaboot libpsl 0.23.1
 
 license             MIT
 description         A C library and utility to handle the Public Suffix List
@@ -15,9 +15,9 @@ categories          net
 
 github.tarball_from releases
 
-checksums           rmd160  19a8f10cbd6ec309aa1bc3b0fda249a2acf43862 \
-                    sha256  f39b9631b3d369a21259ea4654f8875c0ec6995ce9551c0eb5d423e4c011f911 \
-                    size    7822832
+checksums           rmd160  422fc5f83902badf623d2b277e924b0830e31524 \
+                    sha256  8fbb03054556498ba9c4cc48fcaa36a4483748c6504a65bdb9ba348f555b0e56 \
+                    size    7821902
 
 # Please note this port is (indirectly, via cmake) a dependency of the
 # various clang-X ports. When updating the port versions


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update libpsl to 0.23.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
