### PR TITLE
ipatool: Update to 2.3.2

### DIFF
--- a/sysutils/ipatool/Portfile
+++ b/sysutils/ipatool/Portfile
@@ -3,20 +3,20 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/majd/ipatool 2.3.1 v
+go.setup                github.com/majd/ipatool 2.3.2 v
+go.toolchain_min        1.25.0
 revision                0
 categories              sysutils
 license                 MIT
-platforms               {darwin >= 21}
 installs_libs           no
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             CLI for searching and downloading iOS app packages from the App Store
 long_description        {*}${description}.
 
-checksums               rmd160  3adc2270aafd50890ce70020e1347ada2579ffda \
-                        sha256  2fe03975acd6eb184c3cc6e0bb5d49f973c39aa518d36279685f442c23e87956 \
-                        size    723049
+checksums               rmd160  7fc8bc370feb2d8188ffb7ac59a2c49d175b228f \
+                        sha256  669630b7bd181d90ce4a2aa45d5a10548e7a31894bc0eedcef2d709c14bfecd1 \
+                        size    724645
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no


### PR DESCRIPTION
#### Description

Update ipatool to 2.3.2. Declare minimum Go toolchain required to build.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
