### PR TITLE
openjdk8-temurin: update to 8u502

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      ${feature}u482
-set build    08
+version      ${feature}u502
+set build    07
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least November 2026)
@@ -31,9 +31,9 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  d413a1ae191956e2c4effb76a9afa8e1059af25b \
-             sha256  b57e16395bc5171ddcdce25631ed1402cc2c8efe945e3edf7ddba4e21bea5c53 \
-             size    108011923
+checksums    rmd160  ec6d184d91f96ef19f5fcee356c4acbe3dcbc931 \
+             sha256  66565d468f4a48e9defa7420bbe522bf811a00609f618da1a85fc4ff149683b1 \
+             size    108024763
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u502.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?