### PR TITLE
filebrowser: declare the Go it needs

### DIFF
--- a/net/filebrowser/Portfile
+++ b/net/filebrowser/Portfile
@@ -24,6 +24,7 @@ checksums           rmd160  c9066bb6cf228f68ebcbe610e967ccf14122d50d \
                     size    5462514
 
 go.offline_build    no
+go.toolchain_min    1.25.0
 
 # Notes for updating this port:
 # Remember to update git commit hash


### PR DESCRIPTION
Adds go.toolchain_min 1.25.0, copied verbatim from the `go` directive in the
project's go.mod at the packaged tag (v2.63.23). No version change.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

No revbump: the annotation does not change the built product — it only affects
which systems attempt the build.

Built green on macOS 14, 15 and 26 in fork CI.
