### PR TITLE
httrack: Update to 3.49.19

### DIFF
--- a/net/httrack/Portfile
+++ b/net/httrack/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
 
-name                httrack
-version             3.49.2
-revision            3
+github.setup        xroche httrack 3.49.19
+github.tarball_from releases
+revision            0
 categories          net
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
 
@@ -15,47 +16,39 @@ description         Website Copier/Offline Browser
 long_description    HTTrack is an offline browser utility that allows you to \
                     download a website from the Internet to a local directory.
 
-homepage            http://www.httrack.com/
-master_sites        http://mirror.httrack.com/historical/
+homepage            https://www.httrack.com/
 
-checksums           rmd160  e1ce07330443a0f4db366d1355681319026eae05 \
-                    sha256  3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025
+checksums           rmd160  036be4a4fb7087cad43772715f20e5903ad47a0c \
+                    sha256  ada3c241f2b39bf55c4f01657bcd6cd96e5c0452838223a9bf67445a3a844cf4 \
+                    size    4275270
 
-depends_build       port:gmake
-depends_lib         path:lib/libssl.dylib:openssl \
-                    port:libiconv \
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:libiconv \
                     port:zlib
 
 patchfiles          patch-src-htsweb.c.diff \
-                    patch-src-webhttrack.diff
+                    patch-src-webhttrack.diff \
+                    patch-u_int.diff
 
 # See https://trac.macports.org/ticket/42384
 patchfiles-append   patch-libiconv.diff
-depends_build-append \
-                    port:autoconf-archive
 
 post-patch {
-    reinplace -locale C "s|@PREFIX@|${prefix}|g" \
-        ${worksrcpath}/src/htsweb.c \
-        ${worksrcpath}/src/webhttrack
+    reinplace "s|@PREFIX@|${prefix}|" ${worksrcpath}/src/htsweb.c
 }
 
-configure.args      --with-sysroot=${prefix} \
-                    --with-zlib=${prefix}
-
-# Makefile fails during parallel builds
-use_parallel_build  no
-use_autoreconf      yes
+configure.args-append \
+                    --with-sysroot=${prefix} \
+                    --with-zlib=${prefix} \
+                    --disable-origin-rpath
 
 post-destroot {
     # Remove metadata files not used by darwin or OS X
-    file delete ${destroot}${prefix}/share/pixmaps/httrack.xpm
+    file delete -force ${destroot}${prefix}/share/pixmaps/
     file delete -force ${destroot}${prefix}/share/applications/
 }
 
 test.run            yes
 test.target         check
-
-livecheck.type      regex
-livecheck.url       http://download.httrack.com/cserv.php3?queryVersionNumberDigit
-livecheck.regex     ^(.+)$

--- a/net/httrack/files/patch-libiconv.diff
+++ b/net/httrack/files/patch-libiconv.diff
@@ -1,11 +1,16 @@
---- configure.ac.orig	2017-10-03 11:28:52.000000000 -0600
-+++ configure.ac	2017-10-03 11:29:23.000000000 -0600
-@@ -212,7 +212,7 @@
- AC_SUBST(SOCKET_LIBS)
- 
- ### Check for iconv
--AC_CHECK_LIB(iconv, iconv, [ICONV_LIBS="-liconv"
-+AC_CHECK_LIB(iconv, libiconv, [ICONV_LIBS="-liconv"
- AC_DEFINE(LIBICONV, 1,[Check for libiconv])], AC_MSG_RESULT([not necessary]))
- AC_SUBST(ICONV_LIBS)
- 
+--- configure.orig	2026-08-08 16:13:55.000000000 -0400
++++ configure	2026-08-09 19:13:04.954825425 -0400
+@@ -17931,11 +17931,11 @@
+ #ifdef __cplusplus
+ extern "C"
+ #endif
+-char iconv (void);
++char libiconv (void);
+ int
+ main (void)
+ {
+-return iconv ();
++return libiconv ();
+   ;
+   return 0;
+ }

--- a/net/httrack/files/patch-src-htsweb.c.diff
+++ b/net/httrack/files/patch-src-htsweb.c.diff
@@ -1,11 +1,11 @@
 --- src/htsweb.c.orig	2013-08-18 12:25:48.000000000 -0400
-+++ src/htsweb.c	2013-08-18 12:26:05.000000000 -0400
-@@ -123,7 +123,7 @@
-     fprintf(stderr,
-             "usage: %s [--port <port>] <path-to-html-root-dir> [key value [key value]..]\n",
++++ src/htsweb.c	2026-08-09 00:21:58.463900406 -0400
+@@ -186,7 +186,7 @@
+             "usage: %s [--port <port>] [--bind <address>] [--ppid parent-pid] "
+             "<path-to-html-root-dir> [key value [key value]..]\n",
              argv[0]);
 -    fprintf(stderr, "example: %s /usr/share/httrack/\n", argv[0]);
-+    fprintf(stderr, "example: %s @PREFIX@/share/httrack/\n", argv[0]);
++    fprintf(stderr, "example: %s @PREFIX@/bin/httrack/\n", argv[0]);
      return 1;
    }
  

--- a/net/httrack/files/patch-src-webhttrack.diff
+++ b/net/httrack/files/patch-src-webhttrack.diff
@@ -1,14 +1,22 @@
---- src/webhttrack.orig	2013-06-28 13:45:59.000000000 -0400
-+++ src/webhttrack	2013-08-18 12:31:40.000000000 -0400
-@@ -17,9 +17,9 @@
- BROWSEREXE="/usr/bin/open -W"
- fi
- BINWD=`dirname "$0"`
--SRCHPATH="$BINWD /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin ${HOME}/usr/bin ${HOME}/bin"
-+SRCHPATH="@PREFIX@/bin"
- SRCHPATH="$SRCHPATH "`echo $PATH | tr ":" " "`
--SRCHDISTPATH="$BINWD/../share $BINWD/.. /usr/share /usr/local /usr /local /usr/local/share ${HOME}/usr ${HOME}/usr/share /opt/local/share /sw ${HOME}/usr/local ${HOME}/usr/share"
-+SRCHDISTPATH="@PREFIX@/share"
+--- src/Makefile.in.orig 2026-08-08 16:13:56.000000000 -0400
++++ src/Makefile.in	2026-08-09 19:38:16.897204745 -0400
+@@ -1962,7 +1962,7 @@
+ # $(datadir) only expands at make time, so substitute here rather than through
+ # AC_CONFIG_FILES (#887).
+ webhttrack: webhttrack.in Makefile
+-	$(AM_V_GEN)$(SED) -e 's|@datadir[@]|$(datadir)|g' $(srcdir)/webhttrack.in >$@.tmp \
++	$(AM_V_GEN)$(SED) -e 's|@datadir[@]|$(datadir)|g' -e 's|@bindir[@]|$(bindir)|g' $(srcdir)/webhttrack.in >$@.tmp \
+ 		&& chmod +x $@.tmp && mv -f $@.tmp $@
  
- ###
- # And now some famous cuisine
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+--- src/webhttrack.in.orig	2026-08-08 16:13:49.000000000 -0400
++++ src/webhttrack.in	2026-08-09 19:40:11.883718920 -0400
+@@ -17,7 +17,7 @@
+     BROWSEREXEFALLBACK="/usr/bin/open -W"
+ fi
+ BINWD=$(dirname "$0")
+-SRCHPATH=("$BINWD" /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin "${HOME}/usr/bin" "${HOME}/bin")
++SRCHPATH=("$BINWD" "@bindir@" /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin "${HOME}/usr/bin" "${HOME}/bin")
+ IFS=':' read -ra pathdirs <<<"$PATH"
+ for d in "${pathdirs[@]}"; do
+     # drop empty PATH fields, matching the old echo|tr word-split

--- a/net/httrack/files/patch-u_int.diff
+++ b/net/httrack/files/patch-u_int.diff
@@ -1,0 +1,10 @@
+--- src/htsrandom.c.orig	2026-08-08 16:13:49.000000000 -0400
++++ src/htsrandom.c	2026-08-09 20:28:18.000000000 -0400
+@@ -40,6 +40,7 @@
+ #else
+ #include <errno.h>
+ #include <stdio.h>
++#include <sys/types.h>
+ #ifdef HAVE_SYS_RANDOM_H
+ #include <sys/random.h>
+ #endif


### PR DESCRIPTION
#### Description

Update httrack to 3.49.19. Switch to new upstream and add patches to support legacy systems (by adding appropriate headers).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
