### PR TITLE
ticker: update to 5.3.0, declare the Go it needs

### DIFF
--- a/finance/ticker/Portfile
+++ b/finance/ticker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/achannarasappa/ticker 5.2.1 v
+go.setup            github.com/achannarasappa/ticker 5.3.0 v
 revision            0
 
 description         Terminal stock ticker with live updates and position \
@@ -20,14 +20,15 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f44f7dbda30f4ed5ee8abe572d34b1945eb74aac \
-                    sha256  774b060941aed0773b49633bb5b009247ff8122ee7d45ddfe406940c635f6926 \
-                    size    1672520
+checksums           rmd160  4beff5a09fd0d10ee17d7bb4e1a4c02a973a8718 \
+                    sha256  c11e522a309feee522cf3af22d1581a5a1ef338bb6a597fc0c1839b6f0142b42 \
+                    size    1681529
 
 # Building with go.vendors doesn't work very well as ticker is not using a
 # fully qualified module name in both go.mod and Go sources.  Allow to build
 # as it naturally would for now.
 go.offline_build no
+go.toolchain_min    1.26.4
 
 build.pre_args-append \
                     -ldflags \"-X ${go.package}/v5/cmd.Version=v${version}\"


### PR DESCRIPTION
Update to 5.3.0.

Declares `go.toolchain_min 1.26.4`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
