### PR TITLE
fldigi: Update to 4.2.13

### DIFF
--- a/science/fldigi/Portfile
+++ b/science/fldigi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                fldigi
-version             4.2.11
+version             4.2.13
 revision            1
 # same sources but with different version
 set version_flarq   4.3.9
@@ -20,9 +20,9 @@ long_description    Fldigi (Fast Light Digital Modem Application), is a \
 homepage            http://www.w1hkj.com
 master_sites        sourceforge:project/fldigi/${name}
 
-checksums           rmd160  db5c4adc41062dc2ca29be1eea59e425e41876fa \
-                    sha256  762b370ffe9cae773a2a03b512d0b7242e7e90407c11d5abbd2d31ae6501664f \
-                    size    5282315
+checksums           rmd160  f10c3c7703bb4db346d21ba23f4c1b8aba85803c \
+                    sha256  a1e8d990359ce9c0cce3ceb5116fd0cf72c95528969766898640ca6ca2dba8d4 \
+                    size    5244946
 
 depends_build-append \
     port:pkgconfig \
@@ -55,7 +55,13 @@ pre-configure {
         set merger_configure_args(i386)   configure.args-append --enable-optimizations=i686
     } elseif {[variant_isset native]} {
         if {${configure.build_arch} eq "arm64"} {
-            configure.args-append --enable-optimizations=nativeARM
+            notes-append {
++native is no longer avilable on MacOS ARM64 due to compiler 
+changes.  The option remains so your upgrades won't fail
+but it does nothing.
+
+To remove this notice, reinstall without the "+native" option
+}
         } else {
             configure.args-append --enable-optimizations=native
         }


### PR DESCRIPTION
#### Description

Update to the latest stable version.

* Maintenance Updates

MacPorts only changes

* Disabled +native variant optimisation for MacOS ARM64 build as it generates a compiler error.  Variant is still there, but now just displays a message saying that it does nothing and how to remove the message.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
