### PR TITLE
steampipe: update to 2.4.4, declare the Go it needs

### DIFF
--- a/net/steampipe/Portfile
+++ b/net/steampipe/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/turbot/steampipe 2.4.0 v
+go.setup            github.com/turbot/steampipe 2.4.4 v
 go.offline_build    no
+go.toolchain_min    1.26.1
 revision            0
 
 homepage            https://steampipe.io
@@ -22,9 +23,9 @@ license             AGPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dcab2c5aa6ff3732aa4b47b95ab466c62fe5d34d \
-                    sha256  dcbde3f1fa438bf0640b4ce71c6a34bdb889a4080945a428f3804136b091ff0d \
-                    size    592704
+checksums           rmd160  07fde5bb588ebff5fcdc3aa95062f72a899cbcc0 \
+                    sha256  3b9dae922cc9bd1976208d4a32e00e1bee8a6ed099734b019172d8e1f3769f90 \
+                    size    593963
 
 build.args          -ldflags '-X main.version=${version}'
 


### PR DESCRIPTION
Update to 2.4.4.

Declares `go.toolchain_min 1.26.1`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.