### PR TITLE
flyctl: update to 0.4.77, declare the Go it needs

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/superfly/flyctl 0.4.67 v
+go.setup            github.com/superfly/flyctl 0.4.77 v
 go.offline_build    no
+go.toolchain_min    1.26.1
 revision            0
 
 categories          devel
@@ -19,9 +20,9 @@ long_description    ${name} is a command-line interface for fly.io.
 
 homepage            https://fly.io
 
-checksums           rmd160  55b4d91339d5ab5fdb26e28aa4a4da3d6617b210 \
-                    sha256  74dfecfdf368a23e09c14492c03934dbb7eefba57c9cc60926783169e57eda6b \
-                    size    1961097
+checksums           rmd160  8e76ea4156e1e3cde1f36548e504720347195f34 \
+                    sha256  9ec64882ac1780e400bdbd5e3f477ae30d423703f9f03f5e8b6af1d980354954 \
+                    size    1978797
 
 build.cmd           "${go.bin} generate ./... && ${go.bin} build"
 


### PR DESCRIPTION
Update to 0.4.77.

Declares `go.toolchain_min 1.26.1`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.