### PR TITLE
libgsasl: update and add variants

### DIFF
--- a/security/libgsasl/Portfile
+++ b/security/libgsasl/Portfile
@@ -84,3 +84,8 @@ variant gssapi_mit description {Use MIT GSSAPI implementation} conflicts gssapi_
 variant gssapi_native description {Use native GSSAPI implementation} conflicts gssapi_gss gssapi_mit {
     configure.args-replace  --without-gssapi-impl --with-gssapi-impl=framework
 }
+
+variant ntlm description {Add NTLM support} {
+    depends_lib-append      port:libntlm
+    configure.args-replace  --disable-ntlm --enable-ntlm
+}

--- a/security/libgsasl/Portfile
+++ b/security/libgsasl/Portfile
@@ -46,7 +46,6 @@ depends_build           port:autoconf \
 depends_lib             port:gettext \
                         port:libgcrypt \
                         port:libiconv \
-                        port:libidn \
                         port:readline
 
 configure.args          --disable-silent-rules \
@@ -57,7 +56,7 @@ configure.args          --disable-silent-rules \
                         --without-gssapi-impl \
                         --with-libgcrypt \
                         --without-openssl \
-                        --with-stringprep \
+                        --without-stringprep \
                         --with-packager=MacPorts
 
 # <https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr>
@@ -65,7 +64,8 @@ configure.checks.implicit_function_declaration.whitelist-append \
                         alignof \
                         strchr
 
-default_variants        +starttls
+default_variants        +idn \
+                        +starttls
 
 # GSS framework was added in macOS 10.7
 if {${os.platform} eq "darwin" && ${os.major} >= 11} {
@@ -85,6 +85,11 @@ variant gssapi_mit description {Use MIT GSSAPI implementation} conflicts gssapi_
 
 variant gssapi_native description {Use native GSSAPI implementation} conflicts gssapi_gss gssapi_mit {
     configure.args-replace  --without-gssapi-impl --with-gssapi-impl=framework
+}
+
+variant idn description {Add non-ASCII support} {
+    depends_lib-append      port:libidn
+    configure.args-replace  --without-stringprep --with-stringprep
 }
 
 variant ntlm description {Add NTLM support} {

--- a/security/libgsasl/Portfile
+++ b/security/libgsasl/Portfile
@@ -65,6 +65,8 @@ configure.checks.implicit_function_declaration.whitelist-append \
                         alignof \
                         strchr
 
+default_variants        +starttls
+
 # GSS framework was added in macOS 10.7
 if {${os.platform} eq "darwin" && ${os.major} >= 11} {
     default_variants-append +gssapi_native
@@ -88,4 +90,9 @@ variant gssapi_native description {Use native GSSAPI implementation} conflicts g
 variant ntlm description {Add NTLM support} {
     depends_lib-append      port:libntlm
     configure.args-replace  --disable-ntlm --enable-ntlm
+}
+
+variant starttls description {Add STARTTLS support} {
+    depends_lib-append      port:gnutls
+    configure.args-replace  --without-gnutls --with-gnutls
 }

--- a/security/libgsasl/Portfile
+++ b/security/libgsasl/Portfile
@@ -74,6 +74,11 @@ if {${os.platform} eq "darwin" && ${os.major} >= 11} {
     default_variants-append +gssapi_gss
 }
 
+variant doc description {Install HTML documentation} {
+    depends_build-append    port:gtk-doc
+    configure.args-replace  --disable-gtk-doc --enable-gtk-doc
+}
+
 variant gssapi_gss description {Use GNU GSSAPI implementation} conflicts gssapi_mit gssapi_native {
     depends_lib-append      port:gss
     configure.args-replace  --without-gssapi-impl --with-gssapi-impl=gss

--- a/security/libgsasl/Portfile
+++ b/security/libgsasl/Portfile
@@ -44,7 +44,6 @@ depends_build           port:autoconf \
                         bin:wget:wget
 
 depends_lib             port:gettext \
-                        port:gss \
                         port:libgcrypt \
                         port:libiconv \
                         port:libidn \
@@ -55,7 +54,7 @@ configure.args          --disable-silent-rules \
                         --disable-ntlm \
                         --disable-valgrind-tests \
                         --without-gnutls \
-                        --with-gssapi-impl=gss \
+                        --without-gssapi-impl \
                         --with-libgcrypt \
                         --without-openssl \
                         --with-stringprep \
@@ -66,7 +65,22 @@ configure.checks.implicit_function_declaration.whitelist-append \
                         alignof \
                         strchr
 
-variant gssapi_mit description {Use MIT GSS-API implementation} {
-    depends_lib-delete port:gss
-    configure.args-replace --with-gssapi-impl=gss --with-gssapi-impl=mit
+# GSS framework was added in macOS 10.7
+if {${os.platform} eq "darwin" && ${os.major} >= 11} {
+    default_variants-append +gssapi_native
+} else {
+    default_variants-append +gssapi_gss
+}
+
+variant gssapi_gss description {Use GNU GSSAPI implementation} conflicts gssapi_mit gssapi_native {
+    depends_lib-append      port:gss
+    configure.args-replace  --without-gssapi-impl --with-gssapi-impl=gss
+}
+
+variant gssapi_mit description {Use MIT GSSAPI implementation} conflicts gssapi_gss gssapi_native {
+    configure.args-replace  --without-gssapi-impl --with-gssapi-impl=mit
+}
+
+variant gssapi_native description {Use native GSSAPI implementation} conflicts gssapi_gss gssapi_mit {
+    configure.args-replace  --without-gssapi-impl --with-gssapi-impl=framework
 }

--- a/security/libgsasl/Portfile
+++ b/security/libgsasl/Portfile
@@ -1,20 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               gitlab 1.0
 
 name                    libgsasl
-version                 1.10.0
+gitlab.setup            gsasl gsasl 2.2.4 v
 revision                0
-checksums               rmd160  9ea418b967e6a898d76f44125640612ece8ba29a \
-                        sha256  f1b553384dedbd87478449775546a358d6f5140c15cccc8fb574136fdc77329f \
-                        size    1854755
+checksums               rmd160  ee68fb789e997add97866848201080977217cd7e \
+                        sha256  bc001fe4b5947cc5152b40637e3c921ce73db1f0f4693cd34a9e61c680b9ea33 \
+                        size    721145
 
 maintainers             {ryandesign @ryandesign} openmaintainer
 categories              security net
 license                 LGPL-2.1+
-platforms               darwin
-homepage                https://josefsson.org/libgsasl/
-master_sites            gnu:gsasl
+homepage                https://www.gnu.org/software/gsasl/
 
 description             GNU SASL: an authentication library.
 
@@ -25,21 +24,49 @@ long_description        GNU SASL is an implementation of the Simple \
                         authentication from clients, and in clients to \
                         authenticate against servers.
 
+patchfiles              remove-solaris-patch.patch
+
+use_autoreconf          yes
+autoreconf.cmd          ./bootstrap
+autoreconf.args
+
+depends_build           port:autoconf \
+                        port:automake \
+                        port:gengetopt \
+                        bin:git:git \
+                        bin:tar:gnutar \
+                        bin:gperf:gperf \
+                        bin:gzip:gzip \
+                        port:help2man \
+                        port:libtool \
+                        bin:perl:perl5 \
+                        port:texinfo \
+                        bin:wget:wget
+
 depends_lib             port:gettext \
                         port:gss \
                         port:libgcrypt \
                         port:libiconv \
-                        port:libidn
+                        port:libidn \
+                        port:readline
 
-configure.args          --disable-silent-rules
+configure.args          --disable-silent-rules \
+                        --disable-gtk-doc \
+                        --disable-ntlm \
+                        --disable-valgrind-tests \
+                        --without-gnutls \
+                        --with-gssapi-impl=gss \
+                        --with-libgcrypt \
+                        --without-openssl \
+                        --with-stringprep \
+                        --with-packager=MacPorts
 
-use_parallel_build      yes
-
-livecheck.type          regex
-livecheck.url           ftp://ftp.gnu.org/pub/gnu/gsasl/
-livecheck.regex         "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+# <https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr>
+configure.checks.implicit_function_declaration.whitelist-append \
+                        alignof \
+                        strchr
 
 variant gssapi_mit description {Use MIT GSS-API implementation} {
     depends_lib-delete port:gss
-    configure.args-append --with-gssapi-impl=mit
+    configure.args-replace --with-gssapi-impl=gss --with-gssapi-impl=mit
 }

--- a/security/libgsasl/files/remove-solaris-patch.patch
+++ b/security/libgsasl/files/remove-solaris-patch.patch
@@ -1,0 +1,11 @@
+--- bootstrap.conf.orig	2026-08-05 17:45:18
++++ bootstrap.conf	2026-08-11 01:25:10
+@@ -154,8 +154,6 @@
+ {
+   ${GNULIB_SRCDIR}/gnulib-tool --import --lib=liblgl --source-base=lib/gl --local-dir=lib/gl --m4-base=lib/m4 --doc-base=doc --aux-dir=build-aux --tests-base=lib/gltests --lgpl=2 --no-conditional-dependencies --libtool --macro-prefix=lgl --without-tests $libgnulib_modules
+ 
+-  patch -d m4 < gl/0001-Fix-export-symbols-and-export-symbols-regex-support-.patch
+-
+   touch ChangeLog
+ 
+   if ! gtkdocize; then


### PR DESCRIPTION
#### Description

Update libgsasl to version 2.2.4 and add some variants to control relevant build properties.

Note that I've squashed the changes for updating the version, but kept each added variant a separate commit due to (IMO) each being a logically independent change.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6 25G72 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vs install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
