### PR TITLE
doggo: update to 1.2.0, declare the Go it needs

### DIFF
--- a/net/doggo/Portfile
+++ b/net/doggo/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mr-karan/doggo 1.1.5 v
+go.setup            github.com/mr-karan/doggo 1.2.0 v
 go.offline_build    no
+go.toolchain_min    1.26.4
 revision            0
 
 description         Command-line DNS Client for Humans
@@ -22,9 +23,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  3e33053618916d0a38682795938ec2b20dbfe799 \
-                    sha256  0266fe51cd7c6001011c3424380ff0f48809dcaf631fa65f51bfcbe66e59face \
-                    size    2460993
+checksums           rmd160  03bdabd85765f19d6834306e60111947b99dd422 \
+                    sha256  ddea7da5f8e6263626ffbff57e3df5e84df4343a740b2f7a8dae2505aae645d9 \
+                    size    2471501
 
 build.cmd           make
 build.pre_args      VERSION=${version}


### PR DESCRIPTION
Update to 1.2.0.

Declares `go.toolchain_min 1.26.4`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
