### PR TITLE
kubescape: update to 4.0.11, declare the Go it needs

### DIFF
--- a/sysutils/kubescape/Portfile
+++ b/sysutils/kubescape/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang  1.0
 
-go.setup            github.com/kubescape/kubescape 4.0.8 v
+go.setup            github.com/kubescape/kubescape 4.0.11 v
 revision            0
 
 description         Tool for testing if Kubernetes is deployed securely as \
@@ -17,12 +17,13 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f7a6559d8c4c2ad32f061d5514d094775dff35cd \
-                    sha256  28866380b6c8a17c7548d5467aaf4197937602c673d8fed51b973e4aadee8298 \
-                    size    9855075
+checksums           rmd160  40e010378c29d29a21767883474eefdcd153948b \
+                    sha256  6e42077f7c5981da93322e6caef4a67cdb483ccdce1df11a94ce5536437b7653 \
+                    size    11796056
 
 # Allow Go to fetch dependencies at build time
 go.offline_build no
+go.toolchain_min    1.26.0
 build.pre_args-append -ldflags \" \
     -X main.version=v${version} \
     -X main.commit=d7539c2264560a8685f59e89a731d6de833258a6 \


### PR DESCRIPTION
Update to 4.0.11.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.