### PR TITLE
tclsqlite2: Update Makefile to avoid compiler warnings

### DIFF
--- a/devel/tclsqlite2/files/Makefile
+++ b/devel/tclsqlite2/files/Makefile
@@ -16,8 +16,9 @@ TOP = .
 #
 config.h:
 	echo '#include <stdio.h>' >temp.c
-	echo 'int main(){printf(' >>temp.c
-	echo '"#define SQLITE_PTR_SZ %d",sizeof(char*));' >>temp.c
+	echo '#include <stdlib.h>' >temp.c
+	echo 'int main(void){printf(' >>temp.c
+	echo '"#define SQLITE_PTR_SZ %zu",sizeof(char*));' >>temp.c
 	echo 'exit(0);}' >>temp.c
 	$(BCC) -o temp temp.c
 	./temp >config.h


### PR DESCRIPTION
#### Description
I have CodeQL code scanning turned on in my fork. It gave me an alert about a file with path `devel/tclsqlite2/files/temp.c`, which doesn't actually exist. I went looking in that directory to see what might have generated that `temp.c` file, and found a `Makefile` with some old code in it. This PR cleans it up a bit. Specifically:
- include `<stdlib.h>` so that `exit()` is declared
- use "`%zu`" formatting specifier for output of `sizeof()`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.2 25F84 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
