### PR TITLE
fzf: update to 0.74.2, declare the Go it needs

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.74.1 v
+go.setup            github.com/junegunn/fzf 0.74.2 v
 github.tarball_from archive
+go.toolchain_min    1.23.0
 revision            0
 
 description         A command-line fuzzy finder written in Go
@@ -19,9 +20,9 @@ maintainers         {isi.edu:calvin @cardi} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fc246860c0a3dfacdc9f45ca581faa56f26fb0a3 \
-                        sha256  ba37120bbe45966c6eba6a00c8ea64b86c3c57e349cb55b1c3e0f522976fd978 \
-                        size    451508
+                        rmd160  cc746df78f4c65c8e470705540af0b45f71521ef \
+                        sha256  3ce36bd4fb0cde458a7f93c11ef534408d92c3bf19e6acc90e112f3e9e2acc60 \
+                        size    461367
 
 go.vendors          golang.org/x/text \
                         lock    v0.28.0 \
@@ -49,10 +50,10 @@ go.vendors          golang.org/x/text \
                         sha256  6c9e81a6b46220612b97ebc35e8d29d1907fd225a9ce3e40b7cebd64cc58d09c \
                         size    18496 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.22 \
-                        rmd160  17623a5f25dfb8ed55495c059c4d0ca5744624f5 \
-                        sha256  831ddc530128a925738793863e9814ccb148f0fd22b242f6e593f20107b19643 \
-                        size    4804 \
+                        lock    v0.0.24 \
+                        rmd160  06eb44028c6d8e99905f1ffbdb75a35de0ade2f2 \
+                        sha256  8b1e834f93ebe2e7f607a82bb236c8ec7bdbf2a58fe9ba29cf148d309c8ae227 \
+                        size    4960 \
                     github.com/lucasb-eyer/go-colorful \
                         lock    v1.2.0 \
                         rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \


### PR DESCRIPTION
Update to 0.74.2.

Declares `go.toolchain_min 1.23.0`, the `go` directive from the project's `go.mod` at this tag.

The port keeps its vendored GOPATH build — an earlier revision of this pull request converted it to module mode, and that has been dropped. In GOPATH mode Go does not read `go.mod`, so the directive is not enforced by the build; the declaration records what upstream asks for rather than a limit the toolchain imposes. It gates nothing today either way, since `go` provides 1.24 from 10.13 upward.

The only vendor change is `go-isatty` v0.0.22 → v0.0.24, regenerated with `go2port`.

See: https://trac.macports.org/ticket/73086
