### PR TITLE
dav1d: Rev bump dependents

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -7,7 +7,7 @@ conflicts           mplayer-devel
 version             1.5.0
 distname            ${name}-1.5
 livecheck.version   1.5
-revision            3
+revision            4
 categories          multimedia
 license             GPL-2+
 maintainers         {jeremyhu @jeremyhu} openmaintainer

--- a/multimedia/ffmpeg4/Portfile
+++ b/multimedia/ffmpeg4/Portfile
@@ -16,7 +16,7 @@ name                ffmpeg4
 set my_name         ffmpeg
 
 version             4.4.8
-revision            0
+revision            1
 
 license             LGPL-2.1+
 categories          multimedia

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -16,7 +16,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.1.5
-revision            1
+revision            2
 
 license             LGPL-2.1+
 categories          multimedia

--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -11,7 +11,7 @@ name                ffmpeg7
 set my_name         ffmpeg
 
 version             7.1.4
-revision            1
+revision            2
 
 license             LGPL-2.1+
 categories          multimedia

--- a/multimedia/ffmpeg8/Portfile
+++ b/multimedia/ffmpeg8/Portfile
@@ -12,7 +12,7 @@ set my_name         ffmpeg
 
 # version synced with ffmpeg port
 version             8.1.2
-revision            0
+revision            1
 
 license             LGPL-2.1+
 categories          multimedia

--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            AOMediaCodec libavif 1.4.2 v
-revision                0
+revision                2
 
 checksums               rmd160  8093bd79fb9a29f332731e79c58f878785989072 \
                         sha256  2b645287340ba5a631d268b551dc2d72bd73ac33335962dd36dcdb6d8366921d \

--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            AOMediaCodec libavif 1.4.2 v
-revision                2
+revision                1
 
 checksums               rmd160  8093bd79fb9a29f332731e79c58f878785989072 \
                         sha256  2b645287340ba5a631d268b551dc2d72bd73ac33335962dd36dcdb6d8366921d \

--- a/multimedia/libheif-devel/Portfile
+++ b/multimedia/libheif-devel/Portfile
@@ -30,7 +30,7 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
 
 if {${which_version} eq "latest"} {
     github.setup            strukturag libheif 1.23.1 v
-    revision                0
+    revision                1
 
     checksums               rmd160  52f1ade573cd8c3137d06e09a0019462d4481193 \
                             sha256  0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a \
@@ -39,7 +39,7 @@ if {${which_version} eq "latest"} {
     compiler.cxx_standard   2020
 } else {
     github.setup            strukturag libheif 1.18.2 v
-    revision                0
+    revision                1
 
     checksums               rmd160  fb41f7c4d109883a214b8db5db1039809a3fb8eb \
                             sha256  c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf \

--- a/multimedia/mplayer-devel/Portfile
+++ b/multimedia/mplayer-devel/Portfile
@@ -12,7 +12,7 @@ version             38435
 set ffmpeg_branch   master
 set ffmpeg_ver      7aa9684db39a8ecf444b3af1c74c225757d8e49f
 
-revision            2
+revision            3
 categories          multimedia
 license             GPL-2+
 maintainers         {jeremyhu @jeremyhu} openmaintainer

--- a/multimedia/xine-lib/Portfile
+++ b/multimedia/xine-lib/Portfile
@@ -5,7 +5,7 @@ PortGroup           ffmpeg 1.0
 
 name                xine-lib
 version             1.2.13
-revision            7
+revision            8
 checksums           rmd160  2b1045e3dfe475c92a442f3506ee8b570b73da32 \
                     sha256  5f10d6d718a4a51c17ed1b32b031d4f9b80b061e8276535b2be31e5ac4b75e6f \
                     size    5004196


### PR DESCRIPTION
#### Description

* Rev bump 9 dependent ports that were missed in the original dav1d update.
* See #33791.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?