### PR TITLE
cmctl: update to 2.5.0, declare the Go it needs

### DIFF
--- a/sysutils/cmctl/Portfile
+++ b/sysutils/cmctl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/cert-manager/cmctl 2.4.0 v
+go.setup            github.com/cert-manager/cmctl 2.5.0 v
 revision            0
 
 homepage            https://cert-manager.io
@@ -19,11 +19,12 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9ed30002f6d8259d4950efd29e506c8ef9ad6195 \
-                    sha256  3de4456c6f36a143992661f7357a2bd111b224a72ce7b61d83bfdb3679f36a96 \
-                    size    381192
+checksums           rmd160  429c6c91a9d270f48e768e67ed85a092d0a05f30 \
+                    sha256  4e7f137c2b5411f92948749dbdb31d61911088a54d32e14aea609da02c203bb5 \
+                    size    383105
 
 go.offline_build no
+go.toolchain_min    1.26.0
 
 build.pre_args-append \
     -ldflags \


### PR DESCRIPTION
Update to 2.5.0.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
