### PR TITLE
go-task: update to 3.52.0, declare the Go it needs

### DIFF
--- a/devel/go-task/Portfile
+++ b/devel/go-task/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-task/task 3.50.0 v
+go.setup            github.com/go-task/task 3.52.0 v
 go.offline_build    no
+go.toolchain_min    1.25.10
 name                go-task
 revision            0
 
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  db15a29ef71c5deeb38db93cc140f7994bf6baa3 \
-                    sha256  d026cc8b9a766d623b8d42ae83986268cb2af91927d0ec66015e4053292dce88 \
-                    size    609396 \
+checksums           rmd160  18d3c86366404e1d653a4ac43a5855707f157e87 \
+                    sha256  54833f32465c45d222867cc89c6bc138d07c63d2b43f0512e2cdb4b2164ad87e \
+                    size    604188 \
 
 build.env-append    CGO_ENABLED=0
 build.args          -o ${worksrcpath}/task \


### PR DESCRIPTION
Update to 3.52.0.

Declares `go.toolchain_min 1.25.10`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
