### PR TITLE
weechat: update to 4.10.0

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.9.5
+version             4.10.0
 revision            0
-checksums           rmd160  3f341d82ca9a2aa759487ff0c13e37e2e3770956 \
-                    sha256  3b3946104e64536d0602370a30e55dd5a301cc8ff420184ff0a101926dad1d16 \
-                    size    2801244
+checksums           rmd160  10c7f48b05fba59c3c7b12514c1e77c809fd37d3 \
+                    sha256  c3a7e7c6a5401dde9a46d0264fa44aa3032ca98aa86410c454d3de5c69505c54 \
+                    size    2847188
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.10.0

###### Tested on
macOS 15.7.9 24G830 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
