### PR TITLE
openssl3: Fix CVE-2026-54876, fix livecheck

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -13,12 +13,15 @@ set major_v         3
 epoch               1
 github.setup        openssl openssl ${major_v}.6.3 openssl-
 name                openssl3
-revision            0
+revision            1
 
 github.tarball_from releases
 checksums           rmd160  550c37050d1a45c79b577b674e78265b0456d833 \
                     sha256  243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1 \
                     size    54953005
+
+# CVE-2026-54876
+patchfiles-append   155b5fe0f93365e6df1c56ee3606b121080c6c12.patch
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
@@ -202,4 +205,4 @@ variant legacy description {enable legacy providers by default} {
     }
 }
 
-livecheck.regex      "archive/refs/tags/openssl-((?!.*(alpha|beta))\[^\"]+)\\.tar\\.gz"
+livecheck.regex      "archive/refs/tags/openssl-((?!.*(alpha|beta))3\.\[^\"]+)\\.tar\\.gz"

--- a/devel/openssl3/files/155b5fe0f93365e6df1c56ee3606b121080c6c12.patch
+++ b/devel/openssl3/files/155b5fe0f93365e6df1c56ee3606b121080c6c12.patch
@@ -1,0 +1,56 @@
+From 155b5fe0f93365e6df1c56ee3606b121080c6c12 Mon Sep 17 00:00:00 2001
+From: Mounir IDRASSI <mounir.idrassi@idrix.fr>
+Date: Mon, 29 Jun 2026 16:00:00 +0900
+Subject: [PATCH] x509: fix OCSP BasicResponse leak in in-verify check
+
+In check_cert_ocsp_resp(), OCSP_response_get1_basic() returns an owning
+OCSP_BASICRESP. The combined-condition early return on
+OCSP_resp_count(bs) < 1 bypassed the end: cleanup label, leaking bs when
+a stapled OCSP response decoded to a BasicResponse with no single
+responses.
+
+Separate the count check from the acquisition and route the empty case
+through end: (ret = X509_V_ERR_OCSP_NO_RESPONSE; goto end;) so bs is
+freed while preserving the previous return value. Reachable only with
+the non-default X509_V_FLAG_OCSP_RESP_CHECK with peer-supplied (e.g.
+TLS 1.3 stapled) responses.
+
+Reported-by: geeknik (https://github.com/geeknik)
+Suggested-by: geeknik (https://github.com/geeknik)
+Fixes #31759
+
+Reviewed-by: Andrew Dinh <andrewd@openssl.org>
+Reviewed-by: Daniel Kubec <kubec@openssl.foundation>
+MergeDate: Mon Aug  3 07:03:00 2026
+(Merged from https://github.com/openssl/openssl/pull/31764)
+---
+ crypto/x509/x509_vfy.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 6e1d8f1f291d5..3194519c3677d 100644
+--- ./crypto/x509/x509_vfy.c
++++ ./crypto/x509/x509_vfy.c
+@@ -1192,10 +1192,20 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
+         return X509_V_ERR_OCSP_NO_RESPONSE;
+ 
+     if ((resp = sk_OCSP_RESPONSE_value(ctx->ocsp_resp, ctx->error_depth)) == NULL
+-        || (bs = OCSP_response_get1_basic(resp)) == NULL
+-        || (num = OCSP_resp_count(bs)) < 1)
++        || (bs = OCSP_response_get1_basic(resp)) == NULL)
+         return X509_V_ERR_OCSP_NO_RESPONSE;
+ 
++    /*
++     * OCSP_response_get1_basic() returns an owning reference, so once bs is
++     * non-NULL it must be released via the end: cleanup label. Route an empty
++     * BasicResponse (no single responses) through end: rather than returning
++     * directly, otherwise bs leaks.
++     */
++    if ((num = OCSP_resp_count(bs)) < 1) {
++        ret = X509_V_ERR_OCSP_NO_RESPONSE;
++        goto end;
++    }
++
+     if (OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+         OCSP_BASICRESP_free(bs);
+         bs = NULL;


### PR DESCRIPTION
#### Description

No revbump of the openssl port or any other dependent ports becaues this doesn't change ABI.

CVE: CVE-2026-54876

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
