### PR TITLE
gat: Update to 0.30.2

### DIFF
--- a/textproc/gat/Portfile
+++ b/textproc/gat/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/koki-develop/gat 0.27.2 v
+go.setup            github.com/koki-develop/gat 0.30.2 v
+go.toolchain_min    1.25
 go.offline_build    no
 revision            0
 
@@ -17,9 +18,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  bd5dd8f3e45862099287e833972a080b0c903fa4 \
-                    sha256  7c7ec037dbc99610796f198699dab6b82d0d39588e3581bbb57fac0b9f575523 \
-                    size    15729343
+checksums           rmd160  d0ca2dabca510b6e5d43a105df34f20b47658dc8 \
+                    sha256  47e4c84f898fe0022f0add0fcd1649a1b77c0b6c452b4e022645523fb1955f57 \
+                    size    16441445
 
 build.pre_args-append \
     -ldflags \"-X ${go.package}/cmd.version=${github.tag_prefix}${version}\"


### PR DESCRIPTION
#### Description

Update gat to 0.30.2. Adopt `go_toolchain` PortGroup changes and declare minimum Go toolchain required to build.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
