### PR TITLE
gitsign: update to 0.17.0, declare the Go it needs

### DIFF
--- a/security/gitsign/Portfile
+++ b/security/gitsign/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/sigstore/gitsign 0.16.0 v
+go.setup            github.com/sigstore/gitsign 0.17.0 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 description         Keyless Git signing using Sigstore
@@ -17,9 +18,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  485aa671fd3bdf7732db72bdadfa85d6f72828f1 \
-                    sha256  98aae793562337414bc67d529eb2971efa6168020fa4640634b8942faf9a6ea9 \
-                    size    301848
+checksums           rmd160  06b9228bca2d85248cb22ecbfe32539f6b77d389 \
+                    sha256  e0dc7e9108c1da49dea4e0a68b6fdab4d7387428c244d687ea299c8b96d85a30 \
+                    size    355995
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
Update to 0.17.0.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
