### PR TITLE
palm/palmgoogle-mac: new port

### DIFF
--- a/palm/palmgoogle-mac/Portfile
+++ b/palm/palmgoogle-mac/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        HodsonTech palmgoogle-mac 1.3 v
+github.tarball_from archive
+revision            0
+
+name                palmgoogle-mac
+categories          palm python
+platforms           darwin
+license             {GPL-2 MIT}
+maintainers         {jeff.hodson:hodsontech.com @HodsonTech} openmaintainer
+conflicts           palm365-mac
+
+description         Sync a Palm OS PDA with Google Calendar/Tasks/Contacts via a jpilot plugin
+
+long_description    palmgoogle-mac bidirectionally syncs a Palm OS PDA's \
+                    calendar, tasks, and contacts with a Google account. \
+                    It runs automatically as a jpilot plugin -- a \
+                    down-sync when jpilot launches, and a full push-up + \
+                    down-sync right after every HotSync -- with no manual \
+                    sync command needed day to day. One-time setup requires \
+                    creating a free Google Cloud OAuth client, which \
+                    ${prefix}/share/${name}/setup.py walks through. Not \
+                    installable alongside palm365-mac -- both are \
+                    full-rebuild engines against the same Palm databases, \
+                    and running two independent ones at once is a real \
+                    hazard, not a supported configuration.
+
+homepage            https://github.com/HodsonTech/palmgoogle-mac
+
+checksums           rmd160  7c9276a9512a75230ffa7af63763b40b7f5d4627 \
+                    sha256  5ff0e91adc2e781016a99200afb05e24ebe8def67b9f5e26365810ca56ad26c5 \
+                    size    29079
+
+depends_build       port:gtk3
+depends_lib         port:jpilot \
+                    port:pilot-link \
+                    port:python314 \
+                    port:py314-requests \
+                    port:py314-palm-sync-core
+
+use_configure       no
+
+build {
+    system -W ${worksrcpath}/jpilot-plugin \
+        "${configure.cc} -arch ${configure.build_arch} -bundle \
+         -Wl,-undefined,dynamic_lookup \
+         -DPYTHON_BIN=\\\"${prefix}/bin/python3.14\\\" \
+         -DSYNC_CWD=\\\"${prefix}/share/${name}\\\" \
+         -I vendor \
+         `${prefix}/bin/pkg-config --cflags gtk+-3.0` \
+         -o libpalmgoogleplugin.so palmgoogleplugin.c"
+}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/lib/jpilot/plugins
+    xinstall -m 755 ${worksrcpath}/jpilot-plugin/libpalmgoogleplugin.so \
+        ${destroot}${prefix}/lib/jpilot/plugins/
+
+    xinstall -d ${destroot}${prefix}/share/${name}
+    foreach f {config.example.toml google_client.py google_field_mapper.py \
+               pc3_seed.py setup.py sync_to_palm.py README.md LICENSE} {
+        xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/${name}/
+    }
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/jpilot-plugin/COPYING \
+        ${destroot}${prefix}/share/doc/${name}/COPYING.plugin
+}
+
+notes "
+palmgoogle-mac needs a one-time setup step before it can sync anything --\n\
+it creates a free Google Cloud OAuth client (a real Google requirement,\n\
+not something this port can skip) and writes your config.\n\
+\n\
+    cd ${prefix}/share/${name} && ${prefix}/bin/python3.14 setup.py\n\
+\n\
+After that, just launch jpilot and HotSync -- syncing happens\n\
+automatically from then on, no manual commands needed.
+"

--- a/palm/palmgoogle-mac/Portfile
+++ b/palm/palmgoogle-mac/Portfile
@@ -5,11 +5,10 @@ PortGroup           github 1.0
 
 github.setup        HodsonTech palmgoogle-mac 1.3 v
 github.tarball_from archive
-revision            0
+revision            1
 
 name                palmgoogle-mac
 categories          palm python
-platforms           darwin
 license             {GPL-2 MIT}
 maintainers         {jeff.hodson:hodsontech.com @HodsonTech} openmaintainer
 conflicts           palm365-mac
@@ -35,12 +34,19 @@ checksums           rmd160  7c9276a9512a75230ffa7af63763b40b7f5d4627 \
                     sha256  5ff0e91adc2e781016a99200afb05e24ebe8def67b9f5e26365810ca56ad26c5 \
                     size    29079
 
-depends_build       port:gtk3
+# Single source of truth for the Python version this port targets --
+# propagated to the dependency names, the build-time PYTHON_BIN define,
+# and the setup instructions in `notes`, so it only ever needs updating
+# in one place.
+set py_ver          314
+set py_branch        3.14
+
+depends_build       path:lib/pkgconfig/gtk+-3.0.pc:gtk3
 depends_lib         port:jpilot \
                     port:pilot-link \
-                    port:python314 \
-                    port:py314-requests \
-                    port:py314-palm-sync-core
+                    port:python${py_ver} \
+                    port:py${py_ver}-requests \
+                    port:py${py_ver}-palm-sync-core
 
 use_configure       no
 
@@ -48,7 +54,7 @@ build {
     system -W ${worksrcpath}/jpilot-plugin \
         "${configure.cc} -arch ${configure.build_arch} -bundle \
          -Wl,-undefined,dynamic_lookup \
-         -DPYTHON_BIN=\\\"${prefix}/bin/python3.14\\\" \
+         -DPYTHON_BIN=\\\"${prefix}/bin/python${py_branch}\\\" \
          -DSYNC_CWD=\\\"${prefix}/share/${name}\\\" \
          -I vendor \
          `${prefix}/bin/pkg-config --cflags gtk+-3.0` \
@@ -76,7 +82,7 @@ palmgoogle-mac needs a one-time setup step before it can sync anything --\n\
 it creates a free Google Cloud OAuth client (a real Google requirement,\n\
 not something this port can skip) and writes your config.\n\
 \n\
-    cd ${prefix}/share/${name} && ${prefix}/bin/python3.14 setup.py\n\
+    cd ${prefix}/share/${name} && ${prefix}/bin/python${py_branch} setup.py\n\
 \n\
 After that, just launch jpilot and HotSync -- syncing happens\n\
 automatically from then on, no manual commands needed.


### PR DESCRIPTION
## Summary

Bidirectional sync between a Palm OS PDA and Google Calendar/Tasks/Contacts, running automatically as a [jpilot](https://jpilot.org) plugin. As far as I'm aware, this is the first bridge of its kind for Google — nobody else has connected Palm OS to Google Calendar/Tasks/Contacts this way before.

This is the Google-side sibling of [palm365-mac](https://github.com/macports/macports-ports/pull/33861) (Microsoft 365), sharing the same provider-agnostic reconciliation engine, [palm-sync-core](https://github.com/macports/macports-ports/pull/33864). This package supplies only the Google-specific pieces: OAuth (desktop-app loopback redirect + PKCE — Google's device-code flow is restricted to a scope allowlist that excludes Calendar/Tasks/Contacts), the Calendar/Tasks/People API client, and field mapping.

- `conflicts palm365-mac`: both are full-rebuild engines against the same Palm databases, and running two independent ones at once is a real hazard, not a supported configuration. One cloud provider per Palm, by design.
- One-time setup (Google Cloud OAuth client creation) is walked through by `${prefix}/share/palmgoogle-mac/setup.py`, same pattern as palm365-mac's Azure app registration walkthrough.
- Live-tested end-to-end against a real Palm Vx and a real Google account: bidirectional sync for calendar (both timed and all-day events), contacts, and tasks, including deletion propagation in both directions (device → cloud and cloud → device).

## Test plan

- [x] `port lint palm/palmgoogle-mac` (local)
- [x] `port -d install palmgoogle-mac` from a local port source
- [x] Live HotSync round-trips against a real Palm Vx + real Google account: push-up of device-created contact/event/task, down-sync of cloud items (including all-day events), and deletion propagation in both directions
- [ ] CI (destroot/livecheck lint) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
