### PR TITLE
ggc: update to 8.7.2, declare the Go it needs

### DIFF
--- a/devel/ggc/Portfile
+++ b/devel/ggc/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/bmf-san/ggc 8.6.4 v
+go.setup            github.com/bmf-san/ggc 8.7.2 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         \
@@ -24,9 +25,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dab2aa642164442f42daecc2232c0ebff7b3649d \
-                    sha256  cd0b2abf2eb20b2c258a82062597bf5b76f82c9702f665f5db5c3056dcbe8074 \
-                    size    4907825
+checksums           rmd160  ea9eb89f50d2f81b7aafed8f9684b78c82192929 \
+                    sha256  baeff020de9cb5ced3da94d50805727071c9faa5bc06089b14404430f95b9334 \
+                    size    4887638
 
 build.args-append   \
     -ldflags \" -X main.version=${version} \"


### PR DESCRIPTION
Update to 8.7.2.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
