### PR TITLE
mise: Update to 2026.8.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.7.14 v
+github.setup        jdx mise 2026.8.0 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  66a5180f2b1b94471bf63fc74a9989809bbf90fa \
-                    sha256  75fd7c1b43c2d2af5b8cf3716aaf809f92f20919ee65f7febef1e0659e1ccf74 \
-                    size    12696744
+                    rmd160  7cd0d07e2f767eb25d6b82c2a99f73aaad88ed2f \
+                    sha256  c053fb4f4373712e72505b3b1e2a3088a8fa165e621fd50882dc231feb659a0b \
+                    size    12949941
 
 depends_build-append \
                     port:bin/cmake:cmake
@@ -98,7 +98,7 @@ cargo.crates \
     aead                                 0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
     aead                                 0.6.1  1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99 \
     aes                                  0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
-    aes                                  0.9.1  f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138 \
+    aes                                  0.9.2  f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58 \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
     aes-kw                               0.2.1  69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c \
     age                                 0.11.5  047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43 \
@@ -139,19 +139,19 @@ cargo.crates \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
     async-trait                         0.1.91  ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    aube                                1.33.1  551ab991fd7d877da9f94099163cc278336b52a5a27f6d0d53bf2a99119e1e75 \
-    aube-codes                          1.33.1  142d0a70354e58d16a4550c49ea9c7b8b6e4c608d00c66fbfbe63a26f4e19456 \
-    aube-linker                         1.33.1  a64288c1754206e9c02f6de7c1c2a07925b5ddccda04652885c2873c7818cca6 \
-    aube-lockfile                       1.33.1  5b8766aa34b4f27b87399ca95ececb29b28754f11245cda65e41af49e9ff7515 \
-    aube-manifest                       1.33.1  5d874c3b77ef64260d3ffc0004238d921a4ea2bde7e942f4d3ad9d880f389a45 \
-    aube-registry                       1.33.1  c5c823bd9dc7f4fafc73143fc245f736daa4221385d566cf0a77277216b219c4 \
-    aube-resolver                       1.33.1  26e64a34e8de78be4e274bebcd83e7b5bbcfaefe20b9a083429a1afad7bff4af \
-    aube-runtime                        1.33.1  e81cd711e9a73565f51b61ab0f37866a3bc57dd7aa3825a4553af63a7f0b1018 \
-    aube-scripts                        1.33.1  fa129c5b70bf7d6e3a609de1e2bc14ed6f425974b99023123371a19b5edfd6f4 \
-    aube-settings                       1.33.1  377fcdc8fe07f4b30f11588efcefb41328f6a9d9f1e3dc0e2ce8da2a92fd892d \
-    aube-store                          1.33.1  712a6f0483e4207eecc50caf814465d43e634d04467ddac3a491c4462c23714a \
-    aube-util                           1.33.1  08b729c64f4ad8143c1da960561d14014fa0b9069609a23c4f58c5b74b5443eb \
-    aube-workspace                      1.33.1  d543ba7b5ee964f9f0a021398f68ab8f6fea938ea17bb3ffed1530660d5f48c5 \
+    aube                                1.37.0  1adc6f39cc5afd58a6cc578dfcb4dafcab9fe14fb6dbcaa2d50a530aa6ed558e \
+    aube-codes                          1.37.0  57b802f0a009c344d3a493c4f9f67f50e0012522db7eea32c53086bfbe231a4b \
+    aube-linker                         1.37.0  2e7dfa60c4ad71e79dc811119ea8d53f5a17b5b2ad812e141002639e3fef3be1 \
+    aube-lockfile                       1.37.0  0ce5c79419dada6ec1a6c4dcd5a5306684f6436b4517224e11adf699c4c357cd \
+    aube-manifest                       1.37.0  e47a036bd03aaeeab293e6be73faf9139b6edbb303bfbddfdf84d5069205751c \
+    aube-registry                       1.37.0  a3e472bea7624c2caae172603f855a6124bc434b4e132fb89e0e7eda22dc3ce3 \
+    aube-resolver                       1.37.0  681fd4570c2e8ccf5b45516ca1c4c8c951eebaf2e1ce2a4e68335e315ea7885f \
+    aube-runtime                        1.37.0  8fe29236d34f652cfdedc5fcb04f73ebc9589431e375ffa6caebd03c4f4df738 \
+    aube-scripts                        1.37.0  7e4e9804d041c81c6ab7c7382d64e1630480088adab0aede900dc3da90f7ddae \
+    aube-settings                       1.37.0  fc67ab05335c6cf84dd02aa7ee411e519d6a2a2b4b765f0183f8dbb45f7a8efe \
+    aube-store                          1.37.0  de2e17b61820b71eef2d09594bfd580a6d3f813be4e036d22704fb2181be9fcc \
+    aube-util                           1.37.0  e4dd6e9f42aa3bd013c823a5a0da673ece1e17cd667a8c73a5941d3abd85921c \
+    aube-workspace                      1.37.0  675be8ee8f9d4b485581774218c76f9c6ce8e1e86309594ea1f103a23da6f3d0 \
     autocfg                              1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
     aws-credential-types                1.2.13  6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0 \
@@ -193,6 +193,8 @@ cargo.crates \
     beef                                 0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                             0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
+    bisync                               0.3.0  5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7 \
+    bisync_macros                        0.2.3  d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6 \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
     bitfields                            1.0.3  ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195 \
@@ -221,16 +223,14 @@ cargo.crates \
     bytes                               1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
     bytes-utils                          0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
     bytesize                             2.4.2  3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e \
-    bzip2                                0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2                                0.6.1  f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c \
-    bzip2-sys                     0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     cache_control                        0.2.0  1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     camellia                             0.1.0  3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30 \
     cast5                               0.11.1  26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                   1.3.0  c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8 \
+    cc                                   1.4.0  5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9 \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfb-mode                             0.8.2  738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
@@ -246,14 +246,14 @@ cargo.crates \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     cipher                               0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
     clang-sys                            1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                                 4.6.3  0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776 \
+    clap                                 4.6.4  d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7 \
     clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
     clap_builder                         4.6.2  f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b \
-    clap_derive                          4.6.3  32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077 \
+    clap_derive                          4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
     clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
-    clap_usage                           2.0.3  7179a7bcab80d71e4524ae4a384cb9180b6ca3eb30d8e398add707541989ce4a \
+    clap_usage                           4.0.0  46d067625f5704e5722fe7e46407fef7e79680d6dfd045d29036149d90ec044b \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
-    clx                                  3.0.0  58ae514e7ddc9e3b7b6d5fd3efe8428ad45273cb0cd69f3d4f6c6fc78b6389de \
+    clx                                  3.0.2  03a65674abcd65c2846d6bfc4c9816ab9177b15277a18a78aa1691683ce63095 \
     cmac                                 0.7.2  8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa \
     cmake                               0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
     cmov                                 0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
@@ -270,16 +270,14 @@ cargo.crates \
     comfy-table                          7.2.2  958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47 \
     compression-codecs                  0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
     compression-core                    0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
-    concurrent-queue                     2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     configparser                         3.2.0  b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4 \
     confique                             0.4.0  06b4f5ec222421e22bb0a8cbaa36b1d2b50fd45cdd30c915ded34108da78b29f \
     confique-macro                      0.0.13  e4d1754680cd218e7bcb4c960cc9bae3444b5197d64563dccccfdf83cab9e1a7 \
     console                             0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     const-oid                            0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const-oid                           0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
-    constant_time_eq                     0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
     constant_time_eq                     0.4.2  3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b \
-    contracts                            0.6.7  008eb94d541da40512913ef5e0707c3fb0e7280ba1af13f062461e46dd96ef7e \
+    contracts                            0.6.8  1be22136880ccef017b6b3d2e2ab23ba62755b308093862bad6b6e78d26d5e46 \
     convert_case                        0.10.0  633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
     cookie                              0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
     cookie-factory                       0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
@@ -306,7 +304,7 @@ cargo.crates \
     crypto-bigint                        0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    ctor                                 1.0.9  a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3 \
+    ctor                                1.0.11  e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209 \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -328,7 +326,7 @@ cargo.crates \
     defmt                                1.1.1  e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1 \
     defmt-macros                         1.1.1  bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8 \
     defmt-parser                         1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
-    demand                               2.0.4  5439b2dab1b826af399f3b21a84538f52102a4b32f0dd59b0c69b40725e20fdd \
+    demand                               2.0.5  6c7f0bec8d94f8eb4d2efec0325ef991480abab44dc42f2f3cbf10c41aeb73fc \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     der                                  0.8.1  a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
@@ -360,7 +358,7 @@ cargo.crates \
     ecdsa                               0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
     ed25519                              2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                        2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
-    either                              1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
+    either                              1.17.0  9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d \
     elliptic-curve                      0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     elsa                                1.11.2  9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e \
     encode_unicode                       1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
@@ -377,7 +375,7 @@ cargo.crates \
     errno                                0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
     errno                               0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
     errno-dragonfly                      0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
-    event-listener                       5.4.1  e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab \
+    event-listener                       5.4.2  5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2 \
     exec                                 0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                            1.1.1  e6e6e9a6990c24970375077a97a392146b5be2155a957d9a4e5337ca0bde0c26 \
     eyre                                0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
@@ -433,63 +431,64 @@ cargo.crates \
     getrandom                            0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     ghash                                0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                               0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
-    gix                                 0.85.0  fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6 \
-    gix-actor                           0.41.1  8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f \
-    gix-archive                         0.34.0  1303ed647e048d2bbecb9fd3a627d753e73f883a20ad5c039b30c7cbc85e217f \
-    gix-attributes                      0.33.2  39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4 \
-    gix-bitmap                           0.3.2  52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283 \
-    gix-blame                           0.15.0  cf49c828ad8a8a674d52caaf0b61fdee1f20cc46c15439ca3d875ef3b6f64bdc \
-    gix-chunk                            0.7.2  9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb \
+    gix                                 0.86.0  bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce \
+    gix-actor                           0.41.2  33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b \
+    gix-archive                         0.35.0  6760ef6ef4edfa6449918977d59518ff209676f47e89bdce87a36a50be35e834 \
+    gix-attributes                      0.34.0  c31c593692ebdc1e38858d9a2b56f6a594c501e24a38971fe6685571f5a07be0 \
+    gix-bitmap                           0.3.3  7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7 \
+    gix-blame                           0.16.0  b06d20ff0e88ada2dd852b3852727b664ec9baefdf653d1d4e722e858c52cd17 \
+    gix-chunk                            0.7.3  b2a871e5cab12ba568845714473505deefffb3c04eb47f4708ce344cd459c1cc \
     gix-command                          0.9.1  00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6 \
-    gix-commitgraph                     0.37.1  7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb \
-    gix-config                          0.58.0  a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583 \
-    gix-config-value                    0.18.1  ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab \
-    gix-credentials                     0.38.2  e8a0fcfcd73229d1a9c34e04edd05dbcb80364ec6f3788d24c546de2916671eb \
+    gix-commitgraph                     0.38.0  a2cd7f054ae2727223fe46dd39c012f066b12f532962d336d29ee193261787da \
+    gix-config                          0.59.0  103d11bef95c467577ecfa8b7b86a22e65af3507b2c9bfa3809a4afbae7df301 \
+    gix-config-value                    0.19.0  9f813e312a3f7f327187823cd4c754a3e4d948c98907d11e8f37554a2b6b8059 \
+    gix-credentials                     0.39.0  73b637f873d5f9aa67e672c1b23741a18e046d33028017adede32f4b4087a2e7 \
     gix-date                            0.15.6  7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567 \
-    gix-diff                            0.65.0  92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3 \
-    gix-dir                             0.27.0  20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f \
-    gix-discover                        0.53.0  d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722 \
+    gix-diff                            0.66.0  fee7d89a3c507491cdfc57a1d1e0e300214720b4f7709ebc253e422f99822bfc \
+    gix-dir                             0.28.0  f24bc78f283946ac64757c8a61ffa71f0230aa1e8d98cbb0771db479871dd5b6 \
+    gix-discover                        0.54.0  b9f517766fa1101dfe2606c1a19a8ffa699099030995a9194445446dfe261bdf \
     gix-error                            0.2.5  4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329 \
-    gix-features                        0.48.1  1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc \
-    gix-filter                          0.32.0  6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c \
-    gix-fs                              0.21.2  6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe \
-    gix-glob                            0.26.1  d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756 \
-    gix-hash                            0.25.1  cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce \
-    gix-hashtable                       0.15.2  7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e \
-    gix-ignore                          0.21.1  d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d \
-    gix-imara-diff                       0.2.3  b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b \
-    gix-index                           0.53.0  36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681 \
-    gix-lock                            23.0.1  65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c \
-    gix-mailmap                         0.33.1  195fd20808055824531be2fd0d34136d900e5fbca3ffb0a3c07e8beeefb9c828 \
-    gix-negotiate                       0.33.0  63d6081882a5f575ace9f53924a7c85f69bbd0f96071b982df12f258ab338cc9 \
-    gix-object                          0.62.0  019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e \
-    gix-odb                             0.82.0  7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a \
-    gix-pack                            0.72.0  ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b \
-    gix-packetline                      0.21.5  b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7 \
-    gix-path                            0.12.2  cbbecb0f8dc5cdf6cbde69133f7072064dfc9da4cf0046913afb6857b07300fa \
-    gix-pathspec                        0.18.1  3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f \
-    gix-prompt                          0.15.1  3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8 \
-    gix-protocol                        0.63.0  978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2 \
+    gix-features                        0.49.0  20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc \
+    gix-filter                          0.33.0  5e7b5dbf524d97e839f642930c76d7f011c0791e7d11d8148989ac5af7c76aa8 \
+    gix-fs                              0.22.0  865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80 \
+    gix-glob                            0.27.0  421e92a711554fa5827d1b0599d3389acdd0f6729e97a8c5a57d79af1e50bf36 \
+    gix-hash                            0.26.0  13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e \
+    gix-hashtable                       0.16.0  78fccd6fea3bcf0b39c076bae60ae49b08daaf538b950202101a981f9d3c01d3 \
+    gix-ignore                          0.22.0  12cff8e8aa125e39377456073e63df3334d9e5741372ddcc226198015076dda2 \
+    gix-imara-diff                       0.2.4  1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1 \
+    gix-index                           0.54.0  5009c4e7e9f9b4cfaaab1153e49133eb04d79c015b5702d6c3d2ab94271a89c6 \
+    gix-lock                            24.0.0  d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848 \
+    gix-mailmap                         0.33.2  a824767d38b81475059cb01f5020a13fb96e7ed6bbf9851c7112b46ada78db48 \
+    gix-negotiate                       0.34.0  2fa5aa789990f124e4f559b142cecfb60662cb4ae17006684ea9d668f4f07689 \
+    gix-object                          0.63.0  0e48c235e7f886eb819fc878af75be889333dd3c38bee02ed7af48ae2cf596c4 \
+    gix-odb                             0.83.0  8dd494ffb5037e62b8220109e894d2861ff2150a2cacbfccdba57ae1ebab2b96 \
+    gix-pack                            0.73.0  6d5446127b269706e85998065267ddd2ccc3550179da6780b22fe496175ccb20 \
+    gix-packetline                      0.22.0  3766025c72319c4accdd854a18e6f0dd176c8eb0f3bc8a60a7765be2b50cabf2 \
+    gix-path                            0.12.3  1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9 \
+    gix-pathspec                        0.19.0  49f6fa5f8007f008187c3f60b4373209ca83d1cc947f35ede03e16cd15a4d137 \
+    gix-prompt                          0.16.0  5cb1f1eb92d6f4c9d4c105a6ca912cff637fbd5cacbcbafa5deccd88bfaa3565 \
+    gix-protocol                        0.64.0  dede40e89c1e90f548415f50636bb051f6d9c60f68b8b710bc07825722d19588 \
     gix-quote                            0.7.2  a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef \
-    gix-ref                             0.65.0  9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e \
-    gix-refspec                         0.43.0  7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f \
-    gix-revision                        0.47.0  885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f \
-    gix-revwalk                         0.33.0  8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455 \
-    gix-sec                             0.14.1  ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3 \
-    gix-shallow                         0.12.1  a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97 \
-    gix-status                          0.32.0  aec3293f75db1212f99217832cbc70c30faeb95cefc97c7f1a17fd3bcf13a72e \
-    gix-submodule                       0.32.0  a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8 \
-    gix-tempfile                        23.0.2  6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f \
-    gix-trace                           0.1.20  44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678 \
-    gix-transport                       0.57.2  186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3 \
-    gix-traverse                        0.59.0  5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1 \
-    gix-url                             0.36.2  57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29 \
-    gix-utils                            0.3.4  d773a906e39472c2b00aaf1993cd120d40198c1ff6db07c0ee9a44d4431b66c1 \
-    gix-validate                        0.11.2  7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3 \
-    gix-worktree                        0.54.0  92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036 \
-    gix-worktree-state                  0.32.0  c0f926b6a249bdb0086b307c704b7abd9d643e08f98040efe6467f00bb6d2ef5 \
-    gix-worktree-stream                 0.34.0  55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f \
-    glob                                 0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
+    gix-ref                             0.66.0  eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883 \
+    gix-refspec                         0.44.0  7406282cc0259b51f6aee299ca3d31279a020530363152a2e6c96e8a7f7bbc83 \
+    gix-revision                        0.48.0  e55e09d4a1ecf2beecc8c09cafcad37979e805b31f588b0e957e191df5783681 \
+    gix-revwalk                         0.34.0  36c113c0a53294dc6280ffc06cbcc4f50f820397e97d6a00b429a44b8db26e29 \
+    gix-sec                             0.14.2  af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f \
+    gix-shallow                         0.13.0  1ecc9f4b40537043e4bbd7d3d1760e74fb8e7b07a546166b558acaa73ad97f4a \
+    gix-status                          0.33.0  5f83b1c74e69b90411fbfe89ccebc47aa49457ce4eb9b942b1311258fc863d22 \
+    gix-submodule                       0.33.0  5fd98077a56d08886112e6b08dc94076d03539f4bc0b9d7880e4be2b8a640d8c \
+    gix-tempfile                        24.0.0  b675b920bd5a61d17ad542772f03ec34c60feb8ff683e1560c03ae967363731e \
+    gix-trace                           0.1.21  be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814 \
+    gix-transport                       0.58.0  b7c1bcf30081eb8ab04540a5795c67a2fcb22cb2e976e8b1a4ea657b1ed61469 \
+    gix-traverse                        0.60.0  008c5cd879e46e86b5c2469e633611978b18775d53d05668d691bc13088bd409 \
+    gix-url                             0.37.0  42d10e53b8eae21ee601687f47bbbd6cb2ed7162cb4c1cafdd422fb7ec64cbee \
+    gix-utils                            0.3.5  b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8 \
+    gix-validate                        0.11.3  9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc \
+    gix-worktree                        0.55.0  31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424 \
+    gix-worktree-state                  0.33.0  bc47372fc12b9fbea51b257bcc8d4970326cf5c7e42135bbfb5d72871bb30bd4 \
+    gix-worktree-stream                 0.35.0  3b088c8724e7be120c4798dd86925cf05332c9d356a463542578600c50c7a549 \
+    gix-zlib                             0.1.0  3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c \
+    glob                                 0.3.4  e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
     globset                             0.4.19  e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     group                               0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
@@ -574,9 +573,9 @@ cargo.crates \
     itertools                           0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     jdx-tar                              1.1.0  ea172082e0f86db95eb1eb387cf802b02749322e79219378e59ca390dd0cd284 \
-    jiff                                0.2.34  e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16 \
+    jiff                                0.2.35  668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc \
     jiff-core                            0.1.0  7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09 \
-    jiff-static                         0.2.34  323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de \
+    jiff-static                         0.2.35  3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204 \
     jiff-tzdb                            0.1.8  142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
@@ -593,8 +592,7 @@ cargo.crates \
     keccak                               0.1.6  cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653 \
     kem                            0.3.0-pre.0  2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
-    kstring                              2.0.2  558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1 \
-    landlock                             0.4.5  635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d \
+    landlock                             0.4.6  aa9b598524037d06d8466ec364866121281a2398c343ae8640b28bbe7be50cdb \
     lazy-regex                           3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
     lazy-regex-proc_macros               3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
@@ -607,7 +605,7 @@ cargo.crates \
     libyaml-rs                           0.3.0  2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777 \
     libz-ng-sys                         1.1.29  879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469 \
     line-index                           0.1.2  3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2 \
-    link-section                        0.19.0  e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9 \
+    link-section                        0.19.1  8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1 \
     linktime-proc-macro                  0.2.0  8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
@@ -622,11 +620,9 @@ cargo.crates \
     lru-slab                             0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     lua-src                            550.1.1  75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949 \
     luajit-src                 210.7.2+b925b3e  920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6 \
-    lzma-rs                              0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     lzma-rust2                          0.16.5  ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
-    maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
     memchr                               2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
@@ -706,10 +702,10 @@ cargo.crates \
     pem-rfc7468                          0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     pem-rfc7468                          1.0.0  a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9 \
     percent-encoding                     2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                                 2.8.7  47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9 \
-    pest_derive                          2.8.7  4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58 \
-    pest_generator                       2.8.7  6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7 \
-    pest_meta                            2.8.7  f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210 \
+    pest                                 2.8.8  7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2 \
+    pest_derive                          2.8.8  9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd \
+    pest_generator                       2.8.8  6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6 \
+    pest_meta                            2.8.8  85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c \
     petgraph                             0.8.3  8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455 \
     pgp                                 0.20.0  1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1 \
     phf                                 0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
@@ -727,7 +723,7 @@ cargo.crates \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    platforms                           3.12.0  9245c6e7c5a6bcdd7977fdf6d1e1c67f4cc2d0d58c041df0ea5940953033e6ca \
+    platforms                            4.1.0  acff5dfd42135d89cd7ad74a8c52813bbec91bf62c018ddd89390127767caab5 \
     plist                               1.10.0  7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85 \
     pluralizer                           0.5.0  4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
@@ -801,7 +797,6 @@ cargo.crates \
     regex-syntax                        0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     rend                                 0.5.4  663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240 \
     replace_with                         0.1.8  51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884 \
-    reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     resolvo                             0.11.1  cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
@@ -814,7 +809,6 @@ cargo.crates \
     rmcp-macros                          2.2.0  783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
-    roff                                 0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
     rops                                 0.1.7  b4beb52a5d008a707436d388c05e9fee9ae81039cce62813ee750918a13c0aaf \
     rowan                              0.15.19  a2441aaccb50f4267d4f0f58b21e0138e96a449f361ed57a2673a83c9bca0772 \
@@ -830,7 +824,7 @@ cargo.crates \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                             0.23.42  3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138 \
     rustls-native-certs                  0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
-    rustls-pki-types                    1.15.0  764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046 \
+    rustls-pki-types                    1.15.1  2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
@@ -842,8 +836,8 @@ cargo.crates \
     same-file                            1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                            0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     schemars                             0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
-    schemars                             1.2.1  a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc \
-    schemars_derive                      1.2.1  7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f \
+    schemars                             1.2.2  687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a \
+    schemars_derive                      1.2.2  d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba \
     scoped-tls                           1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                           1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                              0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
@@ -863,7 +857,7 @@ cargo.crates \
     serde_bytes                        0.11.19  a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8 \
     serde_core                         1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
     serde_derive                       1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
-    serde_derive_internals              0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
+    serde_derive_internals              0.30.0  f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd \
     serde_ignored                       0.1.14  115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798 \
     serde_json                         1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     serde_json_canonicalizer             0.3.2  fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2 \
@@ -917,8 +911,8 @@ cargo.crates \
     slab                                0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slug                                 0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                            1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
-    snafu                                0.9.1  d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522 \
-    snafu-derive                         0.9.1  5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda \
+    snafu                                0.9.2  e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7 \
+    snafu-derive                         0.9.2  287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72 \
     snap                                 1.1.2  199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886 \
     socket2                              0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
     socks                                0.3.4  f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b \
@@ -937,7 +931,7 @@ cargo.crates \
     strum                               0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                        0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     strum_macros                        0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
-    subfeature                          1.27.0  bae27fccb1615a3b3ae930cf93c0c4d32b7daffb57477ca0406f07fc0e68ea57 \
+    subfeature                          1.28.0  f6be2c63b5abd9caec364547309f51653179b216193c7be5e70dcf0c1c84d418 \
     subtle                               2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     superslice                           1.0.0  ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f \
     supports-color                       3.0.2  c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6 \
@@ -945,7 +939,7 @@ cargo.crates \
     supports-unicode                     3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
     syn                                1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                                2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
-    syn                                  3.0.2  a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3 \
+    syn                                  3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
     sync_wrapper                         1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                        0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     sysctl                               0.5.5  ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea \
@@ -958,7 +952,7 @@ cargo.crates \
     tar                                 0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                            3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     tera                                1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
-    tera                                 2.0.0  38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c \
+    tera                                 2.1.0  511f07fd91a70e92efbe4793d111aaa9035f8474dd157aaa1e31e7c27f5051da \
     tera-contrib                         0.2.0  a3792553c620406661d510095e5885bfb77b2296db30369bcc8308329a6fe78c \
     termcolor                            1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                        0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
@@ -985,8 +979,8 @@ cargo.crates \
     tokio-macros                         2.7.1  6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba \
     tokio-native-tls                     0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                        0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
-    tokio-stream                        0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
-    tokio-util                          0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
+    tokio-stream                        0.1.19  a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b \
+    tokio-util                          0.7.19  494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52 \
     toml                                0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                                0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
     toml                      1.1.3+spec-1.1.0  53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c \
@@ -994,7 +988,7 @@ cargo.crates \
     toml_datetime             1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
     toml_edit                          0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
     toml_edit               0.25.13+spec-1.1.0  6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b \
-    toml_parser               1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_parser               1.1.3+spec-1.1.0  1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56 \
     toml_write                           0.1.2  5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801 \
     toml_writer               1.1.2+spec-1.1.0  7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
@@ -1018,7 +1012,7 @@ cargo.crates \
     typed-path                          0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typeid                               1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                             1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
-    ubi                                  0.9.0  eb72e0fb81c47ba1a6adcb248084193109710f482786856ff5e820605ac52546 \
+    ubi                                 0.10.0  2a9b94e51ea832e8eee7c3b7c7958efd43b127e435bb95bb6fd5e0539a4ffd3a \
     ucd-trie                             0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uluru                                3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unarray                              0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
@@ -1043,7 +1037,6 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                           2.18.2  1851c9ddbc3a428af152852227363e7f66b73ca2ce732c8db3c2d4ab37eb63d2 \
     usage-lib                            4.0.0  b60d4043943b220cc7269576a383ff2d62ab00f208f10d94b2496791729f8b02 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
@@ -1161,7 +1154,6 @@ cargo.crates \
     zerotrie                             0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
     zerovec                             0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
     zerovec-derive                      0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
-    zip                                  3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \
     zip                                  6.0.0  eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b \
     zip                                  7.2.0  c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0 \
     zip                                  8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \


### PR DESCRIPTION
#### Description

mise: Update to 2026.8.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
