### PR TITLE
libavif: Fix builds for 10.10 Yosemite and earlier, retry

### DIFF
--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -50,6 +50,7 @@ compiler.blacklist-append \
 
 # Starting with release 1.4.2
 compiler.c_standard     2011
+cmake.set_c_standard    yes
 
 # Needed when compiling with lib dep libargparse
 compiler.cxx_standard   2014


### PR DESCRIPTION
#### Description

* Use C11, following upstream change.
* Tell CMake to use C11.
* Fixes https://trac.macports.org/ticket/74300
* No rev bumps. Build fixes only.
* This is a continuation of #33906.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.
* Waiting for merge to check builder results for 10.6 - 10.10.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?