### PR TITLE
lefthook: update to 2.1.10, declare the Go it needs

### DIFF
--- a/devel/lefthook/Portfile
+++ b/devel/lefthook/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/evilmartians/lefthook 2.0.4 v
+go.setup            github.com/evilmartians/lefthook 2.1.10 v
 go.offline_build    no
+go.toolchain_min    1.26.4
 revision            0
 
 homepage            https://lefthook.dev/
@@ -24,9 +25,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f51f174104614a7675a6b66333a39d69c67c413a \
-                    sha256  5d152b84e6a1aecd1d3173865a69f0466d1c166c3978ce6e679293194973b845 \
-                    size    153660
+checksums           rmd160  d950fca06806d7e1acbc6eaa9724ecd8ba9761a9 \
+                    sha256  9a0b4b2ff3f31a4cb16347851826be6791ad70e123849cb34acde8cd1b99eb82 \
+                    size    225559
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 2.1.10.

Declares `go.toolchain_min 1.26.4`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
