### PR TITLE
openjdk21-temurin: update to 21.0.12

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=21&os=mac
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.11
-set build    10
+version      ${feature}.0.12
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least December 2029)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5cf073ec8efca8df7c837bac1cd15b82307aaefd \
-                 sha256  34180eb03e6d207c388cce3da668f6cc7cd7508c185c24782fadac2c9c0e66f9 \
-                 size    194283642
+    checksums    rmd160  a33a6eee48be29498d63afa3809dbf4a10b1779d \
+                 sha256  6b85c260eea574a995eacd0b3ee23c8042aa93b23a08e6478edafca0a0333d7f \
+                 size    194309619
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  9f6fafcdf98cd1fbea497b597a5da2e7049b1e73 \
-                 sha256  6ebcf221c9b41507b14c098e93c6ead6440b8d9bd154f8ec666c4c73abbdb201 \
-                 size    200030394
+    checksums    rmd160  f53e512c7a08cd6a4780818114124e6376c132b7 \
+                 sha256  021d629349ebc12a409faa517b837ec80ceee8f58a5ac85c788ecad07ca6881c \
+                 size    200069721
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.12.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?