### PR TITLE
nebula: update to 1.11.0, declare the Go it needs

### DIFF
--- a/net/nebula/Portfile
+++ b/net/nebula/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/slackhq/nebula 1.10.1 v
+go.setup            github.com/slackhq/nebula 1.11.0 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 categories          net
@@ -23,9 +24,9 @@ long_description    Nebula is a scalable overlay networking tool with a focus \
                     It can be used to connect a small number of computers, \
                     but is also able to connect tens of thousands of computers.
 
-checksums           rmd160  fe5e4f98ec2475ec0368b736997f2c2a5a763d18 \
-                    sha256  43223baae6909f08ce369d1100b5098b8f77c39fc8ce736afc74bed9917db752 \
-                    size    1048731
+checksums           rmd160  92216fcb8167982e7bbb30300df31bdf401f9439 \
+                    sha256  d570e30a04e4e25fb1bddac6e131f26b325f7c5226c4961c6c37ef6f297d60a6 \
+                    size    1170741
 
 build.env-append    BUILD_NUMBER="${version}"
 build.cmd           make


### PR DESCRIPTION
Update to 1.11.0.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
