### PR TITLE
kage: update to 0.3.11, declare the Go it needs

### DIFF
--- a/www/kage/Portfile
+++ b/www/kage/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tamnd/kage 0.3.8 v
+go.setup            github.com/tamnd/kage 0.3.11 v
 go.offline_build    no
+go.toolchain_min    1.26.5
 revision            0
 
 description         \
@@ -21,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  33c2cede236207067e146ebb1661b187da3093a8 \
-                    sha256  b26b8c99b62d7df6a7118dd75c74df793c3be7194a136dbad415637515e414c0 \
-                    size    1074858
+checksums           rmd160  7f8021d691a61219d7e7656a814b8c4ba1bc5d07 \
+                    sha256  076eee307e4bf777fa5101741380a0c54d768a08da5ef75f46bf8b2c6bd1f447 \
+                    size    1137674
 
 set kage_commit     f370402
 


### PR DESCRIPTION
Update to 0.3.11.

Declares `go.toolchain_min 1.26.5`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.