### PR TITLE
ci: fallback to regenerating full portindex

### DIFF
--- a/.github/workflows/bootstrap.sh
+++ b/.github/workflows/bootstrap.sh
@@ -170,6 +170,6 @@ fi
 ## Ignore portindex errors on common ancestor
 (cd ports/ && portindex)
 git -C ports/ checkout -qf -
-(cd ports/ && portindex -e)
+(cd ports/ && portindex -e) || (cd ports/ && rm -f PortIndex PortIndex.quick && portindex -e)
 endgroup
 fi


### PR DESCRIPTION
#### Description

I noticed recent CI builds on PRs were failing due to an unrelated portindex error.
This error seems to happen when a subport listed in the pre-built PortIndex ends up
being moved into another port. This is probably rare; it'll only turn up in cases
when the pre-built PortIndex is generated and a commit lands after that that moves
a subport before the pre-built PortIndex can be regenerated. This PR adds a simple
fallback. If the incremental index fails, it falls back to deleting the pre-built
PortIndex file and rebuilding a full one. This will add a few minutes to the job,
but it should avoid this case of the job failing.

This happened with php83-oracle moving from lang/php to php/php-oracle in
9a53cdb4e196127a602622e824341841de962b48).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
