### PR TITLE
fq: build in module mode and declare the Go it needs

### DIFF
--- a/sysutils/fq/Portfile
+++ b/sysutils/fq/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/wader/fq 0.17.0 v
-revision            0
+go.offline_build    no
+go.toolchain_min    1.25.0
+revision            1
 
 description         jq for binary formats
 
@@ -33,103 +35,3 @@ checksums           ${distname}${extract.suffix} \
                         sha256  c5658b2bc635a1d344c64e37d7311157f0fc4b20cc3cfa4d09bdd2f023692d57 \
                         size    17997865
 
-go.vendors          gopkg.in/yaml.v3 \
-                        lock    v3.0.1 \
-                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
-                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
-                        size    91208 \
-                    gopkg.in/check.v1 \
-                        lock    8fa46927fb4f \
-                        rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
-                        sha256  c41439b343f3fc3c0b6f943b4aae642f10f19451e945c23dfb324c9c8f87d0b7 \
-                        size    31616 \
-                    golang.org/x/text \
-                        lock    v0.35.0 \
-                        rmd160  79c26a586fe05605522d5cde21d4a90d15a52e72 \
-                        sha256  a15836dcf181252dba63fdc0f81bd7bd7c71dbf0f7cc09f194def5ce77659985 \
-                        size    6774061 \
-                    golang.org/x/term \
-                        lock    v0.41.0 \
-                        rmd160  1ca3505605c1604700a5421204aa5d61594ef0da \
-                        sha256  1bde581886ac0719d57bbe95e249648b0a098d74ea154618ff3d0222cb57b022 \
-                        size    16451 \
-                    golang.org/x/sys \
-                        lock    v0.42.0 \
-                        rmd160  9bf28fd4fb2566093e52db9828dace0cad68ece6 \
-                        sha256  95cce678922f8cd653b53365de74085c97ca91d3f0c1ac20d96df2f0657d4e02 \
-                        size    1540175 \
-                    golang.org/x/net \
-                        lock    v0.52.0 \
-                        rmd160  70d7b37d0e8e0290435349b81ee66c0b42c552e8 \
-                        sha256  65b3b4aef66168347c35f7a4705d160f0323372bdee42341d75f3ffdd636878b \
-                        size    1551232 \
-                    golang.org/x/crypto \
-                        lock    v0.49.0 \
-                        rmd160  bafd6fc7a23618105c5264ec75e8ddc71871cd98 \
-                        sha256  054024022845b9468e3b16645373d4f16223d2d75dbbbea7374aee442862d451 \
-                        size    2150227 \
-                    github.com/wader/gojq \
-                        lock    6d8c75fc0e74 \
-                        rmd160  beb6f691f5711e7498744f439bce9685acc2db16 \
-                        sha256  15e61c21e9febe97ab0216681618048185b7ba62ad5e9069bdf745741180677c \
-                        size    137633 \
-                    github.com/niemeyer/pretty \
-                        lock    a10e7caefd8e \
-                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
-                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
-                        size    9405 \
-                    github.com/mitchellh/reflectwalk \
-                        lock    v1.0.2 \
-                        rmd160  0371e346bfe14926662afff3eeda22ce6dc6d2a4 \
-                        sha256  472ea8302bfe36cd5ea5a66cb9ee996d6984ce74bfc9b7c15e763f21687b3eff \
-                        size    6863 \
-                    github.com/mitchellh/mapstructure \
-                        lock    v1.5.0 \
-                        rmd160  c838fb22a642081963c8e6f236cdd4c6000bfaf4 \
-                        sha256  bd695f63e58f35f07aac6883ac5dc53d44db6cf24caa53efaadcf0842d03d762 \
-                        size    30135 \
-                    github.com/mitchellh/copystructure \
-                        lock    v1.2.0 \
-                        rmd160  401559c8d2db7a6becabf583dca6843e5cd3c5ac \
-                        sha256  e6cbd00eca63c91837cd094e89bda52d067163dc5b5db12758b8995c75fd3377 \
-                        size    9936 \
-                    github.com/kr/text \
-                        lock    v0.1.0 \
-                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
-                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
-                        size    8691 \
-                    github.com/itchyny/timefmt-go \
-                        lock    v0.1.7 \
-                        rmd160  1359cdcdecdec83ec4290fe661d0eba6230c8874 \
-                        sha256  68e65fc18274f2e9be835ea655e9926fdfc1ac1fe2ed46254ad2d79db27fa614 \
-                        size    15117 \
-                    github.com/gopacket/gopacket \
-                        lock    v1.5.0 \
-                        rmd160  009d8841d165019c065c9749c2e55fb83500b349 \
-                        sha256  bf45318809c91476be122d7f3a70e1c4f06454571c0b41641f98e2653b5cc062 \
-                        size    2019075 \
-                    github.com/gomarkdown/markdown \
-                        lock    37c66b85d6ab \
-                        rmd160  31b2eab1e50561e1d511ee6e36738ec6b2d001b4 \
-                        sha256  b4ec121de2c498ab9e93498a49ebf0e8357e32fcfb36018904e7691d430585d0 \
-                        size    126162 \
-                    github.com/golang/snappy \
-                        lock    v1.0.0 \
-                        rmd160  ecac40a18983ad6c8eae67112d4786a5a1171498 \
-                        sha256  c67f26cd4d8e5fe382f9ce4e6d8cfd76d4e43383986b7f9fd9539efe3e842dd2 \
-                        size    66178 \
-                    github.com/ergochat/readline \
-                        lock    v0.1.3 \
-                        rmd160  601bc82bf6892ceb566e283d2659714876ee9d7c \
-                        sha256  fe86f18b6bdf15313683217a4cc304adb4795c1c0c2489b4b73de848d7942373 \
-                        size    49552 \
-                    github.com/creasty/defaults \
-                        lock    v1.8.0 \
-                        rmd160  af446c452f64ceea3c56d0d072ce151cc256a966 \
-                        sha256  fabfec02b3b6b757438941d57b3a09a51dd8ae702e45aa729f1cb67927871834 \
-                        size    9461 \
-                    github.com/BurntSushi/toml \
-                        lock    v1.6.0 \
-                        rmd160  ee9250da7143a9cf859c12d8c40c6977eb60155a \
-                        sha256  68a2fb378f023b562792f70079c48d68e25e58bdbe0914d4b3f21d70a692beb3 \
-                        size    141986


### PR DESCRIPTION
Switches from vendored GOPATH builds to module mode and drops the 20-entry `go.vendors` block, so updates no longer need it regenerated. Declares `go.toolchain_min 1.25.0` from the project's `go.mod` at the packaged version.

No version change; revision bumped because the build mechanism changes.
