### PR TITLE
libavif: Revert last 1 commit

### DIFF
--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -50,7 +50,6 @@ compiler.blacklist-append \
 
 # Starting with release 1.4.2
 compiler.c_standard     2011
-cmake.set_c_standard    yes
 
 # Needed when compiling with lib dep libargparse
 compiler.cxx_standard   2014


### PR DESCRIPTION
#### Description

* Revert commit https://github.com/macports/macports-ports/commit/0943d44ee5afb75c29aa44ad0cd7061c94c0989d / PR #33910 because of negative side effect.
* See comments on that commit.
* No rev bumps.  Should not affect current MacPorts pre-built binaries.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

* CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?