### PR TITLE
gomplate: update to 5.2.0, declare the Go it needs

### DIFF
--- a/textproc/gomplate/Portfile
+++ b/textproc/gomplate/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/hairyhenderson/gomplate 5.1.0 v
+go.setup            github.com/hairyhenderson/gomplate 5.2.0 v
 go.package          github.com/hairyhenderson/gomplate/v5
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 description         \
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  522aab2ea8a06c6e8cf7b8cd4432f13b5a844ae4 \
-                    sha256  b6763aaf2c52a2e57a02f5e4cae199166b1ae8df8beb43ef5c927bb10ca775fc \
-                    size    608049
+checksums           rmd160  a938639d7970b1a21f47883aefe1dfe43d9526b3 \
+                    sha256  fb08872f54f776863a30adcd58dce0437529d0e6a468839d107803bbff1d0b23 \
+                    size    611285
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
Update to 5.2.0.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
