### PR TITLE
deark: Update to 1.7.3

### DIFF
--- a/archivers/deark/Portfile
+++ b/archivers/deark/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                deark
-version             1.7.1
+version             1.7.3
 revision            0
 
 categories          archivers
@@ -17,22 +17,25 @@ long_description    Deark is a command-line utility that can decode certain \
                     types of files, and either convert them to a more-modern or \
                     more-readable format, or extract embedded files from them
 
-homepage            https://entropymine.com/deark/
+homepage            https://entropymine.com/deark
 master_sites        ${homepage}/releases/
 
-checksums           rmd160  d24d3accd94ddde8330d888a545bc0d3e2f8431f \
-                    sha256  f7e7d286e0e3b8003e1e758b59f8aee1fa2dd24e1c9aceb03d4e603cb8efcad4 \
-                    size    2510959
+checksums           rmd160  c8c7e978727f3d40f52f97f9b7b6af16690c504a \
+                    sha256  84f9e0134830389e4ab12c89dc09cf42a3f885ec551254e9fdc22952858add11 \
+                    size    2624697
 
-depends_build       port:help2man
+depends_build-append \
+                    port:help2man
+
+# Remove after deark 1.7.3
+patchfiles          0001-Try-to-fix-macOS-builds-st_mtim-st_atim-related.patch
 
 post-build {
     system -W ${worksrcpath} "make man"
 }
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/bin
-    xinstall -m 755 -d ${destroot}${prefix}/share/man/man1
+    xinstall -d ${destroot}${prefix}/share/man/man1
     xinstall -m 755 -s ${worksrcpath}/${name} ${destroot}${prefix}/bin
-    xinstall -m 644 -s ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1
+    xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1
 }

--- a/archivers/deark/files/0001-Try-to-fix-macOS-builds-st_mtim-st_atim-related.patch
+++ b/archivers/deark/files/0001-Try-to-fix-macOS-builds-st_mtim-st_atim-related.patch
@@ -1,0 +1,62 @@
+From d9ad63f9331f7d804c4978a644272810e200eb4c Mon Sep 17 00:00:00 2001
+From: Jason Summers <jason1@pobox.com>
+Date: Sat, 13 Jun 2026 07:36:57 -0400
+Subject: [PATCH] Try to fix macOS builds (st_mtim/st_atim related)
+
+Ref: https://github.com/jsummers/deark/pull/110
+Co-authored-by: Daeho Ro <40587651+daeho-ro@users.noreply.github.com>
+Upstream-Status: Backport [https://github.com/jsummers/deark/commit/d9ad63f9331f7d804c4978a644272810e200eb4c]
+---
+ src/deark-config.h | 16 ++++++++++++++++
+ src/deark-unix.c   |  9 ++++++++-
+ 2 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/src/deark-config.h b/src/deark-config.h
+index b827795a..2d225af5 100644
+--- src/deark-config.h.orig
++++ src/deark-config.h
+@@ -54,6 +54,22 @@
+ #define _TIME_BITS 64
+ #endif
+
++#ifndef DE_USE_MTIMENSEC
++#if defined(__APPLE__)
++#define DE_USE_MTIMENSEC 1
++#else
++#define DE_USE_MTIMENSEC 0
++#endif
++#endif
++
++#ifndef DE_USE_MTIM
++#if (_POSIX_C_SOURCE >= 200809L) && (!DE_USE_MTIMENSEC)
++#define DE_USE_MTIM 1
++#else
++#define DE_USE_MTIM 0
++#endif
++#endif
++
+ #ifndef DE_USE_FSEEKO
+ #define DE_USE_FSEEKO 1
+ #endif
+diff --git a/src/deark-unix.c b/src/deark-unix.c
+index b60d2398..2472649f 100644
+--- src/deark-unix.c.orig
++++ src/deark-unix.c
+@@ -77,7 +77,14 @@ static int de_examine_file_by_fd(struct de_fopen_params *fop, int fd)
+
+	fop->len = (i64)stbuf.st_size;
+
+-#if _POSIX_C_SOURCE >= 200809L
++#if DE_USE_MTIMENSEC
++	de_unix_time_to_timestamp(stbuf.st_mtime, &fop->orig_modtime, 0);
++	de_timestamp_set_subsec(&fop->orig_modtime,
++		(double)stbuf.st_mtimensec/1000000000.0);
++	de_unix_time_to_timestamp(stbuf.st_atime, &fop->orig_acctime, 0);
++	de_timestamp_set_subsec(&fop->orig_acctime,
++		(double)stbuf.st_atimensec/1000000000.0);
++#elif DE_USE_MTIM
+	de_unix_time_to_timestamp(stbuf.st_mtim.tv_sec, &fop->orig_modtime, 0);
+	de_timestamp_set_subsec(&fop->orig_modtime,
+		(double)stbuf.st_mtim.tv_nsec/1000000000.0);
+--
+2.55.0


### PR DESCRIPTION
#### Description

Update deark to 1.7.3.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
