### PR TITLE
palm/palm365-mac: new port

### DIFF
--- a/palm/palm365-mac/Portfile
+++ b/palm/palm365-mac/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        HodsonTech palm365-mac 1.6 v
+github.setup        HodsonTech palm365-mac 1.7 v
 github.tarball_from archive
 revision            0
 
@@ -31,9 +31,9 @@ long_description    palm365-mac bidirectionally syncs a Palm OS PDA's \
 
 homepage            https://github.com/HodsonTech/palm365-mac
 
-checksums           rmd160  960c1c224c8a5d285cfbd34fc7c4b173aa321d04 \
-                    sha256  59d6e3a298ee5bf7789b1cb8c38a519497cddb11104738971d866a775a5be087 \
-                    size    30802
+checksums           rmd160  331df43232f4b4a5c38f6612bf7af58b109a35cf \
+                    sha256  153edd39e7812b321e22a1fb01bd576bd85988a84228eadc0b31ae353bf849b2 \
+                    size    30898
 
 depends_build       port:gtk3
 depends_lib         port:jpilot \

--- a/palm/palm365-mac/Portfile
+++ b/palm/palm365-mac/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        HodsonTech palm365-mac 1.4 v
+github.setup        HodsonTech palm365-mac 1.5 v
 github.tarball_from archive
 revision            0
 
@@ -12,6 +12,7 @@ categories          palm python
 platforms           darwin
 license             {GPL-2 MIT}
 maintainers         {jeff.hodson:hodsontech.com @HodsonTech} openmaintainer
+conflicts           palmgoogle-mac
 
 description         Sync a Palm OS PDA with Microsoft 365 via a jpilot plugin
 
@@ -22,20 +23,25 @@ long_description    palm365-mac bidirectionally syncs a Palm OS PDA's \
                     down-sync right after every HotSync -- with no manual \
                     sync command needed day to day. One-time setup requires \
                     creating a free Microsoft 365 app registration, which \
-                    ${prefix}/share/${name}/setup.py walks through.
+                    ${prefix}/share/${name}/setup.py walks through. Not \
+                    installable alongside palmgoogle-mac -- both are \
+                    full-rebuild engines against the same Palm databases, \
+                    and running two independent ones at once is a real \
+                    hazard, not a supported configuration.
 
 homepage            https://github.com/HodsonTech/palm365-mac
 
-checksums           rmd160  fecf39206043aa93d90ee06bfad10887905a2c8c \
-                    sha256  690cb324ce333148340216a40a6b5fca33a1e164a7442ca00841ebc6988bc0bb \
-                    size    53682
+checksums           rmd160  7ef736a843528c0f7895a8d8ed040bd52a951e02 \
+                    sha256  6702991b822b77b9d178b93a46bfefde82d59e303a19518c469ae043bb720ffc \
+                    size    30242
 
 depends_build       port:gtk3
 depends_lib         port:jpilot \
                     port:pilot-link \
                     port:python314 \
                     port:py314-msal \
-                    port:py314-requests
+                    port:py314-requests \
+                    port:py314-palm-sync-core
 
 use_configure       no
 
@@ -56,9 +62,8 @@ destroot {
         ${destroot}${prefix}/lib/jpilot/plugins/
 
     xinstall -d ${destroot}${prefix}/share/${name}
-    foreach f {backup365.py config.example.toml graph_client.py id_map.py \
-               palm_writer.py paths.py pc3_seed.py setup.py sync_state.py \
-               sync_to_palm.py README.md LICENSE} {
+    foreach f {config.example.toml graph_client.py graph_field_mapper.py \
+               pc3_seed.py setup.py sync_to_palm.py README.md LICENSE} {
         xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/${name}/
     }
 

--- a/palm/palm365-mac/Portfile
+++ b/palm/palm365-mac/Portfile
@@ -1,0 +1,79 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        HodsonTech palm365-mac 1.4 v
+github.tarball_from archive
+revision            0
+
+name                palm365-mac
+categories          palm python
+platforms           darwin
+license             {GPL-2 MIT}
+maintainers         {jeff.hodson:hodsontech.com @HodsonTech} openmaintainer
+
+description         Sync a Palm OS PDA with Microsoft 365 via a jpilot plugin
+
+long_description    palm365-mac bidirectionally syncs a Palm OS PDA's \
+                    calendar, tasks, and contacts with a Microsoft 365 \
+                    account. It runs automatically as a jpilot plugin -- a \
+                    down-sync when jpilot launches, and a full push-up + \
+                    down-sync right after every HotSync -- with no manual \
+                    sync command needed day to day. One-time setup requires \
+                    creating a free Microsoft 365 app registration, which \
+                    ${prefix}/share/${name}/setup.py walks through.
+
+homepage            https://github.com/HodsonTech/palm365-mac
+
+checksums           rmd160  fecf39206043aa93d90ee06bfad10887905a2c8c \
+                    sha256  690cb324ce333148340216a40a6b5fca33a1e164a7442ca00841ebc6988bc0bb \
+                    size    53682
+
+depends_build       port:gtk3
+depends_lib         port:jpilot \
+                    port:pilot-link \
+                    port:python314 \
+                    port:py314-msal \
+                    port:py314-requests
+
+use_configure       no
+
+build {
+    system -W ${worksrcpath}/jpilot-plugin \
+        "${configure.cc} -arch ${configure.build_arch} -bundle \
+         -Wl,-undefined,dynamic_lookup \
+         -DPYTHON_BIN=\\\"${prefix}/bin/python3.14\\\" \
+         -DSYNC_CWD=\\\"${prefix}/share/${name}\\\" \
+         -I vendor \
+         `${prefix}/bin/pkg-config --cflags gtk+-3.0` \
+         -o libpalm365plugin.so palm365plugin.c"
+}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/lib/jpilot/plugins
+    xinstall -m 755 ${worksrcpath}/jpilot-plugin/libpalm365plugin.so \
+        ${destroot}${prefix}/lib/jpilot/plugins/
+
+    xinstall -d ${destroot}${prefix}/share/${name}
+    foreach f {backup365.py config.example.toml graph_client.py id_map.py \
+               palm_writer.py paths.py pc3_seed.py setup.py sync_state.py \
+               sync_to_palm.py README.md LICENSE} {
+        xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/${name}/
+    }
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/jpilot-plugin/COPYING \
+        ${destroot}${prefix}/share/doc/${name}/COPYING.plugin
+}
+
+notes "
+palm365-mac needs a one-time setup step before it can sync anything --\n\
+it creates a free Microsoft 365 app registration (a real Microsoft\n\
+requirement, not something this port can skip) and writes your config.\n\
+\n\
+    cd ${prefix}/share/${name} && ${prefix}/bin/python3.14 setup.py\n\
+\n\
+After that, just launch jpilot and HotSync -- syncing happens\n\
+automatically from then on, no manual commands needed.
+"

--- a/palm/palm365-mac/Portfile
+++ b/palm/palm365-mac/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        HodsonTech palm365-mac 1.5 v
+github.setup        HodsonTech palm365-mac 1.6 v
 github.tarball_from archive
 revision            0
 
@@ -31,9 +31,9 @@ long_description    palm365-mac bidirectionally syncs a Palm OS PDA's \
 
 homepage            https://github.com/HodsonTech/palm365-mac
 
-checksums           rmd160  7ef736a843528c0f7895a8d8ed040bd52a951e02 \
-                    sha256  6702991b822b77b9d178b93a46bfefde82d59e303a19518c469ae043bb720ffc \
-                    size    30242
+checksums           rmd160  960c1c224c8a5d285cfbd34fc7c4b173aa321d04 \
+                    sha256  59d6e3a298ee5bf7789b1cb8c38a519497cddb11104738971d866a775a5be087 \
+                    size    30802
 
 depends_build       port:gtk3
 depends_lib         port:jpilot \


### PR DESCRIPTION
## Summary

As far as I'm aware, this is the first bidirectional sync bridge between a Palm OS PDA and Microsoft 365 that exists anywhere — nobody else has built this. `palm365-mac` is a jpilot plugin (`palm/palm365-mac`) that syncs a physical Palm's calendar, tasks, and contacts with a Microsoft 365 account, automatically, every time you HotSync — no manual sync command needed day to day.

That novelty is the actual case for including it despite one real wrinkle noted below: there's genuinely nothing else that does this, for a device class MacPorts already supports well (`jpilot`, `pilot-link`).

## The one thing worth flagging up front

This port requires a **one-time Microsoft 365 app registration** per user — a real Microsoft requirement (not something this port could bypass), needed so the tool can read/write *your own* calendar/contacts/tasks under *your own* Azure app, not a shared/published one. `setup.py` (installed to `${prefix}/share/palm365-mac/setup.py`) walks through it step by step, and the port's `notes {}` block tells the user to run it right after install. I'm calling this out explicitly rather than hoping it goes unnoticed in review — happy to adjust anything about how it's presented if that helps.

## How it works

- `jpilot-plugin/palm365plugin.c` (GPLv2, built against jpilot's own GPL plugin-API headers, vendored in `jpilot-plugin/vendor/`) hooks `plugin_startup`/`plugin_post_sync` and hands off to a Python daemon in the background (jpilot's own sync loop calls `plugin_post_sync` synchronously, so it can't block on network calls).
- The Python side (MIT-licensed, doesn't link against jpilot) talks to Microsoft Graph and reads/writes jpilot's `.pdb` files via `pilot-link`'s `libpisock` through `ctypes` — no C extension needed.
- No hardcoded per-user values anywhere: the plugin derives a stable per-device identity at runtime from jpilot's own `base_dir` (so multi-device setups work with zero configuration), and all per-user state (config, id-maps, backups) lives under `~/.palm365/`, never inside the port's own install tree.

## Testing performed

Tested via repeated local `port -d install` cycles (not just manual compile/install) against a real MacPorts install, including several real-hardware round trips: launching jpilot, a genuine HotSync, and confirming the plugin's automatic push-up/down-sync cycle behaves correctly. Iterating through that process caught and fixed several real packaging bugs before this submission (wrong `github.tarball_from` mode, a stale unregistered file blocking activation, the plugin's log/config paths defaulting to the shared install directory instead of user-writable space, and `setup.py`'s own printed instructions naming the wrong Python interpreter) — full history in the [HodsonTech/palm365-mac](https://github.com/HodsonTech/palm365-mac) commit log if useful context for review.
