### PR TITLE
fossil: update to 2.28

### DIFF
--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 
 name                fossil
-version             2.27
+version             2.28
 revision            0
 epoch               20110901182519
 categories          devel
@@ -25,9 +25,9 @@ homepage            https://fossil-scm.org/home/
 master_sites        ${homepage}tarball/version-${version}/
 distname            fossil-src-${version}
 
-checksums           rmd160  ee20aed32ce570d6a945a87cb54b2d5c3520e18f \
-                    sha256  0405a96ba4d286b46fb5c3217d6c13391a2c637da90c51a927ee0c31c58f9064 \
-                    size    7181357
+checksums           rmd160  c8a69d801cc6f86faf0f56eff2d90143148f6b17 \
+                    sha256  84c18824ca227e7602d2408b663c3747f754ad306ed5c73ddab959d6589538a6 \
+                    size    7329012
 
 test.run            yes
 


### PR DESCRIPTION
#### Description
https://fossil-scm.org/home/doc/trunk/www/changes.wiki#v2_28

###### Tested on
macOS 15.7.8 24G824 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
