### PR TITLE
shichizip: adopt zig_toolchain pg

### DIFF
--- a/archivers/shichizip/Portfile
+++ b/archivers/shichizip/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               xcode 1.0
+PortGroup               zig_toolchain 1.0
 
 github.setup            idawnlight ShichiZip 0.3.1 v
 name                    [string tolower ${github.project}]
@@ -24,8 +25,8 @@ checksums               rmd160  af0080064047eee20effea4dd4e7a939f7353399 \
                         sha256  8e63954ec293f0b18acfda15c3830d2bbb1bd6cef02f9b1c2159cea898c6d838 \
                         size    10493558
 
-# switch to zig once emutls bug is fixed: https://trac.macports.org/ticket/73950
-depends_build-append    port:zig-bootstrap
+set zig_series          0.16
+depends_build-append    port:zig-${zig_series}
 
 extract.rename          yes
 
@@ -47,8 +48,8 @@ if {![variant_isset zstd]} {
 
 # bundled sfx stub is always Windows x86
 pre-build {
-    system -W ${worksrcpath} "${prefix}/bin/zig-bootstrap build -j${build.jobs} lib ${zig_variant_arg} -Doptimize=ReleaseFast --verbose --verbose-link --verbose-cc --summary all -p build"
-    system -W ${worksrcpath} "${prefix}/bin/zig-bootstrap build -j${build.jobs} sfx ${zig_variant_arg} -Doptimize=ReleaseSmall --verbose --verbose-link --verbose-cc --summary all -p build"
+    system -W ${worksrcpath} "[zig_toolchain.bin ${zig_series}] build -j${build.jobs} lib ${zig_variant_arg} -Doptimize=ReleaseFast --verbose --verbose-link --verbose-cc --summary all -p build"
+    system -W ${worksrcpath} "[zig_toolchain.bin ${zig_series}] build -j${build.jobs} sfx ${zig_variant_arg} -Doptimize=ReleaseSmall --verbose --verbose-link --verbose-cc --summary all -p build"
 }
 
 universal_variant       no


### PR DESCRIPTION
Requires https://github.com/macports/macports-ports/pull/34025

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
