### PR TITLE
mp3rgain: update homepage

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -8,6 +8,8 @@ github.setup        M-Igashi mp3rgain 3.0.0 v
 github.tarball_from archive
 revision            0
 
+homepage            https://mp3rgain.tyna.ninja/
+
 categories          audio
 platforms           {darwin >= 17}
 installs_libs       no


### PR DESCRIPTION
Point `homepage` at the project website (https://mp3rgain.tyna.ninja/) instead of the GitHub repository URL that the `github` PortGroup derives from `github.setup`.

- No `revision` bump — `homepage` is metadata only and does not change the installed image.
- `port lint --nitpick`: 0 errors. The 128 warnings are the pre-existing `cargo.crates` "missing recommended checksum type" notices; the count is identical with and without this change.