### PR TITLE
step-ca: declare the Go it needs

### DIFF
--- a/security/step-ca/Portfile
+++ b/security/step-ca/Portfile
@@ -28,6 +28,7 @@ maintainers         {gmail.com:wyuenho @wyuenho} \
 
 # Allow fetching deps at build time
 go.offline_build no
+go.toolchain_min    1.25.0
 
 checksums           rmd160  bba2ac80c695e5ae9b6e8187b656345d43faecf0 \
                     sha256  327391f301b79818f2418302516b4f6b41bdf08e38edc9011cc7f1b351e19452 \


### PR DESCRIPTION
Adds go.toolchain_min 1.25.0, copied verbatim from the `go` directive in the
project's go.mod at the packaged tag (v0.30.2). No version change.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

No revbump: the annotation does not change the built product — it only affects
which systems attempt the build.

Built green on macOS 14, 15 and 26 in fork CI.
