### PR TITLE
outagedeck: new port

### DIFF
--- a/sysutils/outagedeck/Portfile
+++ b/sysutils/outagedeck/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/outagedeck/cli 0.1.0 v
+name                outagedeck
+go.toolchain_min    1.22
+revision            0
+
+categories          sysutils net
+license             MIT
+maintainers         nomaintainer
+installs_libs       no
+
+description         Check cloud and SaaS provider status from the command line
+
+long_description    OutageDeck is a command-line client for checking current \
+                    cloud and SaaS provider status, searching incidents, and \
+                    inspecting service-level health from normalized official \
+                    status feeds. Public checks do not require an API key.
+
+homepage            https://outagedeck.com
+
+checksums           rmd160  dd1f33129e10a124558741b1ce43e41cd22d28dc \
+                    sha256  ed41c0892099138d685a0a8c29291b6a60c4fb5568e6a4c8058f95e75975410d \
+                    size    6081
+
+build.pre_args-append \
+                    -ldflags \"-s -w -X main.version=${version}\"
+build.args          ./cmd/outagedeck
+
+test.run            yes
+test.target         ./...
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}

--- a/sysutils/outagedeck/Portfile
+++ b/sysutils/outagedeck/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/outagedeck/cli 0.1.0 v
+go.setup            github.com/outagedeck/cli 0.1.1 v
 name                outagedeck
 go.toolchain_min    1.22
 revision            0
@@ -22,9 +22,9 @@ long_description    OutageDeck is a command-line client for checking current \
 
 homepage            https://outagedeck.com
 
-checksums           rmd160  dd1f33129e10a124558741b1ce43e41cd22d28dc \
-                    sha256  ed41c0892099138d685a0a8c29291b6a60c4fb5568e6a4c8058f95e75975410d \
-                    size    6081
+checksums           rmd160  14b1514cfd47dfe6b37bb9bf65923dfdbda01eae \
+                    sha256  67c4d6c12921e8e5aad09fc43e8d506c2d53162ba3e573e9f8a5102b3d22f282 \
+                    size    118349
 
 build.pre_args-append \
                     -ldflags \"-s -w -X main.version=${version}\"

--- a/sysutils/outagedeck/Portfile
+++ b/sysutils/outagedeck/Portfile
@@ -10,7 +10,7 @@ revision            0
 
 categories          sysutils net
 license             MIT
-maintainers         nomaintainer
+maintainers         {@koko3tallah} openmaintainer
 installs_libs       no
 
 description         Check cloud and SaaS provider status from the command line


### PR DESCRIPTION
#### Description

Add the initial MacPorts Portfile for OutageDeck 0.1.0, a Go CLI for checking cloud and SaaS provider status from normalized official status feeds.

The port builds the tagged source archive, runs the upstream Go test suite, and installs the `outagedeck` binary. Public status checks do not require an API key.

I am affiliated with OutageDeck. This contribution was prepared with OpenAI Codex (GPT-5) assistance; the exact validation results are listed below.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`? (0 errors, 0 warnings)
- [x] tried existing tests with `port -vs test outagedeck`? (upstream Go tests passed)
- [x] completed a full source install with `port -vs install outagedeck`? (installed and activated `outagedeck @0.1.0_0`; no broken files or ports)
- [x] tested basic functionality of all binary files? (`outagedeck --version`, `outagedeck --help`, and an earlier tagged-source live status check all passed)

The validation used an isolated, non-root MacPorts prefix. A separate trace-mode attempt reached MacPorts base's recursive dependency collector and hit `wrong # args: should be "llength list"` before the Portfile's configure/build phase; the non-trace source build, test, destroot, install, activation, and binary checks all completed successfully.
