### PR TITLE
sheets: update to 0.3.0, declare the Go it needs

### DIFF
--- a/office/sheets/Portfile
+++ b/office/sheets/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/maaslalani/sheets 0.2.0 v
+go.setup            github.com/maaslalani/sheets 0.3.0 v
 go.offline_build    no
+go.toolchain_min    1.25.7
 revision            0
 
 description         Terminal based spreadsheet
@@ -19,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dd9e91d46d403cdbc1980a18c75bff09f984fe43 \
-                    sha256  e33563769858abba1812d6f9e1f427241a9a5c65da3a34a87d8784c8a050e25e \
-                    size    250213
+checksums           rmd160  0d2c8749e53b52f13c81666c34d8772fc3904c1e \
+                    sha256  d65b37c4d40c0a531a87a81848350528387e1247b24d2aa3a04dd5a41338c9fa \
+                    size    258350
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 0.3.0.

Declares `go.toolchain_min 1.25.7`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
