### PR TITLE
pinact: Update to 4.1.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 4.1.0 v
+go.setup            github.com/suzuki-shunsuke/pinact 4.1.1 v
 go.offline_build    no
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
@@ -18,9 +18,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6055da1f63caabe4c7b3a807b00837afa7487bcb \
-                    sha256  0305c7db5cfcb2a62f7f5faa74e7cc3312c9ec10cbe01eadc23128d6a119eb03 \
-                    size    105638
+                    rmd160  804181cd855f61730bc9a37c810aa952f1da6ab5 \
+                    sha256  d7b2596e871bdd1711c9d81cf074ac4d51e2555509f9f19eafca4ced11b555fa \
+                    size    105886
 
 livecheck.regex     {v(\d+\.\d+\.\d+)$}
 


### PR DESCRIPTION
#### Description

pinact: Update to 4.1.1


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
