### PR TITLE
xray: declare the Go it needs

### DIFF
--- a/net/xray/Portfile
+++ b/net/xray/Portfile
@@ -21,6 +21,7 @@ checksums           rmd160  230756c1534f74e3910161492a54dc036850890a \
                     size    822756
 
 go.offline_build    no
+go.toolchain_min    1.26
 # Since v1.8.6, building requires dependencies from a domain not supported by go PG: git.zx2c4.com
 
 depends_build-append \


### PR DESCRIPTION
Adds go.toolchain_min 1.26, copied verbatim from the `go` directive in the
project's go.mod at the packaged tag (v26.3.27). No version change.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

No revbump: the annotation does not change the built product — it only affects
which systems attempt the build.

Built green on macOS 14, 15 and 26 in fork CI.
