### PR TITLE
llmfit: update to 1.1.7

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 1.1.6 v
+github.setup            AlexsJones llmfit 1.1.7 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  4693f2386aa5fda22aad15fdc367f9ee5f566af2 \
-                        sha256  20464f17882ea45ac4b52708a87da83eadeec4ac31a065807d14b6716078d246 \
-                        size    7817372
+                        rmd160  74fed6e2adf171c4511cf6534286e15a70454713 \
+                        sha256  fe98918db29aed75cc7f0e3dda47d2ac305f26a4b9dfbbb05daf3b5b891636cd \
+                        size    7833700
 
 categories              llm
 platforms               macosx
@@ -231,7 +231,7 @@ cargo.crates \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     html5ever                       0.38.0  1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2 \
-    http                             1.4.1  8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0 \
+    http                             1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
