### PR TITLE
helmfile: update to 1.7.2, declare the Go it needs

### DIFF
--- a/sysutils/helmfile/Portfile
+++ b/sysutils/helmfile/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/helmfile/helmfile 1.6.0 v
+go.setup            github.com/helmfile/helmfile 1.7.2 v
 go.offline_build    no
+go.toolchain_min    1.26.2
 revision            0
 
 homepage            https://helmfile.readthedocs.io
@@ -28,9 +29,9 @@ build.pre_args-append \
                     TAG=v${version}
 build.args          build
 
-checksums           rmd160  ff674f6107e18db13a96b8f7f8f8548bfbf1f47e \
-                    sha256  152894fb2a75171316f8ebd2631a604a01a757d89e1ca7d0804126eed012a15d \
-                    size    1349456
+checksums           rmd160  99e77bc60ec245879c1e70bf75abfe971ec70604 \
+                    sha256  44b147676d77f193d5dc8182ce9056cf313186947a866e7f76a8badeddd9e9be \
+                    size    1391448
 
 use_parallel_build  no
 


### PR DESCRIPTION
Update to 1.7.2.

Declares `go.toolchain_min 1.26.2`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
