### PR TITLE
whichllm, py-dbgpu, py-thefuzz: new port

### DIFF
--- a/llm/whichllm/Portfile
+++ b/llm/whichllm/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    whichllm
+version                 0.5.15
+revision                0
+
+categories              llm python
+license                 MIT
+maintainers             @oytech openmaintainer
+
+homepage                https://github.com/Andyyyy64/whichllm
+description             Find the best LLM that runs on your hardware
+long_description        Find the local LLM that actually runs and performs best on your hardware. \
+                        Auto-detects your GPU/CPU/RAM and ranks the top models from HuggingFace that fit your system. \
+                        Ranked by real, recency-aware benchmarks, not parameter count.
+
+checksums               rmd160  e5e09c0a8446f9a183219b1395018c822a9af327 \
+                        sha256  40a94e7495ceb9f730f57b5ebf4988bdd45e5e57b22c9f058b500fa4fbdeb180 \
+                        size    1103123
+
+python.default_version  314
+python.pep517_backend   hatch
+
+depends_run-append \
+    port:py${python.version}-dbgpu \
+    port:py${python.version}-httpx \
+    port:py${python.version}-psutil \
+    port:py${python.version}-rich \
+    port:py${python.version}-typer

--- a/python/py-dbgpu/Portfile
+++ b/python/py-dbgpu/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-dbgpu
+version             2025.12
+revision            0
+
+license             MIT
+maintainers         @oytech openmaintainer
+
+homepage            https://github.com/painebenjamin/dbgpu
+description         A small easy to use open source database of over 2000 GPUs with \
+                    architecture manufacturing API support and performance details.
+long_description    {*}${description}
+
+checksums           rmd160  fddacf9dd7b4e90e7d45bd4f967d8cb61cb39369 \
+                    sha256  d4a2fdc36ff5ff2af37e8fd8a3e0740ab2af73cc5e0fda199fdff3d6f1686f4e \
+                    size    225653
+
+python.versions     312 313 314
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+        port:py${python.version}-click \
+        port:py${python.version}-pydantic \
+        port:py${python.version}-tabulate \
+        port:py${python.version}-thefuzz
+}

--- a/python/py-thefuzz/Portfile
+++ b/python/py-thefuzz/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-thefuzz
+version             0.22.1
+revision            0
+
+license             MIT
+maintainers         @oytech openmaintainer
+
+homepage            https://github.com/seatgeek/thefuzz
+description         Fuzzy string matching in python
+long_description    {*}${description}
+
+checksums           rmd160  77e677bed25dacb0085ca0340477363c03f75a84 \
+                    sha256  7138039a7ecf540da323792d8592ef9902b1d79eb78c147d4f20664de79f3680 \
+                    size    19993
+
+python.versions     312 313 314
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+        port:py${python.version}-rapidfuzz
+}


### PR DESCRIPTION
#### Description

New port for https://github.com/Andyyyy64/whichllm with 2 dependencies that were not present in macports tree.

Note that I included only some of the optional dependencies for `dbgpu` as whichllm requires `dbgpu[fuzz]`

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
