### PR TITLE
consul: update to 2.0.2, declare the Go it needs

### DIFF
--- a/net/consul/Portfile
+++ b/net/consul/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/hashicorp/consul 2.0.0 v
+go.setup            github.com/hashicorp/consul 2.0.2 v
 go.offline_build    no
+go.toolchain_min    1.26
 revision            0
 
 homepage            https://www.consul.io


### PR DESCRIPTION
Update to 2.0.2.

Declares `go.toolchain_min 1.26`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.