### PR TITLE
influx-cli: update to 2.8.0, declare the Go it needs

### DIFF
--- a/sysutils/influx-cli/Portfile
+++ b/sysutils/influx-cli/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/influxdata/influx-cli 2.7.5 v
+go.setup            github.com/influxdata/influx-cli 2.8.0 v
 go.package          github.com/influxdata/influx-cli/v2
 go.offline_build    no
+go.toolchain_min    1.25
 revision            0
 
 description         CLI for managing resources in InfluxDB v2
@@ -17,9 +18,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  68bde64adf020452c829783523c25a564b3bdfbd \
-                    sha256  2741105c0fa7bf0f728643807aa21e9a8e356b17a681e92f06c4ff680e6944ac \
-                    size    443950
+checksums           rmd160  8ecc9d23896856a4ca6f84374fc8782b71feaeb0 \
+                    sha256  a507a4d0a0f4858d575f5a5c343c0f80e00151715c381d8be402c8bb6c9b8769 \
+                    size    445820
 
 # All gopath/bin to PATH
 build.env-append    PATH=$env(PATH):${gopath}/bin


### PR DESCRIPTION
Update to 2.8.0.

Declares `go.toolchain_min 1.25`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
