### PR TITLE
py-pycares: use system c-ares library

### DIFF
--- a/python/py-pycares/Portfile
+++ b/python/py-pycares/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pycares
 version             5.0.1
-revision            0
+revision            1
 
 categories-append   devel
 license             MIT
@@ -28,7 +28,9 @@ checksums           rmd160  c3ac86e9c1a8315504d26693ac646c5e01e255cf \
 compiler.c_standard 2011
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-wheel \
-                            path:bin/cmake:cmake
-    depends_lib-append      port:py${python.version}-cffi
+    build.env-append        PYCARES_USE_SYSTEM_LIB=1
+
+    depends_build-append    port:py${python.version}-wheel
+    depends_lib-append      port:c-ares \
+                            port:py${python.version}-cffi
 }


### PR DESCRIPTION
Fix the macOS 27/Tahoe build failure in pycares 5.0.1.

pycares hardcodes macOS 10.12 when building its bundled c-ares, causing the bundled build to select `pipe2` while Clang rejects it as unavailable for that target. Use pycares’ documented `PYCARES_USE_SYSTEM_LIB=1` option and depend on the MacPorts `c-ares` port instead.

Validation:
- `portindex .` (full dev tree): 0 failures
- `port lint --nitpick python/py-pycares`: 0 errors, 0 warnings
- Installed `py314-pycares @5.0.1_1` on macOS 27 arm64
- Python 3.14 import and asynchronous localhost resolution smoke test
- Confirmed `_cares.abi3.so` links `/opt/local/lib/libcares.2.dylib`
- Independent full-file review: PASS, no findings