### PR TITLE
mp3rgain: update to 3.0.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.11.0 v
+github.setup        M-Igashi mp3rgain 3.0.0 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  43762c76d5592f8057000e14465184b53b69b68e \
-                    sha256  0e928932d33e76fd83b97b58fe9f18af072996187a09e3f7891e54d44a1f0a53 \
-                    size    529928
+                    rmd160  10b7ced2fce2f9d54f7076780a0b05383bd8273f \
+                    sha256  f2507338804ac2d5c7e7728a33222b38e0c59dfdeaf907e19487a9d436602ecc \
+                    size    539690
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update mp3rgain to 3.0.0.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.0.0

Notable changes: adds opt-in ITU-R BS.1770 loudness modes (`--rg2` / `--r128`) alongside the default mp3gain-compatible ReplayGain 1.0 analysis; removes some unused public Rust library API (semver-major, no CLI behavior change).

- `github.setup` bumped to 3.0.0, `revision` reset to 0
- All three checksums (rmd160 / sha256 / size) recomputed from the GitHub tarball
- `cargo.crates` regenerated from `Cargo.lock` — dependency set unchanged from 2.11.0 (no new crates)