### PR TITLE
mp3rgain: update to 3.2.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.1.1 v
+github.setup        M-Igashi mp3rgain 3.2.0 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  aad354c1a21620d1f320372c12a66017110180af \
-                    sha256  c1b3d500e0832bc5e8c7df41a777253a325ae0e58a857dc7416349bd85ed5b96 \
-                    size    544964
+                    rmd160  178f33789f9028674cdf5655229eb5ff38b64988 \
+                    sha256  67a6c44e773099aff526614c558196c0aeb70d1852c8958c16404445a16bf8a5 \
+                    size    551671
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Upstream release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.2.0

- ReplayGain tags now go to ID3v2 on MP3 (where players read them); the mp3gain undo tags stay in APEv2
- Fixes album mode discarding all tags when the album gain rounded to zero steps
- No dependency changes, so `cargo.crates` is unchanged from 3.1.1
- Checksums recomputed from the new GitHub archive tarball