### PR TITLE
simdutf: add MacPorts libcxx for legacy support

### DIFF
--- a/textproc/simdutf/Portfile
+++ b/textproc/simdutf/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        simdutf simdutf 9.0.0 v
 github.tarball_from archive
@@ -48,5 +49,8 @@ configure.args-append \
 configure.pre_args-replace \
                         -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                         -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+legacysupport.use_mp_libcxx \
+                        yes
 
 test.run                yes

--- a/textproc/simdutf/Portfile
+++ b/textproc/simdutf/Portfile
@@ -50,7 +50,8 @@ configure.pre_args-replace \
                         -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                         -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
-legacysupport.use_mp_libcxx \
-                        yes
+# std::filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx     yes
 
 test.run                yes


### PR DESCRIPTION
#### Description

std::filesystem snippets made building not possible on my machine (10.9). This PR fixes it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
