### PR TITLE
gcli: update to 2.13.0

### DIFF
--- a/devel/gcli/Portfile
+++ b/devel/gcli/Portfile
@@ -4,7 +4,7 @@ PortSystem            1.0
 
 PortGroup             github 1.0
 
-github.setup          herrhotzenplotz gcli 2.10.0 v
+github.setup          herrhotzenplotz gcli 2.13.0 v
 github.tarball_from   archive
 
 revision              0
@@ -22,9 +22,9 @@ long_description      GCLI is a simple and portable CLI tool for interacting wit
 
 homepage              https://herrhotzenplotz.de/gcli/
 
-checksums             rmd160  d4b44bfc691459f7b483c2146412ba9b83931d39 \
-                      sha256  500da41d29fa53ab412a81864624b9e2bcd0785be61234f6cfb6b3b031b83280 \
-                      size    468555
+checksums             rmd160  31550cb35d43ae0efd575f650cf3553f2e7099d1 \
+                      sha256  3dd25f636e439f7af6187248e46f2b4078dffdca4fe2d506d0edb275515d62b4 \
+                      size    490746
 
 depends_lib-append    port:curl
 


### PR DESCRIPTION
#### Description
https://github.com/herrhotzenplotz/gcli/blob/v2.13.0/Changelog.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
