### PR TITLE
ratchet: update to 0.12.0, declare the Go it needs

### DIFF
--- a/devel/ratchet/Portfile
+++ b/devel/ratchet/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/sethvargo/ratchet 0.11.4 v
+go.setup            github.com/sethvargo/ratchet 0.12.0 v
 go.offline_build    no
+go.toolchain_min    1.25.12
 revision            0
 
 description         A tool for securing CI/CD workflows with version pinning.
@@ -24,9 +25,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 build.pre_args-append \
     -ldflags \"-X ${go.package}/internal/version.version=${version}\"
 
-checksums           rmd160  140830217d5d634190c24590b11ff548392c0c83 \
-                    sha256  0f1a540f388d2b8633b8203670d6ec8722d47af40055ce79cd1743a731823b2e \
-                    size    55718
+checksums           rmd160  44a1854359869872671bfc782d0d35c90d7ad8e8 \
+                    sha256  7fe2adcf0f5eea0fdd80812d4a0bb20e0b7a4197b6c448191338214d94a8b594 \
+                    size    63840
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 0.12.0.

Declares `go.toolchain_min 1.25.12`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
