### PR TITLE
mp3rgain: update to 3.1.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.1.0 v
+github.setup        M-Igashi mp3rgain 3.1.1 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  1c0f251832aeeaa110a24cee4c1e35d19b27aa16 \
-                    sha256  a3fb2e9ac4ddab5f08ea768b1abc1ed549985589b4b07c49718497c37295de63 \
-                    size    543556
+                    rmd160  aad354c1a21620d1f320372c12a66017110180af \
+                    sha256  c1b3d500e0832bc5e8c7df41a777253a325ae0e58a857dc7416349bd85ed5b96 \
+                    size    544964
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Patch release.

Upstream release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.1.1

- Fixes wildcard expansion on Windows (no effect on macOS builds)
- No dependency changes, so `cargo.crates` is unchanged from 3.1.0
- Checksums recomputed from the new GitHub archive tarball