### PR TITLE
esbuild: new port (0.28.1)

### DIFF
--- a/devel/esbuild/Portfile
+++ b/devel/esbuild/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/evanw/esbuild 0.28.1 v
+go.offline_build    no
+go.toolchain_min    1.13
+revision            0
+
+categories          devel lang
+license             MIT
+maintainers         nomaintainer
+
+description         An extremely fast bundler for the web
+long_description    Our current build tools for the web are 10-100x slower than they could be. \
+                    The main goal of the esbuild bundler project is to bring about a new era of \
+                    build tool performance, and create an easy-to-use modern bundler along the way.
+homepage            https://esbuild.github.io/
+
+checksums           rmd160  6d12d87a63776459de2f400ee3191ac2c4d53085 \
+                    sha256  65c756fa87d43178ac4a5242454c2bd0fde325f8ecf77997f8fa4b88f94d5cd2 \
+                    size    1997481
+
+build.args          -o esbuild
+build.post_args     -trimpath \
+                    -buildvcs=false \
+                    -ldflags='-s -w -buildid=' \
+                    ./cmd/esbuild
+build.env-append    CGO_ENABLED=0
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/esbuild ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Adds native executable CLI build of `esbuild`, an extremely fast bundler for the web.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6 (25G72) ASi
Xcode 26.1.1 (17B100)

macOS 15.7.8 (24G824) x86-64
Xcode 16.0 (16A242d)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
