### PR TITLE
claude-code: update to 2.1.223

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.222
+version             2.1.223
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  7459936a3b1790b1cd9c4416f99915cf7adbbb99 \
-                 sha256  36bfc6482a25730dbb1cee72589e522c66c45a4dc9ebfdd8a76a8113b01b6188 \
-                 size    280847136
+    checksums    rmd160  2ca1d435c48ed4b0f19f5442fbd89e08ccc68814 \
+                 sha256  350e657428a6d34f7cf71f6738c5ebb6a1952ccb12fc1747f64297e065b1846f \
+                 size    282118560
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  6d84668432a6491ef74fdcbb3cd0a26213cc3885 \
-                 sha256  c66a6cc6fa2e8145bb1a6e77831f2caf4b83690ff04650500dfa6e2c05ca997c \
-                 size    271289792
+    checksums    rmd160  becfb52635069b69b6cd4d1b6ef202330e2a80e5 \
+                 sha256  fcbe0b8d47570c501302dd1ad31cc26ac2810f022c45fa253936a6961dee32bf \
+                 size    272553824
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.223.

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?