### PR TITLE
borgbackup: Update to 1.4.5, use Python 3.14

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                borgbackup
-version             1.4.3
+version             1.4.5
 revision            0
 
 categories          sysutils
@@ -23,14 +23,14 @@ long_description    BorgBackup (short: Borg) is a deduplicating backup \
 
 homepage            https://www.borgbackup.org/
 
-checksums           rmd160  405371493ddcca1b7c8e57c63587051da9a300f3 \
-                    sha256  79bbfa745d1901d685973584bd2d16a350686ddd176f6a2244490fb01996441f \
-                    size    4014143
+checksums           rmd160  661dbe0f37dffea473ff8c85330786dd46690ab7 \
+                    sha256  4f9a5fe584c504b15485841236750dea16aa7cd2ddbc4a594e9d2ce5c49c4508 \
+                    size    4034652
 
 patchfiles          patch-accept-newer-msgpack.diff \
                     patch-docs-use-sphinx_rtd_theme.diff
 
-python.default_version  313
+python.default_version  314
 
 depends_build-append \
                     port:py${python.version}-cython \
@@ -49,14 +49,14 @@ depends_lib-append  path:lib/libssl.dylib:openssl \
 depends_run-append  port:py${python.version}-msgpack \
                     port:py${python.version}-packaging
 
-# Run tests, but skip test_unix_socket, since it will fail because the path is
-# longer than the maximum length of a unix socket name when run in a MacPorts
-# build.
 depends_test-append port:py${python.version}-pytest-xdist \
                     port:py${python.version}-pytest-benchmark
 
+# Run tests, but skip test_atime, since it fails, apparently because setting
+# the atime of a file on macOS doesn't work as expected (or at least it doesn't
+# work in the build path).
 test.run            yes
-test.args-append    -k 'not test_unix_socket' \
+test.args-append    -k 'not test_atime' \
                     -n ${build.jobs} \
                     --pyargs borg.testsuite
 

--- a/sysutils/borgbackup/files/patch-accept-newer-msgpack.diff
+++ b/sysutils/borgbackup/files/patch-accept-newer-msgpack.diff
@@ -73,36 +73,33 @@ downstream tests instead.
 
 Upstream-Status: Inappropriate
 
---- pyproject.toml.orig	2025-11-03 15:18:41
-+++ pyproject.toml	2025-11-03 15:29:19
-@@ -36,8 +36,8 @@
+--- pyproject.toml.orig	2026-07-18 17:39:20
++++ pyproject.toml	2026-08-10 09:35:10
+@@ -35,7 +35,7 @@
      # Please note:
      # Using any other msgpack version is not supported by Borg development and
      # any feedback related to issues caused by this will be ignored.
--    "msgpack >=1.0.3, <=1.1.2",
+-    "msgpack >=1.0.3, <=1.2.1",
 +    "msgpack >=1.0.3",
      "packaging",
  ]
-
-
---- src/borg/helpers/msgpack.py.orig	2025-11-05 22:58:07
-+++ src/borg/helpers/msgpack.py	2025-11-05 23:00:39
-@@ -144,12 +144,14 @@
+ 
+--- src/borg/helpers/msgpack.py.orig	2026-07-18 17:39:20
++++ src/borg/helpers/msgpack.py	2026-08-10 09:37:58
+@@ -144,10 +144,12 @@
  
      version_check = os.environ.get('BORG_MSGPACK_VERSION_CHECK', 'yes').strip().lower()
  
 -    return version_check == 'no' or (
--        (1, 0, 3) <= msgpack.version[:3] <= (1, 1, 2) and
+-        (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 1) and
 -        msgpack.version not in []
 -    )
 +    if version_check == "no":
 +        return True
- 
++ 
 +    if msgpack.version in []:
 +        return False
 +    return True
  
-+
+ 
  def get_limited_unpacker(kind):
-     """return a limited Unpacker because we should not trust msgpack data received from remote"""
-     # Note: msgpack >= 0.6.1 auto-computes DoS-safe max values from len(data) for


### PR DESCRIPTION
#### Description

Update to 1.4.5, use Python 3.14

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6 25G72 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
