### PR TITLE
icann-rdap: update to 0.0.31

### DIFF
--- a/net/icann-rdap/Portfile
+++ b/net/icann-rdap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo 1.0
 PortGroup           github 1.0
 
-github.setup        icann icann-rdap 0.0.30 v
+github.setup        icann icann-rdap 0.0.31 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    {*}${description}. RDAP (Registration Data Access Protocol) 
                     and autonomous system numbers.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  89b5dbc24ba0d3efc5584ad0ba1f3f9f0f1342d6 \
-                    sha256  7dcdd36e6f36ebb8c11b6576c7ba10e314de8594adddde242c8f801ed1a3f4f4 \
-                    size    376216
+                    rmd160  567b8bef3c5c6ed5c70b14af61a253c5deb40912 \
+                    sha256  b40724c334b789dd80d5b12331753c940f244d677f903e4667c10d8038527c49 \
+                    size    394915
 
 destroot {
     set bins {rdap rdap-test rdap-srv rdap-srv-data rdap-srv-store rdap-srv-test-data}
@@ -36,7 +36,7 @@ destroot {
 
 cargo.crates \
     ab-radix-trie                            0.2.1                1996a0a7d153953579280bca89e620b9bc0a609727984e53f1f4073776746866 \
-    aho-corasick                             1.1.4                ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    aho-corasick                             1.1.5                c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba \
     allocator-api2                           0.2.21               683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android_system_properties                0.1.5                819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anstream                                 1.0.0                824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
@@ -44,46 +44,45 @@ cargo.crates \
     anstyle-parse                            1.0.0                52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                            1.1.5                40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                           3.0.11               291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
-    anyhow                                   1.0.103              2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3 \
+    anyhow                                   1.0.104              330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
     array-const-fn-init                      0.1.1                8bcb85e548c05d407fa6faff46b750ba287714ef32afc0f5e15b4641ffd6affb \
     assert_cmd                               2.2.2                2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
-    async-trait                              0.1.89               9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    async-trait                              0.1.91               ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
     atoi                                     2.0.0                f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528 \
     atomic-waker                             1.1.2                1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                                  1.5.1                f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
-    aws-lc-rs                                1.17.1               4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad \
-    aws-lc-sys                               0.42.0               6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444 \
+    aws-lc-rs                                1.17.3               00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1 \
+    aws-lc-sys                               0.43.0               43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c \
     axum                                     0.8.9                31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90 \
     axum-client-ip                           1.3.1                a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67 \
     axum-core                                0.5.6                08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1 \
     axum-extra                               0.12.6               be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970 \
     axum-macros                              0.5.1                7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca \
     base64                                   0.22.1               72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    bitflags                                 2.13.0               b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
+    bitflags                                 2.13.1               b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
     block-buffer                             0.10.4               3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-buffer                             0.12.1               d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
-    bstr                                     1.12.3               5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79 \
+    bstr                                     1.13.0               1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530 \
     buildstructor                            0.6.0                caabaaee17b2a78d7aa349a33edc9090c6bb47e6dfb25b0da281df57628bba68 \
     bumpalo                                  3.20.3               72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     byteorder                                1.5.0                1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                                    1.12.0               8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593 \
-    cc                                       1.2.66               f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996 \
+    bytes                                    1.12.1               fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
+    cc                                       1.4.0                5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9 \
     cfg-if                                   1.0.4                9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
-    cfg_aliases                              0.2.1                613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    cfg_aliases                              0.2.2                f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
     chacha20                                 0.10.1               d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
     chrono                                   0.4.45               1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     cidr                                     0.3.2                579504560394e388085d0c080ea587dfa5c15f7e251b4d5247d1e1a61d1d6928 \
     cidr-utils                               0.7.1                1f59aae4103f56b79b449c67bde6d1e96aa9f617d95af57ed1d72d6f948fe597 \
-    clap                                     4.6.1                1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
-    clap_builder                             4.6.0                714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_derive                              4.6.1                f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
+    clap                                     4.6.5                301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf \
+    clap_builder                             4.6.5                94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078 \
+    clap_derive                              4.6.4                d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
     clap_lex                                 1.1.0                c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     client-ip                                0.2.1                39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729 \
     cmake                                    0.1.58               c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
     cmov                                     0.5.4                0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     colorchoice                              1.0.5                1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     combine                                  4.6.7                ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
-    concurrent-queue                         2.5.0                4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     console                                  0.15.11              054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     const_format                             0.2.36               4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e \
     const_format_proc_macros                 0.2.34               1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
@@ -97,8 +96,8 @@ cargo.crates \
     crc                                      3.4.0                5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
     crc-catalog                              2.5.0                217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
     critical-section                         1.2.0                790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b \
-    crokey                                   1.4.0                04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c \
-    crokey-proc_macros                       1.4.0                847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231 \
+    crokey                                   1.5.0                074bc31bff1084f74e5a145ad5f6ac74469fa312159faa5144f0b1c4506b8d80 \
+    crokey-proc_macros                       1.5.0                b88c4ff2d5717616c3bb4a31d06b0b241ed811c7c0c41d077d77631bee7caad0 \
     crossbeam                                0.8.4                1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
     crossbeam-channel                        0.5.16               d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
     crossbeam-deque                          0.8.7                5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
@@ -110,7 +109,7 @@ cargo.crates \
     crypto-common                            0.1.6                1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     crypto-common                            0.2.2                ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
     ctutils                                  0.4.2                7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
-    data-encoding                            2.11.0               a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
+    data-encoding                            2.11.1               4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06 \
     derive_more                              2.1.1                d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                         2.1.1                799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
     difflib                                  0.4.0                6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
@@ -118,12 +117,12 @@ cargo.crates \
     digest                                   0.11.3               f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
     directories                              6.0.0                16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs-sys                                 0.5.0                e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    displaydoc                               0.2.6                1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
+    displaydoc                               0.2.7                c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8 \
     document-features                        0.2.12               d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                                  0.15.7               1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     dunce                                    1.0.5                92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                                1.0.20               d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
-    either                                   1.16.0               91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
+    either                                   1.17.0               9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d \
     encode_unicode                           1.0.0                34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                              0.8.35               75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     endian-type                              0.1.2                c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d \
@@ -135,8 +134,8 @@ cargo.crates \
     equivalent                               1.0.2                877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                                    0.3.14               39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
     etcetera                                 0.11.0               de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96 \
-    event-listener                           5.4.1                e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab \
-    fastrand                                 2.4.1                9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
+    event-listener                           5.4.2                5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2 \
+    fastrand                                 2.5.0                da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
     find-msvc-tools                          0.1.9                5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
     flume                                    0.12.0               5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be \
     fnv                                      1.0.7                3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -146,21 +145,21 @@ cargo.crates \
     form_urlencoded                          1.2.2                cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     fs_extra                                 1.3.0                42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsio                                     0.4.1                f4944f16eb6a05b4b2b79986b4786867bb275f52882adea798f17cc2588f25b2 \
-    futures-channel                          0.3.32               07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
-    futures-core                             0.3.32               7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
-    futures-executor                         0.3.32               baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d \
+    futures-channel                          0.3.33               262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae \
+    futures-core                             0.3.33               2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7 \
+    futures-executor                         0.3.33               6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458 \
     futures-intrusive                        0.5.0                1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f \
-    futures-io                               0.3.32               cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718 \
-    futures-macro                            0.3.32               e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b \
-    futures-sink                             0.3.32               c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
-    futures-task                             0.3.32               037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
+    futures-io                               0.3.33               4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a \
+    futures-macro                            0.3.33               2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b \
+    futures-sink                             0.3.33               e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307 \
+    futures-task                             0.3.33               b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109 \
     futures-timer                            3.0.4                af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968 \
-    futures-util                             0.3.32               389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    futures-util                             0.3.33               a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa \
     generic-array                            0.14.9               4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2 \
     getrandom                                0.2.17               ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                                0.3.4                899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
     getrandom                                0.4.3                300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
-    glob                                     0.3.3                0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
+    glob                                     0.3.4                e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
     goldenfile                               1.11.0               206600f27ef687e85a572315eb297c79f66620b2b3eeb3a6cde17f25e049ae5b \
     h2                                       0.4.15               6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155 \
     hashbrown                                0.12.3               8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
@@ -176,14 +175,14 @@ cargo.crates \
     hickory-proto                            0.25.2               f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502 \
     hkdf                                     0.13.0               4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018 \
     hmac                                     0.13.0               6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
-    http                                     1.4.2                6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
-    http-body                                1.0.1                1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
-    http-body-util                           0.1.3                b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
+    http                                     1.5.0                918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0 \
+    http-body                                1.1.0                ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
+    http-body-util                           0.1.4                e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2 \
     httparse                                 1.10.1               6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                                 1.0.3                df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     humantime                                2.4.0                15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
-    hybrid-array                             0.4.13               818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c \
-    hyper                                    1.10.1               55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
+    hybrid-array                             0.4.14               707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
+    hyper                                    1.11.0               d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72 \
     hyper-rustls                             0.27.9               33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                                0.6.0                70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                               0.1.20               96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
@@ -201,7 +200,7 @@ cargo.crates \
     indexmap                                 1.9.3                bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                                 2.14.0               d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indoc                                    2.0.7                79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
-    ipnet                                    2.12.0               d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
+    ipnet                                    2.12.1               6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78 \
     is-terminal                              0.4.17               3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46 \
     is_terminal_polyfill                     1.70.2               a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itoa                                     1.0.18               8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
@@ -212,15 +211,15 @@ cargo.crates \
     jobserver                                0.1.35               1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
     js-sys                                   0.3.103              53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
     json-pretty-compact                      0.1.2                62a9c1f06b173b0da0ccc8cae00599d7b3ceda6e76d68be9b6bc2c941adafe0e \
-    jsonpath-rust                            1.0.4                633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa \
+    jsonpath-rust                            1.0.8                2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7 \
     jsonpath_lib                             0.3.0                eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f \
     konst                                    0.2.20               128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb \
     konst_macro_rules                        0.2.19               a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37 \
-    lazy-regex                               3.6.0                6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
-    lazy-regex-proc_macros                   3.6.0                4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
+    lazy-regex                               3.6.1                4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9 \
+    lazy-regex-proc_macros                   3.6.1                fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0 \
     lazy_static                              1.5.0                bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                                     0.2.186              68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
-    libredox                                 0.1.18               c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652 \
+    libc                                     0.2.189              3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
+    libredox                                 0.1.19               2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa \
     libsqlite3-sys                           0.37.0               b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1 \
     linux-raw-sys                            0.12.1               32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                                  0.8.2                92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -231,11 +230,11 @@ cargo.crates \
     matchers                                 0.2.0                d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     matchit                                  0.8.4                47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
     md-5                                     0.11.0               69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
-    memchr                                   2.8.2                88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
+    memchr                                   2.8.3                cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     mime                                     0.3.17               6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
-    minimad                                  0.14.0               df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f \
-    minus                                    5.7.1                2657ec5f6a6edc55a85c8db0c572436b612eb036af00e7eee47e0a622095ed96 \
-    mio                                      1.2.1                02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
+    minimad                                  0.16.0               de632ee829aec3a874d18a4192eae64a0460b3a45c54ed556b334f6fe5a1d62f \
+    minus                                    5.7.2                1db1df1b8dd701aa57b41283b50b751b3ebc8fe1406955ec90c53b46b475fa56 \
+    mio                                      1.2.2                30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
     native-tls                               0.2.18               465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
     nibble_vec                               0.1.0                77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
     nu-ansi-term                             0.50.3               7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
@@ -255,30 +254,30 @@ cargo.crates \
     parking_lot_core                         0.9.12               2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     pct-str                                  3.0.1                756dc82399e1ef9b37bd698266e4b7fed5f3d3cccb09fbc6b602086c9077e4ad \
     percent-encoding                         2.3.2                9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                                     2.8.7                47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9 \
-    pest_derive                              2.8.7                4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58 \
-    pest_generator                           2.8.7                6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7 \
-    pest_meta                                2.8.7                f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210 \
+    pest                                     2.8.8                7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2 \
+    pest_derive                              2.8.8                9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd \
+    pest_generator                           2.8.8                6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6 \
+    pest_meta                                2.8.8                85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c \
     pin-project-lite                         0.2.17               a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pkg-config                               0.3.33               19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    portable-atomic                          1.13.1               c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
+    portable-atomic                          1.14.0               3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3 \
     potential_utf                            0.1.5                0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     ppv-lite86                               0.2.21               85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     predicates                               3.1.4                ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
     predicates-core                          1.0.10               cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144 \
     predicates-tree                          1.0.13               d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
-    prefix-trie                              0.9.3                b81f62da691716444e46e43a913c84b3301ef8a732ad2720306bcbe7320aa4ef \
+    prefix-trie                              0.10.1               6369af434551b9bf8be05ab871ac1263687d6f0c9485e6d781f904f3e06d7d03 \
     proc-macro-crate                         3.5.0                e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f \
-    proc-macro2                              1.0.106              8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    proc-macro2                              1.0.107              985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     quinn                                    0.11.11              0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
     quinn-proto                              0.11.16              2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560 \
     quinn-udp                                0.5.15               35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
-    quote                                    1.0.46               dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
+    quote                                    1.0.47               1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                                    5.3.0                69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                    6.0.0                f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radix_trie                               0.2.1                c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd \
-    rand                                     0.8.6                5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
-    rand                                     0.9.4                44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
+    rand                                     0.8.7                22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a \
+    rand                                     0.9.5                b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
     rand                                     0.10.2               c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                              0.3.1                e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                              0.9.0                d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
@@ -289,8 +288,8 @@ cargo.crates \
     rangemap                                 1.7.1                973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68 \
     redox_syscall                            0.5.18               ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     redox_users                              0.5.2                a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    regex                                    1.12.4               f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
-    regex-automata                           0.4.14               6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex                                    1.13.1               f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                           0.4.18               ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-syntax                             0.8.11               d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     relative-path                            1.9.3                ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
     reqwest                                  0.13.4               219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
@@ -300,9 +299,9 @@ cargo.crates \
     rustc-hash                               2.1.3                6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                            0.4.1                cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                                   1.1.4                b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                                   0.23.41              6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f \
+    rustls                                   0.23.43              0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06 \
     rustls-native-certs                      0.8.4                dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
-    rustls-pki-types                         1.15.0               764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046 \
+    rustls-pki-types                         1.15.1               2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
     rustls-platform-verifier                 0.7.0                26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android         0.1.1                f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                            0.103.13             61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
@@ -315,15 +314,15 @@ cargo.crates \
     security-framework                       3.7.0                b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys                   2.17.0               6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
     semver                                   1.0.28               8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
-    serde                                    1.0.228              9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde_core                               1.0.228              41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                             1.0.228              d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                               1.0.150              e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde                                    1.0.229              4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde_core                               1.0.229              67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                             1.0.229              e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                               1.0.151              c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     serde_path_to_error                      0.1.20               10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
     serde_urlencoded                         0.7.1                d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serial_test                              3.5.0                699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
-    serial_test_derive                       3.5.0                94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
-    sha1                                     0.10.6               e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    serial_test                              4.0.1                a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11 \
+    serial_test_derive                       4.0.1                a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae \
+    sha1                                     0.10.7               a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8 \
     sha1                                     0.11.0               aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha2                                     0.10.9               a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sha2                                     0.11.0               446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
@@ -332,14 +331,14 @@ cargo.crates \
     signal-hook                              0.3.18               d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-mio                          0.2.5                b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc \
     signal-hook-registry                     1.4.8                c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
-    simd_cesu8                               1.1.1                94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
+    simd_cesu8                               1.2.0                11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520 \
     simdutf8                                 0.1.5                e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
     similar                                  2.7.0                bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     similar-asserts                          1.7.0                b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a \
     slab                                     0.4.12               0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     smallvec                                 1.15.2               8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
-    socket2                                  0.6.4                52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
-    spin                                     0.9.8                6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    socket2                                  0.6.5                c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
+    spin                                     0.9.9                3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e \
     sqlx                                     0.9.0                378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71 \
     sqlx-core                                0.9.0                05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb \
     sqlx-macros                              0.9.0                bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf \
@@ -356,34 +355,35 @@ cargo.crates \
     strum                                    0.28.0               9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                             0.28.0               ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     subtle                                   2.6.1                13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    syn                                      2.0.118              1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
+    syn                                      2.0.119              872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
+    syn                                      3.0.3                53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
     sync_wrapper                             1.0.2                0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                             0.13.2               728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     system-configuration                     0.7.0                a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
     system-configuration-sys                 0.6.0                8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
     tempfile                                 3.27.0               32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                                1.4.1                06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
-    termimad                                 0.34.1               889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49 \
+    termimad                                 0.35.1               d53d4b1294b87e81925b7ae7f8f4d000376e3a5b3349d978429665428a793fcb \
     termtree                                 0.5.1                8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     test_dir                                 0.2.0                1fc19daf9fc57fadcf740c4abaaa0cd08d9ce22a2a0629aaf6cbd9ae4b80683a \
     textwrap                                 0.16.2               c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                                1.0.69               b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                                2.0.18               4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror                                2.0.19               09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
     thiserror-impl                           1.0.69               4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                           2.0.18               ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
-    thread_local                             1.1.9                f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
+    thiserror-impl                           2.0.19               43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
+    thread_local                             1.1.10               1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
     tinystr                                  0.8.3                c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
-    tinyvec                                  1.11.0               3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
+    tinyvec                                  1.12.0               bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
     tinyvec_macros                           0.1.1                1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                                    1.52.3               8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
-    tokio-macros                             2.7.0                385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
+    tokio                                    1.53.1               202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
+    tokio-macros                             2.7.2                78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e \
     tokio-native-tls                         0.3.1                bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                             0.26.4               1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
-    tokio-stream                             0.1.18               32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
-    tokio-util                               0.7.18               9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
+    tokio-stream                             0.1.19               a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b \
+    tokio-util                               0.7.19               494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52 \
     toml_datetime                            1.1.1+spec-1.1.0     3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
-    toml_edit                                0.25.12+spec-1.1.0   d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7 \
-    toml_parser                              1.1.2+spec-1.1.0     a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_edit                                0.25.13+spec-1.1.0   6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b \
+    toml_parser                              1.1.3+spec-1.1.0     1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56 \
     tower                                    0.5.3                ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                               0.6.11               4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
     tower-http                               0.7.0                b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233 \
@@ -428,8 +428,8 @@ cargo.crates \
     wasm-streams                             0.5.0                9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     web-sys                                  0.3.103              8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
     web-time                                 1.1.0                5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-root-certs                        1.0.8                0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267 \
-    webpki-roots                             1.0.8                bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf \
+    webpki-root-certs                        1.0.9                b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b \
+    webpki-roots                             1.0.9                7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
     whoami                                   2.1.2                998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d \
     winapi                                   0.3.9                5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu               0.4.0                ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -454,18 +454,18 @@ cargo.crates \
     windows_x86_64_gnu                       0.52.6               147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnullvm                   0.52.6               24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc                      0.52.6               589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                                   1.0.3                0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
+    winnow                                   1.0.4                23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81 \
     wit-bindgen                              0.57.1               1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
     writeable                                0.6.3                1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
     yansi                                    1.0.1                cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                     0.8.3                709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                              0.8.2                de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                                 0.8.53               75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1 \
-    zerocopy-derive                          0.8.53               4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71 \
+    zerocopy                                 0.8.55               b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb \
+    zerocopy-derive                          0.8.55               0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb \
     zerofrom                                 0.1.8                0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                          0.1.7                11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                                  1.9.0                e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
     zerotrie                                 0.2.4                0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
     zerovec                                  0.11.6               90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
     zerovec-derive                           0.11.3               625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
-    zmij                                     1.0.21               b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa
+    zmij                                     1.0.23               29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b


### PR DESCRIPTION
#### Description
icann-rdap: update to 0.0.31

###### Tested on
macOS 15.7.9 24G830 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
