### PR TITLE
libtpms: new port, version 0.10.2

### DIFF
--- a/security/libtpms/Portfile
+++ b/security/libtpms/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        stefanberger libtpms 0.10.2 v
+github.tarball_from archive
+revision            0
+
+categories          security
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
+license             BSD
+
+description         Library for software emulation of a Trusted Platform Module
+
+long_description    {*}${description}. libtpms provides the core TPM 1.2 and \
+                    TPM 2.0 functionality used to integrate TPM emulation \
+                    into hypervisors, primarily QEMU, via the swtpm TPM \
+                    emulator.
+
+checksums           rmd160  21c3efc868077d6b108eb38193a4a4c179f982b1 \
+                    sha256  edac03680f8a4a1c5c1d609a10e3f41e1a129e38ff5158f0c8deaedc719fb127 \
+                    size    1399529
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+use_autoreconf      yes
+
+configure.args-append \
+                    --with-openssl \
+                    --with-tpm2


### PR DESCRIPTION
#### Description

New port: libtpms, a library for software emulation of a Trusted
Platform Module (TPM). It provides TPM 1.2 and TPM 2.0 functionality
for integrating TPM emulation into hypervisors, primarily QEMU, via
the swtpm software TPM emulator.

###### Tested on

macOS 26.6 25G70 arm64 / Command Line Tools 26.6.0.0.1781586589
macOS 27.0 26A5388g arm64 / Command Line Tools 27.0.0.0.1784267383

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?