### PR TITLE
nextdns: Update to 1.48.0

### DIFF
--- a/net/nextdns/Portfile
+++ b/net/nextdns/Portfile
@@ -3,15 +3,14 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/nextdns/nextdns 1.43.5 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/nextdns/nextdns 1.48.0 v
 revision            0
 categories          net sysutils
 maintainers         nomaintainer
+platforms           {darwin >= 21}
 license             MIT
 
-homepage            https://nextdns.io
+homepage            https://nextdns.io/
 
 description         NextDNS CLI client
 
@@ -21,50 +20,68 @@ long_description    NextDNS protects you from all kinds of security threats, \
                     all networks.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  bf0b31f634a8673a4323d50e8115a1feb834bdec \
-                        sha256  712c86463c64a17dae22efb8fa7fb0d04f2c01d740fb03fe05b6849a5984372c \
-                        size    201541
+                        rmd160  6ea7b28960707e991e1ef30ecbd34ef39f675406 \
+                        sha256  ddcb5e0022d3c2c732f333666704b5c890dd57438e45f295ccd6347b943d6011 \
+                        size    238868
 
 go.vendors          golang.org/x/sys \
-                        lock    v0.19.0 \
-                        rmd160  b8d5c2b9cfad17163b4f700b771438ccf303248a \
-                        sha256  d66ea87fcd714685af230190cddc8a9de6343f1d0ab83a3688f6a4189c7ab478 \
-                        size    1449936 \
+                        lock    v0.47.0 \
+                        rmd160  1be59a8208fd6f7f4319b306138e77f215293e1a \
+                        sha256  2bed220513067f721fc7c19314bab58860c28397f5e48093a8fe35a27a915b06 \
+                        size    1551474 \
                     golang.org/x/net \
-                        lock    v0.24.0 \
-                        rmd160  6807b3cdfc1c32af42a5cd90300a3df39cd47ca1 \
-                        sha256  4a4da64294973ffabff518ec5d4cf49dac16c1d7075a41887c163861d40ad762 \
-                        size    1509202 \
-                   github.com/spaolacci/murmur3 \
-                        lock    f09979ecbc72 \
-                        rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
-                        sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
-                        size    7396 \
-                    github.com/hashicorp/golang-lru \
-                        lock    v1.0.2 \
-                        rmd160  fb377c61169fbae9e49e879d0839886ee6668aab \
-                        sha256  37ae3b7e8ac550bc8881281d881f19e7066df477cbd3e4fe5bc8ce340f9bd9ab \
-                        size    14464 \
+                        lock    v0.57.0 \
+                        rmd160  32c1b1c4903de772168076e5747a60c0b27f245e \
+                        sha256  1f5e7fae3267c8d518156b2b6e24c7f92175c82e6e2a7e8383b41cf50805c600 \
+                        size    1443429 \
+                    github.com/hashicorp/golang-lru/v2 \
+                        lock    v2.0.7 \
+                        rmd160  2f1bb029285d1f25ec7b2b55623c8b8a221154c0 \
+                        sha256  7e0d056d9ae52e411de5945162e0dee0e7974dec527858f2fec39cfeff6afd3f \
+                        size    23862 \
+                    github.com/godbus/dbus/v5 \
+                        lock    v5.2.2 \
+                        rmd160  246dd5e5235b59b789f02727588f70369b0f13bd \
+                        sha256  4255168f8ba1a60120341af5d5c0a5f4d956caa1de5e7dd2147efe65f761898c \
+                        size    79076 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.1 \
+                        rmd160  3c799a1cbda2e82f3d35ec20e539581fd9c24b9d \
+                        sha256  aa5a5059ebd8fffc9e9b9e3c888d85cdb1f4c8f7b73944a6c027647039a83df7 \
+                        size    17709 \
+                    github.com/dgraph-io/ristretto/v2 \
+                        lock    v2.4.2 \
+                        rmd160  c885b27dd1d269f677a0a62b7f8abef4d393bf9b \
+                        sha256  7f256536b7b743c13ebf1ee1c6d154b54cf1d65da7138f68e83c85faec24d46f \
+                        size    159842 \
                     github.com/denisbrodbeck/machineid \
                         lock    v1.0.1 \
                         rmd160  c782c29a666ff8e4ad93945389ca9c395754c2c4 \
                         sha256  98e4169e90ef7e087d47c2620f94aba71f2087f41f64d85509570c2161e85101 \
                         size    27812 \
-                    github.com/cespare/xxhash \
-                        lock    v1.1.0 \
-                        rmd160  881eb63e94fa02d315ee4b023a35832a3d67d672 \
-                        sha256  509b8d4670440aa84dc4e902ed5ca2f9109bf65af830a062da91d23a007fe2e0 \
-                        size    8208 \
-                    github.com/OneOfOne/xxhash \
-                        lock    v1.2.2 \
-                        rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
-                        sha256  e6a73b9f6acc9b361ea77edcb6f29103e96ac0c623c6d2882909698180e54694 \
-                        size    13444
+                    github.com/cespare/xxhash/v2 \
+                        lock    v2.3.0 \
+                        rmd160  dfed275969e04769f613bd08336420dc9009794a \
+                        sha256  79cc788ad30f0d7987fb1f259f21477a74178e30f4a2b2803af2b43c3ebcfa91 \
+                        size    12704
 
 build.args          -ldflags="-X main.version=${version}"
 
+post-build {
+    foreach shell {bash zsh fish} {
+        system -W ${worksrcpath} "./${name} completion ${shell} > ${name}.${shell}"
+    }
+}
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    set comp_file(bash) ${destroot}${prefix}/share/bash-completion/completions/${name}
+    set comp_file(zsh)  ${destroot}${prefix}/share/zsh/site-functions/_${name}
+    set comp_file(fish) ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish
+    foreach shell {bash zsh fish} {
+        xinstall -d [file dirname $comp_file(${shell})]
+        xinstall -m 644 ${worksrcpath}/${name}.${shell} $comp_file(${shell})
+    }
 }
 
 notes "


### PR DESCRIPTION
#### Description

Update nextdns to 1.48.0. Include shell completions.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
