### PR TITLE
qq: update to 0.3.4, declare the Go it needs

### DIFF
--- a/textproc/qq/Portfile
+++ b/textproc/qq/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/JFryy/qq 0.3.3 v
+go.setup            github.com/JFryy/qq 0.3.4 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         \
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  078170d07c27315b96d574b327d5e8c9eb042ec4 \
-                    sha256  ea705de059cd7b2af7fadbf5c812d5928dcf0f17209045cc6e062e9623915c9b \
-                    size    2103503
+checksums           rmd160  26cea1c71405903f77354ef21667af3ba3bfb77d \
+                    sha256  9b1f7404b99d8fd9e71b6590ef8842c9686fe1de9cdbc714428b6434fa9004fb \
+                    size    2124087
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 0.3.4.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.