### PR TITLE
cdebug: update to 0.0.19, declare the Go it needs

### DIFF
--- a/sysutils/cdebug/Portfile
+++ b/sysutils/cdebug/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/iximiuz/cdebug 0.0.18 v
+go.setup            github.com/iximiuz/cdebug 0.0.19 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         A swiss army knife of container debugging
@@ -22,9 +23,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e0c1e258d55678d6e211ebbe3dd873a3a85e6354 \
-                    sha256  c28d6c079177aa8de850e2edcbd284ac08cd3f9d77aac851928e1cc85a77fbcb \
-                    size    321726
+checksums           rmd160  574a27a8472e0709d3df76577cc9bb6fe357dc41 \
+                    sha256  9bc1779fb342029e2e7b53ac4708ac939d2d55914974752cd64b040617c3b496 \
+                    size    328857
 
 build.args-append   \
     -ldflags=\" -X \'main.version=${github.tag_prefix}${version}\' \"


### PR DESCRIPTION
Update to 0.0.19.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.