### PR TITLE
gmt6: update to 6.7.0

### DIFF
--- a/science/gmt6/Portfile
+++ b/science/gmt6/Portfile
@@ -5,10 +5,10 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 name                gmt6
-github.setup        GenericMappingTools gmt 6.6.0
+github.setup        GenericMappingTools gmt 6.7.0
 github.tarball_from releases
 distname            ${github.project}-${github.version}-src
-revision            2
+revision            0
 epoch               1
 
 categories          science
@@ -35,9 +35,9 @@ use_xz              yes
 distname            gmt-${version}
 distfiles           ${distname}-src${extract.suffix}
 
-checksums           rmd160  70d58506e93abcd1b5242860558c247fa344ffda \
-                    sha256  18ac98b11b8fc924463ce5138385c02e9426780fba9ff63a991e2e8ecdbd1082 \
-                    size    15363892
+checksums           rmd160  9685e1f30fc76e7b1aa8aed81cf673138f318f1a \
+                    sha256  17c03353839c71a1b11efe4f4e9d5e3f0586a7a7b5f84a298d95ccc35241b001 \
+                    size    12311088
 
 depends_lib         port:curl \
                     port:dcw-gmt \


### PR DESCRIPTION
#### Description

Simple update to upstream version 4.7.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.7 24G720 x86_64
Command Line Tools 26.3.0.0.1.1771626560


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
