### PR TITLE
radare2: Update to 6.2.0

### DIFF
--- a/devel/radare2/Portfile
+++ b/devel/radare2/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
-github.setup        radareorg radare2 6.1.8
+github.setup        radareorg radare2 6.2.0
 github.tarball_from archive
 revision            0
 categories          devel
@@ -14,22 +15,31 @@ description         Opensource tools to disasm, debug, analyze and manipulate bi
 long_description    ${name} provides {*}${description}.
 homepage            https://www.radare.org/
 
-depends_build       port:pkgconfig \
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig \
                     port:git
 
-depends_lib         port:capstone \
+depends_lib-append  port:capstone \
                     port:zlib \
                     port:libzip
 
+# clock_gettime, strnlen
+legacysupport.newest_darwin_requires_legacy 15
+
+# See: https://trac.macports.org/ticket/57688
 conflicts_build     ${name}
 
-checksums           rmd160  125e08b697590aed111a855156eba00575a8fb00 \
-                    sha256  84d0e32af697f720c9f480f6b3e56b08f64251d90cfe2d8f163431c006c0053e \
-                    size    12021317
+checksums           rmd160  e270b78df29d7cf885757b9c06a334575c7bcaec \
+                    sha256  60b31af14772cdcff1703a80f51558dbdf2ee6c114768ca51ca2033fb4bd534b \
+                    size    11987568
 
 configure.args-append \
                     --with-syscapstone \
                     --with-syszip
+
+# r_vec.h:163:6: error: use of unknown builtin '__builtin_mul_overflow' on macOS < 10.11
+compiler.blacklist-append \
+                    {clang < 800}
 
 if {[string match *clang* ${configure.compiler}]} {
     configure.args-append \
@@ -41,13 +51,12 @@ if {[string match *clang* ${configure.compiler}]} {
 
 build.env-append    HOST_CC=${configure.cc}
 
-
 variant openssl description {Use OpenSSL library} {
-    depends_lib-append \
-                    path:lib/libssl.dylib:openssl
+    PortGroup       openssl 1.0
 
     configure.args-append \
-                    --with-openssl
+                    --with-ssl \
+                    --with-ssl-crypto
 }
 
 default_variants    +openssl


### PR DESCRIPTION
#### Description

Update radare2 to 6.2.0. Fix build on legacy systems with legacysupport PG and select the right compiler on macOS < 10.11. Universal variant still broken since capstone's universal variant is also broken.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
