### PR TITLE
ntpsec: update to 1.2.5

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -14,7 +14,7 @@ legacysupport.newest_darwin_requires_legacy 15
 # isn't believed to cause trouble with the specific functions used here.
 
 name                ntpsec
-version             1.2.4
+version             1.2.5
 revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
@@ -27,9 +27,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  455ed30dc803e83dd19a0ab28d8361459ce45eb1 \
-                    sha256  443e54a6149d1b0bf08677d17b18fced9028b101fc2ffd2c81e0834f87eebc7d \
-                    size    2736913
+checksums           rmd160  556b0b0a6a66d7089d4e5f005279dbb352666ca4 \
+                    sha256  6fb191cddaf607e7754b1f6915a1a61dc4018b3e4eef3d2ffacec961c9682949 \
+                    size    2753014
 
 # ntpsec requires Python 2.7 or 3.3+.
 # We skip 3.3, but keep 2.7 and 3.4+.
@@ -98,11 +98,10 @@ depends_lib-append  port:python${pyver_no_dot}
 
 # Consolidated patchfile, based on GitLab/fhgwright/ntpsec
 #
-# This diff is from NTPsec_1_2_4 vs. macports-1_2_4
+# This diff is from NTPsec_1_2_5 vs. macports-1_2_5
 #
-# The patches are reduced from earlier versions, based on using legacy-support
-# to provide some missing features.  Some patches are still needed, though,
-# to accommodate OS versions <10.13 (plus a Python 2 fix in ntpq).
+# These patches are needed to do without "timex" support on <10.13.
+# Other issues with <10.12 are handled by legacy-support.
 #
 patchfiles          patch-allfixes.diff
 

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,5 +1,5 @@
 --- include/ntp_stdlib.h.orig	2025-04-18 12:54:14.000000000 -0700
-+++ include/ntp_stdlib.h	2025-04-20 16:24:35.000000000 -0700
++++ include/ntp_stdlib.h	2026-08-02 13:12:45.000000000 -0700
 @@ -103,7 +103,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -11,7 +11,7 @@
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
 --- include/ntp_syscall.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_syscall.h	2025-04-20 16:24:35.000000000 -0700
++++ include/ntp_syscall.h	2026-08-02 13:12:45.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -24,8 +24,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- libntp/clockwork.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ libntp/clockwork.c	2025-04-20 16:24:35.000000000 -0700
+--- libntp/clockwork.c.orig	2026-07-30 21:35:58.000000000 -0700
++++ libntp/clockwork.c	2026-08-02 13:12:45.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -39,8 +39,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- libntp/statestr.c.orig	2025-04-18 12:54:14.000000000 -0700
-+++ libntp/statestr.c	2025-04-20 16:24:35.000000000 -0700
+--- libntp/statestr.c.orig	2026-07-30 21:35:58.000000000 -0700
++++ libntp/statestr.c	2026-08-02 13:12:45.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -141,25 +141,8 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ntpclients/ntpq.py.orig	2025-04-18 12:54:14.000000000 -0700
-+++ ntpclients/ntpq.py	2025-04-20 16:24:35.000000000 -0700
-@@ -25,6 +25,14 @@ import socket
- import sys
- import time
- 
-+# The BrokenPipeError doesn't exist in Python 2, but the problem that requires
-+# catching it also doesn't seem to exist in Python 2, so just make it a dummy
-+# in Python 2.
-+try:
-+    BrokenPipeError
-+except NameError:
-+    BrokenPipeError = None
-+
- try:
-     import ntp.control
-     import ntp.ntpc
---- ntpd/ntp_control.c.orig	2025-04-18 12:54:14.000000000 -0700
-+++ ntpd/ntp_control.c	2025-04-20 16:24:35.000000000 -0700
+--- ntpd/ntp_control.c.orig	2026-07-30 21:35:58.000000000 -0700
++++ ntpd/ntp_control.c	2026-08-02 13:12:45.000000000 -0700
 @@ -37,7 +37,9 @@ struct utsname utsnamebuf;
  
  /* Variables that need updating each time. */
@@ -186,7 +169,7 @@
  
  
  /* refclock stuff in ntp_io */
-@@ -1402,7 +1406,9 @@ ctl_putarray(
+@@ -1405,7 +1409,9 @@ ctl_putarray(
   */
  static void
  ctl_putsys(const struct var * v) {
@@ -196,7 +179,7 @@
  	static unsigned long ntp_leap_time;
  
  /* older compilers don't allow declarations on each case without {} */
-@@ -1414,6 +1420,7 @@ ctl_putsys(const struct var * v) {
+@@ -1417,6 +1423,7 @@ ctl_putsys(const struct var * v) {
   * This should get pushed up a layer: flag, once per request
   * This could get data from 2 samples if the clock ticks while we are working..
   */
@@ -204,7 +187,7 @@
  	/* The Kernel clock variables need up-to-date output of ntp_adjtime() */
  	if (v->flags&N_CLOCK && current_time != ntp_adjtime_time) {
  		ZERO(ntx);
-@@ -1422,6 +1429,7 @@ ctl_putsys(const struct var * v) {
+@@ -1425,6 +1432,7 @@ ctl_putsys(const struct var * v) {
                              "MODE6: ntp_adjtime() for mode 6 query failed: %s", strerror(errno));
                  ntp_adjtime_time = current_time;
  	}
@@ -212,8 +195,8 @@
  
  	/* The leap second variables need up-to-date info */
          if (v->flags&N_LEAP && current_time != ntp_leap_time) {
---- ntpd/ntp_loopfilter.c.orig	2025-04-18 12:54:14.000000000 -0700
-+++ ntpd/ntp_loopfilter.c	2025-04-20 16:24:35.000000000 -0700
+--- ntpd/ntp_loopfilter.c.orig	2026-07-30 21:35:58.000000000 -0700
++++ ntpd/ntp_loopfilter.c	2026-08-02 13:12:45.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -422,8 +405,8 @@
  	}
  }
 -
---- ntpd/ntp_timer.c.orig	2025-04-18 12:54:14.000000000 -0700
-+++ ntpd/ntp_timer.c	2025-04-20 16:24:35.000000000 -0700
+--- ntpd/ntp_timer.c.orig	2026-07-30 21:35:58.000000000 -0700
++++ ntpd/ntp_timer.c	2026-08-02 13:12:45.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -434,7 +417,7 @@
  
  #ifdef HAVE_TIMER_CREATE
  /* TC_ERR represents the timer_create() error return value. */
-@@ -373,7 +375,11 @@ check_leapsec(
+@@ -388,7 +390,11 @@ check_leapsec(
  
  	leap_result_t lsdata;
  	uint32_t       lsprox;
@@ -447,7 +430,7 @@
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
 --- ntpd/refclock_local.c.orig	2025-04-18 12:54:14.000000000 -0700
-+++ ntpd/refclock_local.c	2025-04-20 16:24:35.000000000 -0700
++++ ntpd/refclock_local.c	2026-08-02 13:12:45.000000000 -0700
 @@ -164,6 +164,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -471,7 +454,7 @@
  	refclock_receive(peer);
  }
 --- tests/libntp/statestr.c.orig	2025-04-18 12:54:14.000000000 -0700
-+++ tests/libntp/statestr.c	2025-04-20 16:24:35.000000000 -0700
++++ tests/libntp/statestr.c	2026-08-02 13:12:45.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -493,7 +476,7 @@
  
  // statustoa
 --- wafhelpers/bin_test.py.orig	2025-04-18 12:54:14.000000000 -0700
-+++ wafhelpers/bin_test.py	2025-04-20 16:24:35.000000000 -0700
++++ wafhelpers/bin_test.py	2026-08-02 13:12:45.000000000 -0700
 @@ -88,8 +88,11 @@ def cmd_bin_test(ctx):
          (BIN, NTPCLIENTS, "ntpleapfetch", "--version"),
          (SBIN, NTPD, "ntpd", "--version"),
@@ -508,7 +491,7 @@
          (BIN, NTPCLIENTS, "ntpdig", "--version"),
          (BIN, NTPCLIENTS, "ntpkeygen", "--version"),
 --- wafhelpers/options.py.orig	2025-04-18 12:54:14.000000000 -0700
-+++ wafhelpers/options.py	2025-04-20 16:24:35.000000000 -0700
++++ wafhelpers/options.py	2026-08-02 13:12:45.000000000 -0700
 @@ -24,6 +24,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -518,9 +501,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- wscript.orig	2025-04-18 12:54:14.000000000 -0700
-+++ wscript	2025-04-20 16:24:35.000000000 -0700
-@@ -578,7 +578,7 @@ int main(int argc, char **argv) {
+--- wscript.orig	2026-07-30 21:35:58.000000000 -0700
++++ wscript	2026-08-02 13:12:45.000000000 -0700
+@@ -540,7 +540,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -529,7 +512,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -809,6 +809,21 @@ int main(int argc, char **argv) {
+@@ -771,6 +771,21 @@ int main(int argc, char **argv) {
      if ctx.options.disable_fuzz:
          pprint("YELLOW", "--disable-fuzz is now standard.  Clock fuzzing is gone.")
  


### PR DESCRIPTION
TESTED:
Built (including running tests) on 10.4-10.5 ppc, 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-26.x arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.7 23J520, arm64, Xcode 16.2 16C5032a
macOS 15.7.7 24G720, arm64, Xcode 26.3 17C529
macOS 26.5.2 25F84, arm64, Xcode 26.6 17F113
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
