### PR TITLE
open-code-review: update to 1.8.6

### DIFF
--- a/llm/open-code-review/Portfile
+++ b/llm/open-code-review/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/alibaba/open-code-review 1.8.0 v
-set git-commit      e670b3b
+go.setup            github.com/alibaba/open-code-review 1.8.6 v
+set git-commit      1b193db
 
 categories          llm
 maintainers         @oytech openmaintainer
@@ -19,9 +19,9 @@ long_description    Open Code Review is an AI-powered code review CLI tool. \
                     and produce deep reviews — not just surface-level diff feedback.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9912739da750c9211aac8660d70b2a7445a75579 \
-                    sha256  f6ff2f770e8994a73ee8d24346fc3daaa47e6ceef129c25c4780d5bf514bcfaf \
-                    size    4035982
+                    rmd160  c5bc5c166719d0fc85bca96e08f9b562d9833c0d \
+                    sha256  91229340a3f66da8e91d39465a1fb030afa3edb298d279f644527509ea45e044 \
+                    size    4648017
 
 build.pre_args      -ldflags '-s -w -X main.Version=v${version} -X main.GitCommit=${git-commit}'
 build.args          ./cmd/opencodereview
@@ -38,10 +38,10 @@ go.vendors          google.golang.org/protobuf \
                         size    1822283 \
                     google.golang.org/grpc \
                         repo    github.com/grpc/grpc-go \
-                        lock    v1.81.1 \
-                        rmd160  643c90ad76dc3a8a8cbe578598d457aba273f85e \
-                        sha256  3d2dfa3281c794f34d412770dd31c32ca05fbc54be1d8275688bc8160e2cef73 \
-                        size    3044304 \
+                        lock    v1.82.1 \
+                        rmd160  739515b08a117d9ec06a1ba489e43c51c4a92d10 \
+                        sha256  b82e03be1d08e0a967e11aea147923f1783312e6f220e7927fc936a9c1b9a45f \
+                        size    3093784 \
                     google.golang.org/genproto/googleapis/rpc \
                         repo    github.com/googleapis/go-genproto \
                         lock    3dc84a4a5aaa \
@@ -204,6 +204,16 @@ go.vendors          google.golang.org/protobuf \
                         rmd160  e7b394ee7c9cb14f16863da91a51624e937860bc \
                         sha256  2005290b35023419f272f58b802c52d1f1a38bf68691fe50446dbed23512cec9 \
                         size    125383 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.9 \
+                        rmd160  d4d57de66f1e75d7398a6d6a703c2050454b24ba \
+                        sha256  afc6ee76d0a69c8761f339ac7916c38d997b19c50627ceb9d69df89d8de9e543 \
+                        size    63041 \
+                    github.com/spf13/cobra \
+                        lock    v1.10.2 \
+                        rmd160  88d3b436be943e051ed95bb512ad07508cffab97 \
+                        sha256  35dc1e3b51a9ef4bee86dc22d335293a1d9d9cae242a6efc605fee8f75808d31 \
+                        size    201456 \
                     github.com/segmentio/encoding \
                         lock    v0.5.4 \
                         rmd160  a239004fd8b12074fff087c79c3d67ec7f01af60 \
@@ -259,6 +269,11 @@ go.vendors          google.golang.org/protobuf \
                         rmd160  89e6e520987ed82eab28c0662ba2fa850885d258 \
                         sha256  4369cc921cd22a0feb7092f1cde09cbcd8bd41325482307535e3b4f765cc15e5 \
                         size    35694 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
                     github.com/grpc-ecosystem/grpc-gateway/v2 \
                         lock    v2.29.0 \
                         rmd160  6e6b88b3e1d0dfb6071679a74b323e1066aab921 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
