### PR TITLE
corsixth: update to 0.70.0

### DIFF
--- a/games/corsixth/Portfile
+++ b/games/corsixth/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake   1.1
-PortGroup           github  1.0
+PortGroup           cmake         1.1
+PortGroup           github        1.0
+PortGroup           legacysupport 1.1
 
-github.setup        CorsixTH CorsixTH 0.69.2 v
+github.setup        CorsixTH CorsixTH 0.70.0 v
 github.tarball_from archive
 name                corsixth
 revision            0
@@ -22,9 +23,18 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  8f6747977587cfcf741c64e37acd32092b6280fd \
-                    sha256  cbad15f9a16edd4c068ce14fb17f39cdb811dab0135fca80fafffa9a45732aec \
-                    size    4323503
+checksums           rmd160  9bd30205d998c7c82b3692ca872c749a1ed42b18 \
+                    sha256  e8f9803f6f64d23f057506202fbf275fe136c3245bab4bc19ff4c63691459cb7 \
+                    size    4414049
+
+legacysupport.use_mp_libcxx \
+                    yes
+# std::filesystem
+legacysupport.newest_darwin_requires_legacy \
+                    18
+
+compiler.cxx_standard \
+                    2017
 
 patchfiles-append   patch-cmakelists.txt.diff
 
@@ -38,9 +48,10 @@ depends_lib-append  \
                     port:bzip2 \
                     port:libsdl2 \
                     port:libsdl2_mixer \
-                    port:lua53 \
-                    port:lua53-luafilesystem \
-                    port:lua53-lpeg \
+                    port:lua54 \
+                    port:lua54-luafilesystem \
+                    port:lua54-lpeg \
+                    port:rtmidi \
                     port:zlib
 
 notes "


### PR DESCRIPTION
#### Description

Bumps CXX standard and CorsixTH itself. Introduces legacysupport portgroup due to std::filesystem, bumps Lua to 5.4 and adds rtmidi.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
