### PR TITLE
syft: new port in security

### DIFF
--- a/security/syft/Portfile
+++ b/security/syft/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/anchore/syft 1.51.0 v
+go.offline_build    no
+go.toolchain_min    1.26.3
+revision            0
+
+description         \
+    A CLI tool and library for generating a Software Bill of \
+    Materials (SBOM) from container images and filesystems
+
+long_description    \
+    {*}${description}. Syft supports dozens of packaging \
+    ecosystems, multiple image sources, and output formats \
+    including CycloneDX, SPDX, and Syft JSON. Exceptional for \
+    vulnerability detection when used with a scanner like Grype.
+
+categories          security sysutils
+installs_libs       no
+license             Apache-2
+maintainers         {sub-pop.net:link @subpop} \
+                    openmaintainer
+
+checksums           rmd160  99a90d929f6d76e9e8b5c61fdcc8e299f6774d58 \
+                    sha256  d48bca3091ec4862f5041af6cbdeedb3f2322ae7a059199a22d99e099cabd4ae \
+                    size    7271534
+
+build.args-append   -ldflags \"-X main.version=${version} \
+                               -X main.gitCommit=macports-release \
+                               -X main.buildDate=${source_date_epoch}\" \
+                    -o ./dist/${name}
+
+build.post_args-append \
+                    ./cmd/${name}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
A CLI tool and library for generating a Software
Bill of Materials (SBOM) from container images and
filesystems. Syft supports dozens of packaging
ecosystems, multiple image sources, and output
formats including CycloneDX, SPDX, and Syft JSON.
Exceptional for vulnerability detection when used
with a scanner like Grype.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
