### PR TITLE
google-cloud-sdk: update to 580.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             579.0.0
+version             580.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  6121bcc7992d0fc8ac1752a252811308a5757ce4 \
-                    sha256  ff04c4b7dfc47e6006d9da361ae38973cd365ce9bda6f978875b01c046e70a3a \
-                    size    60035102
+    checksums       rmd160  02edacbb937a406aba71bd67138be55faf9277a2 \
+                    sha256  43090b89de9487291d20815b343a9a383250da5d662c0373fda442a3b4528159 \
+                    size    60119483
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  8f49a4452dfa463f9acd1190d906dee95a7ba08a \
-                    sha256  e09794cbadce5bf95d9f3fc69dc7f64a9f810a2c39e392c0a18e01f446e33fac \
-                    size    61690047
+    checksums       rmd160  ff08c32f2d34b306b684d1cf7176c96d49bb1305 \
+                    sha256  9688006c182a95b83a21c0246216b2f5439fb71eb7d70b526a9f480dd9ce1317 \
+                    size    61774587
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  3fbe288b986efa101c90b4a0f0f2b50600be14c0 \
-                    sha256  783758eb9eb1fe2c645ce7f12442a0f9a2211eb67a1bf2ec127489305ca26cad \
-                    size    61595762
+    checksums       rmd160  81d506e65e5dad64c693a9b2f7b6d5574a093191 \
+                    sha256  4f704fd6e2f918c667da53c96304fa4c831a8a4e84f3c24c4b27ad0880d8f3af \
+                    size    61679977
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 580.0.0.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?