### PR TITLE
goss: update to 0.4.10, declare the Go it needs

### DIFF
--- a/sysutils/goss/Portfile
+++ b/sysutils/goss/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/goss-org/goss 0.4.9 v
+go.setup            github.com/goss-org/goss 0.4.10 v
 go.offline_build    no
+go.toolchain_min    1.25.12
 revision            0
 
 homepage            https://goss.rocks
@@ -24,9 +25,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  a7fd7449f836ecd0e43f65a1665f14d9c57b8f13 \
-                    sha256  fa92143bdcba9e2c7ae210bc72ee15cc301092cc53ca3913f80cfab8e4585f78 \
-                    size    149439
+checksums           rmd160  60323d0145d639a720ddf2e21915d5da37895305 \
+                    sha256  b32ec432c310bd54423e8733a8f55561d898d0b3aca579b50684ccab1e04dfb6 \
+                    size    149299
 
 build.pre_args-append \
                     -ldflags \" \


### PR DESCRIPTION
Update to 0.4.10.

Declares `go.toolchain_min 1.25.12`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.