### PR TITLE
CocoaRestClient: bump min Darwin to 18 (10.14)

### DIFF
--- a/www/CocoaRestClient/Portfile
+++ b/www/CocoaRestClient/Portfile
@@ -13,6 +13,7 @@ platforms           macosx
 supported_archs     x86_64
 license             BSD
 maintainers         nomaintainer
+platforms           {darwin >= 18}
 
 description         A free, native macOS app for testing HTTP/REST endpoints
 long_description    Test and interact with HTTP/REST resources:\
@@ -36,13 +37,6 @@ use_dmg             yes
 checksums           rmd160  7d981bd5d77b147209a3c3555a957ea8aac3ef78 \
                     sha256  8e974818e5b77e6e4291acbe09d439c3c17b01c23e48d2272f7817e2d18e9968 \
                     size    6776617
-
-if {${os.major} < 16} {
-    known_fail      yes
-    pre-fetch {
-        return -code error "This port requires at least macOS Sierra (10.12)."
-    }
-}
 
 use_configure       no
 build               {}


### PR DESCRIPTION
[skip ci]
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This port was updated to 1.(forgot...).7, but from .6, the app requires 10.14. This PR bumps the min version to the appropriate version, from 16 (10.12).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Unfortunately nowhere. But it should work in theory, this just changes a single version number.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
