### PR TITLE
fortio: update to 1.75.2, declare the Go it needs

### DIFF
--- a/net/fortio/Portfile
+++ b/net/fortio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/fortio/fortio 1.75.0 v
+go.setup            github.com/fortio/fortio 1.75.2 v
 go.package          fortio.org/fortio
 revision            0
 
@@ -29,14 +29,15 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e2d9557e490e6945c6ee53c502306ab9beda6fe8 \
-                    sha256  8d31b23732334efb5c7a6930d73515612b8a46366ab230af4bea4c384a3772ca \
-                    size    304505
+checksums           rmd160  c63d07ee7a86c24aa1dde7e82354ec7502aea356 \
+                    sha256  b57e4df1fe2fc94c5e074bab0c9350076f7e15c8068d6f82a36e5cb9115cc97b \
+                    size    304496
 
 set _ft_share_dir   ${prefix}/share/${name}
 
 # Allow Go to fetch deps at runtime
 go.offline_build no
+go.toolchain_min    1.25.0
 
 build.cmd           make
 build.pre_args      BUILD_DIR=${gopath} \


### PR DESCRIPTION
Update to 1.75.2.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.