### PR TITLE
aom: check for git binary before introducing dependency

### DIFF
--- a/multimedia/aom/Portfile
+++ b/multimedia/aom/Portfile
@@ -35,7 +35,7 @@ compiler.c_standard     1999
 set pyver               3.14
 set python_version      [string index ${pyver} 0][string range ${pyver} 2 end]
 
-depends_build-append    port:git \
+depends_build-append    bin:git:git \
                         port:perl5 \
                         port:python${python_version}
 


### PR DESCRIPTION
#### Description

The git program provided on macOS (Apple Git) can be used to build the `aom` port successfully.  So change the port's build dependency on git to first check for this executable before requiring installation of the `git` port.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?