### PR TITLE
newsraft: update to 0.37

### DIFF
--- a/net/newsraft/Portfile
+++ b/net/newsraft/Portfile
@@ -5,7 +5,7 @@ PortGroup           codeberg 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
-codeberg.setup      newsraft newsraft 0.36 newsraft-
+codeberg.setup      newsraft newsraft 0.37 newsraft-
 revision            0
 
 categories          net
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Feed reader for terminal
 long_description    {*}${description}
 
-checksums           rmd160  012d5525418be64d5f470ff5e189c9d8ede3e176 \
-                    sha256  769dce748a4de741f1888eb199f71aeb41068b8527e0d5779fe0eb51fbbd72e3 \
-                    size    234475
+checksums           rmd160  638d1cf8645a1a6bdedfb189c2523ed8af74b9a5 \
+                    sha256  725fdbf4c14d87eb7e926aebd9b116f540dca812bea02e73078070156d986ad4 \
+                    size    238830
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
https://codeberg.org/newsraft/newsraft/releases/tag/newsraft-0.37

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
