### PR TITLE
openjdk11-temurin: update to 11.0.32

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?os=mac&version=11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.31
-set build    11
+version      ${feature}.0.32
+set build    9
 revision     0
 
 # See https://adoptium.net/support/ for end of support date
@@ -32,14 +32,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  f9ad4e2d794e2e2d64381c63f1e9be3cd32521bd \
-                 sha256  e541fa6c6100b6dd6ae0c92c96ae8d97ed4d94ddefb0cd2770dae4772bfc9d9e \
-                 size    187361454
+    checksums    rmd160  f7fd9cbbd36d40efad10de641fb0597c0926e08a \
+                 sha256  e4c30df263e3ebb4b2b5df52c736fbd0b16df5ae6b9a6789460a784620ba1319 \
+                 size    187336978
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  dba0d18cfd08771f6a8691da7c00210d0c1d87b1 \
-                 sha256  e3377bbe07f4396ba03adcfc5f3d71d151d6a7b858abdf1d0dd20ac4d8d709b0 \
-                 size    184652768
+    checksums    rmd160  6388c8972f24f73b4d244a97d4c13b7eda8e3dd8 \
+                 sha256  3e3687488e472035b7a27732f0f6127d59903ba9fd0cb6c815f1a182f4160109 \
+                 size    184657053
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.32.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?