### PR TITLE
claude-code: update to 2.1.227

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.226
+version             2.1.227
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5fef4d5ec787fde87049cecd9f5d70d0a25e27ec \
-                 sha256  773b095876f13ddb8336bfae202a57c62e358b1882746f1d55e3680601a32c59 \
-                 size    289284768
+    checksums    rmd160  58d5583ac4840451d3b85a8d888f289b91bc5acc \
+                 sha256  14484fb9a0480b6b638230685a7d9a248a5339b384a162e0df127e4a4a07249b \
+                 size    294700704
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  7b229fa2eb2d46ebda78d18e2f42f40d7bebb0aa \
-                 sha256  013a1cf17df5ff1dcc189d5d6fd3fdd5f097ddc3cd41aa9992e99805574febbe \
-                 size    279661952
+    checksums    rmd160  3e5abfec1c17ed30dd307423440418f4b23e7cc5 \
+                 sha256  7432511ba3be818e01f23f6eef8630d214a8b618451e188c3c7d61a987eef6c7 \
+                 size    285046400
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.227.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?