### PR TITLE
libpsl: update to 0.23.2

### DIFF
--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           clang_dependency 1.0
 
 epoch               1
-github.setup        rockdaboot libpsl 0.23.1
+github.setup        rockdaboot libpsl 0.23.2
 
 license             MIT
 description         A C library and utility to handle the Public Suffix List
@@ -15,9 +15,9 @@ categories          net
 
 github.tarball_from releases
 
-checksums           rmd160  422fc5f83902badf623d2b277e924b0830e31524 \
-                    sha256  8fbb03054556498ba9c4cc48fcaa36a4483748c6504a65bdb9ba348f555b0e56 \
-                    size    7821902
+checksums           rmd160  34b63c4f5cd1b0606c23a4e77e8793a491803794 \
+                    sha256  f2ea0e59bffb36597a872f6ef89893ffa4c30196c87eff7aeb2c47e4e8c98133 \
+                    size    7830466
 
 # Please note this port is (indirectly, via cmake) a dependency of the
 # various clang-X ports. When updating the port versions


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update libpsl to 0.23.2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.1 arm64
Xcode 26.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
