### PR TITLE
v2ray: declare the Go it needs

### DIFF
--- a/net/v2ray/Portfile
+++ b/net/v2ray/Portfile
@@ -23,6 +23,7 @@ checksums           rmd160  20c9f4aaab92a3ca3696b627a1b0a1a6b8f207a5 \
                     size    1305402
 
 go.offline_build    no
+go.toolchain_min    1.25.5
 
 depends_build-append \
                     port:wget


### PR DESCRIPTION
Adds go.toolchain_min 1.25.5, copied verbatim from the `go` directive in the
project's go.mod at the packaged tag (v5.52.0). No version change.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

No revbump: the annotation does not change the built product — it only affects
which systems attempt the build.

Built green on macOS 14, 15 and 26 in fork CI.
