### PR TITLE
oq: update to 0.0.22, declare the Go it needs

### DIFF
--- a/devel/oq/Portfile
+++ b/devel/oq/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/plutov/oq 0.0.21 v
+go.setup            github.com/plutov/oq 0.0.22 v
 go.offline_build    no
+go.toolchain_min    1.25.1
 revision            0
 
 description         Terminal OpenAPI Spec viewer
@@ -16,9 +17,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9c13d255cbceb1385631520bc05e63e42bd79c54 \
-                    sha256  9bc98cedf6b74c78617bb40f2d1883bf760bbdf23faf1d2bda8cfe12ba7d8e88 \
-                    size    904566
+checksums           rmd160  d468215f1240aa5d52d0147586fa8d5710871a6e \
+                    sha256  4b4b3f294482bdd45a044c5a20f0ebf5db47c6eb7906584e927ca48f3c14ecd6 \
+                    size    905031
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 0.0.22.

Declares `go.toolchain_min 1.25.1`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.