### PR TITLE
air: update to 1.67.4, declare the Go it needs

### DIFF
--- a/devel/air/Portfile
+++ b/devel/air/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/air-verse/air 1.67.1 v
+go.setup            github.com/air-verse/air 1.67.4 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 description         Live reload for Go apps
@@ -18,9 +19,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  430043bf6b412368248ffab70353b1f2d7dc0953 \
-                    sha256  5cefce955beb727e3025cfa10df022d592c3d447a4d55aa62d25080dc5c936f3 \
-                    size    1069819
+checksums           rmd160  c3e085f139d0146b7c7353746cbbb00eb459648d \
+                    sha256  d74de50458f4f2cd744bb08a1acf84dbbcc99138ea0682176568f9a381a81887 \
+                    size    1082237
 
 pre-build {
     set go_ver [exec ${go.bin} version]


### PR DESCRIPTION
Update to 1.67.4.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.