### PR TITLE
oh-my-pi: add new port

### DIFF
--- a/llm/oh-my-pi/Portfile
+++ b/llm/oh-my-pi/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                oh-my-pi
+version             17.2.12
+revision            0
+
+categories          llm
+maintainers         {@oakimov} openmaintainer
+license             MIT
+supported_archs     x86_64 arm64
+
+description         oh-my-pi (omp) is a coding agent CLI built on Pi with batteries included
+long_description    oh-my-pi (omp) is a coding agent CLI that wires the IDE in, \
+                    built on Mario Zechner's Pi with batteries included.\
+                    \n\
+                    \nThe agent runs in a TUI with 40+ model providers, 32 \
+                    built-in tools, and LSP/DAP operations, and can execute \
+                    code with tool-calling through persistent Python and a \
+                    Bun worker that call back into the agent's own tools over \
+                    a loopback bridge.\
+                    \n\
+                    \noh-my-pi installs and runs as the "omp" command and \
+                    requires bun >= 1.3.14.
+
+homepage            https://omp.sh
+
+master_sites        https://registry.npmjs.org/@oh-my-pi/pi-coding-agent/-/
+distname            pi-coding-agent-${version}
+extract.suffix      .tgz
+extract.only
+
+checksums           rmd160  77fcff49f3b2e67add4948609a8ce3565f7d001d \
+                    sha256  cecd485ed36e8ada3f96b5dccd079ccdd78aee9907ba253beca6fec11c5ba5a3 \
+                    size    10399637
+
+depends_build       path:bin/bun:bun
+depends_lib         path:bin/bun:bun
+
+use_configure       no
+build   {}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/bin
+    system -W ${workpath} "env BUN_INSTALL=${destroot}${prefix}/lib/bun bun install -g --silent ${distpath}/${distfiles}"
+    # bun's global install keeps a redundant copy of every package under
+    # install/cache; the installed tree in install/global is all that is
+    # needed at runtime, so drop the cache to avoid doubling the footprint.
+    file delete -force ${destroot}${prefix}/lib/bun/install/cache
+    file link -symbolic ${destroot}${prefix}/bin/omp \
+        ../lib/bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js
+}
+
+livecheck.url       https://registry.npmjs.org/@oh-my-pi/pi-coding-agent/latest
+livecheck.regex     {\\"version\\":\\"(\[^\\"]+)\\"}


### PR DESCRIPTION
#### Description

New port for **oh-my-pi** (binary `omp`), a coding agent CLI built on Pi with batteries included. It is written for bun (`>= 1.3.14`) and installs via `bun install -g @oh-my-pi/pi-coding-agent`, so it is a separate port from the existing `pi-coding-agent` (@earendil-works).

The port downloads the `@oh-my-pi/pi-coding-agent` tarball from the npm registry (checksummed), installs it with `bun install -g` into a `BUN_INSTALL` tree under `${prefix}/lib/bun`, drops bun's redundant `install/cache`, and symlinks `omp` into `${prefix}/bin`.

All native binaries (pi-natives, mupdf wasm, onnxruntime, sharp) are prebuilt and shipped in platform-specific packages, so no lifecycle scripts run at install time and `--trust` is not needed.

`depends_lib path:bin/bun:bun` provides the bun runtime the `omp` shebang (`#!/usr/bin/env bun`) requires.

###### Type(s)

- [x] submission (new Portfile)

###### Tested on

macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and minimized your commits
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? (0 errors, 0 warnings)
- [x] tried a full install with `sudo port -vst install`? (install + uninstall verified)
- [x] tested basic functionality of all binary files? (`omp --version` → `omp/17.2.12`)
