### PR TITLE
Update and declare the Go needed by 15 more module-mode ports

### DIFF
--- a/databases/sq/Portfile
+++ b/databases/sq/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/neilotoole/sq 0.50.0 v
+go.setup            github.com/neilotoole/sq 0.54.1 v
 go.offline_build    no
-revision            1
+go.toolchain_min    1.26.3
+revision            0
 
 homepage            https://sq.io
 

--- a/devel/actionlint/Portfile
+++ b/devel/actionlint/Portfile
@@ -10,6 +10,7 @@ revision            0
 # (github.com/yaml/go-yaml) used by this version of actionlint. Until this is resolved, we
 # can't do offline builds.
 go.offline_build    no
+go.toolchain_min    1.25.0
 
 description         Static checker for GitHub Actions workflow files
 

--- a/devel/jjui/Portfile
+++ b/devel/jjui/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/idursun/jjui 0.10.8 v
+go.setup            github.com/idursun/jjui 0.10.9 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 description         \
@@ -19,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  d844c4ea27bf2c6dd8813b43e06a07682679c539 \
-                    sha256  964fc721c5494237a8259b044001327d7c93aa58aba07f9444d873f05d18d21d \
-                    size    264443
+checksums           rmd160  a49c80f33fe9c91dbd2f31c129d2e8d727f3e760 \
+                    sha256  1e6f74b3e00bb652f533331a15e4e0b9d6139a0db6f3f0f1e5b348ce547f72d0 \
+                    size    277222
 
 depends_run         port:jujutsu
 

--- a/devel/kops/Portfile
+++ b/devel/kops/Portfile
@@ -6,6 +6,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/kubernetes/kops 1.36.1 v
 go.offline_build    no
+go.toolchain_min    1.26.5
 revision            0
 go.package          k8s.io/kops
 

--- a/graphics/vhs/Portfile
+++ b/graphics/vhs/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/charmbracelet/vhs 0.11.0 v
 go.offline_build    no
+go.toolchain_min    1.25.8
 revision            0
 
 description         Your CLI home video recorder

--- a/security/amass/Portfile
+++ b/security/amass/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/owasp-amass/amass 5.1.1 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 homepage            https://owasp.org/www-project-amass

--- a/security/grype/Portfile
+++ b/security/grype/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/anchore/grype 0.109.0 v
+go.setup            github.com/anchore/grype 0.116.1 v
 go.offline_build    no
+go.toolchain_min    1.26.3
 revision            0
 
 description         \

--- a/security/trivy/Portfile
+++ b/security/trivy/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/aquasecurity/trivy 0.72.0 v
+go.setup            github.com/aquasecurity/trivy 0.73.0 v
 go.offline_build    no
+go.toolchain_min    1.26.3
 revision            0
 
 description         \

--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -28,6 +28,7 @@ checksums           rmd160  b3ae385e2ad028b1c3fba60ba1ff988093c259b8 \
 depends_run         port:lima
 
 go.offline_build no
+go.toolchain_min    1.25.0
 
 build.pre_args-append \
     -ldflags \" \

--- a/sysutils/confluent-cli/Portfile
+++ b/sysutils/confluent-cli/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/confluentinc/cli 4.61.0 v
+go.setup            github.com/confluentinc/cli 4.71.0 v
 go.offline_build    no
+go.toolchain_min    1.26.5
 name                confluent-cli
 revision            0
 

--- a/sysutils/krew/Portfile
+++ b/sysutils/krew/Portfile
@@ -29,6 +29,7 @@ depends_build-append \
 
 # Allow Go to fetch dependencies at build time
 go.offline_build no
+go.toolchain_min    1.25
 
 build.env-append    OSARCH=${goos}/${goarch}
 

--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -6,6 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/kubernetes/minikube 1.38.1 v
 go.package          k8s.io/minikube
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://minikube.sigs.k8s.io

--- a/sysutils/packer/Portfile
+++ b/sysutils/packer/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/hashicorp/packer 1.16.0 v
 go.offline_build    no
+go.toolchain_min    1.26.3
 revision            0
 
 homepage            https://www.packer.io

--- a/sysutils/prometheus/Portfile
+++ b/sysutils/prometheus/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/prometheus/prometheus 3.13.0 v
+go.setup            github.com/prometheus/prometheus 3.13.2 v
 go.offline_build    no
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://prometheus.io
@@ -47,9 +48,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums           rmd160  e35f765d9a50ea4ce972ea3ef273071f8d06b94f \
-                    sha256  fd0bfdc1390e71c3eeb05532293f9e2a1279e75d3546aa86dc4881627c9e143d \
-                    size    5939062
+checksums           rmd160  04adabf092eaf21a0a0d51e504960cb43d398600 \
+                    sha256  fb8eb45635c29b120cf54aa19a1b724348d49e385062ff519b8e0b4f457c26e1 \
+                    size    5939195
 
 add_users           ${prom_user} \
                     group=${prom_user} \

--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/gohugoio/hugo 0.164.0 v
 go.offline_build    no
+go.toolchain_min    1.26.0
 revision            0
 
 checksums           rmd160  1ca69a1e0ab864316ecf776052404a5e6854e950 \


### PR DESCRIPTION
Annotates the remaining 15 module-mode Go ports I maintain that declare Go 1.25 or newer, one commit per port. Six are also brought up to their newest upstream release in the same commit.

These are the ones with dependencies, which the earlier batches deliberately skipped. Every Go-port dependency was checked for a higher floor than the dependent declares — `colima` on `lima`, `grype`/`trivy`/`confluent-cli` on `goreleaser`, `prometheus` on `golangci-lint`. All of those declare 1.25 or 1.26, which floor at the same darwin major as the ports themselves, so no dependency gates a port earlier than its own annotation already does.

Each `go.toolchain_min` is the `go` directive from the `go.mod` of the release the port packages — for the six updated ports, from the new release. The nine annotate-only commits carry no revision bump: the annotation changes whether a port is attempted, not what it produces.

See: https://trac.macports.org/ticket/73086
