### PR TITLE
blosc2: Update to 3.3.2

### DIFF
--- a/archivers/blosc2/Portfile
+++ b/archivers/blosc2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        Blosc c-blosc2 2.23.0 v
+github.setup        Blosc c-blosc2 3.3.2 v
 revision            0
 
 name                blosc2
@@ -18,14 +18,17 @@ long_description    {*}${description}.
 
 homepage            https://www.blosc.org
 
-checksums           rmd160  fa41e1b89fb7a58b33741671ee7d2cf605ec2c08 \
-                    sha256  125e0ac2fac3d81239c1de036cb335bc8eca86b19216e97e0b23de3283d3274b \
-                    size    3337937
+checksums           rmd160  561d6056b8dbcee9467aa4bcafcb5a83fae52880 \
+                    sha256  a8fb27bae6403872bb6e5bb8672e79a5b7eb6b3d8fd7c3e6aa7b888436b68ee2 \
+                    size    1946986
 github.tarball_from archive
 
 depends_lib-append  port:lz4 \
                     port:zlib \
                     port:zstd
+
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2 {clang < 900}
 
 configure.args-append \
                     -DBUILD_BENCHMARKS:BOOL=OFF \
@@ -34,9 +37,6 @@ configure.args-append \
                     -DPREFER_EXTERNAL_LZ4:BOOL=ON \
                     -DPREFER_EXTERNAL_ZLIB:BOOL=ON \
                     -DPREFER_EXTERNAL_ZSTD:BOOL=ON
-
-# error: ‘for’ loop initial declaration used outside C99 mode
-configure.cflags-append -std=c99
 
 # https://trac.macports.org/ticket/67478
 platform darwin {

--- a/python/py-blosc2/Portfile
+++ b/python/py-blosc2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-blosc2
-version             4.1.2
+version             4.11.0
 revision            0
 
 categories-append   archivers devel
@@ -17,9 +17,9 @@ long_description    A Python wrapper for the extremely fast Blosc2 \
 
 homepage            https://pypi.python.org/pypi/blosc2/
 
-checksums           rmd160 733c89366fd4e4d780d1648c704b1e818383897a \
-                    sha256 c127342d976de44fee242137e83660097e0b072779f4164a34e149ac9f693c8a \
-                    size 4341120
+checksums           rmd160  1306cf4efef2aad15747e959c8bd15d5cdee5f3f \
+                    sha256  3c610b076ad0422d861ff10732013c7c3461135968c3c442630542e71249a4a2 \
+                    size    6820440
 
 python.versions     310 311 312 313 314
 


### PR DESCRIPTION
#### Description

Update blosc2 to 3.3.2.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
