### PR TITLE
tfmigrate: update to 0.4.5, declare the Go it needs

### DIFF
--- a/sysutils/tfmigrate/Portfile
+++ b/sysutils/tfmigrate/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/minamijoyo/tfmigrate 0.4.4 v
+go.setup            github.com/minamijoyo/tfmigrate 0.4.5 v
 go.offline_build    no
+go.toolchain_min    1.25
 revision            0
 
 description         A Terraform state migration tool for GitOps
@@ -17,9 +18,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  95a2a67dbe3fecac2002796c64fd504b72f65159 \
-                    sha256  85d8fa6881efdd444a3102dfbddc0559380643d2d72d871c1cbe3cfd3df1902d \
-                    size    94825
+checksums           rmd160  5d9613b7a083eb9d827ec7a15023559fc978219e \
+                    sha256  306c8d14bfbe86a532c85fffca2c4ea2cca6412bcbc4016680f81643d0d630e9 \
+                    size    95216
 
 build.cmd           make
 build.target        build


### PR DESCRIPTION
Update to 0.4.5.

Declares `go.toolchain_min 1.25`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.