### PR TITLE
Add vulkan variant to llama.cpp

### DIFF
--- a/llm/llama.cpp/Portfile
+++ b/llm/llama.cpp/Portfile
@@ -86,6 +86,19 @@ variant metal description {Enable Metal support} {
                         -DGGML_METAL_EMBED_LIBRARY=OFF -DGGML_METAL_EMBED_LIBRARY=ON
 }
 
+variant vulkan description {Enable Vulkan support via MoltenVK} conflicts metal {
+    depends_build-append \
+                        port:vulkan-headers
+    depends_lib-append \
+                        path:lib/libMoltenVK.dylib:MoltenVK-latest \
+                        path:bin/glslc:shaderc \
+                        path:bin/glslang:glslang \
+                        port:vulkan-loader
+    configure.args-append \
+                        -DGGML_VULKAN=ON
+                        
+}
+
 variant model_converters description {install extra model conversion Python scripts} {
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/${name}


### PR DESCRIPTION
#### Description

Adds Vulkan support to llama.cpp.

On pre-Apple Silicon Macs, using Metal directly on the backend produces garbage output in llama.cpp. See https://github.com/ggml-org/llama.cpp/issues/19563 for more info. 

This merge request adds Vulkan support via MoltenVK and makes it a default variant (over Metal) on x86.

I've tried to touch nothing else!

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 x86_64
Command Line Tools 26.6.0.0.1781586589

On a 2020 iMac with an AMD Radeon Pro 5500 XT 8GB:
```
> ollama ps
NAME          ID              SIZE      PROCESSOR          CONTEXT    UNTIL              
gemma4:12b    4eb23ef187e2    8.4 GB    18%/82% CPU/GPU    4096       4 minutes from now    
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?