### PR TITLE
zot: update to 0.3.33, declare the Go it needs

### DIFF
--- a/llm/zot/Portfile
+++ b/llm/zot/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/patriceckhart/zot 0.2.3 v
+go.setup            github.com/patriceckhart/zot 0.3.33 v
 revision            0
 
 homepage            https://zot.sh
@@ -26,11 +26,12 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  b18221290ee3ee0bf393b3cf0dc9a69f14f0f601 \
-                    sha256  069bc5062fb223afde919870d61ac2e358a3c33b157ea5240243c301e9fb2415 \
-                    size    2243615
+checksums           rmd160  04908f1083236f01c07dd460fd5c00c495e261d7 \
+                    sha256  ddaf0cada06906ea7ba18c1eeb460598fe1453b40c6401da864a22bd119fd7ea \
+                    size    2512784
 
 go.offline_build    no
+go.toolchain_min    1.25.0
 
 build.args          -o ./${name} \
                     -ldflags \"-s -w -X main.version=${version}\" \


### PR DESCRIPTION
Update to 0.3.33.

Declares `go.toolchain_min 1.25.0`, copied from the project's `go.mod` at this tag. The port builds in module mode, so the directive is enforced; systems that cannot provide that series now skip the port instead of failing on it.
