### PR TITLE
neonmodem: update to 1.1.0, declare the Go it needs

### DIFF
--- a/net/neonmodem/Portfile
+++ b/net/neonmodem/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mrusme/neonmodem 1.0.7 v
+go.setup            github.com/mrusme/neonmodem 1.1.0 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://neonmodem.com
@@ -23,9 +24,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  cdccd678c63ed98dfb31c5c78517826fb7812fa0 \
-                    sha256  4488d7f4713154830d2a39cd8f71d16db5aea5a537924aeaca214c25211aef00 \
-                    size    2150700
+checksums           rmd160  a4477f34475288f281234e20943cf7b2c5e37536 \
+                    sha256  662ed77f11971c60bdabbe914d99d78a004411fa2dc33ecb49a5bd1b5538f124 \
+                    size    2155596
 
 build.cmd           make
 build.pre_args      VERSION="${github.tag_prefix}${version}"


### PR DESCRIPTION
Update to 1.1.0.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
