### PR TITLE
claude-code: update to 2.1.222

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.220
+version             2.1.222
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  4ccaa67d9b958d75f2ea828c415d50f9447c16d6 \
-                 sha256  dca7be0aa7d3d924836d440e0c6d8e3d47ef3c8e61fa5809b54b9017170ce2f3 \
-                 size    266397712
+    checksums    rmd160  7459936a3b1790b1cd9c4416f99915cf7adbbb99 \
+                 sha256  36bfc6482a25730dbb1cee72589e522c66c45a4dc9ebfdd8a76a8113b01b6188 \
+                 size    280847136
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5a5ee9ab82877ecd82dab4e7ae6dcc9512044a7d \
-                 sha256  8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081 \
-                 size    256908272
+    checksums    rmd160  6d84668432a6491ef74fdcbb3cd0a26213cc3885 \
+                 sha256  c66a6cc6fa2e8145bb1a6e77831f2caf4b83690ff04650500dfa6e2c05ca997c \
+                 size    271289792
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.222.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?