### PR TITLE
container: update to 1.2.1

### DIFF
--- a/devel/container/Portfile
+++ b/devel/container/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        apple container 1.2.0
+github.setup        apple container 1.2.1
 github.tarball_from archive
 
 revision            0
@@ -19,9 +19,9 @@ long_description    container is a tool that you can use to create and run Linux
                     registry. You can push images that you build to those registries \
                     as well, and run the images in any other OCI-compatible application.
 
-checksums           rmd160  b24de4341e021db12ee27d5dd5da5dc42a6a0a36 \
-                    sha256  40f2d98cb41a5f688e5b4b6dbe6d66eba7451c78ce6f3afe351da1550adf1591 \
-                    size    1009748
+checksums           rmd160  e1dd53207c30e7fb656c8755dc08fc4fbcb0e290 \
+                    sha256  0cbc4820cacff200a733fc7e994cf6ccf9d605691e30713e6bd3600d3b6cf07c \
+                    size    1040716
 
 # The version number for macosx is the darwin version number (os.major)
 platforms           {macosx >= 25}
@@ -42,7 +42,7 @@ installs_libs       no
 
 build.target        build
 # Disable the swift sandbox since the port build already runs in a sandbox
-build.pre_args      BUILD_CONFIGURATION=release SWIFT_CONFIGURATION="--disable-sandbox --cache-path ${workpath}/.swiftpm/cache --security-path ${workpath}/.swiftpm/security --config-path ${workpath}/.swiftpm/config -Xswiftc -enable-testing" ${build.target}
+build.pre_args      BUILD_CONFIGURATION=release SWIFT_CONFIGURATION="--disable-sandbox --cache-path ${workpath}/.swiftpm/cache --security-path ${workpath}/.swiftpm/security --config-path ${workpath}/.swiftpm/config -Xswiftc -enable-testing" RELEASE_VERSION=${version} GIT_COMMIT=n/a ${build.target}
 
 destroot.target     install
 destroot.pre_args   BUILD_CONFIGURATION=release DEST_DIR="${destroot}${prefix}/" RELEASE_VERSION=${version} SUDO= ${destroot.target}


### PR DESCRIPTION
#### Description

- Include version information in the build.

  > The build relies on `RELEASE_VERSION` and `GIT_COMMIT` to provide strings for `container --version`. These were previously unset during build causing the `container --version` command to produce the (unhelpful) output:
  >
  > ```
  > container CLI version  (build: release, commit: )
  > ```
  >
  > These are typically produced by shelling out to `git` commands to get the tag and commit respectively, but since the port is built from the tarball, these values are left unset. Here, we change the `RELEASE_VERSION` to be the port version (matching the tag used upstream) and just leave the `GIT_COMMIT` as `n/a` (tracking the Git commit is error-prone: it not only can be forgotten to be updated manually on new port versions, but also the repository can modify a tag and cause the commit hash to silently become incorrect). With this change, we get more helpful output from the `container --version` command:
  >
  > ```
  > container CLI version 1.2.1 (build: release, commit: n/a)
  > ```
  >
  > If there is a built-in way to get MacPorts to figure out the GitHub commit corresponding to a tarball, then I would prefer to use that (but I couldn't find anything while looking at the GitHub port group).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?