### PR TITLE
gobuster: declare the Go it needs

### DIFF
--- a/www/gobuster/Portfile
+++ b/www/gobuster/Portfile
@@ -23,6 +23,7 @@ checksums           rmd160  d3fea27e8535bb83f45230754c58e07a83400e42 \
 
 # Incompatible domains in 3.7.0
 go.offline_build    no
+go.toolchain_min    1.25
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Adds go.toolchain_min 1.25, copied verbatim from the `go` directive in the
project's go.mod at the packaged tag (v3.8.2). No version change.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

No revbump: the annotation does not change the built product — it only affects
which systems attempt the build.

Built green on macOS 14, 15 and 26 in fork CI.
