### PR TITLE
stunnel: Update to 5.80

### DIFF
--- a/security/stunnel/Portfile
+++ b/security/stunnel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 
 name                stunnel
-version             5.79
+version             5.80
 revision            0
 
 set major           [lindex [split ${version} .] 0]
@@ -27,9 +27,9 @@ master_sites        https://www.stunnel.org/downloads/archive/${major}.x/ \
                     http://ftp.nluug.nl/pub/networking/stunnel/archive/${major}.x/ \
                     http://stunnel.cybermirror.org/archive/${major}.x/
 
-checksums           rmd160  83e58f9ca3e3dde485c0dd837c41fed1656a9fba \
-                    sha256  8ea0de6e5ea76f38ea987fa831c7fd47f7a1f1e7dd465fd6fa8622edf30d3a45 \
-                    size    927184
+checksums           rmd160  56df7cda5d153f905df1d7efa50525edd9b8d77b \
+                    sha256  6d0841d48de07cbbaf4a055919065bf7bb5ebc63cc15c97a2c76caa2bf285513 \
+                    size    941784
 
 openssl.branch      no_version
 


### PR DESCRIPTION
#### Description

CVE: CVE-2026-70367
CVE: CVE-2026-70368

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
