### PR TITLE
berty: update to 2.471.14, declare the Go it needs

### DIFF
--- a/net/berty/Portfile
+++ b/net/berty/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/berty/berty 2.471.10 v
+go.setup            github.com/berty/berty 2.471.14 v
 go.package          berty.tech/berty/v2
 revision            0
 
@@ -21,12 +21,13 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  5efa6a4de9836203e3147dca90da1fe619cd037e \
-                    sha256  a796e1c6f21e30b65582861c3e30c3a1227b17c463346d2382f50c9cd1495a96 \
-                    size    8997597
+checksums           rmd160  07e451f08c46350b839135410efdd02633971bff \
+                    sha256  22a97aead0119c0f338ac5be6aa32efb2ef40f1a4ac218ffae8cba76dcdfb030 \
+                    size    9014589
 
 # Allow Go to fetch dependencies at build time
 go.offline_build no
+go.toolchain_min    1.26.4
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
Update to 2.471.14.

Declares `go.toolchain_min 1.26.4`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.