### PR TITLE
jlv: update to 1.7.1, declare the Go it needs

### DIFF
--- a/textproc/jlv/Portfile
+++ b/textproc/jlv/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/hedhyw/json-log-viewer 1.6.0 v
+go.setup            github.com/hedhyw/json-log-viewer 1.7.1 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 name                jlv
 revision            0
 
@@ -18,9 +19,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  42bc814d64e3ee48b7629fb5bac50c6af604ed93 \
-                    sha256  5136470f8f43d35e23d78b8660f06a1f800a86078680ba2774e86fc05103f2ec \
-                    size    582273
+checksums           rmd160  7d0e8e4f097adf698a47299e370d1ff89032dfd7 \
+                    sha256  1b008c9285d917a58fe6e1567aac79e590ab23d8091819e7c05ea2a17e76450e \
+                    size    585987
 
 build.cmd           make
 build.pre_args      VERSION=v${version}


### PR DESCRIPTION
Update to 1.7.1.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
