### PR TITLE
php-sqlsrv, php-pdo_sqlsrv, msodbcsql: updates ; new Port

### DIFF
--- a/databases/msodbcsql/Portfile
+++ b/databases/msodbcsql/Portfile
@@ -3,43 +3,172 @@
 PortSystem          1.0
 
 name                msodbcsql
-version             18.6.2.1
-revision            0
-epoch               1
 categories          databases
-supported_archs     x86_64 arm64
 maintainers         {jann @roederja} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license             Restrictive
 
 description         ODBC Driver for Microsoft(R) SQL Server(R).
-long_description    ODBC Driver for Microsoft(R) SQL Server(R).
+long_description    ${description}
 
 homepage            https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server
-master_sites        https://download.microsoft.com/download/27f541d3-645c-455a-9249-515065cfa507/
 
 depends_run         port:unixODBC \
                     port:openssl3
                     
 use_configure       no
 
-set workpathdir     "${workpath}/${name}-${version}"
-set major           [lindex [split ${version} "."] 0]
+set workpathdir     ""
+set major           ""
+set master_base     "https://download.microsoft.com/download"
 
-switch ${configure.build_arch} {
-    x86_64 {
-        supported_archs                 x86_64
-        distname                        msodbcsql${major}-${version}-amd64
-        checksums                       rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
-                                        sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
-                                        size    858198
+proc set_defaults args {
+    global  name workpath version
+    upvar   workpathdir     s_wpd
+    upvar   major           s_m
+    set s_wpd   "${workpath}/${name}-${version}"
+    set s_m     [lindex [split ${version} "."] 0]
+}
+
+set macOS   macos_version_major
+# https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/system-requirements
+if { ${macOS} >= 14 } {
+    version             18.6.2.1
+    revision            0
+    epoch               1
+    set_defaults 
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/27f541d3-645c-455a-9249-515065cfa507/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
     }
-    arm64 {
-        supported_archs                 arm64
-        distname                        msodbcsql${major}-${version}-arm64
-        checksums                       rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
-                                        sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
-                                        size    771221
+} elseif { ${macOS} >= 13 } {
+    version             18.5.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/fae28b9a-d880-42fd-9b98-d779f0fdd77f/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
     }
+} elseif { ${macOS} >= 11 } {
+    version             18.4.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/7/6/d/76de322a-d860-4894-9945-f0cc5d6a45f8/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macOS} >= 10.15 } {
+    version             18.1.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macOS} >= 10.14 } {
+    version             17.8.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macOS} >= 10.13 } {
+    version             17.6.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64
+    master_sites        ${master_base}/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/
+    distname            msodbcsql${major}-${version}-amd64
+    checksums           rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                        sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                        size    858198
+} elseif { ${macOS} >= 10.11 } {
+    version             17.4.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64
+    master_sites        ${master_base}/1/9/A/19AF548A-6DD3-4B48-88DC-724E9ABCEB9A/
+    distname            msodbcsql${major}-${version}-amd64
+    checksums           rmd160  56ea30fa0861d76d222f1428baa9d6e11a90fd84 \
+                        sha256  0bfa5c3d2599e6a284add3d1d49b713e1fe2637433403135a7e931518201fbb5 \
+                        size    843627
+} else {
+    version             13.1.9.2
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64
+    master_sites        ${master_base}/4/9/5/495639C0-79E4-45A7-B65A-B264071C3D9A/
+    distname            msodbcsql${major}-${version}-amd64
+    checksums           rmd160  c3f5763dda0e8b6b65fe79a043906be1c504afd1 \
+                        sha256  06f4f45bbf16438d681227c6eeada89cbf03a78c61338bdc5eda51ab0e314e5d \
+                        size    906899
 }
 
 patch {
@@ -71,3 +200,6 @@ post-activate {
 pre-deactivate {
     system "odbcinst -u -d -n \"ODBC Driver ${major} for SQL Server\""
 }
+
+livecheck.url       ${homepage}?view=sql-server-ver17
+livecheck.regex     {Release number\: (${major}\\.\\d\\.\\d\\.\\d)}

--- a/databases/msodbcsql/Portfile
+++ b/databases/msodbcsql/Portfile
@@ -3,53 +3,190 @@
 PortSystem          1.0
 
 name                msodbcsql
-version             18.6.2.1
-revision            0
-epoch               1
 categories          databases
-supported_archs     x86_64 arm64
 maintainers         {jann @roederja} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license             Restrictive
 
 description         ODBC Driver for Microsoft(R) SQL Server(R).
-long_description    ODBC Driver for Microsoft(R) SQL Server(R).
+long_description    ${description}
 
 homepage            https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server
-master_sites        https://download.microsoft.com/download/27f541d3-645c-455a-9249-515065cfa507/
 
 depends_run         port:unixODBC \
                     port:openssl3
                     
 use_configure       no
 
-set workpathdir     "${workpath}/${name}-${version}"
-set major           [lindex [split ${version} "."] 0]
+set workpathdir     ""
+set major           ""
+set master_base     "https://download.microsoft.com/download"
+
+proc set_defaults args {
+    global  name workpath version
+    upvar   workpathdir     s_wpd
+    upvar   major           s_m
+    set s_wpd   "${workpath}/${name}-${version}"
+    set s_m     [lindex [split ${version} "."] 0]
+}
+
+# https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/system-requirements
+if { ${macos_version_major} >= 14 } {
+    version             18.6.2.1
+    revision            0
+    epoch               1
+    set_defaults 
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/27f541d3-645c-455a-9249-515065cfa507/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macos_version_major} >= 13 } {
+    version             18.5.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/fae28b9a-d880-42fd-9b98-d779f0fdd77f/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macos_version_major} >= 11 } {
+    version             18.4.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/7/6/d/76de322a-d860-4894-9945-f0cc5d6a45f8/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macos_version_major} >= 10.15 } {
+    version             18.1.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macos_version_major} >= 10.14 } {
+    version             17.8.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64 arm64
+    master_sites        ${master_base}/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/
+    switch ${configure.build_arch} {
+        x86_64 {
+            distname                msodbcsql${major}-${version}-amd64
+            checksums               rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                                    sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                                    size    858198
+        }
+        arm64 {
+            distname                msodbcsql${major}-${version}-arm64
+            checksums               rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
+                                    sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
+                                    size    771221
+        }
+    }
+} elseif { ${macos_version_major} >= 10.13 } {
+    version             17.6.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64
+    master_sites        ${master_base}/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/
+    distname            msodbcsql${major}-${version}-amd64
+    checksums           rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
+                        sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
+                        size    858198
+} elseif { ${macos_version_major} >= 10.11 } {
+    version             17.4.1.1
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64
+    master_sites        ${master_base}/1/9/A/19AF548A-6DD3-4B48-88DC-724E9ABCEB9A/
+    distname            msodbcsql${major}-${version}-amd64
+    checksums           rmd160  56ea30fa0861d76d222f1428baa9d6e11a90fd84 \
+                        sha256  0bfa5c3d2599e6a284add3d1d49b713e1fe2637433403135a7e931518201fbb5 \
+                        size    843627
+} else {
+    version             13.1.9.2
+    revision            0
+    epoch               0
+    set_defaults
+    supported_archs     x86_64
+    master_sites        ${master_base}/4/9/5/495639C0-79E4-45A7-B65A-B264071C3D9A/
+    distname            msodbcsql${major}-${version}-amd64
+    checksums           rmd160  c3f5763dda0e8b6b65fe79a043906be1c504afd1 \
+                        sha256  06f4f45bbf16438d681227c6eeada89cbf03a78c61338bdc5eda51ab0e314e5d \
+                        size    906899
+}
 
 switch ${configure.build_arch} {
     x86_64 {
-        supported_archs                 x86_64
-        distname                        msodbcsql${major}-${version}-amd64
-        checksums                       rmd160  92ce1fadd39c44599c105249d8ccc3ea61d4333b \
-                                        sha256  c0db485b006aed4a160526781b910a35ab6002a9336e8bafc4d314f291f979d4 \
-                                        size    858198
+        set old_prefix  "/usr/local"
     }
     arm64 {
-        supported_archs                 arm64
-        distname                        msodbcsql${major}-${version}-arm64
-        checksums                       rmd160  aa6aca9de3941aee3d0bebc210b8b91c0370fecc \
-                                        sha256  b92d00a71b1193bd18def562a0864325a197f2ffeb565e3862cf8db2474d17a0 \
-                                        size    771221
+        set old_prefix  "/opt/homebrew"
     }
 }
 
 patch {
-    reinplace "s|/usr/local|${prefix}|g" ${workpathdir}/odbcinst.ini
+    reinplace "s|${old_prefix}|${prefix}|g"    ${workpathdir}/odbcinst.ini
 }
                     
 build {
-    system "install_name_tool -change /usr/local/lib/libodbcinst.2.dylib ${prefix}/lib/libodbcinst.2.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
-    system "install_name_tool -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib ${prefix}lib/openssl-3/libcrypto.3.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
-    system "install_name_tool -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib ${prefix}/lib/openssl-3/libssl.3.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
+    system "install_name_tool -change ${old_prefix}/lib/libodbcinst.2.dylib ${prefix}/lib/libodbcinst.2.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
+    system "install_name_tool -change ${old_prefix}/opt/openssl/lib/libcrypto.1.0.0.dylib ${prefix}/lib/openssl-3/libcrypto.3.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
+    system "install_name_tool -change ${old_prefix}/opt/openssl/lib/libssl.1.0.0.dylib ${prefix}/lib/openssl-3/libssl.3.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
     system "install_name_tool -id ${prefix}/lib/libmsodbcsql.${major}.dylib ${workpathdir}/lib/libmsodbcsql.${major}.dylib"
 }
 
@@ -71,3 +208,6 @@ post-activate {
 pre-deactivate {
     system "odbcinst -u -d -n \"ODBC Driver ${major} for SQL Server\""
 }
+
+livecheck.url       ${homepage}?view=sql-server-ver17
+livecheck.regex     {Release number\: (${major}\\.\\d\\.\\d\\.\\d)}

--- a/php/php-pdo_sqlsrv/Portfile
+++ b/php/php-pdo_sqlsrv/Portfile
@@ -1,0 +1,96 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                      1.0
+PortGroup                       legacysupport 1.1
+PortGroup                       github 1.0
+PortGroup                       php 1.1
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
+
+name                            php-pdo_sqlsrv
+categories-append               databases
+maintainers                     {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+license                         MIT
+
+php.branches                    7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+
+description                     Microsoft Drivers for PHP for SQL Server (PDO_SQLSRV)
+long_description \
+    The Microsoft Drivers for PHP for SQL Server are PHP extensions \
+    that allow for the reading and writing of SQL Server data from within PHP scripts. \
+    The SQLSRV extension provides a procedural interface \
+    while the PDO_SQLSRV extension implements PDO for accessing data \
+    in all editions of SQL Server 2012 and later (including Azure SQL DB). \
+    These drivers rely on the Microsoft ODBC Driver for SQL Server \
+    to handle the low-level communication with SQL Server. \
+    *This package contains only the PDO_SQLSRV driver.*
+
+github.tarball_from             archive
+
+if {[vercmp ${php.branch} >= 8.3]} {
+    github.setup                microsoft msphpsql 5.13.3 v
+    revision                    0
+    checksums                   rmd160  eb5abb55571d69bef03baf0d3b0dd5b95917d5bd \
+                                sha256  0fa6db7c7df8927ddb816c6184d129026338cfa6fe2721f9db41d91290be2cdc \
+                                size    10853229
+} elseif {[vercmp ${php.branch} >= 8.1]} {
+    github.setup                microsoft msphpsql 5.12.0 v
+    revision                    0
+    checksums                   rmd160  d741e123d82bdc85a4c40ad27a5ec272e74e60e9 \
+                                sha256  c2a67f20a49555243a1b6c45d4a735e58dcbed0bafefbf7de8e196f317544fbc \
+                                size    10776978
+} elseif {[vercmp ${php.branch} >= 8.0]} {
+    github.setup                microsoft msphpsql 5.11.1 v
+    revision                    0
+    checksums                   rmd160  d9b7f85ae00b5503aa5775c062682ca8e993e839 \
+                                sha256  aef6c480bff2e5e8de326fd03c6465006bee6c2aef8b3d5b5e56e4352c7e707f \
+                                size    10776759
+} elseif {[vercmp ${php.branch} >= 7.4]} {
+    github.setup                microsoft msphpsql 5.10.1 v
+    revision                    0
+    checksums                   rmd160  630d46bffca54d89ff2a5739c81bb985d4eb02a2 \
+                                sha256  1e66ce803bd36dbee6c45852ac831e83c0d18dd4d4c5095188f3fa08d4f19724 \
+                                size    11091586
+} elseif {[vercmp ${php.branch} >= 7.3]} {
+    github.setup                microsoft msphpsql 5.9.0 v
+    revision                    0
+    checksums                   rmd160  640edda514939d44b2684bc90dbee2b12bedfcf5 \
+                                sha256  fe960c4c32c83cd98c84fe85c5cdcb145ed0679ee36a3ab6f16132249a4c0d61 \
+                                size    10762839
+} elseif {[vercmp ${php.branch} >= 7.2]} {
+    github.setup                microsoft msphpsql 5.8.1 v
+    revision                    0
+    checksums                   rmd160  86eed46d32e67169d39f13f83fea54e990bfa816 \
+                                sha256  c24e8a267fab06d99ecb639d6195dadb3ca8e4b9a3264b564a9b730fc61d26f5 \
+                                size    11030927
+} elseif {[vercmp ${php.branch} >= 7.1]} {
+    github.setup                microsoft msphpsql 5.6.1 v
+    revision                    0
+    checksums                   rmd160  e42eb031ee9c0aca5177a493b3ef33ada1575088 \
+                                sha256  ff05186ea1d33ecd7b258b3a453896cabaa9e944598e7dddb0d6dbe3c8ef1b48 \
+                                size    10858444
+} elseif {[vercmp ${php.branch} >= 7.0]} {
+    github.setup                microsoft msphpsql 5.3.0 v
+    revision                    0
+    checksums                   rmd160  cd52cc3276e79f115ce1e011cea0ac2e3f36868c \
+                                sha256  2519522891746a02e1c9f4674e379bbb75eb044305aee1522097c2d9923545af \
+                                size    10819430
+}
+
+if {${subport} ne ${name}} {
+    depends_lib-append          port:msodbcsql
+
+    if {[vercmp ${version} < 5.9.0]} {
+        patchfiles-append       ${php}-deployment_target.patch
+    }
+
+    php.build_dirs              [list "${worksrcpath}/source/pdo_sqlsrv"]
+
+    post-extract {
+        set build_dir [lindex   ${php.build_dirs} 0]
+        file link -symbolic     "${build_dir}/shared" "${build_dir}/../shared"
+    }
+
+    compiler.cxx_standard 2011
+}

--- a/php/php-pdo_sqlsrv/files/php70-deployment_target.patch
+++ b/php/php-pdo_sqlsrv/files/php70-deployment_target.patch
@@ -1,0 +1,12 @@
+Do not override the deployment target that MacPorts sets.
+https://github.com/microsoft/msphpsql/commit/f59f0bcce7d0d000900c820ad4bc1917b3a20dd8
+--- config.m4.orig	2018-07-20 02:58:46.000000000 -0500
++++ config.m4	2022-02-03 03:47:07.000000000 -0600
+@@ -56,7 +56,6 @@
+   HOST_OS_ARCH=`uname`
+   if test "${HOST_OS_ARCH}" = "Darwin"; then
+       SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-bind_at_load"
+-      MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion`
+   else
+       SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-z,now"
+   fi

--- a/php/php-pdo_sqlsrv/files/php71-deployment_target.patch
+++ b/php/php-pdo_sqlsrv/files/php71-deployment_target.patch
@@ -1,0 +1,12 @@
+Do not override the deployment target that MacPorts sets.
+https://github.com/microsoft/msphpsql/commit/f59f0bcce7d0d000900c820ad4bc1917b3a20dd8
+--- config.m4.orig	2019-03-19 16:33:46.000000000 -0500
++++ config.m4	2022-02-03 03:45:07.000000000 -0600
+@@ -59,7 +59,6 @@
+   HOST_OS_ARCH=`uname`
+   if test "${HOST_OS_ARCH}" = "Darwin"; then
+       SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-bind_at_load"
+-      MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion`
+   else
+       SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-z,now"
+   fi

--- a/php/php-pdo_sqlsrv/files/php72-deployment_target.patch
+++ b/php/php-pdo_sqlsrv/files/php72-deployment_target.patch
@@ -1,0 +1,12 @@
+Do not override the deployment target that MacPorts sets.
+https://github.com/microsoft/msphpsql/commit/f59f0bcce7d0d000900c820ad4bc1917b3a20dd8
+--- config.m4.orig	2020-04-14 12:16:07.000000000 -0500
++++ config.m4	2022-02-03 03:46:02.000000000 -0600
+@@ -59,7 +59,6 @@
+   HOST_OS_ARCH=`uname`
+   if test "${HOST_OS_ARCH}" = "Darwin"; then
+     SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-bind_at_load"
+-    MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion`
+   else
+     SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-z,now"
+     IS_ALPINE_1=`uname -a | cut -f 4 -d ' ' | cut -f 2 -d '-'`

--- a/php/php-sqlsrv/Portfile
+++ b/php/php-sqlsrv/Portfile
@@ -1,21 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               legacysupport 1.1
-PortGroup               github 1.0
-PortGroup               php 1.1
+PortSystem                      1.0
+PortGroup                       legacysupport 1.1
+PortGroup                       github 1.0
+PortGroup                       php 1.1
 
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-name                    php-sqlsrv
-categories-append       databases
-maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
-license                 MIT
+name                            php-sqlsrv
+categories-append               databases
+maintainers                     {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+license                         MIT
 
-php.branches            7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
+php.branches                    7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
 
-description             Microsoft Drivers for PHP for SQL Server (SQLSRV)
+description                     Microsoft Drivers for PHP for SQL Server (SQLSRV)
 long_description \
     The Microsoft Drivers for PHP for SQL Server are PHP extensions \
     that allow for the reading and writing of SQL Server data from within PHP scripts. \
@@ -26,77 +26,75 @@ long_description \
     to handle the low-level communication with SQL Server. \
     *This package contains only the SQLSRV driver.*
 
-github.tarball_from     archive
+github.tarball_from             archive
 
 if {[vercmp ${php.branch} >= 8.3]} {
-    github.setup        microsoft msphpsql 5.13.3 v
-    revision            0
-    checksums           rmd160  eb5abb55571d69bef03baf0d3b0dd5b95917d5bd \
-                        sha256  0fa6db7c7df8927ddb816c6184d129026338cfa6fe2721f9db41d91290be2cdc \
-                        size    10853229
+    github.setup                microsoft msphpsql 5.13.3 v
+    revision                    0
+    checksums                   rmd160  eb5abb55571d69bef03baf0d3b0dd5b95917d5bd \
+                                sha256  0fa6db7c7df8927ddb816c6184d129026338cfa6fe2721f9db41d91290be2cdc \
+                                size    10853229
 } elseif {[vercmp ${php.branch} >= 8.1]} {
-    github.setup        microsoft msphpsql 5.12.0 v
-    revision            1
-    checksums           rmd160  d741e123d82bdc85a4c40ad27a5ec272e74e60e9 \
-                        sha256  c2a67f20a49555243a1b6c45d4a735e58dcbed0bafefbf7de8e196f317544fbc \
-                        size    10776978
+    github.setup                microsoft msphpsql 5.12.0 v
+    revision                    1
+    checksums                   rmd160  d741e123d82bdc85a4c40ad27a5ec272e74e60e9 \
+                                sha256  c2a67f20a49555243a1b6c45d4a735e58dcbed0bafefbf7de8e196f317544fbc \
+                                size    10776978
 } elseif {[vercmp ${php.branch} >= 8.0]} {
-    github.setup        microsoft msphpsql 5.11.1 v
-    revision            1
-    checksums           rmd160  d9b7f85ae00b5503aa5775c062682ca8e993e839 \
-                        sha256  aef6c480bff2e5e8de326fd03c6465006bee6c2aef8b3d5b5e56e4352c7e707f \
-                        size    10776759
+    github.setup                microsoft msphpsql 5.11.1 v
+    revision                    1
+    checksums                   rmd160  d9b7f85ae00b5503aa5775c062682ca8e993e839 \
+                                sha256  aef6c480bff2e5e8de326fd03c6465006bee6c2aef8b3d5b5e56e4352c7e707f \
+                                size    10776759
 } elseif {[vercmp ${php.branch} >= 7.4]} {
-    github.setup        microsoft msphpsql 5.10.1 v
-    revision            1
-    checksums           rmd160  630d46bffca54d89ff2a5739c81bb985d4eb02a2 \
-                        sha256  1e66ce803bd36dbee6c45852ac831e83c0d18dd4d4c5095188f3fa08d4f19724 \
-                        size    11091586
+    github.setup                microsoft msphpsql 5.10.1 v
+    revision                    1
+    checksums                   rmd160  630d46bffca54d89ff2a5739c81bb985d4eb02a2 \
+                                sha256  1e66ce803bd36dbee6c45852ac831e83c0d18dd4d4c5095188f3fa08d4f19724 \
+                                size    11091586
 } elseif {[vercmp ${php.branch} >= 7.3]} {
-    github.setup        microsoft msphpsql 5.9.0 v
-    revision            0
-    checksums           rmd160  640edda514939d44b2684bc90dbee2b12bedfcf5 \
-                        sha256  fe960c4c32c83cd98c84fe85c5cdcb145ed0679ee36a3ab6f16132249a4c0d61 \
-                        size    10762839
+    github.setup                microsoft msphpsql 5.9.0 v
+    revision                    0
+    checksums                   rmd160  640edda514939d44b2684bc90dbee2b12bedfcf5 \
+                                sha256  fe960c4c32c83cd98c84fe85c5cdcb145ed0679ee36a3ab6f16132249a4c0d61 \
+                                size    10762839
 } elseif {[vercmp ${php.branch} >= 7.2]} {
-    github.setup        microsoft msphpsql 5.8.1 v
-    revision            0
-    checksums           rmd160  86eed46d32e67169d39f13f83fea54e990bfa816 \
-                        sha256  c24e8a267fab06d99ecb639d6195dadb3ca8e4b9a3264b564a9b730fc61d26f5 \
-                        size    11030927
+    github.setup                microsoft msphpsql 5.8.1 v
+    revision                    0
+    checksums                   rmd160  86eed46d32e67169d39f13f83fea54e990bfa816 \
+                                sha256  c24e8a267fab06d99ecb639d6195dadb3ca8e4b9a3264b564a9b730fc61d26f5 \
+                                size    11030927
 } elseif {[vercmp ${php.branch} >= 7.1]} {
-    github.setup        microsoft msphpsql 5.6.1 v
-    revision            1
-    checksums           rmd160  e42eb031ee9c0aca5177a493b3ef33ada1575088 \
-                        sha256  ff05186ea1d33ecd7b258b3a453896cabaa9e944598e7dddb0d6dbe3c8ef1b48 \
-                        size    10858444
+    github.setup                microsoft msphpsql 5.6.1 v
+    revision                    1
+    checksums                   rmd160  e42eb031ee9c0aca5177a493b3ef33ada1575088 \
+                                sha256  ff05186ea1d33ecd7b258b3a453896cabaa9e944598e7dddb0d6dbe3c8ef1b48 \
+                                size    10858444
 } elseif {[vercmp ${php.branch} >= 7.0]} {
-    github.setup        microsoft msphpsql 5.3.0 v
-    revision            0
-    checksums           rmd160  cd52cc3276e79f115ce1e011cea0ac2e3f36868c \
-                        sha256  2519522891746a02e1c9f4674e379bbb75eb044305aee1522097c2d9923545af \
-                        size    10819430
+    github.setup                microsoft msphpsql 5.3.0 v
+    revision                    0
+    checksums                   rmd160  cd52cc3276e79f115ce1e011cea0ac2e3f36868c \
+                                sha256  2519522891746a02e1c9f4674e379bbb75eb044305aee1522097c2d9923545af \
+                                size    10819430
 }
 
 if {${subport} ne ${name}} {
     # remove w/ next update
-    dist_subdir         ${name}/${version}_1
+    dist_subdir                 ${name}/${version}_1
 
-    depends_lib-append  port:msodbcsql \
-                        port:${php}-pdo_sqlsrv
+    depends_lib-append          port:msodbcsql \
+                                port:${php}-pdo_sqlsrv
 
     if {[vercmp ${version} < 5.9.0]} {
-        patchfiles-append \
-                        ${php}-deployment_target.patch
+        patchfiles-append       ${php}-deployment_target.patch
     }
 
-    php.build_dirs      [list "${worksrcpath}/source/sqlsrv"]
+    php.build_dirs              [list "${worksrcpath}/source/sqlsrv"]
 
     post-extract {
-        set build_dir   [lindex ${php.build_dirs} 0]
-        file link -symbolic \
-                        "${build_dir}/shared" "${build_dir}/../shared"
+        set build_dir           [lindex ${php.build_dirs} 0]
+        file link -symbolic     "${build_dir}/shared" "${build_dir}/../shared"
     }
 
-    compiler.cxx_standard 2011
+    compiler.cxx_standard       2011
 }

--- a/php/php-sqlsrv/Portfile
+++ b/php/php-sqlsrv/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               legacysupport 1.1
+PortGroup               github 1.0
 PortGroup               php 1.1
 
 # strnlen
@@ -13,9 +14,8 @@ maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @Bjar
 license                 MIT
 
 php.branches            7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
-php.pecl                yes
 
-description             Microsoft sqlsrv drivers for PHP
+description             Microsoft Drivers for PHP for SQL Server (SQLSRV)
 long_description \
     The Microsoft Drivers for PHP for SQL Server are PHP extensions \
     that allow for the reading and writing of SQL Server data from within PHP scripts. \
@@ -26,64 +26,76 @@ long_description \
     to handle the low-level communication with SQL Server. \
     *This package contains only the SQLSRV driver.*
 
-long_description        ${description}
+github.tarball_from     archive
 
 if {[vercmp ${php.branch} >= 8.3]} {
-    version             5.13.1
+    github.setup        microsoft msphpsql 5.13.3 v
     revision            0
-    checksums           rmd160  e7f9975f44992125b1a88308e3da20113eee4252 \
-                        sha256  7c4ea8f25ebbc8999084239e7e0ef75315097e013df0e290fcef76c3d977b9d8 \
-                        size    199271
+    checksums           rmd160  eb5abb55571d69bef03baf0d3b0dd5b95917d5bd \
+                        sha256  0fa6db7c7df8927ddb816c6184d129026338cfa6fe2721f9db41d91290be2cdc \
+                        size    10853229
 } elseif {[vercmp ${php.branch} >= 8.1]} {
-    version             5.12.0
+    github.setup        microsoft msphpsql 5.12.0 v
     revision            1
-    checksums           rmd160  6b307e55af04354f862eb805ed5761287683bce4 \
-                        sha256  a9ebb880b2a558d3d6684f6e6802c53c5bffa49e1ee60d1473a7124fc9cb72ad \
-                        size    193767
+    checksums           rmd160  d741e123d82bdc85a4c40ad27a5ec272e74e60e9 \
+                        sha256  c2a67f20a49555243a1b6c45d4a735e58dcbed0bafefbf7de8e196f317544fbc \
+                        size    10776978
 } elseif {[vercmp ${php.branch} >= 8.0]} {
-    version             5.11.1
+    github.setup        microsoft msphpsql 5.11.1 v
     revision            1
-    checksums           rmd160  c7b5cbbdd8dd0db1a85666008f12d8ea773e9513 \
-                        sha256  678ab60174be56b09c6916307700e716a4ff266ad53e43990a9d9740d4728463 \
-                        size    192830
+    checksums           rmd160  d9b7f85ae00b5503aa5775c062682ca8e993e839 \
+                        sha256  aef6c480bff2e5e8de326fd03c6465006bee6c2aef8b3d5b5e56e4352c7e707f \
+                        size    10776759
 } elseif {[vercmp ${php.branch} >= 7.4]} {
-    version             5.10.1
+    github.setup        microsoft msphpsql 5.10.1 v
     revision            1
-    checksums           rmd160  071bcabc68b28995482bb9c43b2a6dd9f51f3cee \
-                        sha256  5cdaedb4d8a286343e6b3b99992d9fcb44a8fb69dd02aa5d7bc20eb2ea5e59d2 \
-                        size    193661
+    checksums           rmd160  630d46bffca54d89ff2a5739c81bb985d4eb02a2 \
+                        sha256  1e66ce803bd36dbee6c45852ac831e83c0d18dd4d4c5095188f3fa08d4f19724 \
+                        size    11091586
 } elseif {[vercmp ${php.branch} >= 7.3]} {
-    version             5.9.0
+    github.setup        microsoft msphpsql 5.9.0 v
     revision            0
-    checksums           rmd160  6a0e569f7f5575d2db164cac09144ccfb3098b07 \
-                        sha256  0a108e0408e8b984e5ae8bc52824ed32872d72e3a571cd2a5d2b63b200215ab3 \
-                        size    189701
+    checksums           rmd160  640edda514939d44b2684bc90dbee2b12bedfcf5 \
+                        sha256  fe960c4c32c83cd98c84fe85c5cdcb145ed0679ee36a3ab6f16132249a4c0d61 \
+                        size    10762839
 } elseif {[vercmp ${php.branch} >= 7.2]} {
-    version             5.8.1
+    github.setup        microsoft msphpsql 5.8.1 v
     revision            0
-    checksums           rmd160  36f76974cf9653273b429d5bf08ad0e7256fe541 \
-                        sha256  39c5c07989d8b53e9ccdd79e8dc5eb6159632be89b1c01e23ea308c8e0332a31 \
-                        size    186879
+    checksums           rmd160  86eed46d32e67169d39f13f83fea54e990bfa816 \
+                        sha256  c24e8a267fab06d99ecb639d6195dadb3ca8e4b9a3264b564a9b730fc61d26f5 \
+                        size    11030927
 } elseif {[vercmp ${php.branch} >= 7.1]} {
-    version             5.6.1
+    github.setup        microsoft msphpsql 5.6.1 v
     revision            1
-    checksums           rmd160  2ef591fa12fc8829ef7c2736adba10c45c6f9b78 \
-                        sha256  0ab48ae7a9957586f5ec3ea1c19c528951517529078679a0dc3fd9fe83305445 \
-                        size    183396
+    checksums           rmd160  e42eb031ee9c0aca5177a493b3ef33ada1575088 \
+                        sha256  ff05186ea1d33ecd7b258b3a453896cabaa9e944598e7dddb0d6dbe3c8ef1b48 \
+                        size    10858444
 } elseif {[vercmp ${php.branch} >= 7.0]} {
-    version             5.3.0
+    github.setup        microsoft msphpsql 5.3.0 v
     revision            0
-    checksums           rmd160  ab9e9d47f6385fb0a57f489933859def1b6761fc \
-                        sha256  dfcacbaf5ea505d11a057c673544ff923e74c78f16cc95ee57808a44ee20967a \
-                        size    173492
+    checksums           rmd160  cd52cc3276e79f115ce1e011cea0ac2e3f36868c \
+                        sha256  2519522891746a02e1c9f4674e379bbb75eb044305aee1522097c2d9923545af \
+                        size    10819430
 }
 
 if {${subport} ne ${name}} {
-    depends_lib-append  port:msodbcsql
+    # remove w/ next update
+    dist_subdir         ${name}/${version}_1
+
+    depends_lib-append  port:msodbcsql \
+                        port:${php}-pdo_sqlsrv
 
     if {[vercmp ${version} < 5.9.0]} {
         patchfiles-append \
                         ${php}-deployment_target.patch
+    }
+
+    php.build_dirs      [list "${worksrcpath}/source/sqlsrv"]
+
+    post-extract {
+        set build_dir   [lindex ${php.build_dirs} 0]
+        file link -symbolic \
+                        "${build_dir}/shared" "${build_dir}/../shared"
     }
 
     compiler.cxx_standard 2011


### PR DESCRIPTION
#### Description
1. msodbcsql: add versions
the provious update only had the newest version for  `macos_version_major >= 14`
this adds versions for all `macos_version_major`
2. php-pdo_sqlsrv: new Port
missing dependecy to php-sqlsrv
3. php-sqlsrv: update to 5.13.2
switched to use Github due to PECL being deprecated

