### PR TITLE
aws-nuke: update to 3.66.0, declare the Go it needs

### DIFF
--- a/sysutils/aws-nuke/Portfile
+++ b/sysutils/aws-nuke/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ekristen/aws-nuke 3.65.0 v
+go.setup            github.com/ekristen/aws-nuke 3.66.0 v
 go.package          github.com/ekristen/aws-nuke/v3
 go.offline_build    no
+go.toolchain_min    1.26.1
 revision            0
 
 homepage            https://aws-nuke.ekristen.dev/
@@ -20,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  10be0b14c1a446d1a1421d05b200a2a50de9d052 \
-                    sha256  feb73b963ef14fe8fb1a3b77ad274e497edf41479a8f5d02155d0144de5625e1 \
-                    size    635743
+checksums           rmd160  90bc80872c32988abdabac6433c1a7a1b2412bc8 \
+                    sha256  3071dd7f1d61f42ca065af87aa675ada8ec11abfac08d135058845635561b676 \
+                    size    659693
 
 set commit          4a5a004edd67fbbc9aab475171784dce32b9a63f
 


### PR DESCRIPTION
Update to 3.66.0.

Declares `go.toolchain_min 1.26.1`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.