### PR TITLE
llama-swap: update to 247

### DIFF
--- a/llm/llama-swap/Portfile
+++ b/llm/llama-swap/Portfile
@@ -3,15 +3,16 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/mostlygeek/llama-swap 246 v
+go.setup                github.com/mostlygeek/llama-swap 247 v
 go.offline_build        no
+go.toolchain_min        1.26.1
 revision                0
-set git-commit          22df230
+set git-commit          40027d6
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  283f02ffd3c95d25591b88cf6913f8e88c7e606e \
-                        sha256  7bbbcce88bd6da81026e51819be1f6d6b38e17e3c560271b41e147840b622876 \
-                        size    3728392
+                        rmd160  2496287111833b7fa5c33bf8c18273c968073e58 \
+                        sha256  8c1f8aa905348c437587faabf64b0aa2b4ed79e4167cf28b321aa4d558f9a6f1 \
+                        size    3749306
 
 categories              llm
 license                 MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.8 24G824 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
