### PR TITLE
bonfyre-statement-import: new port, version 1.0.1

### DIFF
--- a/finance/bonfyre-statement-import/Portfile
+++ b/finance/bonfyre-statement-import/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        Nickgonzales76017 bonfyre-statement-import 1.0.1 v
 github.tarball_from archive
@@ -24,19 +25,9 @@ checksums           rmd160  8c0e76f1e75bc4d01735a550ce92dd83cf4597f0 \
                     sha256  ca9ea9aaa58cbb13481c7ecae7fd4b62e4968659c22fce187266eebcdb7db178 \
                     size    7827
 
-use_configure       no
-
-build.args          CC=${configure.cc}
-
-pre-build {
-    build.args-append \
-                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]"
-}
-
 test.run            yes
 test.cmd            make
 test.target         test
-test.args           {*}${build.args}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin

--- a/finance/bonfyre-statement-import/Portfile
+++ b/finance/bonfyre-statement-import/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Nickgonzales76017 bonfyre-statement-import 1.0.1 v
+github.tarball_from archive
+revision            0
+
+categories          finance textproc
+license             MIT
+maintainers         {github:Nickgonzales76017 @Nickgonzales76017} \
+                    openmaintainer
+
+description         Convert normalized bank statement text to verified CSV
+
+long_description    \
+    ${name} is an offline native-C tool that converts normalized bank \
+    statement text to CSV using declarative layout packs. It verifies \
+    running balances and closing totals before emitting a machine-readable \
+    receipt.
+
+checksums           rmd160  8c0e76f1e75bc4d01735a550ce92dd83cf4597f0 \
+                    sha256  ca9ea9aaa58cbb13481c7ecae7fd4b62e4968659c22fce187266eebcdb7db178 \
+                    size    7827
+
+use_configure       no
+
+build.args          CC=${configure.cc}
+
+pre-build {
+    build.args-append \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]"
+}
+
+test.run            yes
+test.cmd            make
+test.target         test
+test.args           {*}${build.args}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/${name}/packs
+    xinstall -m 0644 ${worksrcpath}/packs/demo-bank.pack \
+                    ${destroot}${prefix}/share/${name}/packs
+}


### PR DESCRIPTION
#### Description

Adds a new `finance` port for Bonfyre Statement Import 1.0.1, an MIT-licensed native-C CLI that converts normalized bank-statement text to verified CSV and refuses output when running-balance or closing-total invariants fail. The port installs the binary and synthetic demo layout pack.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification

- [x] followed the Commit Message Guidelines
- [x] squashed and minimized commits
- [x] checked for other open pull requests for this port
- [ ] checked with `port lint` — MacPorts is not installed on this host
- [ ] ran `sudo port test` — MacPorts is not installed on this host
- [ ] ran `sudo port -vst install` — MacPorts is not installed on this host
- [x] built the exact v1.0.1 archive with Apple Clang
- [x] ran the upstream test suite successfully
- [x] staged the proposed binary and demo pack under a clean prefix
- [x] verified the staged binary converts the synthetic fixture and emits non-empty CSV and receipt files

Upstream release: https://github.com/Nickgonzales76017/bonfyre-statement-import/releases/tag/v1.0.1