### PR TITLE
gmailctl: update to 0.12.0, declare the Go it needs

### DIFF
--- a/mail/gmailctl/Portfile
+++ b/mail/gmailctl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mbrt/gmailctl 0.11.0 v
+go.setup            github.com/mbrt/gmailctl 0.12.0 v
 revision            0
 
 description         \
@@ -23,12 +23,13 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 # Allow Go to fetch dependencies at build time
 go.offline_build no
+go.toolchain_min    1.25.0
 
 build.target        ./cmd/${name}
 
-checksums           rmd160  abf759c9d87eaaee51e8dda57a2199b5494ba292 \
-                    sha256  6a299e60cfd5e58a327d2768cb9ce791b87d2e8be5293d29a4f4919d00cca2cf \
-                    size    98428
+checksums           rmd160  441bf96efbde04966552d15a0ab551cfd9a8e1b4 \
+                    sha256  30cd3e21e8f150081c79a2f656d43b46550a795ccc9cb7775bb7e68da686ee95 \
+                    size    103489
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 0.12.0.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
