### PR TITLE
netcdf-fortran: update to 4.6.4

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -20,7 +20,7 @@ PortGroup                   github 1.0
 #        I/O feature disabled. Abort.
 mpi.enforce_variant         netcdf
 
-github.setup                Unidata netcdf-fortran 4.6.3 v
+github.setup                Unidata netcdf-fortran 4.6.4 v
 github.tarball_from         archive
 revision                    0
 maintainers                 {takeshi @tenomoto} \
@@ -40,9 +40,9 @@ long_description \
     This software package provides Fortran application interfaces \
     for accessing netCDF data.
 
-checksums           rmd160  fff258e8a9b4c29ec2a23f5ee35c3b82471a03c7 \
-                    sha256  b9de820c4823faa5b4e1cd9ee82dd7c57acad105ebd8f6ae36b0244105518655 \
-                    size    8107630
+checksums           rmd160  8648b047367ae6754ec50bb68d7560d250a11259 \
+                    sha256  fc8df99e78cd2aa5ea7b312bce5307b1bea73a118d4860b3b4358971ec376c54 \
+                    size    8121692
 
 patchfiles          patch-nf03_test4-Makefile.in.diff \
                     patch-nf-config.diff \


### PR DESCRIPTION
#### Description

Simple update to upstream version 4.6.4.
(Two tests related to double-complex remain to fail as in 4.6.3, as expected).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.7 24G720 x86_64
Command Line Tools 26.3.0.0.1.1771626560

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
