### PR TITLE
stimfit: update to 0.17.2

### DIFF
--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -126,7 +126,7 @@ variant accelerate description {Use Apple Accelerate framework for BLAS/LAPACK} 
 
 variant openblas description {Use MacPorts OpenBLAS libraries} conflicts accelerate atlas {
     depends_lib-append \
-        port:openblas
+        path:lib/libopenblas.dylib:OpenBLAS
 
     configure.args-append \
         -DSTF_LAPACK_PROVIDER=OPENBLAS

--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -5,10 +5,10 @@ PortGroup           wxWidgets 1.0
 PortGroup           cmake 1.1
 
 name                stimfit
-version             0.17.1
-checksums           rmd160  c07ad51c7dddb533aaa1edb544386c2c8875b4b5 \
-                    sha256  c6a5761644d9fb6504a097b9232197a0e65cc6f19afb9162c2e20a39e2efcf84 \
-                    size    20174648
+version             0.17.2
+checksums           rmd160  6996d3cdefa43a7556037fd2b0e2a56af68e810a \
+                    sha256  3de8af1fef8f11b77ef32308dc53249a2d7a9aaa0a8585eab8b7642b0bb04bcd \
+                    size    31617090
 
 categories          science
 license             GPL-2
@@ -35,6 +35,7 @@ configure.args      -DCMAKE_INSTALL_PREFIX=${applications_dir} \
                     -DSTF_ENABLE_PYTHON=OFF \
                     -DSTF_WITH_BIOSIG=ON \
                     -DSTF_BIOSIG_PROVIDER=SUBMODULE \
+                    -DSTF_LAPACK_PROVIDER=AUTO \
                     -DSTF_BUILD_MODULE=OFF \
                     -DSTF_BUILD_TESTS=OFF \
                     -DSTF_MACOS_APP_BUNDLE=ON \
@@ -55,6 +56,18 @@ foreach python_branch ${python_branches} {
 
 if {$none_selected} {
     default_variants +python314
+}
+
+set lapack_none_selected 1
+foreach lapack_variant {accelerate openblas atlas} {
+    if {[variant_isset ${lapack_variant}]} {
+        set lapack_none_selected 0
+        break
+    }
+}
+
+if {$lapack_none_selected} {
+    default_variants +accelerate
 }
 
 foreach python_branch ${python_branches} {
@@ -80,7 +93,8 @@ foreach python_branch ${python_branches} {
     if {[variant_isset python${python_version}]} {
         depends_build-append \
             port:swig-python \
-            port:py${python_version}-setuptools
+            port:py${python_version}-setuptools \
+            port:py${python_version}-ipython
 
         depends_lib-replace \
             port:${wxWidgets.port} \
@@ -89,7 +103,8 @@ foreach python_branch ${python_branches} {
         depends_lib-append \
             port:python${python_version} \
             port:py${python_version}-numpy \
-            port:py${python_version}-matplotlib
+            port:py${python_version}-matplotlib \
+            port:py${python_version}-ipython
 
         configure.args-replace \
             -DSTF_ENABLE_PYTHON=OFF \
@@ -104,11 +119,25 @@ foreach python_branch ${python_branches} {
     }
 }
 
-variant atlas description {Use MacPorts ATLAS libraries} {
+variant accelerate description {Use Apple Accelerate framework for BLAS/LAPACK} conflicts openblas atlas {
+    configure.args-append \
+        -DSTF_LAPACK_PROVIDER=ACCELERATE
+}
+
+variant openblas description {Use MacPorts OpenBLAS libraries} conflicts accelerate atlas {
+    depends_lib-append \
+        port:openblas
+
+    configure.args-append \
+        -DSTF_LAPACK_PROVIDER=OPENBLAS
+}
+
+variant atlas description {Use MacPorts ATLAS libraries (legacy provider)} conflicts accelerate openblas {
     depends_lib-append \
         port:atlas
 
     configure.args-append \
+        -DSTF_LAPACK_PROVIDER=LEGACY \
         -DBLA_VENDOR=ATLAS
 }
 

--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -67,7 +67,11 @@ foreach lapack_variant {accelerate openblas atlas} {
 }
 
 if {$lapack_none_selected} {
-    default_variants +accelerate
+    if {${os.platform} eq "darwin" && (${os.major} > 22 || ${os.major} == 22 && ${os.minor} >= 4)} {
+        default_variants +accelerate
+    } else {
+        default_variants +openblas
+    }
 }
 
 foreach python_branch ${python_branches} {
@@ -119,9 +123,11 @@ foreach python_branch ${python_branches} {
     }
 }
 
-variant accelerate description {Use Apple Accelerate framework for BLAS/LAPACK} conflicts openblas atlas {
-    configure.args-append \
-        -DSTF_LAPACK_PROVIDER=ACCELERATE
+if {${os.platform} eq "darwin" && (${os.major} > 22 || ${os.major} == 22 && ${os.minor} >= 4)} {
+    variant accelerate description {Use Apple Accelerate framework for BLAS/LAPACK} conflicts openblas atlas {
+        configure.args-append \
+            -DSTF_LAPACK_PROVIDER=ACCELERATE
+    }
 }
 
 variant openblas description {Use MacPorts OpenBLAS libraries} conflicts accelerate atlas {


### PR DESCRIPTION
#### Description

Update Stimfit to 0.17.2. Mac-relevant changes include a DPI-aware toolbar and dark trace mode, Cmd+W support, event-polarity filtering, a Jupyter/IPython shell, Apple Accelerate as the default LAPACK provider, and macOS bundle/install fixes.

Python 3.10 through 3.14 remain supported, matching the common supported set of wxPython, IPython, NumPy, Matplotlib, and setuptools in the current ports tree. Python 3.14 remains the default, matching the MacPorts Python PortGroup default.

###### Tested on

macOS 15.7.9 24G830 x86_64
Xcode 26.3 17C529

###### Verification

- [x] followed the Commit Message Guidelines
- [x] squashed and minimized commits
- [x] checked for other open pull requests for this port
- [x] checked the Portfile with `port lint --nitpick` (0 errors, 0 warnings)
- [x] built and destrooted the exact uploaded source with the default `+python314+accelerate` configuration
- [x] smoke-tested the resulting binary with `stimfit --help`
- [x] verified dependency expansion for every Python variant (3.10-3.14)
- [ ] ran `sudo port -vst install` (interactive sudo is unavailable in this session)