### PR TITLE
aws-vault: update to 7.13.2, declare the Go it needs

### DIFF
--- a/security/aws-vault/Portfile
+++ b/security/aws-vault/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ByteNess/aws-vault 7.12.1 v
+go.setup            github.com/ByteNess/aws-vault 7.13.2 v
 go.offline_build    no
+go.toolchain_min    1.26
 go.package          github.com/ByteNess/aws-vault
 revision            0
 
@@ -20,9 +21,9 @@ long_description    \
     designed to be complementary to the AWS CLI tools, and is aware of your \
     profiles and configuration in ~/.aws/config.
 
-checksums           rmd160  581d5f9cb2773ee26a59563bee5c0709892343fb \
-                    sha256  ff60781aaf5378aa4600c4b9989c6d3e3cbfa0454124f291c8b0dcea8f0c3c91 \
-                    size    102250
+checksums           rmd160  c9fb4b275011e67807f87084ba0c17e2c0b7dd39 \
+                    sha256  4f970bcdb71ba97c6780d079caa16e71bb68eaa5b9b34e22ff9d654a1328a9d9 \
+                    size    110190
 
 categories          security
 installs_libs       no


### PR DESCRIPTION
Update to 7.13.2.

Declares `go.toolchain_min 1.26`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
