### PR TITLE
Update and declare the Go needed by 14 more module-mode ports

### DIFF
--- a/devel/gh-grep/Portfile
+++ b/devel/gh-grep/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/k1LoW/gh-grep 1.2.3 v
+go.setup            github.com/k1LoW/gh-grep 1.2.5 v
 go.offline_build    no
+go.toolchain_min    1.23.0
 revision            0
 
 description         Find lines matching a pattern within Github repositories \
@@ -18,15 +19,21 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9620c321faaf70ed9b631d6244a57acff0420e00 \
-                    sha256  0dbe1aae817ef95db69cfbc5c9032fe99d7af1a202fff1e591133b0bcf3e2a45 \
-                    size    22908
+checksums           rmd160  8f43e638d980371b372e5b7883956b84660ddc43 \
+                    sha256  e8ca23c20693a989295422661507bb99d20ae18e14ce49f670525ae2b3f71dc0 \
+                    size    23291
 
 build.pre_args-append \
     -ldflags \
     \"-X ${go.package}/version.Version=${github.tag_prefix}${version} \
       -X ${go.package}/gh-grep.version=${github.tag_prefix}${version}\"
 
+# The source tree ships a `gh-grep` shell script -- the gh(1) extension
+# entry point -- in the same directory `go build` would write its binary to.
+# Go refuses to overwrite a file that is not an object, so build to a
+# distinct name and install that.
+build.args-append   -o ${name}.bin
+
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/${name}.bin ${destroot}${prefix}/bin/${name}
 }

--- a/devel/go-critic/Portfile
+++ b/devel/go-critic/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-critic/go-critic 0.14.3 v
+go.setup            github.com/go-critic/go-critic 0.14.4 v
 go.offline_build    no
+go.toolchain_min    1.24.0
 revision            0
 
 homepage            https://go-critic.com
@@ -21,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  4177f231c502423317b6076a1ad7f9e902774775 \
-                    sha256  baf54665063087dc48d2261822229a3d8ab670fcec38fc5e25cd6350732746cb \
-                    size    184539
+checksums           rmd160  bb69d95825ccc5e6828060373abb8cea0605b519 \
+                    sha256  03c19c7a0d1ed931ae1f2c227bd881725d520f4767ccbbac0085644f69069094 \
+                    size    184657
 
 build.cmd           make
 build.pre_args-append \

--- a/devel/microplane/Portfile
+++ b/devel/microplane/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Clever/microplane 0.0.34 v
+go.setup            github.com/Clever/microplane 0.0.37 v
 revision            0
 
 description         A CLI tool to make git changes across many repos, \
@@ -18,12 +18,13 @@ categories          devel
 license             Apache-2
 platforms           darwin
 
-checksums           rmd160  0d992f50cc11560f7c4016ead9559db44c0b1210 \
-                    sha256  289b3df07b3847fecb0d815ff552dad1b1b1e4f662eddc898ca7b1e7d81d6d7c \
-                    size    57756
+checksums           rmd160  abfceec63bc72b387907f7661268fe2ea5542d35 \
+                    sha256  437f65748272de89b8a6990f0f9fca57addf6ff6f8e4de077869976d2ce36154 \
+                    size    38479
 
 # Allow Go to fetch dependencies at build time
 go.offline_build no
+go.toolchain_min    1.24.0
 
 build.pre_args-append \
                     -ldflags \" \

--- a/net/zget/Portfile
+++ b/net/zget/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/schollz/zget 1.1.11 v
+go.setup            github.com/schollz/zget 1.1.12 v
 revision            0
 
 description         zack's wget
@@ -18,15 +18,16 @@ license             MIT
 
 # Allow Go to download deps during build time
 go.offline_build no
+go.toolchain_min    1.23.0
 
 build.pre_args-append \
                     -ldflags \" \
                         -s -w -X main.Version=${github.tag_prefix}${version} \
                     \"
 
-checksums           rmd160  6838e6dba2e93230d5108ae1f71c508348fef362 \
-                    sha256  812a508ff02a37ed80d78a2a42f958e09f977f6a837087aa6db97dc6a4984de1 \
-                    size    60327
+checksums           rmd160  d156bd4deafa1a62aabe15d4d8d78fad7492a3b7 \
+                    sha256  d7870449d64899a00e9b29dfb95e53139931b46466dcf9cb981159bcf5c80419 \
+                    size    46046
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/office/dstask/Portfile
+++ b/office/dstask/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/naggie/dstask 1.0
+go.setup            github.com/naggie/dstask 1.0.1 v
 go.offline_build    no
+go.toolchain_min    1.23.4
 revision            0
 
 description         \
@@ -22,9 +23,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  2909c13b4edf7178cb99a2809b009c3d8518dfee \
-                    sha256  faec7a671331435ddf5be644404a62eef3b6fc0f895811b1f7c6b840e0bec234 \
-                    size    4720029
+checksums           rmd160  c646454d7fdfc2212d7e9fe72326da99f9af1fab \
+                    sha256  afca526d049874e2609d91c0e5f186d614c684ec13b2fe517e00ec4eeb4f70da \
+                    size    4721534
 
 use_parallel_build  no
 

--- a/security/harp/Portfile
+++ b/security/harp/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/elastic/harp 0.2.11 v
+go.setup            github.com/elastic/harp 0.2.12 v
 go.offline_build    no
+go.toolchain_min    1.23.8
 revision            0
 
 categories          security
@@ -34,9 +35,9 @@ long_description    \
     SDK to allow developers to integrate Harp features in their products, \
     and/or extend the Harp pipeline features by creating new plugins.
 
-checksums           rmd160  7d616bc13700d7777be337cc9fcfaf119b98cad3 \
-                    sha256  a84116377a4e770b604bddca9810bac2c679e7e715886ba9993836ef3808f8ac \
-                    size    3149692
+checksums           rmd160  c3b5feb74b899d04d40ae7f40eb65ec2e89e4746 \
+                    sha256  edba6e0fc8c87ea3814b8dce3ce7a61a74ae897d4b00b88f95752b9e8810923e \
+                    size    3078183
 
 build.pre_args-append \
     -ldflags \" \

--- a/security/vulnx/Portfile
+++ b/security/vulnx/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/projectdiscovery/vulnx 2.0.1 v
+go.setup            github.com/projectdiscovery/vulnx 2.0.2 v
 go.offline_build    no
+go.toolchain_min    1.24.0
 revision            0
 
 description         Modern CLI for exploring vulnerability data
@@ -19,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dd9dca1f06d73e5d2c589de549e5bb20e9df33da \
-                    sha256  101dcbc93c412b1acfb4b8149660488f42d5c5e4d1b3ff1fd8be3f41c787a4dc \
-                    size    18621376
+checksums           rmd160  8a44977694708b874f076ba06dc1a9340b53f337 \
+                    sha256  d3954dbcbee35fc7ff5417d3314949d7f7e1cf4939082a153515ce58b51ab7a6 \
+                    size    18612537
 
 build.pre_args-append \
     -ldflags \" -s -w -X ${go.package}/v2/cmd/${name}/clis.Version=${version} \"

--- a/sysutils/assh/Portfile
+++ b/sysutils/assh/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/moul/assh 2.17.1 v
+go.setup            github.com/moul/assh 2.17.3 v
 go.package          moul.io/assh/v2
 go.offline_build    no
+go.toolchain_min    1.24.0
 revision            0
 
 homepage            https://v1.manfred.life/assh-intro
@@ -23,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  6a97b79415a289675c5fa297c3e1c830ac87ebcb \
-                    sha256  9571e3424dcfa5d52e32f3f7dd19995e3d1f30c9d80420e77d47681d4a201744 \
-                    size    363320
+checksums           rmd160  43f3caa9a28f445b6b380a9c8e54442d805f95d1 \
+                    sha256  531cb10be20c86f464637428cc216525bb33e4651dc8aa801c09034521497172 \
+                    size    363678
 
 build.cmd           \
     "make generate && \

--- a/sysutils/kaf/Portfile
+++ b/sysutils/kaf/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/birdayz/kaf 0.2.13 v
+go.setup            github.com/birdayz/kaf 0.2.14 v
 go.offline_build    no
+go.toolchain_min    1.24.0
 revision            0
 
 description         Modern CLI for Apache Kafka, written in Go
@@ -24,9 +25,9 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
 
-checksums          rmd160  14a2a742ec0b546a61dcfe0743bfbcc66520269d \
-                   sha256  df0ad80c7be9ba53a074cb84033bd477780c151d7cbf57b6d2c2d9b8c62b7847 \
-                   size    846118
+checksums          rmd160  eea4177d4e28459bd68cac65220c0284c4fcd711 \
+                   sha256  83e78c19e5bce2d1922910809c19bacf489f6d16bbabefa6dcdd3e4b5c292b13 \
+                   size    849948
 
 notes "
 

--- a/sysutils/kubeswitch/Portfile
+++ b/sysutils/kubeswitch/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/danielfoehrKn/kubeswitch 0.9.1
+go.setup            github.com/danielfoehrKn/kubeswitch 0.9.3
 go.package          github.com/danielfoehrkn/kubeswitch
 revision            0
 
@@ -20,9 +20,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  aedfa8d4bdafb25dd12457e900897505104f3c2e \
-                    sha256  b35ae018245283142cdb5c4c3f9c342cb3194dec398cf69f2af955aa373da3a8 \
-                    size    19916372
+checksums           rmd160  d0abaa9ddac9c987f08ffa7d3a824da5f2bb6ae8 \
+                    sha256  1eaebe6332b07cfe04b804defc02ae89e5e6854fee149f7c4e34015e63391d38 \
+                    size    22016477
 
 build.cmd           make
 build.pre_args-append \
@@ -37,27 +37,21 @@ patch {
 
 # Issues vendoring with go.vendor.  Allow downloading deps at build time.
 go.offline_build no
+go.toolchain_min    1.22.7
 
 set ks_libexec_path ${prefix}/libexec/${name}
-set ks_hooks_path   ${ks_libexec_path}/hooks
 
 destroot {
     xinstall -d -m 0755 ${destroot}${ks_libexec_path}
-    xinstall -d -m 0755 ${destroot}${ks_hooks_path}
 
     xinstall -m 0755 \
         ${worksrcpath}/hack/switch/switcher ${destroot}${prefix}/bin/
 
     xinstall ${worksrcpath}/hack/switch/switch.sh ${destroot}${ks_libexec_path}
-
-    xinstall ${worksrcpath}/hack/hooks/hook_gardener_landscape_sync \
-        ${destroot}${ks_hooks_path}
 }
 
 notes "
     Please add the following to your .bashrc/.zshrc:
 
         source ${ks_libexec_path}/switch.sh
-
-    ${name} hooks have been installed to: ${ks_hooks_path}
 "

--- a/sysutils/popeye/Portfile
+++ b/sysutils/popeye/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/popeye 0.22.0 v
+go.setup            github.com/derailed/popeye 0.22.1 v
 revision            0
 
 homepage            https://popeyecli.io
@@ -29,12 +29,13 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  4155d8971dd55afaf379878915f1cd035b55da32 \
-                    sha256  eb6fb55174b0ca27d32bc7287fc1e091f5ef50fde339fe0a07832832b0302477 \
-                    size    2628795
+checksums           rmd160  971467581f55c6a19fd61a963b203e09d62c6872 \
+                    sha256  f8eef3d6b9cda24f4d9bdc24620c1368cd6a749f1321a499e88b339258e01d92 \
+                    size    2628880
 
 # Allow Go to fetch deps at build time
 go.offline_build no
+go.toolchain_min    1.23.0
 
 build.cmd           make
 build.pre_args-append \

--- a/sysutils/timer/Portfile
+++ b/sysutils/timer/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caarlos0/timer 1.4.5 v
+go.setup            github.com/caarlos0/timer 1.4.6 v
 go.offline_build    no
+go.toolchain_min    1.21
 revision            0
 
 description         A \`sleep\` with progress
@@ -16,9 +17,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  02df71e543f4a41c1e532a3e3ef0e2c961ba7ba3 \
-                    sha256  d4cbc30c118b8bd79e270c1cb7bec75a2431204c221d9c3bfea5e0fd86205e5b \
-                    size    9046
+checksums           rmd160  dfd36a3b572ee9c1bcf1e34b359a9890206d04b0 \
+                    sha256  b8286a449fb2fcaa685f2c4bd0300494414ce168e0123ba33ef6e15de9bb3a3a \
+                    size    8672
 
 build.cmd           \
     "go build && ./scripts/completions.sh && ./scripts/manpages.sh"

--- a/textproc/mdtree/Portfile
+++ b/textproc/mdtree/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caarlos0/mdtree 0.1.0 v
+go.setup            github.com/caarlos0/mdtree 0.1.1 v
 go.offline_build    no
+go.toolchain_min    1.22.5
 revision            0
 
 description         Convert markdown lists into ASCII trees
@@ -16,9 +17,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e2d0af51cb3131a169b2ad9905b7acdaf832076c \
-                    sha256  0c495b59cc0fa53818a3d25daca4c970fab01279ceb827d0d938301122982109 \
-                    size    4979
+checksums           rmd160  60efb847e4c38d584032314d0029935fd43d360f \
+                    sha256  498260edd5b1f95b454c50a713146cc7c16a555fbab230ba5dfe73314acfdfc5 \
+                    size    5349
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/textproc/rare/Portfile
+++ b/textproc/rare/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zix99/rare 0.5.5
+go.setup            github.com/zix99/rare 0.5.6
 go.package          rare
 go.offline_build    no
+go.toolchain_min    1.23
 revision            0
 
 homepage            https://rare.zdyn.net
@@ -22,9 +23,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  650ca50b1bac13962dac170ffc4e901ed58867ee \
-                    sha256  89e9738097f3a42b564d8c06ca4bacffe22f9f6436679298f5441d502d97e9b4 \
-                    size    3135796
+checksums           rmd160  dc92ca7b47ec2d1f849ac7917b580bfa197e7c59 \
+                    sha256  bf92a495dd491c6d56abbb3122a16eafbd85c063849cb4bb6291e353a3c5584e \
+                    size    3137741
 
 build.pre_args-append \
     -ldflags    \" -X main.version=${version} \" \


### PR DESCRIPTION
Updates 14 module-mode Go ports to their newest upstream release and declares the Go each needs, one commit per port.

Each `go.toolchain_min` is the `go` directive from the `go.mod` of the **new** release. Half of these directives moved with the update even though every version bump is patch-level — `microplane` goes 1.15 to 1.24.0 and `harp` 1.19 to 1.23.8 — so annotating from the packaged version would have recorded stale values.

All declare 1.24 or lower, so none of these gates anything today: `go` provides 1.24 from 10.13 upward. They are recorded so the practice is uniform across Go ports and so the values are already right if the toolchain floors move again.

`dstask` also gains a tag prefix argument: upstream tagged `1.0` without a `v` but switched to `v1.0.1`.

See: https://trac.macports.org/ticket/73086
