### PR TITLE
infracost: update to 0.10.45, declare the Go it needs

### DIFF
--- a/sysutils/infracost/Portfile
+++ b/sysutils/infracost/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/infracost/infracost 0.10.41 v
+go.setup            github.com/infracost/infracost 0.10.45 v
 go.offline_build    no
+go.toolchain_min    1.25.11
 revision            0
 
 homepage            https://www.infracost.io
@@ -22,9 +23,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  35bbb161a13a3e89ac58340b7a2fb23697ebaa8e \
-                    sha256  daec27ad58abcb8a823ad21862b4143eaa8a8fd03b3c7f3621e8fca61eb8e68e \
-                    size    1801087
+checksums           rmd160  2dde7ec4f26aed0175487312681543fc911af423 \
+                    sha256  32f884ea2be99f70a4c2c81dd63dd923cf15996e494c046b9d4e019917658b79 \
+                    size    5336415
 
 build.cmd           make
 build.pre_args      VERSION=v${version}


### PR DESCRIPTION
Update to 0.10.45.

Declares `go.toolchain_min 1.25.11`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.