### PR TITLE
mani: update to 0.32.1, declare the Go it needs

### DIFF
--- a/devel/mani/Portfile
+++ b/devel/mani/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/alajmo/mani 0.32.0 v
+go.setup            github.com/alajmo/mani 0.32.1 v
 revision            0
 
 homepage            https://manicli.com
@@ -24,12 +24,13 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  7818f5fafcb57a94b742b430bd240e1bbc185559 \
-                    sha256  63151cc156130b335b1f844c6e88049670647c44d4a42516510a9fd70edff9b0 \
-                    size    932011
+checksums           rmd160  761345c7c8df287430a92370cf07dc9bff7779a4 \
+                    sha256  7b061b6606aeb3b024d14009d9028c30b0b56d8d8d4078b39c8d87db696bde1b \
+                    size    933017
 
 # Allow Go to fetch deps at build time
 go.offline_build no
+go.toolchain_min    1.25.5
 
 build.cmd           make
 build.pre_args      DATE=""


### PR DESCRIPTION
Update to 0.32.1.

Declares `go.toolchain_min 1.25.5`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.