### PR TITLE
msmtp: update to version 1.8.34 and add some variants

### DIFF
--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -29,12 +29,12 @@ checksums           rmd160  d9955f50173953251a04fb3f862d4f034927b0fa \
                     size    463940
 
 depends_build       path:bin/pkg-config:pkgconfig
-depends_lib         port:gettext \
-                    port:libidn2
+depends_lib         port:gettext
 
-configure.args      --disable-silent-rules \
+configure.args      --disable-gai-idn \
+                    --disable-silent-rules \
                     --without-libgsasl \
-                    --with-libidn \
+                    --without-libidn \
                     --without-libsecret \
                     --without-macosx-keyring \
                     --without-msmtpd \
@@ -48,8 +48,14 @@ platform macosx {
 
 livecheck.url       ${homepage}download/
 
-default_variants    +sasl \
+default_variants    +idn \
+                    +sasl \
                     +tls_gnu
+
+variant idn description {Support internationalized domain names} {
+    depends_lib-append      port:libidn2
+    configure.args-replace  --without-libidn --with-libidn
+}
 
 variant mta description {Use msmtp as the system MTA} {
     conflicts               postfix opensmtpd

--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 name                msmtp
-version             1.8.32
+version             1.8.34
 revision            0
 categories          mail
 maintainers         {ra1nb0w @ra1nb0w} openmaintainer
@@ -24,9 +24,9 @@ homepage            https://marlam.de/msmtp/
 master_sites        ${homepage}releases/
 use_xz              yes
 
-checksums           rmd160  5d4d011cbaed7f4dc0efa02f059ff65f905a81bb \
-                    sha256  20cd58b58dd007acf7b937fa1a1e21f3afb3e9ef5bbcfb8b4f5650deadc64db4 \
-                    size    456960
+checksums           rmd160  d9955f50173953251a04fb3f862d4f034927b0fa \
+                    sha256  84e8fe2a5a80a1ee7802013b3fbdb846a3f27a4163cf37a1c6d7c7f888873ead \
+                    size    463940
 
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:gettext \
@@ -36,20 +36,24 @@ depends_lib         port:gettext \
 
 configure.args      --disable-silent-rules \
                     --with-libgsasl \
-                    --without-libsecret
+                    --with-libidn \
+                    --without-libsecret \
+                    --without-macosx-keyring \
+                    --without-msmtpd \
+                    --with-tls=gnutls
 
 startupitem.name    msmtpd
 
 platform macosx {
-    configure.args-append   --with-macosx-keyring
+    configure.args-replace  --without-macosx-keyring --with-macosx-keyring
 }
 
-livecheck.url       https://marlam.de/msmtp/download/
+livecheck.url       ${homepage}download/
 
 variant mta description {Use msmtp as the system MTA} {
     conflicts               postfix opensmtpd
 
-    configure.args-append   --with-msmtpd
+    configure.args-replace  --without-msmtpd --with-msmtpd
 
     startupitem.create      yes
     startupitem.executable  ${prefix}/bin/msmtpd

--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -30,7 +30,6 @@ checksums           rmd160  d9955f50173953251a04fb3f862d4f034927b0fa \
 
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:gettext \
-                    path:lib/pkgconfig/gnutls.pc:gnutls \
                     port:libidn2
 
 configure.args      --disable-silent-rules \
@@ -39,7 +38,7 @@ configure.args      --disable-silent-rules \
                     --without-libsecret \
                     --without-macosx-keyring \
                     --without-msmtpd \
-                    --with-tls=gnutls
+                    --without-tls
 
 startupitem.name    msmtpd
 
@@ -49,7 +48,8 @@ platform macosx {
 
 livecheck.url       ${homepage}download/
 
-default_variants    +sasl
+default_variants    +sasl \
+                    +tls_gnu
 
 variant mta description {Use msmtp as the system MTA} {
     conflicts               postfix opensmtpd
@@ -63,6 +63,16 @@ variant mta description {Use msmtp as the system MTA} {
 variant sasl description {Support extra SASL mechanisms} {
     depends_lib-append      port:libgsasl
     configure.args-replace  --without-libgsasl --with-libgsasl
+}
+
+variant tls_gnu description {Support TLS via GnuTLS} conflicts tls_libre {
+    depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls
+    configure.args-replace  --without-tls --with-tls=gnutls
+}
+
+variant tls_libre description {Support TLS via LibreSSL} conflicts tls_gnu {
+    depends_lib-append      port:libressl
+    configure.args-replace  --without-tls --with-tls=libtls
 }
 
 post-destroot {

--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -31,11 +31,10 @@ checksums           rmd160  d9955f50173953251a04fb3f862d4f034927b0fa \
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:gettext \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
-                    port:libgsasl \
                     port:libidn2
 
 configure.args      --disable-silent-rules \
-                    --with-libgsasl \
+                    --without-libgsasl \
                     --with-libidn \
                     --without-libsecret \
                     --without-macosx-keyring \
@@ -50,6 +49,8 @@ platform macosx {
 
 livecheck.url       ${homepage}download/
 
+default_variants    +sasl
+
 variant mta description {Use msmtp as the system MTA} {
     conflicts               postfix opensmtpd
 
@@ -57,6 +58,11 @@ variant mta description {Use msmtp as the system MTA} {
 
     startupitem.create      yes
     startupitem.executable  ${prefix}/bin/msmtpd
+}
+
+variant sasl description {Support extra SASL mechanisms} {
+    depends_lib-append      port:libgsasl
+    configure.args-replace  --without-libgsasl --with-libgsasl
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

Update the msmtp port to version 1.8.34 and also add some variants to allow more fine-grained control over the build and dependencies.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.6 25G72 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?