### PR TITLE
tree-sitter: update to 0.26.11

### DIFF
--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        tree-sitter tree-sitter 0.26.8 v
+github.setup        tree-sitter tree-sitter 0.26.11 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 dist_subdir         ${name}/${version}_${revision}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e29630c70a28559a82a39d7519f7d87bc4ff7433 \
-                    sha256  e6826b7533ec3a885aba598377a6d20b5a6321ff3db76968e960c2352d3a5077 \
-                    size    908286
+                    rmd160  d117c472b4e006304704e804e56c7d78c597fc33 \
+                    sha256  1bab01ed21464f3272665b9c60e39ee79f68da1333e80b23f2c9356569d06971 \
+                    size    920828
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
