### PR TITLE
opencode: update to 1.18.15

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.18.14
+version             1.18.15
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  d3f3ff25b9d9067b3031aeee7503594c0aec634a \
-                    sha256  2e0008ba711b8e3f09c3f36df3cdca3ffc24a9694f4c718af18a8647dc57901c \
-                    size    3040
+checksums           rmd160  a1da469959498ce1f167adb67f3c4deed029eaca \
+                    sha256  aae2e10aa53da715d097ac109ca03c0feb451bd453dce9d21d335c6fc7a37c0a \
+                    size    3051


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.15.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?