### PR TITLE
google-cloud-sdk: update to 579.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             578.0.0
+version             579.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  848704b6b9d7de6309cd8237e5422c240d579ed7 \
-                    sha256  aaa96575fdaf76676e088443869dd2419b48f8bdaf4c8d67553cb9e2483d02fe \
-                    size    59928640
+    checksums       rmd160  6121bcc7992d0fc8ac1752a252811308a5757ce4 \
+                    sha256  ff04c4b7dfc47e6006d9da361ae38973cd365ce9bda6f978875b01c046e70a3a \
+                    size    60035102
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  877d19f0c6ddc188d9768d832efa95fa97f5c61e \
-                    sha256  e91d1f8077450afe2dd23a8f549f1d62a1a426f27259fac2e16364a09fbde607 \
-                    size    61586379
+    checksums       rmd160  8f49a4452dfa463f9acd1190d906dee95a7ba08a \
+                    sha256  e09794cbadce5bf95d9f3fc69dc7f64a9f810a2c39e392c0a18e01f446e33fac \
+                    size    61690047
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  f1f4d0d7aaf4739a3bd574edfe790779cb2f2dbe \
-                    sha256  d02e61d44bfee07eb6baf56923337d8f656e538bc853dd648b3f970ce1ec821e \
-                    size    61495460
+    checksums       rmd160  3fbe288b986efa101c90b4a0f0f2b50600be14c0 \
+                    sha256  783758eb9eb1fe2c645ce7f12442a0f9a2211eb67a1bf2ec127489305ca26cad \
+                    size    61595762
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 579.0.0.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?