### PR TITLE
step-cli: update to 0.30.6, declare the Go it needs

### DIFF
--- a/security/step-cli/Portfile
+++ b/security/step-cli/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/smallstep/cli 0.30.2 v
+go.setup            github.com/smallstep/cli 0.30.6 v
 go.offline_build    no
+go.toolchain_min    1.25.8
 name                step-cli
 revision            0
 
@@ -27,9 +28,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 # already present.
 dist_subdir         ${name}
 
-checksums           rmd160  5ed971608f982ab84f65044c5e087f6bf421bf17 \
-                    sha256  0def585a03b9f1dd3e72df33baf38016ba15e198f8532d538a236d65b10bac7f \
-                    size    1653362
+checksums           rmd160  43226842c7b6a58fff57c2489d7bf1641e913528 \
+                    sha256  0c8562b95150cc24bf69ba18fcf9f0bf671f334f5d3ccb39f287692b61531b7c \
+                    size    1654697
 
 build.cmd           make
 build.target        binary-${goos}-${goarch}


### PR DESCRIPTION
Update to 0.30.6.

Declares `go.toolchain_min 1.25.8`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.