### PR TITLE
tfupdate: update to 0.10.2, declare the Go it needs

### DIFF
--- a/sysutils/tfupdate/Portfile
+++ b/sysutils/tfupdate/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/minamijoyo/tfupdate 0.9.3 v
+go.setup            github.com/minamijoyo/tfupdate 0.10.2 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         Update version constraints in your Terraform configurations
@@ -17,9 +18,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  5dfbded42b131aec569f632ace23953c8eb98a21 \
-                    sha256  282c5d0cb02d5bc43a4f0e7093e3ddc65ee04acf45ba9d47ec7bafbee19f7208 \
-                    size    97200
+checksums           rmd160  87108f185eae50aeeac8eb7cc4433b8b5d160325 \
+                    sha256  e5aa33dcf1840bd390aabb3d6c663d9d67ae8dd3592b8e22958f8e0db80d230e \
+                    size    104296
 
 build.cmd           make
 build.target        build


### PR DESCRIPTION
Update to 0.10.2.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
