### PR TITLE
trufflehog: update to 3.96.0, declare the Go it needs

### DIFF
--- a/security/trufflehog/Portfile
+++ b/security/trufflehog/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/trufflesecurity/trufflehog 3.95.8 v
+go.setup            github.com/trufflesecurity/trufflehog 3.96.0 v
 go.package          github.com/trufflesecurity/trufflehog/v3
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         Find credentials all over the place
@@ -24,9 +25,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 build.args-append \
     -ldflags \" -X ${go.package}/pkg/version.BuildVersion=${version} \"
 
-checksums           rmd160  66f542d52e7e88ad3657560042b6142a7851df78 \
-                    sha256  274ad44b514061239ff4e22dc74f33ceb25b3db842e8bd7d59a7a1a3e22d3b71 \
-                    size    6118277
+checksums           rmd160  23d0567f6ce70962803ad27e71cada32e42bef09 \
+                    sha256  f5b01224d4f43a5b3e5614d1fb3d53b3286fe5481b076bb059c42db0dec5adf8 \
+                    size    6154192
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Update to 3.96.0.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
