### PR TITLE
claude-code: update to 2.1.228

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.227
+version             2.1.228
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  58d5583ac4840451d3b85a8d888f289b91bc5acc \
-                 sha256  14484fb9a0480b6b638230685a7d9a248a5339b384a162e0df127e4a4a07249b \
-                 size    294700704
+    checksums    rmd160  b008d0063489dd25972a39d8eeadad63865a6cd1 \
+                 sha256  7852f1ae0efb64d46d77a57d8852daddc4a6ffb58aeda6267bd3f3428adc09b3 \
+                 size    298977312
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  3e5abfec1c17ed30dd307423440418f4b23e7cc5 \
-                 sha256  7432511ba3be818e01f23f6eef8630d214a8b618451e188c3c7d61a987eef6c7 \
-                 size    285046400
+    checksums    rmd160  2b5d599dfbc136546f489e65558d8028ba4362d6 \
+                 sha256  43484b1352cef03a08346f36ef0437755b1aad646ab9313ce187857b794b7247 \
+                 size    289298144
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.228.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?