### PR TITLE
outagedeck: update to 0.1.3

### DIFF
--- a/sysutils/outagedeck/Portfile
+++ b/sysutils/outagedeck/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/outagedeck/cli 0.1.1 v
+go.setup            github.com/outagedeck/cli 0.1.3 v
 name                outagedeck
 go.toolchain_min    1.22
 revision            0
@@ -22,9 +22,9 @@ long_description    OutageDeck is a command-line client for checking current \
 
 homepage            https://outagedeck.com
 
-checksums           rmd160  14b1514cfd47dfe6b37bb9bf65923dfdbda01eae \
-                    sha256  67c4d6c12921e8e5aad09fc43e8d506c2d53162ba3e573e9f8a5102b3d22f282 \
-                    size    118349
+checksums           rmd160  bd7041240879cfe1bbc0a9bd24fee799235182ad \
+                    sha256  1b642f123cba3faa5c8cd32abe28e9991039e571ac9d24089aca70e528d424d0 \
+                    size    119439
 
 build.pre_args-append \
                     -ldflags \"-s -w -X main.version=${version}\"


### PR DESCRIPTION
#### Description

Update OutageDeck from 0.1.1 to 0.1.3.

This includes friendlier no-argument command discovery and a local `outagedeck alerts` handoff that preserves selected providers in the account URL. I am the founder of OutageDeck and maintain this port.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5.2 25F84 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification

Have you

- [x] followed the commit message guidelines?
- [x] squashed and minimized your commits?
- [x] checked that there are no other open pull requests for the same change?
- [ ] checked the Portfile with `port lint --nitpick`? MacPorts is not installed in this environment.
- [x] run the tagged source test suite with `go test ./...`?
- [x] run `go vet ./...` against the tagged source?
- [x] built the tagged source with the Portfile's version linker flag?
- [x] tested `outagedeck version` and the new `outagedeck alerts github cloudflare github` command?
- [x] recalculated the rmd160, sha256, and size fields from the public v0.1.3 tag archive?
