### PR TITLE
nmap-formatter: update to 3.1.4, declare the Go it needs

### DIFF
--- a/sysutils/nmap-formatter/Portfile
+++ b/sysutils/nmap-formatter/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/vdjagilev/nmap-formatter 3.1.3 v
+go.setup            github.com/vdjagilev/nmap-formatter 3.1.4 v
 go.package          github.com/vdjagilev/nmap-formatter/v3
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         \
@@ -20,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  fe072c3fb5cfbabec86fe736f4b9017a74866f22 \
-                    sha256  261457566f83fcd21689991fbaaec356eddcdb40c460c26e59db8792a2165c9f \
-                    size    255246
+checksums           rmd160  cc51f1a87613c88a1641c57190b17d5ac63e69ff \
+                    sha256  46bc1cc7fc47ea2db15b45f3732b7511a3b9479b94bc77b44e830b2e194f8643 \
+                    size    255829
 
 build.args-append   -o nmap-formatter
 


### PR DESCRIPTION
Update to 3.1.4.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.