### PR TITLE
multi-gitter: update to 0.63.1, declare the Go it needs

### DIFF
--- a/devel/multi-gitter/Portfile
+++ b/devel/multi-gitter/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lindell/multi-gitter 0.63.0 v
+go.setup            github.com/lindell/multi-gitter 0.63.1 v
 go.offline_build    no
+go.toolchain_min    1.26
 revision            0
 
 description         A CLI to update multiple Git repositories in bulk
@@ -23,9 +24,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c5c63ddae4e427ad0690da240f6e2bc92f862d08 \
-                    sha256  cbc52f249e89bfb435de934cf1d38b263770f0aa67f8635d7ef84b3dc4e4d5fa \
-                    size    333275
+checksums           rmd160  dd51761eb8ae26583f52f1164fb2332cc06f9052 \
+                    sha256  44114005fd83484a9a3f066aff58cc5d75607a6af14796eeb3c90ab45a70c211 \
+                    size    334251
 
 build.pre_args-append \
                     -ldflags \"-X main.version=${github.tag_prefix}${version} \


### PR DESCRIPTION
Update to 0.63.1.

Declares `go.toolchain_min 1.26`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.