### PR TITLE
mp3rgain: update to 3.1.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,9 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.0.0 v
+github.setup        M-Igashi mp3rgain 3.1.0 v
 github.tarball_from archive
 revision            0
+
+homepage            https://mp3rgain.tyna.ninja/
 
 categories          audio
 platforms           {darwin >= 17}
@@ -26,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  10b7ced2fce2f9d54f7076780a0b05383bd8273f \
-                    sha256  f2507338804ac2d5c7e7728a33222b38e0c59dfdeaf907e19487a9d436602ecc \
-                    size    539690
+                    rmd160  1c0f251832aeeaa110a24cee4c1e35d19b27aa16 \
+                    sha256  a3fb2e9ac4ddab5f08ea768b1abc1ed549985589b4b07c49718497c37295de63 \
+                    size    543556
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -48,7 +50,7 @@ cargo.crates \
     either                       1.15.0           48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode               1.0.0            34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     flate2                       1.1.9            843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
-    id3                          1.17.0           70d6d9f23a28c6feab60d7b4a339e004809019ec9d5fd964b3f4c655ff9bc141 \
+    id3                          1.17.1           24993fcabcbc07c8ac076a8e62db8593d1a5c4dbe81d57e531d2b7cb7f737380 \
     indicatif                    0.18.6           9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
     itoa                         1.0.18           8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     js-sys                       0.3.94           2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9 \


### PR DESCRIPTION
Update `audio/mp3rgain` to upstream 3.1.0.

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.1.0

### Changes
- `github.setup` bumped to 3.1.0, distfile checksums (rmd160 / sha256 / size) recomputed
- `cargo.crates`: `id3` 1.17.0 → 1.17.1 (only dependency change in this release)
- Added `homepage https://mp3rgain.tyna.ninja/` — the project now has a dedicated site; without it the port inherits the GitHub URL

`revision` stays at 0 (version changed).

### Verification
`port lint --nitpick` reports **0 errors** (128 warnings, all the usual "missing recommended checksum type: rmd160/size" notices for `cargo.crates` entries, which carry sha256 only).

Maintainer of both the port and the upstream project.