### PR TITLE
Update and declare the Go needed by 47 module-mode ports

### DIFF
--- a/devel/act/Portfile
+++ b/devel/act/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/nektos/act 0.2.89 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         Run your GitHub Actions locally

--- a/devel/cue/Portfile
+++ b/devel/cue/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/cue-lang/cue 0.17.1 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 go.package          cuelang.org/go
 revision            0
 

--- a/devel/delve/Portfile
+++ b/devel/delve/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-delve/delve 1.27.0 v
+go.setup            github.com/go-delve/delve 1.27.1 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         \
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  60a9000c4f50ef06f9f30c694dbcfe1d3b10f41e \
-                    sha256  84979ac689ba26dc0a086b245cb0a3f3e6a7a246a435b2c757867e76823187a5 \
-                    size    9392113
+checksums           rmd160  3cd7e4d4a6bbc4465a3b91a2ac4362dec84e9fa3 \
+                    sha256  dca9ec6f2c392a00449ad748b3a229e92ba4efa67f4e7582f2cc45974429928f \
+                    size    9521825
 
 post-extract {
     reinplace -E s|@go|@${go.bin}| ${worksrcpath}/Makefile

--- a/devel/go-tools/Portfile
+++ b/devel/go-tools/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/golang/tools 0.44.0 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 epoch               7
 revision            0
 

--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golangci/golangci-lint 2.10.1 v
+go.setup            github.com/golangci/golangci-lint 2.12.2 v
 revision            0
 
 homepage            https://golangci-lint.run
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {@steenzout} \
                     openmaintainer
 
-checksums           rmd160  b8314828b973b708e5c3f7c0271a99a8d2c7cf6f \
-                    sha256  e34fdc0efa6dc7a8b71ceba372a5714bcab24eda2c519518b3141a8e4448c78f \
-                    size    5433302
+checksums           rmd160  6b517ebe0fc8e63997dc739681d9cf005f848fd4 \
+                    sha256  568cfb0ad40832177826608003065a976254415509dd8b4e3ba19ee586388b94 \
+                    size    5463246
 
 build.args          -trimpath \
                     -ldflags="-s -w -X main.version=v${version} -X main.commit=v${version} -X main.date=20251207" \
@@ -35,6 +35,7 @@ build.args          -trimpath \
 # dependencies during the build phase. See
 # https://trac.macports.org/ticket/61192
 go.offline_build no
+go.toolchain_min    1.25.0
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}

--- a/devel/goreleaser/Portfile
+++ b/devel/goreleaser/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/goreleaser/goreleaser 2.15.3 v
+go.setup            github.com/goreleaser/goreleaser 2.17.1 v
 go.offline_build    no
+go.toolchain_min    1.26.5
 revision            0
 
 homepage            https://goreleaser.com
@@ -20,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  599efc6abf3d48c834b5b4c6c716006baec2d640 \
-                    sha256  a5b0f9c06fb9032be04d6f7db5e64d016ac4bd7993f9c2aa5f085402c62a4e9e \
-                    size    2703756
+checksums           rmd160  c8d48e5521779cefd486b9d2455dac8d6755cf62 \
+                    sha256  7570a245c67cbf3f468d698b410fed1755525bb48624ed4198babb372c15ca76 \
+                    size    2660235
 
 build.args-append   \
     -ldflags \" -X main.version=${version} -X main.builtBy=macports \"

--- a/devel/oasdiff/Portfile
+++ b/devel/oasdiff/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/Tufin/oasdiff 1.27.0 v
 go.offline_build    no
+go.toolchain_min    1.26
 revision            0
 
 homepage            https://www.oasdiff.com/

--- a/devel/treefmt/Portfile
+++ b/devel/treefmt/Portfile
@@ -7,6 +7,7 @@ PortGroup           github  1.0
 go.setup            github.com/numtide/treefmt 2.5.0 v
 go.package          github.com/numtide/treefmt/v2
 go.offline_build    no
+go.toolchain_min    1.26.1
 revision            0
 
 homepage            https://treefmt.com/

--- a/llm/sx/Portfile
+++ b/llm/sx/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/sleuth-io/sx 1.0.4 v
+go.setup            github.com/sleuth-io/sx 2.3.1 v
 go.offline_build    no
+go.toolchain_min    1.26
 revision            0
 
 description         sx is a package manager for AI coding assistants
@@ -18,9 +19,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c3afd0848d0a3a75e3454f88270ff4508aeaa4e2 \
-                    sha256  62494319ed113c688ae7878e43cb77dcea756ff16b1d8d195cf60716e0fb2695 \
-                    size    3216773
+checksums           rmd160  be35a3867b62e55eb3bdef8cb6de378c2b2708dc \
+                    sha256  857e7075ccd50b604469e48c33e23975209a8b31c5ad15e6686ab0a328e2993e \
+                    size    7652394
 
 build.cmd           make
 build.pre_args-append \

--- a/net/croc/Portfile
+++ b/net/croc/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/schollz/croc 10.5.0 v
+go.setup            github.com/schollz/croc 11.0.1 v
 go.package          github.com/schollz/croc/v10
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 epoch               1
 
@@ -30,9 +31,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  66efd941783079477c2c0f680945551c2044ab86 \
-                    sha256  e1a8053091dd00e0c5b9949374df1e2f0671e0d98ea8ff81a447c421312246e4 \
-                    size    617097
+checksums           rmd160  91e37a17cae27d9f34c20c710520098f03832ed0 \
+                    sha256  44152e31cf651a9ac2b0492573f562a2784fcf75afa7ff5a9ce815f7ec5352d0 \
+                    size    5086965
 
 build.pre_args-append \
     -ldflags \" -s -w  \

--- a/net/k6/Portfile
+++ b/net/k6/Portfile
@@ -6,6 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/k6io/k6 2.1.0 v
 go.package          go.k6.io/k6
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://k6.io

--- a/net/quien/Portfile
+++ b/net/quien/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/retlehs/quien 0.2.0 v
+go.setup            github.com/retlehs/quien 0.12.0 v
 go.offline_build    no
+go.toolchain_min    1.26.4
 revision            0
 
 homepage            https://benword.com/quien-a-better-whois-lookup-tool
@@ -21,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  7bb9987112e3b826709735bab442eaf65fac9e84 \
-                    sha256  cdcd41e6d7e632cca75d6fe3fe81121a4f019d1aba4d64abcc884b05aa0b3e91 \
-                    size    840029
+checksums           rmd160  40b272ebd1585df6f652e4fbb0eaa9eec12f43c9 \
+                    sha256  49eef2d196a1b9c1e46c037c8fa300f6ced71c952828761fb4810ad8151e14c2 \
+                    size    1179730
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/net/scw/Portfile
+++ b/net/scw/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/scaleway/scaleway-cli 2.56.1 v
+go.setup            github.com/scaleway/scaleway-cli 2.60.0 v
 go.offline_build    no
+go.toolchain_min    1.26.3
 revision            0
 name                scw
 
@@ -22,9 +23,9 @@ description         Command Line Interface for Scaleway
 long_description    Scaleway CLI is a tool to help you pilot your Scaleway \
                     infrastructure directly from your terminal.
 
-checksums           rmd160  725a341b0d21ceea2ed2c8daf34c6bb43aa54d90 \
-                    sha256  d4c8224879f5aabaf7b5831eebc8564f19f54501f62eeeaf63ad027f38b65d72 \
-                    size    4009516
+checksums           rmd160  3587ead9926835e102e8696155a2ba918949ebff \
+                    sha256  744deb8a1a28c90b0d0e34cf06f60f40638f0ee17d55ba6dcd803be410baddf6 \
+                    size    4020230
 
 build.pre_args-append \
     -ldflags \" -X main.Version=${github.tag_prefix}${version} \"

--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/syncthing/syncthing 2.1.2 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://syncthing.net

--- a/net/tailscale/Portfile
+++ b/net/tailscale/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tailscale/tailscale 1.100.0 v
+go.setup            github.com/tailscale/tailscale 1.102.1 v
 go.package          tailscale.com
 go.offline_build    no
+go.toolchain_min    1.26.5
 revision            0
 
 homepage            https://tailscale.com
@@ -22,9 +23,9 @@ license             BSD
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  d57ab15726a3ea8a79284fb0ceb8e32e322c45cf \
-                    sha256  d9e097d82f08c8557c887ca71962b20f08e27f3b305902ea504bd0e472486b97 \
-                    size    4889482
+checksums           rmd160  9a299e78b01895692134a678a8defad9b31f6f5e \
+                    sha256  ececb81b4608c40b823ef2a8a1f083eebbb44f8ded8c74f51f03d07462668e7c \
+                    size    5281621
 
 startupitem.create  yes
 startupitem.executable \

--- a/net/zdns/Portfile
+++ b/net/zdns/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/zmap/zdns 2.1.1 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         Fast DNS Lookup Library and CLI Tool

--- a/security/betterleaks/Portfile
+++ b/security/betterleaks/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/betterleaks/betterleaks 1.4.1 v
+go.setup            github.com/betterleaks/betterleaks 1.7.3 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://betterleaks.com/
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9466cc27e62dc1b3d70a603089cb8aa4eb32c4e1 \
-                    sha256  ddebea272658c703c8ca9b3096f3e98eedb1495fdca1159f350e10e25d11bc9f \
-                    size    1344504
+checksums           rmd160  81c6c7a57c99fcc569f099b9bda60f5802e8e7cc \
+                    sha256  7359ae820c62c276d31cef3d1431eb8beb6db07d5c44830bad03dbe9c0cf3850 \
+                    size    1431658
 
 build.cmd           make
 build.pre_args-append \

--- a/security/gosec/Portfile
+++ b/security/gosec/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/securego/gosec 2.24.7 v
+go.setup            github.com/securego/gosec 2.28.0 v
 go.package          github.com/securego/gosec/v2
 go.offline_build    no
+go.toolchain_min    1.25.8
 revision            0
 
 homepage            https://securego.io
@@ -21,9 +22,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  4d8bc4373bdef0913ac6cf7463333d29c4110b80 \
-                    sha256  0d5509b17bb89ca1fa8f135ff88e498400a81bbb4c6fad19cb6aa34654249db8 \
-                    size    351192
+checksums           rmd160  a426e009e1351e89f519483bc196a5d1221225e7 \
+                    sha256  ccf7fa75b606c2adfcafadd6a3830966a161c4350a90fdfe4f15d6230da86d8f \
+                    size    389975
 
 build.cmd           make
 build.pre_args-append \

--- a/security/lego/Portfile
+++ b/security/lego/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-acme/lego 4.35.1 v
+go.setup            github.com/go-acme/lego 5.3.1 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://go-acme.github.io/lego
@@ -28,9 +29,9 @@ build.cmd           make
 build.pre_args      VERSION=v${version}
 build.args          build
 
-checksums           rmd160  221b5d613ca11a4d54f8e1fc931d3aed2245e976 \
-                    sha256  50a3246798c8808b7d4d78b3141d18d41363d413880ee8d663cbfa3efdde0640 \
-                    size    1091609
+checksums           rmd160  d24bce67876e38bde316bca757104388dd095675 \
+                    sha256  4692d2481042349c758eb0f7ee04904c4e1c26afc145e25b0833a42777c5ee72 \
+                    size    1280270
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin/

--- a/security/mfa/Portfile
+++ b/security/mfa/Portfile
@@ -20,6 +20,7 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 installs_libs       no
 
 go.offline_build no
+go.toolchain_min    1.25
 
 build.pre_args      -ldflags  \"-X ${go.package}/cmd.version=${version} \
                                 -X ${go.package}/cmd.revision=${revision}\"

--- a/security/nuclei/Portfile
+++ b/security/nuclei/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/projectdiscovery/nuclei 3.9.0 v
+go.setup            github.com/projectdiscovery/nuclei 3.11.0 v
 go.package          github.com/projectdiscovery/nuclei/v[lindex [split ${version} .] 0]
 go.offline_build    no
+go.toolchain_min    1.25.7
 revision            0
 
 homepage            https://docs.projectdiscovery.io/tools/nuclei/overview
@@ -27,9 +28,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  8d89d2383273222b4248bffa31337de9e532ae37 \
-                    sha256  40b4b736071377dd11e9637c02ae956797faa6f497e8401012aaa8870d283303 \
-                    size    12196947
+checksums           rmd160  cf1ee8600dd6a3b1a76aa6e44bb9d2863f7e1164 \
+                    sha256  33dcc4a5c03681018aac1d7f4f4772d0bf6a0d0403bc1c94cdead23db93bb4e1 \
+                    size    12283428
 
 build.cmd           make
 build.pre_args      CMDGO=${go.bin}

--- a/security/oauth2c/Portfile
+++ b/security/oauth2c/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/cloudentity/oauth2c 1.20.0 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 description         User-friendly CLI for OAuth2

--- a/security/sops/Portfile
+++ b/security/sops/Portfile
@@ -6,6 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/mozilla/sops 3.13.3 v
 go.package          go.mozilla.org/sops/v3
 go.offline_build    no
+go.toolchain_min    1.25.8
 revision            0
 
 description         Simple and flexible tool for managing secrets

--- a/security/vault/Portfile
+++ b/security/vault/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/hashicorp/vault 2.0.3 v
+go.setup            github.com/hashicorp/vault 2.0.4 v
 go.offline_build    no
+go.toolchain_min    1.26.4
 revision            0
 
 homepage            https://www.vaultproject.io

--- a/sysutils/certigo/Portfile
+++ b/sysutils/certigo/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/square/certigo 1.18.0 v
 go.offline_build    no
+go.toolchain_min    1.25
 github.tarball_from archive
 revision            0
 

--- a/sysutils/eksctl/Portfile
+++ b/sysutils/eksctl/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/weaveworks/eksctl 0.229.0 v
 go.offline_build    no
+go.toolchain_min    1.25.8
 revision            0
 
 homepage            https://eksctl.io

--- a/sysutils/gdu/Portfile
+++ b/sysutils/gdu/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/dundee/gdu 5.36.1 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 go.package          github.com/dundee/gdu/v5
 revision            0
 

--- a/sysutils/k0sctl/Portfile
+++ b/sysutils/k0sctl/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/k0sproject/k0sctl 0.29.0 v
+go.setup            github.com/k0sproject/k0sctl 0.32.2 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 set git-commit      48ad3a5
 revision            0
 
@@ -18,9 +19,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  baf2e1ed99f37b8e77e306322ab41418c3c11b8e \
-                    sha256  a65f0d1d803f1668bb40f5f0f6a2637949ab5ac29b91b35148a598fcab7ed8db \
-                    size    149618
+checksums           rmd160  04faa04f2445d63dbcbbe8fcbc86fa25d72a5bba \
+                    sha256  0df9d24cd7a04b039c31ed641983c41a8b23cd26e17288c9cda099f4f271ba54 \
+                    size    152844
 
 build.cmd           make
 build.pre_args-append \

--- a/sysutils/k3d/Portfile
+++ b/sysutils/k3d/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/rancher/k3d 5.9.0 v
 go.offline_build    no
+go.toolchain_min    1.26.3
 revision            0
 
 homepage            https://k3d.io

--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/derailed/k9s 0.51.0 v
 go.offline_build    no
+go.toolchain_min    1.25.8
 revision            0
 
 homepage            https://k9scli.io

--- a/sysutils/kapp/Portfile
+++ b/sysutils/kapp/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/vmware-tanzu/carvel-kapp 0.66.0 v
 go.offline_build    no
+go.toolchain_min    1.25.7
 name                kapp
 revision            0
 

--- a/sysutils/kl/Portfile
+++ b/sysutils/kl/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/robinovitch61/kl 0.9.1 v
 go.offline_build    no
+go.toolchain_min    1.26
 revision            0
 
 description         An interactive Kubernetes log viewer for your terminal.

--- a/sysutils/ksctl/Portfile
+++ b/sysutils/ksctl/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/ksctl/kli 2.9.0 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 name                ksctl
 revision            0
 

--- a/sysutils/kubeseal/Portfile
+++ b/sysutils/kubeseal/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/bitnami-labs/sealed-secrets 0.36.6 v
+go.setup            github.com/bitnami-labs/sealed-secrets 0.38.4 v
 go.offline_build    no
+go.toolchain_min    1.26.4
 name                kubeseal
 revision            0
 
@@ -18,9 +19,9 @@ maintainers         @tux-o-matic \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0012760b84aa1b58496d29134732595b58e81943 \
-                    sha256  ace1ca2c50379538514f5a8116c8a48d24ef3a856d3699d2085159e2ba75a1ae \
-                    size    1329367
+checksums           rmd160  26828a3ba3c452e0ac38b61e5230b2b560f5b11d \
+                    sha256  7076a3278ac29e5f3f8ac6676414e4c24f01303c1405b99a1caebe88f5977d7e \
+                    size    1336342
 
 build.cmd           make
 build.target        ${name}

--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/lima-vm/lima 2.2.0 v
 go.offline_build    no
+go.toolchain_min    1.25.7
 revision            0
 
 homepage            https://lima-vm.io

--- a/sysutils/mactop/Portfile
+++ b/sysutils/mactop/Portfile
@@ -29,6 +29,7 @@ checksums           rmd160  ab2d8e52925316ead1fdacb21675a223633032ec \
                     size    15034921
 
 go.offline_build    no
+go.toolchain_min    1.25.4
 
 build.args-append   -o ./${name}
 

--- a/sysutils/superfile/Portfile
+++ b/sysutils/superfile/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/yorukot/superfile 1.6.0 v
 go.offline_build    no
+go.toolchain_min    1.25.7
 revision            0
 
 description         Pretty fancy and modern terminal file manager

--- a/sysutils/tflint/Portfile
+++ b/sysutils/tflint/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/terraform-linters/tflint 0.61.0 v
+go.setup            github.com/terraform-linters/tflint 0.64.0 v
 go.offline_build    no
+go.toolchain_min    1.26.3
 revision            0
 
 description         \
@@ -19,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  148b54b075a2a95f96d41dd55395e83b6e1a4307 \
-                    sha256  d99c9eb3003375a4220607e1b479c9292450fd2c576549b1887f1c7259730e17 \
-                    size    1392232
+checksums           rmd160  41b3cc1dc65a272fa4e91005a9df87b8064841eb \
+                    sha256  995a3816520ec99e2518b6cd845d003b8eddf8ca51322c2b7e9053f908326d15 \
+                    size    1399149
 
 build.cmd           make
 build.args          build

--- a/sysutils/tfmv/Portfile
+++ b/sysutils/tfmv/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/suzuki-shunsuke/tfmv 1.0.0 v
 go.offline_build    no
+go.toolchain_min    1.25.5
 revision            0
 
 description         \

--- a/sysutils/vals/Portfile
+++ b/sysutils/vals/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/variantdev/vals 0.43.8 v
+go.setup            github.com/variantdev/vals 0.45.0 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 description         \
@@ -22,9 +23,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  018a73f7d863e1aec732f97d295f3ba1a37fce82 \
-                    sha256  a05fdfb08a065cca20d399df1d79cba665e2a9a9abe26ba9cd82d253dc9d4197 \
-                    size    163183
+checksums           rmd160  692c2e2fdc7b73ea294be0f84d7cadc247ae87e7 \
+                    sha256  861d05c54e8f5461832ea761926a4cbc41b2c252c5950184804c4307185a79b4 \
+                    size    181059
 
 build.pre_args-append \
     -ldflags \" -X main.version=${github.tag_prefix}${version} \"

--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -31,6 +31,7 @@ build.args          -o ${name}
 # dependencies during the build phase. See
 # https://trac.macports.org/ticket/61192
 go.offline_build no
+go.toolchain_min    1.26.4
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}

--- a/textproc/dasel/Portfile
+++ b/textproc/dasel/Portfile
@@ -6,6 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/TomWright/dasel 3.11.2 v
 go.package          github.com/tomwright/dasel
 go.offline_build    no
+go.toolchain_min    1.25
 revision            0
 
 homepage            https://daseldocs.tomwright.me

--- a/textproc/dyff/Portfile
+++ b/textproc/dyff/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/homeport/dyff 1.12.0 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         diff tool for YAML files, and sometimes JSON

--- a/textproc/glow/Portfile
+++ b/textproc/glow/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/charmbracelet/glow 2.1.2 v
 go.offline_build    no
+go.toolchain_min    1.25.9
 revision            1
 
 description         Render markdown on the CLI, with pizzazz!

--- a/textproc/moor/Portfile
+++ b/textproc/moor/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/walles/moor 2.13.3 v
+go.setup            github.com/walles/moor 2.16.2 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         Moor is a pager. It's designed to just do the right thing \
@@ -15,9 +16,9 @@ long_description    Moor should work as a drop-in replacement for Less. \
                     support, incremental search and automatic decompression, \
                     among others.
 
-checksums           rmd160  4d3c12f2b5d52259518307c8ce6f0e151fa2d37a \
-                    sha256  0e441201b119a5b31eb61fb1d2165cec83a5a2beb93f50905344ff51c3076606 \
-                    size    5331025
+checksums           rmd160  cc2f43f95a83b00e86f54b4c5cdc8dd39f74da1e \
+                    sha256  20873548bbc9200bfd07b464f420ee6428d433f8a96d98c81af1b65020a84114 \
+                    size    5365952
 
 categories          textproc
 installs_libs       no

--- a/textproc/ov/Portfile
+++ b/textproc/ov/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/noborus/ov 0.54.0 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         Feature rich terminal pager

--- a/textproc/yq/Portfile
+++ b/textproc/yq/Portfile
@@ -6,6 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/mikefarah/yq 4.53.3 v
 go.package          github.com/mikefarah/yq/v4
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 dist_subdir         ${name}/${version}_${revision}
 


### PR DESCRIPTION
Annotates 47 module-mode Go ports with the Go version they need, one commit per port. 18 of them are also brought up to their newest upstream release in the same commit.

* Each `go.toolchain_min` is the `go` directive from the `go.mod` of the release the port packages — for the 18 updated ports, from the **new** release. 11 of those 18 directives moved with the update, so annotating without updating would have recorded a stale value.

* All declare 1.25 or 1.26, so these ports are now skipped below 12 Monterey rather than fetched, built and failed on every push.

* The 29 annotate-only commits carry no revision bump: the annotation changes whether a port is attempted, not what it produces.

All are module mode (`go.offline_build no`), where Go reads `go.mod` and enforces the directive, and none has dependencies that could confound the gate.

See: https://trac.macports.org/ticket/73086
