### PR TITLE
zeit: update to 1.0.2, declare the Go it needs

### DIFF
--- a/office/zeit/Portfile
+++ b/office/zeit/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mrusme/zeit 1.0.1 v
+go.setup            github.com/mrusme/zeit 1.0.2 v
 go.offline_build    no
+go.toolchain_min    1.25.1
 revision            0
 
 homepage            \
@@ -21,9 +22,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  b49419cc2f4232cf2432c83f4e5daefaff9714ef \
-                    sha256  546859a5e35242e31053a9784084e9350d6ceed62b580ed662a8ab385acac76c \
-                    size    17369217
+checksums           rmd160  f060700888f8eeabd7f4c5de85e02a147c1c540e \
+                    sha256  3b5697384769055bdb76a79ac4e43f03cef31f1df4b110d027fef1e22928b31e \
+                    size    17492264
 
 build.pre_args-append \
     -ldflags \" -X ${go.package}/z.VERSION=${version} \"


### PR DESCRIPTION
Update to 1.0.2.

Declares `go.toolchain_min 1.25.1`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.