### PR TITLE
maven4: update to 4.0.0-rc-6

### DIFF
--- a/java/maven4/Portfile
+++ b/java/maven4/Portfile
@@ -6,8 +6,8 @@ PortGroup java 1.0
 
 name            maven4
 # Until the final 4.0.0 release is out, we use a version that sorts before 4.0.0 to avoid upgrade problems
-version         3.9.9-rc5
-set real_version 4.0.0-rc-5
+version         3.9.9-rc6
+set real_version 4.0.0-rc-6
 revision        0
 
 categories      java devel
@@ -29,9 +29,9 @@ master_sites    apache:maven/maven-4/${real_version}/binaries
 distname        apache-maven-${real_version}-bin
 worksrcdir      apache-maven-${real_version}
 
-checksums       rmd160  4d153dc4e3755a3cadd7157f8845e6f4d6dc6eeb \
-                sha256  ece6a5c99d3d041c76e7fed1814eb9ea3a20a120bcb3c235a73d2c4e8db16ca1 \
-                size    14873186
+checksums       rmd160  3b28b454f5c7574415a61f675964d8e990b77d23 \
+                sha256  fc1d150b01999f096629bbaf48e8ae434d004d5dc36c33962bc8be6579d3f91d \
+                size    15310757
 
 java.version    17+
 java.fallback   openjdk21


### PR DESCRIPTION
#### Description

Update to Maven 4.0.0-rc-6.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?