### PR TITLE
svu: update to 3.4.1, declare the Go it needs

### DIFF
--- a/devel/svu/Portfile
+++ b/devel/svu/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caarlos0/svu 3.4.0 v
+go.setup            github.com/caarlos0/svu 3.4.1 v
 go.offline_build    no
+go.toolchain_min    1.25.3
 revision            0
 
 description         Semantic Version Util
@@ -20,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0aa19be2188749a9af4e6c5bbc37f16a24fea12a \
-                    sha256  7448fafc958551e06ad7c8bb2eddc5db9bd5d7335a7d5c80750193b68b6f78bd \
-                    size    22447
+checksums           rmd160  4d31b4c66740006d350d86f559c7973698cba33c \
+                    sha256  b40fe73b43926051885045cdf72a3882d3b5e4826577532bd95ef15a9313e418 \
+                    size    22441
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 3.4.1.

Declares `go.toolchain_min 1.25.3`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.