### PR TITLE
gtk3: sync with devel port regarding focus

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -12,7 +12,7 @@ name                gtk3
 conflicts           gtk3-devel
 set my_name         gtk3
 version             3.24.52
-revision            1
+revision            2
 epoch               1
 
 categories          gnome x11
@@ -90,6 +90,8 @@ patchfiles-append   patch-gtk-menu-crash.diff
 # Upstream patch (fixes lack of focus)
 # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9951
 patchfiles-append   patch-focus.patch
+# https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/10037
+patchfiles-append   patch-focus-2.patch
 
 # gtk3 +quartz uses instancetype which is not available
 # before approximately Xcode 4.6 (#49391)

--- a/gnome/gtk3/files/patch-focus-2.patch
+++ b/gnome/gtk3/files/patch-focus-2.patch
@@ -1,0 +1,58 @@
+From 9667dc9166513ba0e99043920cf80562f8a8b926 Mon Sep 17 00:00:00 2001
+From: Dan Raymond <raymod2@gmail.com>
+Date: Sat, 13 Jun 2026 22:39:37 -0600
+Subject: [PATCH] Focus does not return to the main window when closing File
+ Chooser
+
+The changes from GIMP #14901 (Wild strobing in multi window mode)
+introduced two regressions that made it into the 3.24.52 release:
+(1) Focus does not move to a newly opened dialog window.
+(2) Focus does not return to the main window when a dialog is closed.
+The changes that caused (1) have since been reverted on the gtk-3-24
+branch (commit f80b61d6).  This commit fixes (2).
+
+Fixes #8237
+
+Part-of: <https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/10037>
+---
+ gdk/quartz/gdkwindow-quartz.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git gdk/quartz/gdkwindow-quartz.c gdk/quartz/gdkwindow-quartz.c
+index 672103f7bd6..9fe7f4a203e 100644
+--- gdk/quartz/gdkwindow-quartz.c
++++ gdk/quartz/gdkwindow-quartz.c
+@@ -791,12 +791,27 @@ _gdk_quartz_window_did_become_main (GdkWindow *window)
+ void
+ _gdk_quartz_window_did_resign_main (GdkWindow *window)
+ {
+-  /* Don't try to make another window key when one resigns main.
+-   * macOS handles this automatically, and GTK's attempt to manage focus
+-   * here causes focus fighting between windows.
++  GdkWindow *new_window = window->transient_for;
++
++  /* Explicitly reassign focus only if a dialog/transient is closing.
++   * For normal window switches, macOS handles focus automatically.
++   * Unconditionally reassigning focus here causes fighting in
++   * multi-window apps.
+    * See: https://gitlab.gnome.org/GNOME/gimp/-/issues/14901
+    *      https://gitlab.gnome.org/GNOME/gimp/-/issues/15480
+    */
++
++  if (new_window &&
++      new_window != window &&
++      GDK_WINDOW_IS_MAPPED (new_window) &&
++      WINDOW_IS_TOPLEVEL (new_window))
++    {
++      GdkWindowImplQuartz *impl = gdk_window_get_quartz_impl (new_window);
++
++      if (impl)
++        [impl->toplevel makeKeyAndOrderFront:impl->toplevel];
++    }
++
+   clear_toplevel_order ();
+ }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
#### Description

See: https://github.com/macports/macports-ports/pull/33718

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
