### PR TITLE
fabric: update to 1.4.470, declare the Go it needs

### DIFF
--- a/llm/fabric/Portfile
+++ b/llm/fabric/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/danielmiessler/Fabric 1.4.442 v
+go.setup            github.com/danielmiessler/Fabric 1.4.470 v
 revision            0
 name                [string tolower ${github.project}]
 categories          llm
@@ -16,12 +16,13 @@ long_description    ${name} is an ${description}. It provides a modular system f
 
 homepage            https://danielmiessler.com/p/fabric-origin-story
 
-checksums           rmd160  504f45eb74bd3e6757defc378d22e3bb372259f1 \
-                    sha256  bd18dabf5d758c69e2ff029b3ff4e1d2fef417c66cb2f76f2f679656048d08fe \
-                    size    20735478
+checksums           rmd160  943e08a4994a6bfcd33303c751d4f7091a995b7b \
+                    sha256  bd632fc8681767e76ae86f0fe09401decd7b6d093ea9ecc8171240bc78196285 \
+                    size    20871999
 
 # go2port fails on too many packages to be manually fixable
 go.offline_build    no
+go.toolchain_min    1.26.0
 build.args          -o ./${name} -ldflags '-s -w' ./cmd/${name}
 
 destroot {


### PR DESCRIPTION
Updates fabric 1.4.442 → 1.4.470 and adds the new go.toolchain_min annotation.

* Checksums refreshed; revision stays 0.
* go.toolchain_min 1.26.0, copied verbatim from the `go` directive in go.mod
  at v1.4.470.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

Built green on macOS 14, 15 and 26 in fork CI.
