### PR TITLE
openjdk26-openj9: update to 26.0.2

### DIFF
--- a/java/openjdk26-openj9/Portfile
+++ b/java/openjdk26-openj9/Portfile
@@ -20,10 +20,9 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.1
+version      ${feature}.0.2
+set build    10
 revision     0
-
-set build    8
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until September 2026)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -33,14 +32,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  cd31d35c0ed2057500d94be91cbe387be50b61c0 \
-                 sha256  deb49f5bc18dae5aeea91cbf38720255e47ddbf25431fcca0fca14c337bde2dc \
-                 size    244028854
+    checksums    rmd160  5960d8c4f02a0451b0c1a3c9159703c84d602749 \
+                 sha256  171ede5edcafb7616d57353c17a9d37f4d668e29e8500e5b4421ff59d2d34430 \
+                 size    244734343
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  7fa4d39c573bb51e7635404c36d1f8a5dc5e503a \
-                 sha256  6d7cc426e35c63fe83260026229a8c66201c20dd0912e0a19950abb245ef0ca0 \
-                 size    238179879
+    checksums    rmd160  ffcf184fa94b421c3ce81b78afa79bd96cb5666d \
+                 sha256  5c00a6ae25519cb33c106d38dd70987a0d0923f958679d72d2fd674bd400d9d0 \
+                 size    238615556
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 26.0.2.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?