### PR TITLE
mat2: update to 0.15.0

### DIFF
--- a/multimedia/mat2/Portfile
+++ b/multimedia/mat2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0 
 
-github.setup        jvoisin mat2 0.14.0                    
+github.setup        jvoisin mat2 0.15.0                    
 github.tarball_from archive
 
 name                mat2
@@ -21,9 +21,9 @@ long_description    mat2 is a metadata removal tool, supporting a wide range \
                     of commonly used file formats, written in python3.
 homepage            https://github.com/jvoisin/mat2
 
-checksums           rmd160  1093685b62e90489fb1113f1cfe89fee620a8423 \
-                    sha256  bf15251cb249a6028fd8532d31388b296dffc28c90782fcc0e7ba6f56354f4c5 \
-                    size    11544055
+checksums           rmd160  a169ccb879474ac2c454e39a252bbc4f7f2b2f7e \
+                    sha256  4ced25714542477f60ec231ae0e88d9b1cedd0a75acbeb7151a84c124d538ce1 \
+                    size    12575635
 
 python.default_version 314
 


### PR DESCRIPTION
#### Description

mat2: update to 0.15.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
