### PR TITLE
p11-kit: Appropriately update to 0.26.5

### DIFF
--- a/security/p11-kit/Portfile
+++ b/security/p11-kit/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        p11-glue p11-kit 0.26.5
-revision            0
+revision            1
 
 license             Permissive
 description         PKCS#11 module discovery and loading
@@ -22,9 +22,12 @@ checksums           rmd160  9ffc612957f05fa10e3930466a714195658ef5e6 \
                     sha256  f2cc09111e44bf3fea58f023180b33acea90aa82d042d6fbb623fbc5ba033bb7 \
                     size    1082584
 
+set py_ver          3.14
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
 depends_build       port:gettext \
                     path:bin/pkg-config:pkgconfig \
-                    port:python314
+                    port:python${py_ver_nodot}
 
 depends_lib         port:gettext-runtime \
                     port:libtasn1 \
@@ -33,6 +36,12 @@ depends_lib         port:gettext-runtime \
 
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
+# p11-kit/uri.gnu.c:93: error: redefinition of typedef 'CK_ULONG'
+# pkcs11x.h:102: error: redefinition of typedef 'CK_TRUST'
+# See: https://trac.macports.org/ticket/70399
+# See: https://trac.macports.org/ticket/73614
+compiler.c_standard 2011
+
 configure.args      --disable-doc \
                     --disable-silent-rules \
                     --with-trust-paths=${prefix}/share/curl/curl-ca-bundle.crt:${prefix}/etc/openssl
@@ -40,10 +49,21 @@ configure.args      --disable-doc \
 # /usr/bin/python is Python 2.7 for older systems, and
 # /usr/bin/python3 is too old (< 3.6) on older systems
 # https://trac.macports.org/ticket/68739
-configure.env       PYTHON=${prefix}/bin/python3.14
+configure.env       PYTHON=${prefix}/bin/python${py_ver}
 
 # https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
 configure.checks.implicit_function_declaration.whitelist-append strchr
+
+post-destroot {
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 644 -W ${worksrcpath}/bash-completion ${name} trust ${bash_comp_path}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 644 ${worksrcpath}/zsh-completion/${name}.zsh ${zsh_comp_path}/_${name}
+    xinstall -m 644 ${worksrcpath}/zsh-completion/trust.zsh ${zsh_comp_path}/_trust
+}
 
 variant doc description {Build man pages and documentation} {
     depends_build-append    port:gtk-doc
@@ -52,3 +72,5 @@ variant doc description {Build man pages and documentation} {
 
 test.run            yes
 test.target         check
+# See: https://bugs.freedesktop.org/show_bug.cgi?id=91602#c1
+test.env            FAKED_MODE=1


### PR DESCRIPTION
#### Description

Originally, this pull request updated p11-kit to 0.26.5. However, https://github.com/macports/macports-ports/commit/103731910d04ec6c0b2754f0d50fcbd0a07e72df was rudely pushed. Manually include shell completions since the autotools build system is outdated (and likely to be deprecated over meson).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
