### PR TITLE
kluctl: update to 2.28.2, declare the Go it needs

### DIFF
--- a/sysutils/kluctl/Portfile
+++ b/sysutils/kluctl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kluctl/kluctl 2.27.0 v
+go.setup            github.com/kluctl/kluctl 2.28.2 v
 go.package          github.com/kluctl/kluctl/v2
 revision            0
 
@@ -38,11 +38,12 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  8e057706ac65c0be460314bb7be2a180e36c584e \
-                    sha256  699fc10338436f335f853d58467cc5833aabb967042bec5538ae7af0e48bd2e2 \
-                    size    4801211
+checksums           rmd160  2c631a93926fc673c4ecdd221e51436826d4513b \
+                    sha256  e30c1b32675476e366237e06c30fd393ba32ceb80e6cd94e3cab82e6bed79fe0 \
+                    size    11639978
 
 go.offline_build no
+go.toolchain_min    1.26.0
 
 build.pre_args-append \
     -ldflags \"-X main.version=${github.tag_prefix}${version}\" \


### PR DESCRIPTION
Update to 2.28.2.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
