### PR TITLE
oasdiff: Update to 1.27.0

### DIFF
--- a/devel/oasdiff/Portfile
+++ b/devel/oasdiff/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Tufin/oasdiff 1.23.0 v
+go.setup            github.com/Tufin/oasdiff 1.27.0 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  375be04a8e9dc53b0b6204780f72736ed9e7af36 \
-                    sha256  734596357d6a2743ccd3c1850f37090793793ec3dde88106e325f60d666c5f6f \
-                    size    639604
+                    rmd160  97d30d67a009f39ef9e9b3b34fd8b925560729a7 \
+                    sha256  e0790896f57d2e8d812353a4b2811944b86ed9cad19b791a09d06854e7f7c6da \
+                    size    696922
 
 post-build {
     system -W ${worksrcpath} "./${name} completion bash > ${name}.bash"


### PR DESCRIPTION
#### Description

oasdiff: Update to 1.27.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
