### PR TITLE
javascript-lint: fix patch application on older systems

### DIFF
--- a/lang/javascript-lint/files/add-unistd-include.patch
+++ b/lang/javascript-lint/files/add-unistd-include.patch
@@ -1,6 +1,6 @@
---- editline/editline.c.orig	2006-10-25 06:00:00.000000000 +1000
+--- editline/editline.c.orig
 +++ editline/editline.c
-@@ -63,6 +63,7 @@
+@@ -64,6 +64,7 @@
  #include "editline.h"
  #include <signal.h>
  #include <ctype.h>
@@ -8,14 +8,12 @@
  
  /*
  **  Manifest constants.
-@@ -155,8 +156,10 @@
+@@ -154,8 +155,6 @@
  **  Declarations.
  */
  STATIC CHAR	*editinput();
-+#ifndef _UNISTD_H_
- extern int	read();
- extern int	write();
-+#endif /* _UNISTD_H_ */
+-extern int	read();
+-extern int	write();
  #if	defined(USE_TERMCAP)
  extern char	*getenv();
  extern char	*tgetstr();


### PR DESCRIPTION
Follow-up to #33755, which fixed the build on modern macOS but broke `patch` application on older systems.

### Problem

`add-unistd-include.patch` was written with CRLF line endings on **every** line, including the `---`/`+++`/`@@` headers. Older versions of `patch(1)` see DOS line endings in the headers, decide the whole patch is a DOS file, and strip trailing CRs from the *content* lines as well. Since `editline.c` itself has CRLF line endings, the stripped context no longer matches:

```
(Stripping trailing CRs from patch.)
patching file editline/editline.c
Hunk #1 FAILED at 63.
Hunk #2 FAILED at 156.
2 out of 2 hunks FAILED -- saving rejects to file editline/editline.c.rej
```

Seen on [ports-12_x86_64-builder build 163836](https://build.macports.org/builders/ports-12_x86_64-builder/builds/163836/steps/install-port/logs/stdio).

### Fix

Regenerated the patch with `diff(1)` so the headers use LF and only the content lines carry CRLF — the same layout as the existing `find-va_copy.patch`, which applies correctly on every platform (it applies fine in that same failing log).

Also dropped the legacy K&R declarations of `read()` and `write()` outright rather than guarding them with the private `_UNISTD_H_` macro, since `<unistd.h>` supplies the correct prototypes on all supported OS versions. This avoids depending on an implementation-private include guard.

### Verification

Against a fresh extract of the distfile (sha256 verified against the Portfile), using the exact command MacPorts runs (`patch -t -N -p0` from `${worksrcpath}`):

- Both patches apply cleanly, with **no** "Stripping trailing CRs" message
- `make -f Makefile.ref` completes with **0 errors**
- Resulting binary runs: `JavaScript Lint 0.3.0 (JavaScript-C 1.5 2004-09-24)`

No `revision` bump, as the compiled result is unchanged on platforms where the previous patch applied.
