### PR TITLE
pi-coding-agent: update to 0.84.0

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.83.0
+version             0.84.0
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  ad6db45c83fa23c730f9cbc6f37ebc613b7e0a8e \
-                    sha256  7097fe4b38762dda7ec78001e7b90430c849fbaf717325bfe8109744e32255e6 \
-                    size    4992066
+checksums           rmd160  3327ce0dae9e977afbd29b39bddf56fe8cdd2918 \
+                    sha256  cecaa288d19c392987d98c4eaa853ebbe520b46511fa4dd6d863ce8704c61298 \
+                    size    5085114
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.8 24G824 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
