### PR TITLE
kubectl: declare the Go each subport needs, fix platforms

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -18,6 +18,8 @@ subport kubectl_select {}
 
 set source_build        no
 set offline_build       yes
+set toolchain_min       ""
+set platform_spec       darwin
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
 set latestVersion       kubectl-1.36
@@ -29,7 +31,9 @@ subport kubectl-1.36 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.26
 
     set patchNumber     3
     revision            0
@@ -42,7 +46,9 @@ subport kubectl-1.35 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.25
 
     set patchNumber     7
     revision            0
@@ -55,7 +61,9 @@ subport kubectl-1.34 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.24
 
     set patchNumber     10
     revision            0
@@ -68,7 +76,9 @@ subport kubectl-1.33 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.24
 
     set patchNumber     13
     revision            0
@@ -81,7 +91,9 @@ subport kubectl-1.32 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.23
 
     set patchNumber     13
     revision            0
@@ -94,7 +106,9 @@ subport kubectl-1.31 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.22
 
     set patchNumber     14
     revision            0
@@ -107,7 +121,9 @@ subport kubectl-1.30 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.22
 
     set patchNumber     14
     revision            0
@@ -120,7 +136,9 @@ subport kubectl-1.29 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.21
 
     set patchNumber     15
     revision            0
@@ -133,7 +151,9 @@ subport kubectl-1.28 {
     set source_build    yes
     set offline_build   no
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.20
 
     set patchNumber     15
     revision            0
@@ -145,7 +165,9 @@ subport kubectl-1.28 {
 subport kubectl-1.27 {
     set source_build    yes
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.20
 
     set patchNumber     16
     revision            0
@@ -157,7 +179,9 @@ subport kubectl-1.27 {
 subport kubectl-1.26 {
     set source_build    yes
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.19
 
     set patchNumber     15
     revision            0
@@ -169,7 +193,9 @@ subport kubectl-1.26 {
 subport kubectl-1.25 {
     set source_build    yes
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.19
 
     set patchNumber     16
     revision            0
@@ -181,7 +207,9 @@ subport kubectl-1.25 {
 subport kubectl-1.24 {
     set source_build    yes
     supported_archs     x86_64 arm64
-    platforms           {darwin >= 17}
+    set platform_spec   {darwin >= 17}
+
+    set toolchain_min   1.18
 
     set patchNumber     17
     revision            0
@@ -193,6 +221,8 @@ subport kubectl-1.24 {
 subport kubectl-1.23 {
     set source_build    yes
     supported_archs     x86_64 arm64
+
+    set toolchain_min   1.17
 
     set patchNumber     17
     revision            0
@@ -226,7 +256,7 @@ subport kubectl-1.21 {
 subport kubectl-1.20 {
     set source_build    yes
     supported_archs     x86_64
-    platforms           {darwin < 22}
+    set platform_spec   {darwin < 22}
 
     set patchNumber     15
     revision            0
@@ -241,7 +271,7 @@ subport kubectl-1.20 {
 subport kubectl-1.19 {
     set source_build    yes
     supported_archs     x86_64
-    platforms           {darwin < 22}
+    set platform_spec   {darwin < 22}
 
     set patchNumber     16
     revision            0
@@ -298,7 +328,7 @@ subport kubectl-1.13 {
 }
 
 subport kubectl-1.12 {
-    platforms           {darwin < 21}
+    set platform_spec   {darwin < 21}
     set patchNumber     10
     checksums           rmd160  4212a9f7709ef6a7d36f3ebd477140a7d0ef8e50 \
                         sha256  67acf17bf77b0a9729d17ad5c058a358c0cbd12dbf46478c37111cdd97a0828c \
@@ -306,7 +336,7 @@ subport kubectl-1.12 {
 }
 
 subport kubectl-1.11 {
-    platforms           {darwin < 21}
+    set platform_spec   {darwin < 21}
     set patchNumber     10
     checksums           rmd160  8c3f3121088f745bb9eb279f5531b8b61ff84bc7 \
                         sha256  cf27dd3e8d5a13439de2214b7a07e2371cdbeaf151ee4c7d63e7e7c34ebbf117 \
@@ -314,7 +344,7 @@ subport kubectl-1.11 {
 }
 
 subport kubectl-1.10 {
-    platforms           {darwin < 21}
+    set platform_spec   {darwin < 21}
     set patchNumber     13
     checksums           rmd160  fe455ab0eb7c862c8dbce970632a9e66c8987cb1 \
                         sha256  94ec5409ac6715dfec11309795da9b30254b9d818f8b1d38d1ca2e914945868d \
@@ -369,6 +399,10 @@ if {${subport} == ${name}} {
         go.package          k8s.io/kubernetes
         go.offline_build    ${offline_build}
 
+        if {${toolchain_min} ne ""} {
+            go.toolchain_min    ${toolchain_min}
+        }
+
         build.cmd           make
         build.target        kubectl
 
@@ -409,6 +443,8 @@ if {${subport} == ${name}} {
             legacysupport::relink_libSystem ${destroot}${prefix}/bin/kubectl${baseVersion}
         }
     }
+
+    platforms           ${platform_spec}
 
     depends_run         port:kubectl_select
 


### PR DESCRIPTION
Annotates the source-built subports with the Go they need, and restores the platform limits.

* `go.toolchain_min` comes from the floor in `hack/lib/golang.sh`, which is what aborts the build (`Kubernetes requires go1.26 or greater`) — not `go.mod`. For 1.27 and older, built in GOPATH mode, it is the only binding constraint since `go.mod` is never read.

* **kubectl-1.35 and kubectl-1.36 need Go 1.25 and 1.26**, unavailable below 12 Monterey, so they were fetched, built and failed on 10.13 through 11 on every push. They are skipped there now. The other annotations are for the record — their floors are 1.24 or lower.

* 1.22, 1.20 and 1.19 are left unannotated: they want go1.16 and go1.15, older than any series `go_toolchain` records.

* Each subport declared `platforms` *before* the `golang` PortGroup was included, and that PortGroup overwrote every one with `darwin freebsd linux`. The values are now held in `platform_spec` and applied after the source and prebuilt branches. This restores `darwin >= 17` on 1.24+, `darwin < 22` on 1.19/1.20 and `darwin < 21` on 1.10–1.12, and limits the rest to darwin — the prebuilt subports install a Mach-O from `bin/darwin/amd64` and both branches call `legacysupport`.

Every subport is already at the newest patch of its series, and all 27 distfiles still resolve.
