### PR TITLE
zizmor: Update to 1.29.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.27.0 v
+github.setup        zizmorcore zizmor 1.29.0 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 livecheck.regex     {v(\d+\.\d+\.\d+)}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  16b60ca1e86295a40f29a1ba1ba2a4dd2933b1ec \
-                    sha256  2ef4347065e91b9a07c337d7161085b494866b5239605440b457cdcda4318136 \
-                    size    706463
+                    rmd160  e663abb37e06f0e7c539cfe0e35bfaab0503f91e \
+                    sha256  de3da74599a1e080361e97c0431bdc0f656ea530420fdff953a8e3d679e1153b \
+                    size    751680
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -43,11 +43,11 @@ cargo.crates \
     anstyle-parse                                                           1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                                                           1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
     anstyle-wincon                                                         3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
-    anyhow                                                                1.0.103  2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
+    anyhow                                                                1.0.104  330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
     arrayvec                                                                0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                                                              2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
     async-lock                                                              3.4.1  5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc \
-    async-trait                                                            0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    async-trait                                                            0.1.91  ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
     atomic-waker                                                            1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                                                                 1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     aws-lc-rs                                                              1.17.0  5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00 \
@@ -71,11 +71,12 @@ cargo.crates \
     cesu8                                                                   1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                                                                  1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                                                             0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    chacha20                                                               0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
     clap                                                                    4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-verbosity-flag                                                     3.0.4  9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394 \
     clap_builder                                                            4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
     clap_complete                                                           4.6.7  db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b \
-    clap_complete_nushell                                                   4.6.0  fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897 \
+    clap_complete_nushell                                                   4.6.1  933b05d5d83ff65fd7eaf5d106c792f2264908790a2642aca57429767b762ce2 \
     clap_derive                                                             4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                                                                1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
     cmake                                                                  0.1.54  e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0 \
@@ -88,6 +89,7 @@ cargo.crates \
     core-foundation                                                        0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys                                                     0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpufeatures                                                            0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
+    cpufeatures                                                             0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
     crc32fast                                                               1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-channel                                                      0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-deque                                                         0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
@@ -129,15 +131,15 @@ cargo.crates \
     fraction                                                               0.15.3  0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7 \
     fs_extra                                                                1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fst                                                                     0.4.7  7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a \
-    futures                                                                0.3.32  8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d \
-    futures-channel                                                        0.3.32  07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
-    futures-core                                                           0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
-    futures-executor                                                       0.3.32  baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d \
-    futures-io                                                             0.3.32  cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718 \
-    futures-macro                                                          0.3.32  e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b \
-    futures-sink                                                           0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
-    futures-task                                                           0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
-    futures-util                                                           0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    futures                                                                0.3.33  a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218 \
+    futures-channel                                                        0.3.33  262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae \
+    futures-core                                                           0.3.33  2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7 \
+    futures-executor                                                       0.3.33  6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458 \
+    futures-io                                                             0.3.33  4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a \
+    futures-macro                                                          0.3.33  2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b \
+    futures-sink                                                           0.3.33  e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307 \
+    futures-task                                                           0.3.33  b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109 \
+    futures-util                                                           0.3.33  a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa \
     generic-array                                                          0.14.9  4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2 \
     getrandom                                                              0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
     getrandom                                                               0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
@@ -147,7 +149,6 @@ cargo.crates \
     h2                                                                     0.4.13  2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54 \
     hashbrown                                                              0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                                                              0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
-    hashbrown                                                              0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
     hashbrown                                                              0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heck                                                                    0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                                                                     0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
@@ -174,7 +175,7 @@ cargo.crates \
     id-arena                                                                2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     idna                                                                    1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                                                            1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
-    ignore                                                                 0.4.28  2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7 \
+    ignore                                                                 0.4.31  7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83 \
     indexmap                                                               2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indicatif                                                              0.18.6  9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
     insta                                                                  1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
@@ -188,8 +189,9 @@ cargo.crates \
     jni-sys                                                                 0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                                                              0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     js-sys                                                                 0.3.85  8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3 \
-    jsonschema                                                            0.46.10  f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05 \
-    jsonschema-regex                                                      0.46.10  6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13 \
+    jsonschema                                                             0.48.5  f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901 \
+    jsonschema-regex                                                       0.48.5  84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17 \
+    jsonschema-value                                                       0.48.5  fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556 \
     lazy_static                                                             1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                                                               0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libc                                                                  0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
@@ -203,7 +205,7 @@ cargo.crates \
     lru-slab                                                                0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     ls-types                                                                0.0.2  7a7deb98ef9daaa7500324351a5bab7c80c644cfb86b4be0c4433b582af93510 \
     matchers                                                                0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
-    memchr                                                                  2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
+    memchr                                                                  2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     memmap2                                                                0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     micromap                                                                0.3.0  c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74 \
     miette                                                                 5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
@@ -242,27 +244,26 @@ cargo.crates \
     postcard                                                                1.1.3  6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24 \
     potential_utf                                                           0.1.3  84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a \
     powerfmt                                                                0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
-    ppv-lite86                                                             0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     predicates                                                              3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
     predicates-core                                                         1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
     predicates-tree                                                        1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
     prettyplease                                                           0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     proc-macro2                                                           1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     quinn                                                                  0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
-    quinn-proto                                                           0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
+    quinn-proto                                                           0.11.16  2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560 \
     quinn-udp                                                              0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
     quote                                                                  1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
     r-efi                                                                   5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                                                   6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
-    rand                                                                    0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
-    rand_chacha                                                             0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
-    rand_core                                                               0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
+    rand                                                                   0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
+    rand_core                                                              0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    rand_pcg                                                               0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     redox_syscall                                                          0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     ref-cast                                                               1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                                                          1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    referencing                                                           0.46.10  0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d \
+    referencing                                                            0.48.5  980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba \
     reflink-copy                                                           0.1.28  23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92 \
-    regex                                                                  1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
+    regex                                                                  1.13.0  2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2 \
     regex-automata                                                         0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-syntax                                                           0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     reqwest                                                                0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
@@ -287,13 +288,13 @@ cargo.crates \
     scopeguard                                                              1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     security-framework                                                      3.3.0  80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c \
     security-framework-sys                                                 2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
-    self_cell                                                               1.2.2  b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89 \
+    self_cell                                                               1.3.0  2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813 \
     semver                                                                 1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
-    serde                                                                 1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde_core                                                            1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                                                          1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde                                                                 1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde_core                                                            1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                                                          1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
     serde_derive_internals                                                 0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                                                            1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde_json                                                            1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     serde_spanned                                                           1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                                                        0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha-1                                                                  0.10.1  f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c \
@@ -310,8 +311,11 @@ cargo.crates \
     stable_deref_trait                                                      1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     streaming-iterator                                                      0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strsim                                                                 0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    strum                                                                  0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
+    strum_macros                                                           0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     subtle                                                                  2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                                                                   2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    syn                                                                     3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
     sync_wrapper                                                            1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                                                           0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     sysinfo                                                                0.38.4  92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f \
@@ -324,9 +328,9 @@ cargo.crates \
     termtree                                                                0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     text-size                                                               1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     thiserror                                                              1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                                                              2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror                                                              2.0.19  09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
     thiserror-impl                                                         1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                                                         2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    thiserror-impl                                                         2.0.19  43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
     thread_local                                                            1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
     tikv-jemalloc-sys     0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8  1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0 \
     tikv-jemallocator                                                       0.7.0  249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd \
@@ -336,7 +340,7 @@ cargo.crates \
     tinystr                                                                 0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
     tinyvec                                                                1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
     tinyvec_macros                                                          0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                                                                  1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
+    tokio                                                                  1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
     tokio-macros                                                            2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-rustls                                                           0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                                                           0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
@@ -355,7 +359,7 @@ cargo.crates \
     tracing-indicatif                                                      0.3.14  e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e \
     tracing-log                                                             0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                                                     0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
-    tree-sitter                                                           0.26.10  3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55 \
+    tree-sitter                                                           0.26.11  af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df \
     tree-sitter-bash                                                       0.25.1  9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062 \
     tree-sitter-language                                                    0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
     tree-sitter-powershell                                                 0.26.4  3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022 \
@@ -370,7 +374,7 @@ cargo.crates \
     unicode-xid                                                             0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     unit-prefix                                                             0.5.1  323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817 \
     untrusted                                                               0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    url                                                                     2.5.7  08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b \
+    url                                                                     2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     utf8_iter                                                               1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                                                               0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                                                                   1.23.0  5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.29.0


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
