### PR TITLE
sqlc: update to 1.31.1, declare the Go it needs

### DIFF
--- a/devel/sqlc/Portfile
+++ b/devel/sqlc/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/sqlc-dev/sqlc 1.30.0 v
+go.setup            github.com/sqlc-dev/sqlc 1.31.1 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 homepage            https://sqlc.dev/
@@ -18,9 +19,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  261a61b160d3ded13b300915f3c6a22ca79a3bac \
-                    sha256  32a8ff2acd852c4a004383b441e6614b6c57ce1a294c0e455ab7431f017aa895 \
-                    size    1035958
+checksums           rmd160  711b3392817634b6b16b0c7478049c40d0f71251 \
+                    sha256  de82593a200e4130dc2a0413a808f93fc30fdc7b5ecd402913ed08a8fea06c4a \
+                    size    1093763
 
 build.args-append   -o bin ./cmd/...
 


### PR DESCRIPTION
Update to 1.31.1.

Declares `go.toolchain_min 1.26.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
