### PR TITLE
flux: update to 2.9.3, declare the Go it needs

### DIFF
--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -3,14 +3,15 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/fluxcd/flux2 2.7.5 v
+go.setup                github.com/fluxcd/flux2 2.9.3 v
 go.offline_build        no
+go.toolchain_min        1.26.0
 revision                0
 name                    flux
 
-checksums               rmd160  9eb9d244e2d9415f46d925a43e5eca0f05e5a110 \
-                        sha256  ceb37d65c614fe074e526ea9569ccf4bf8dd8c9421782e191a97ec514aa2821c \
-                        size    1372353
+checksums               rmd160  64f60b66051885183c8453c0a216b8d004281a4d \
+                        sha256  14f8aa691d99b8a238194fc248657096644d35dee76d89fe1737411c5258497b \
+                        size    1432856
 
 homepage                https://fluxcd.io/
 description             Flux CLI


### PR DESCRIPTION
Updates flux 2.7.5 → 2.9.3 and adds the new go.toolchain_min annotation.

* Checksums refreshed; revision stays 0.
* go.toolchain_min 1.26.0, copied verbatim from the `go` directive in go.mod
  at v2.9.3.

go.toolchain_min is the golang PortGroup knob added in
https://trac.macports.org/ticket/73086. It records the Go series the project
itself asks for, so a system that cannot provide it skips the port instead of
fetching, building and failing.

Port is nomaintainer.

Built green on macOS 14, 15 and 26 in fork CI.
