### PR TITLE
mcp-inspector: update to 2.1.0

### DIFF
--- a/llm/mcp-inspector/Portfile
+++ b/llm/mcp-inspector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                mcp-inspector
-version             2.0.0
+version             2.1.0
 revision            0
 
 categories          llm
@@ -20,9 +20,9 @@ homepage            https://modelcontextprotocol.io/docs/tools/inspector
 npm.rootname        @modelcontextprotocol/inspector
 distname            inspector-${version}
 
-checksums           rmd160  3fbe8e38b54dbe7a1d2b84774a95df3b57980cf9 \
-                    sha256  10583f3dd01cfe4e050b2581e50902adae33fe6bec32074182cb47287799d9d3 \
-                    size    1232365
+checksums           rmd160  5560aac3a388ecd326f4371b3182e981312b0933 \
+                    sha256  a2b62c9c28a90702d54a2e0ed0778d9633beec8f15e38aad41a4bf2ec8c42a96 \
+                    size    1235830
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to MCP Inspector 2.1.0.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?