### PR TITLE
nexus-shell: new port

### DIFF
--- a/net/nexus-shell/Portfile
+++ b/net/nexus-shell/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                nexus-shell
+version             1.6.9
+revision            0
+categories          net aqua
+platforms           {darwin >= 23}
+supported_archs     arm64
+license             Restrictive
+maintainers         {@viewer12 nexusshell.app:marketing} openmaintainer
+
+description         native macOS SSH client
+long_description    Nexus Shell is a native macOS SSH client with integrated \
+                    SFTP file management, Docker management, server monitoring, \
+                    encrypted session logs, and optional AI assistance.
+homepage            https://nexusshell.app
+
+master_sites        https://releases.nexusshell.app/
+distname            Nexus-Shell-v${version}
+use_dmg             yes
+
+checksums           rmd160  2330b66f9da0e8701587ccce4479136e432a3eda \
+                    sha256  088938eb901760a3123be7c8df18a41d480f234358a3a56f248de88bcc83a61d \
+                    size    11903735
+
+use_configure       no
+build               {}
+
+destroot {
+    copy ${worksrcpath}/Nexus\ Shell.app ${destroot}${applications_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://github.com/viewer12/Nexus-Shell-Releases/releases/latest
+livecheck.regex     {/tag/v([0-9.]+)}


### PR DESCRIPTION
#### Description

Adds Nexus Shell 1.6.9, a native Apple Silicon macOS SSH client, as a new port in `net`.

The port installs the official Developer ID-signed and notarized application from the versioned DMG published by the developer. The software is proprietary, so the Portfile uses `license Restrictive`; MacPorts should fetch the developer-hosted DMG rather than redistribute a binary archive.

I am the developer of Nexus Shell. Codex (GPT-5) assisted with Portfile preparation and validation.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (No test phase is defined.)
- [ ] tried a full install with `sudo port -vst install`? (The isolated MacPorts prefix did not have administrator privileges.)
- [ ] tested basic functionality of all binary files? (The staged application was validated but not launched from the isolated prefix.)

Additional validation completed:

- `port lint --nitpick nexus-shell`: 0 errors and 0 warnings
- `port checksum nexus-shell`: passed against the developer-hosted DMG
- `port livecheck nexus-shell`: detected 1.6.9 as current
- MacPorts `destroot`: completed in an isolated prefix after mounting the DMG without MacPorts' root-only mount step
- Staged app: version 1.6.9, minimum macOS 14.2, native arm64
- `codesign --verify --deep --strict`: passed
- `spctl --assess --type execute`: accepted as Notarized Developer ID, Team ID `5MBFAB57U2`
