### PR TITLE
libntlm: adopt maintainership and update

### DIFF
--- a/net/libntlm/Portfile
+++ b/net/libntlm/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gitlab 1.0
 
-name                libntlm
-version             1.6
+gitlab.setup        gsasl libntlm 1.8 v
 revision            0
+
 categories          net security devel
 license             LGPL-2.1+
 maintainers         {sethm.id.au:dev @McDaMastR} \
@@ -18,19 +19,38 @@ long_description    NTLM employs a challenge-response mechanism for     \
                     referred to as Type 1 (negotiation), Type 2         \
                     (challenge) and Type 3 (authentication).
 
-homepage            https://www.nongnu.org/libntlm
-master_sites        ${homepage}/releases
+checksums           rmd160  b850a059441b212301a3f3db13e46fb951f3a95f \
+                    sha256  0880e4bd738cd18a480fdf9fe3864679fca5f5e62af35a999b1912c52ff2df80 \
+                    size    47814
 
-checksums           rmd160  673b3b2d18a8429565c09b52b309f598937ca081 \
-                    sha256  f2376b87b06d8755aa3498bb1226083fdb1d2cf4460c3982b05a9aa0b51d6821 \
-                    size    688608
+use_autoreconf      yes
+autoreconf.cmd      ./bootstrap
+autoreconf.args
+
+configure.args-append \
+                    --enable-shared \
+                    --disable-silent-rules \
+                    --enable-static \
+                    --disable-valgrind-tests
 
 test.run            yes
-test.cmd            make
 test.target         check
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:coreutils \
+                    port:gettext \
+                    bin:git:git \
+                    port:libtool
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -W ${worksrcpath} -m 0644 README NEWS ChangeLog \
+    xinstall -W ${worksrcpath} -m 0644 \
+        AUTHORS \
+        COPYING \
+        NEWS \
+        README \
+        THANKS \
         ${destroot}${prefix}/share/doc/${name}
 }

--- a/net/libntlm/Portfile
+++ b/net/libntlm/Portfile
@@ -7,7 +7,8 @@ version             1.6
 revision            0
 categories          net security devel
 license             LGPL-2.1+
-maintainers         nomaintainer
+maintainers         {sethm.id.au:dev @McDaMastR} \
+                    openmaintainer
 
 description         Implement Microsoft's NTLM authentication
 long_description    NTLM employs a challenge-response mechanism for     \


### PR DESCRIPTION
#### Description

Add myself as the maintainer of the `libntlm` port (previously it was unmaintained) and update it to version 1.8.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.6 25G72 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?