### PR TITLE
oauth2-proxy: update to 7.15.3, declare the Go it needs

### DIFF
--- a/security/oauth2-proxy/Portfile
+++ b/security/oauth2-proxy/Portfile
@@ -3,8 +3,9 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/oauth2-proxy/oauth2-proxy 7.15.2 v
+go.setup                github.com/oauth2-proxy/oauth2-proxy 7.15.3 v
 go.offline_build        no
+go.toolchain_min    1.26.0
 revision                0
 
 homepage                https://oauth2-proxy.github.io/oauth2-proxy
@@ -22,9 +23,9 @@ license                 MIT
 maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
-checksums               rmd160  cea6c34b6bfb070c3f14305c39ff7b94c4b7c2f8 \
-                        sha256  1c5687373ac84126ab506c505377c9486e0d1aba2ebc80fafb4e8f6717337a21 \
-                        size    1835430
+checksums               rmd160  6d14724b9d7b38a385b13e5733ef01c8014c0966 \
+                        sha256  a13491bfd083e570d451275458728fb3f722b4d46657644df1ea90c676c552da \
+                        size    1838721
 
 set o2p_conf_dir        ${prefix}/etc/${name}
 set o2p_log_dir         ${prefix}/var/log/${name}


### PR DESCRIPTION
Update to 7.15.3.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.