### PR TITLE
openjdk17-temurin: update to 17.0.20

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.19
-set build    10
+version      ${feature}.0.20
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5279fdb6f131129d12765ddbb7fad33364761754 \
-                 sha256  03632d1fbf139ab3719a9f4b47dc206251449b87557143c822336dbf8c06560f \
-                 size    180540440
+    checksums    rmd160  0169266b27f1d433435fa5b76b7f3af08d2e7180 \
+                 sha256  3710c3131c5d7c090582b357f1310133a90bf701183d065223f1a0b90b9ed5ae \
+                 size    180581753
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  20ce85d17efbc286daf51cf8692f47cf09b00f2b \
-                 sha256  8fa1eff40bb637a33613b2ccb8b12c70dc3661cc22cf8e784943715769a05336 \
-                 size    185818964
+    checksums    rmd160  2e5d13cf0ebd9a013f0c6f3b04026497429dadd1 \
+                 sha256  524850138c742324fb21fca4ff6ef68ea25f25bf59366a864e45b4a0c45ed0df \
+                 size    185860079
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.20.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?