### PR TITLE
duf: build in module mode and declare the Go it needs

### DIFF
--- a/sysutils/duf/Portfile
+++ b/sysutils/duf/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/muesli/duf 0.9.1 v
-revision            0
+go.offline_build    no
+go.toolchain_min    1.23.0
+revision            1
 
 description         Disk Usage/Free Utility - a better 'df' alternative
 long_description    ${description}
@@ -31,88 +33,3 @@ checksums           ${distname}${extract.suffix} \
                         sha256  1334d8c1a7957d0aceebe651e3af9e1c1e0c6f298f1feb39643dd0bd8ad1e955 \
                         size    140930
 
-go.vendors          gopkg.in/yaml.v3 \
-                        lock    v3.0.1 \
-                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
-                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
-                        size    91208 \
-                    golang.org/x/text \
-                        lock    v0.22.0 \
-                        rmd160  81e66eb6e6535b437ea51b57c30a1c436fa0311c \
-                        sha256  45b47148593c730547081bf7f496a80ca839837a94190b43d01529bb2770cb3c \
-                        size    8966982 \
-                    golang.org/x/term \
-                        lock    v0.34.0 \
-                        rmd160  c17f07f42813271264c518e71ffb0e025c096903 \
-                        sha256  ed10832a496fc6e6af32e8a0933942b042f362bb117ccb232a0553bc057da308 \
-                        size    15937 \
-                    golang.org/x/sys \
-                        lock    v0.35.0 \
-                        rmd160  94ac3a8dd72c3a5b79bc8f068285b77634935368 \
-                        sha256  b1c65be93d2d2ced17bd5ad9386a2385fd7258c708d3879f69e2485a1cea1011 \
-                        size    1531744 \
-                    github.com/stretchr/testify \
-                        lock    v1.10.0 \
-                        rmd160  43f142561513d8f10ce4971bf91cabbad9a021cc \
-                        sha256  be33d85711f2b92b7269a39574af64701ed5b2c4e4446547ea75ea046ec97629 \
-                        size    112769 \
-                    github.com/rivo/uniseg \
-                        lock    v0.4.7 \
-                        rmd160  a9056dc9a2a80aa9c46d0ff9e54f9e2e5a498c41 \
-                        sha256  abc6a2f17b64b34b8a0c56eb9d0b53886ebbe0c88d467755c09c7fa696a16677 \
-                        size    458166 \
-                    github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
-                    github.com/muesli/termenv \
-                        lock    v0.16.0 \
-                        rmd160  463214c9628bd837b8372a1fc4e97741390c6c39 \
-                        sha256  d7c5257a53385dfc5a362aa1e28ae1667c18610f61db203a482784b1ea4b3f74 \
-                        size    422997 \
-                    github.com/muesli/roff \
-                        lock    v0.1.0 \
-                        rmd160  f2652e87b0bbba7c8d75d49d4134d6ca64385646 \
-                        sha256  b9272650d5fca3052571b69abf1ba3477a46be729787192c5cbd205acd38c89a \
-                        size    4920 \
-                    github.com/muesli/mango \
-                        lock    v0.2.0 \
-                        rmd160  4532d56beb07dbe56237081ccee5136f97a151f1 \
-                        sha256  27e8917f03d5b5e5bb68e57f5f24062671898f53fdcc7670a3b681b1966da621 \
-                        size    35768 \
-                    github.com/mattn/go-runewidth \
-                        lock    v0.0.16 \
-                        rmd160  297825c4365b5f723ae485e726259ebb620ecd66 \
-                        sha256  6c9e81a6b46220612b97ebc35e8d29d1907fd225a9ce3e40b7cebd64cc58d09c \
-                        size    18496 \
-                    github.com/mattn/go-isatty \
-                        lock    v0.0.20 \
-                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
-                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
-                        size    4717 \
-                    github.com/lucasb-eyer/go-colorful \
-                        lock    v1.2.0 \
-                        rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
-                        sha256  fbad1aade4444bf51409f5b6a008cc14c7a7cdd1af856841fc1170605fae3914 \
-                        size    970841 \
-                    github.com/jedib0t/go-pretty \
-                        lock    v6.6.8 \
-                        rmd160  49e90cfc447568a5591b1b4cdf22410a1a01fdb1 \
-                        sha256  09e89f57daba0eb66200e732a17d9f8ad8225d3438a5700404b25ce4a7ba3efd \
-                        size    781255 \
-                    github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171 \
-                    github.com/aymanbagabas/go-osc52 \
-                        lock    v2.0.1 \
-                        rmd160  8669f2bdcf2704bbc8df6af7e5fd396215737b9b \
-                        sha256  0904dc990e2f1e5bbe290e02f418940def4168b63e36914e3bf76ff2ac1fb2a5 \
-                        size    5889 \
-                    github.com/IGLOU-EU/go-wildcard \
-                        lock    v1.0.3 \
-                        rmd160  99c09cc50d2a7a8bd455d435f26776ef965222a3 \
-                        sha256  29f307b7f649169453f1f37837e515034a9e5f290ce2da82b25d42c898017aaf \
-                        size    10284


### PR DESCRIPTION
Switches from vendored GOPATH builds to module mode and drops the 17-entry `go.vendors` block, so updates no longer need it regenerated. Declares `go.toolchain_min 1.23.0` from the project's `go.mod` at the packaged version.

No version change; revision bumped because the build mechanism changes.
