### PR TITLE
d2: update GitHub organization

### DIFF
--- a/graphics/d2/Portfile
+++ b/graphics/d2/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/terrastruct/d2 0.6.8 v
+go.setup            github.com/d2lang/d2 0.6.8 v
 go.package          oss.terrastruct.com/d2
 go.offline_build    no
 revision            0
+homepage            https://d2lang.com/
 
 description         D2 is a modern diagram scripting language that turns text \
                     to diagrams.


### PR DESCRIPTION
#### Description

Update the D2 Portfile to fetch the existing `v0.6.8` tag from the
repository's new GitHub organization, `d2lang/d2`, and set the upstream
homepage to <https://d2lang.com/>.

This supersedes #33800, which GitHub closed after its head branch was
rewritten.

The version, revision, Go vanity import path, maintainers, fetch mode, and
build/install logic are unchanged.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? (Not applicable; there is no Trac ticket.)
- [ ] checked your Portfile with `port lint`? (MacPorts is not installed on the test machine.)
- [ ] tried existing tests with `sudo port test`? (Not run; metadata-only change.)
- [ ] tried a full install with `sudo port -vst install`? (Not run; MacPorts is not installed on the test machine.)
- [ ] tested basic functionality of all binary files? (Not run; source and binary behavior are unchanged.)
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (The port has no variants, and build logic is unchanged.)

Additional checks:

- `git diff --check`
- Confirmed `d2lang/d2` resolves `v0.6.8` to tag object
  `55b725f5ae1d8403651c89d38599d50f14d9aa2a` and commit
  `47ff87e8fbc1474d0719a1dff813815874d854b8`, identical to the previous URL.

AI disclosure: OpenAI Codex assisted with preparing these metadata changes and
the PR description; the validation performed is listed above.
