### PR TITLE
nfpm: update to 2.47.0, declare the Go it needs

### DIFF
--- a/sysutils/nfpm/Portfile
+++ b/sysutils/nfpm/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/goreleaser/nfpm 2.46.0 v
+go.setup            github.com/goreleaser/nfpm 2.47.0 v
 go.offline_build    no
+go.toolchain_min    1.26.4
 go.package          github.com/goreleaser/nfpm/v2
 revision            0
 
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  20012ad3ffe62ff32cb605e975ae443217679924 \
-                    sha256  b4d6f2065e3a6c2a59520086b149dd51872dc6362bbd8f9df9bd655ca82111f7 \
-                    size    609095
+checksums           rmd160  ed38a85f2e98566a26e38b7c752ccfc88f8e590d \
+                    sha256  906b8dde0c5626376779f3ebddea3554b0eb6e1b8450a09bdc746cba92ef5dea \
+                    size    611939
 
 build.pre_args-append \
     -ldflags \" \


### PR DESCRIPTION
Update to 2.47.0.

Declares `go.toolchain_min 1.26.4`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
