### PR TITLE
diffnav: update to 0.12.0, declare the Go it needs

### DIFF
--- a/textproc/diffnav/Portfile
+++ b/textproc/diffnav/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/dlvhdr/diffnav 0.11.0 v
+go.setup            github.com/dlvhdr/diffnav 0.12.0 v
 go.offline_build    no
+go.toolchain_min    1.26
 revision            0
 
 description         A git diff pager based on delta but with a file tree, à \
@@ -18,9 +19,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  61f90bce305d602a3026b06022f6047e864b9264 \
-                    sha256  df3879b12275bed16065ad9c08107c874445d265aa1fdc51d5f66a1f2fb7f392 \
-                    size    520053
+checksums           rmd160  5f2b081f73b599d6c8ce1d7d6fd2a6e8545db1f6 \
+                    sha256  17d9d1c1c2f5f8d223afaa9a73ce1ce5faa41fe5fb8a7bfd6d65e402d536d8d6 \
+                    size    529797
 
 build.pre_args-append \
     -ldflags \"-X ${go.package}/pkg/version.Version=v${version}\"


### PR DESCRIPTION
Update to 0.12.0.

Declares `go.toolchain_min 1.26`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
