### PR TITLE
swtpm: new port, version 0.10.1

### DIFF
--- a/sysutils/swtpm/Portfile
+++ b/sysutils/swtpm/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        stefanberger swtpm 0.10.1 v
+github.tarball_from archive
+revision            0
+
+categories          sysutils
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
+license             BSD
+
+description         Software TPM emulator based on libtpms
+
+long_description    {*}${description}. swtpm provides TPM 1.2 and TPM 2.0 \
+                    emulation with a TCP/IP or Unix domain socket interface, \
+                    intended primarily for use with hypervisors such as QEMU.
+
+checksums           rmd160  6de58b85fc0242e49adbf22ba6a9468f0c08980c \
+                    sha256  f8da11cadfed27e26d26c5f58a7b8f2d14d684e691927348906b5891f525c684 \
+                    size    415992
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:libtpms \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:json-glib \
+                    port:libtasn1 \
+                    port:gmp
+
+use_autoreconf      yes
+
+configure.args-append \
+                    --with-openssl \
+                    --without-gnutls \
+                    --without-cuse \
+                    --disable-tests

--- a/sysutils/swtpm/Portfile
+++ b/sysutils/swtpm/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           openssl 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        stefanberger swtpm 0.10.1 v
 github.tarball_from archive

--- a/sysutils/swtpm/Portfile
+++ b/sysutils/swtpm/Portfile
@@ -32,7 +32,9 @@ depends_lib-append  port:libtpms \
                     port:gmp
 
 use_autoreconf      yes
-
+# clang: error: unrecognized command line option "-fstack-protector-strong"
+compiler.blacklist-append \
+                    *gcc.4.* {clang < 700}
 configure.args-append \
                     --with-openssl \
                     --without-gnutls \


### PR DESCRIPTION
#### Description

New port: swtpm, a software TPM emulator based on libtpms. It
provides TPM 1.2 and TPM 2.0 emulation over a TCP/IP or Unix domain
socket interface, intended primarily for use with hypervisors such
as QEMU.

Depends on the libtpms port, which has not merged yet:
https://github.com/macports/macports-ports/pull/33884

###### Tested on

macOS 26.6 25G70 arm64 / Command Line Tools 26.6.0.0.1781586589
macOS 27.0 26A5388g arm64 / Command Line Tools 27.0.0.0.1784267383

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?