### PR TITLE
python/palm-sync-core: new port

### DIFF
--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        HodsonTech palm-sync-core 1.0 v
+github.tarball_from archive
+revision            0
+
+name                py-palm-sync-core
+categories          python palm
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {jeff.hodson:hodsontech.com @HodsonTech} openmaintainer
+
+description         Provider-agnostic Palm OS <-> cloud sync engine
+
+long_description    The shared reconciliation engine behind palm365-mac and \
+                    other Palm-to-cloud sync tools: reads/writes jpilot's \
+                    .pdb/.pc3 files via pilot-link, and tracks a stable \
+                    confirmed/pending id-map so records survive repeated \
+                    syncs without duplicating or resurrecting after \
+                    deletion. Not a standalone tool -- installed as a \
+                    dependency of a provider-specific package that supplies \
+                    the actual cloud API client.
+
+homepage            https://github.com/HodsonTech/palm-sync-core
+
+checksums           rmd160  c8274dae5b48af30f925bc3571a66b33bd305b13 \
+                    sha256  15272070b87e1ed8a47f4c3d8afc83b4f5f70bb85ae045f082eb79111665ae3d \
+                    size    26171
+
+python.versions     314
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+    depends_lib-append  port:pilot-link
+    livecheck.type      none
+}

--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        HodsonTech palm-sync-core 1.2 v
+github.setup        HodsonTech palm-sync-core 1.3 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    The shared reconciliation engine behind palm365-mac, \
 
 homepage            https://github.com/HodsonTech/palm-sync-core
 
-checksums           rmd160  798a9d04e1bec4779910d9b97b95c661ad10e89a \
-                    sha256  50c196c7686a750d954295b199d26e705d6df120f0bc05608ab7a3e238c4fd99 \
-                    size    26900
+checksums           rmd160  1c7890aff3866fd79f60d8981d44a22e4ed0537c \
+                    sha256  09b4d9faac62211bacf8d621c841a9e97a8117a13a24e97090bb956d5bb5aea0 \
+                    size    27638
 
 python.versions     314
 

--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        HodsonTech palm-sync-core 1.6 v
+github.setup        HodsonTech palm-sync-core 1.7 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    The shared reconciliation engine behind palm365-mac, \
 
 homepage            https://github.com/HodsonTech/palm-sync-core
 
-checksums           rmd160  732d09c9aa65b6efd2c32e4f0274a002855e9c6f \
-                    sha256  f76eec6c2dfa255b087e7b2f77996b5a4034a456c2030432f78bc93762d8bd5e \
-                    size    29717
+checksums           rmd160  cd0cefb6321adcb13e762f20c68300bec0ef87c5 \
+                    sha256  d7002b15af0cbda838271e35c554ba6657d5d9b00c511a72e700156fea94ad1a \
+                    size    30062
 
 python.versions     314
 

--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        HodsonTech palm-sync-core 1.0 v
+github.setup        HodsonTech palm-sync-core 1.1 v
 github.tarball_from archive
 revision            0
 
@@ -17,20 +17,20 @@ maintainers         {jeff.hodson:hodsontech.com @HodsonTech} openmaintainer
 
 description         Provider-agnostic Palm OS <-> cloud sync engine
 
-long_description    The shared reconciliation engine behind palm365-mac and \
-                    other Palm-to-cloud sync tools: reads/writes jpilot's \
-                    .pdb/.pc3 files via pilot-link, and tracks a stable \
-                    confirmed/pending id-map so records survive repeated \
-                    syncs without duplicating or resurrecting after \
-                    deletion. Not a standalone tool -- installed as a \
-                    dependency of a provider-specific package that supplies \
-                    the actual cloud API client.
+long_description    The shared reconciliation engine behind palm365-mac, \
+                    palmgoogle-mac, and other Palm-to-cloud sync tools: \
+                    reads/writes jpilot's .pdb/.pc3 files via pilot-link, \
+                    and tracks a stable confirmed/pending id-map so records \
+                    survive repeated syncs without duplicating or \
+                    resurrecting after deletion. Not a standalone tool -- \
+                    installed as a dependency of a provider-specific \
+                    package that supplies the actual cloud API client.
 
 homepage            https://github.com/HodsonTech/palm-sync-core
 
-checksums           rmd160  c8274dae5b48af30f925bc3571a66b33bd305b13 \
-                    sha256  15272070b87e1ed8a47f4c3d8afc83b4f5f70bb85ae045f082eb79111665ae3d \
-                    size    26171
+checksums           rmd160  483116a43c02c79c2e7f377f857c14b67bdb76ac \
+                    sha256  d4ecf2b08d2e1666dc40aa07f49321915af986e80d4eab601ce800e21635874b \
+                    size    26503
 
 python.versions     314
 

--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        HodsonTech palm-sync-core 1.3 v
+github.setup        HodsonTech palm-sync-core 1.5 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    The shared reconciliation engine behind palm365-mac, \
 
 homepage            https://github.com/HodsonTech/palm-sync-core
 
-checksums           rmd160  1c7890aff3866fd79f60d8981d44a22e4ed0537c \
-                    sha256  09b4d9faac62211bacf8d621c841a9e97a8117a13a24e97090bb956d5bb5aea0 \
-                    size    27638
+checksums           rmd160  eae29b16704703082414bb07f001eac6a75cd0ad \
+                    sha256  fc18713652eb4dd3c2d3864b6d09a2341e9fc9c670c769f3cff64a349253eec1 \
+                    size    28245
 
 python.versions     314
 

--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        HodsonTech palm-sync-core 1.5 v
+github.setup        HodsonTech palm-sync-core 1.6 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    The shared reconciliation engine behind palm365-mac, \
 
 homepage            https://github.com/HodsonTech/palm-sync-core
 
-checksums           rmd160  eae29b16704703082414bb07f001eac6a75cd0ad \
-                    sha256  fc18713652eb4dd3c2d3864b6d09a2341e9fc9c670c769f3cff64a349253eec1 \
-                    size    28245
+checksums           rmd160  732d09c9aa65b6efd2c32e4f0274a002855e9c6f \
+                    sha256  f76eec6c2dfa255b087e7b2f77996b5a4034a456c2030432f78bc93762d8bd5e \
+                    size    29717
 
 python.versions     314
 

--- a/python/palm-sync-core/Portfile
+++ b/python/palm-sync-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        HodsonTech palm-sync-core 1.1 v
+github.setup        HodsonTech palm-sync-core 1.2 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    The shared reconciliation engine behind palm365-mac, \
 
 homepage            https://github.com/HodsonTech/palm-sync-core
 
-checksums           rmd160  483116a43c02c79c2e7f377f857c14b67bdb76ac \
-                    sha256  d4ecf2b08d2e1666dc40aa07f49321915af986e80d4eab601ce800e21635874b \
-                    size    26503
+checksums           rmd160  798a9d04e1bec4779910d9b97b95c661ad10e89a \
+                    sha256  50c196c7686a750d954295b199d26e705d6df120f0bc05608ab7a3e238c4fd99 \
+                    size    26900
 
 python.versions     314
 


### PR DESCRIPTION
## Summary

A companion port to `palm365-mac` ([#33861](https://github.com/macports/macports-ports/pull/33861)): the provider-agnostic Palm-to-cloud reconciliation engine, extracted out of that port so it can be shared with other cloud-provider packages instead of duplicated. A Google-backed package (`palmgoogle-mac`) depending on this is in progress.

This is a library, not a standalone tool -- it has no useful behavior on its own, only as a dependency of a provider-specific package that supplies the actual cloud API client (Microsoft Graph, Google, ...) and the field-mapping between that API's JSON shapes and Palm records.

## What it does

- Reads/writes jpilot's `.pdb`/`.pc3` files via `pilot-link`'s `libpisock`, through `ctypes`.
- Tracks a stable confirmed/pending id-map (SQLite) so records survive repeated syncs without duplicating or resurrecting after deletion -- this is the part with the most hard-won correctness behind it (six real bugs found and fixed via live physical-hardware testing while building `palm365-mac`).
- Implements the actual sync orchestration (push-up, deletions, down-sync, the full bidirectional cycle) against an injected cloud-client object and field-mapper module, with zero knowledge of any specific provider's API.

## Design note: one provider at a time

This engine has no notion of multiple cloud sources syncing the same data type at once, and deliberately doesn't need one -- a Palm device only has one calendar/contacts/tasks database, and two independent full-rebuild engines racing to write the same file is a real hazard. Provider packages built on this declare a MacPorts `conflicts` against each other rather than attempt to coexist (see `palm365-mac`'s Portfile).

## Testing

Tested via repeated local `port -d install` cycles, and validated as a real dependency by refactoring `palm365-mac` to consume it and running a full real HotSync round-trip (jpilot launch -> plugin_startup down-sync -> HotSync -> plugin_post_sync push-up/deletions/down-sync) with debug logging, confirming identical behavior to the pre-split monolithic version.