### PR TITLE
jiti, eslint: add new ports

### DIFF
--- a/devel/eslint/Portfile
+++ b/devel/eslint/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                eslint
+version             10.8.1
+revision            0
+
+categories          devel
+license             MIT
+platforms           any
+supported_archs     noarch
+maintainers         {@oakimov} openmaintainer
+
+description         Statically analyzes JavaScript and TypeScript to find problems
+
+long_description    ESLint statically analyzes JavaScript and TypeScript code \
+                    to find problems and fix them. Rules are configurable, and \
+                    plugins can add rules, processors, and formatters for \
+                    project-specific conventions.
+
+homepage            https://eslint.org
+
+checksums           rmd160  4512cc0c426b3af34af190c254a07a16eea5a5e3 \
+                    sha256  1fc88add2fbe3ca8c070a6ff3d84a5bb3794c2dd4da056d8fc59dc640d17ee56 \
+                    size    621163
+
+# jiti is an optional peer dependency, needed to load a TypeScript
+# eslint.config.ts. It resolves as a sibling in ${prefix}/lib/node_modules.
+depends_lib-append  port:jiti

--- a/devel/jiti/Portfile
+++ b/devel/jiti/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                jiti
+version             2.7.0
+revision            0
+
+categories          devel
+license             MIT
+platforms           any
+supported_archs     noarch
+maintainers         {@oakimov} openmaintainer
+
+description         Runtime TypeScript and ESM support for Node.js
+
+long_description    jiti loads TypeScript and ESM sources in Node.js at \
+                    runtime, transforming them on the fly and caching the \
+                    result. Tools that accept configuration written in \
+                    TypeScript use it to load those files.
+
+homepage            https://github.com/unjs/jiti
+
+checksums           rmd160  89b73e834ba593e163d11ebe4fd639ded437401f \
+                    sha256  8dd0d365fb49c0e7cc42d6a00df6fb2da9056fc24492094346fc34ecdbcf28ca \
+                    size    427320


### PR DESCRIPTION
#### Description

Two new ports, both on the npm PortGroup:

- **eslint** 10.8.1 — statically analyzes JavaScript and TypeScript to find problems.
- **jiti** 2.7.0 — loads TypeScript and ESM sources in Node.js at runtime.

An earlier revision of this PR installed eslint with the bun PortGroup from #34030 and ran the CLI under bun. @oytech pointed out that upstream supports Node and not other runtimes, which is the right call, so eslint now uses `npm 1.0` like the other JavaScript tooling ports and this PR has no connection to #34030.

eslint declares `"engines": {"node": "^20.19.0 || ^22.13.0 || >=24"}`, which the PortGroup default of `nodejs22` satisfies, so no version override is needed.

##### Why jiti

`jiti` is an optional peer dependency of eslint. Without it, a TypeScript configuration file fails:

```
Error: The 'jiti' library is required for loading TypeScript configuration files. Make sure to install it.
```

eslint resolves `jiti` relative to its own install location, so a project-local copy does not help a globally installed eslint. Installed as a port it lands in `${prefix}/lib/node_modules` alongside eslint, where Node's resolution finds it. It is a useful port in its own right as well, providing a `jiti` CLI that runs TypeScript files directly.

##### Test results

Destroot only, with a user `portdbpath` — no live `port activate` into `/opt/local`. The activated layout was reproduced by merging the two destroot images, since both ports install into `${prefix}/lib/node_modules`.

- `port lint` — 0 errors, 0 warnings on both ports
- `port deps` for eslint — build `npm10`, library `jiti, nodejs22`
- eslint destroot — 1104 files, all under `${prefix}/bin` and `${prefix}/lib/node_modules/eslint`
- jiti destroot — 16 files, all under `${prefix}/bin` and `${prefix}/lib/node_modules/jiti`
- no `.node` binaries in either image, so `supported_archs noarch` holds
- both bins are relative symlinks; no destroot paths anywhere in either image

Running the destrooted binaries:

- `eslint --version` → `v10.8.1`
- a file with two seeded violations reports `no-unused-vars` and `semi` and exits 1; a clean file exits 0
- `--fix` rewrites the file as expected
- `--concurrency auto` across 120 files completes and reports all 120 results
- type-aware TypeScript linting works with a `typescript-eslint` config using `projectService`
- `--config eslint.config.ts` loads and lints, where it previously failed with the jiti error
- `jiti foo.ts` executes a TypeScript file directly
- output is plain text when piped, coloured on a terminal

###### Type(s)

- [x] submission (new Portfile)

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`? (destroot only, as described above)
- [x] tested basic functionality of all binary files?
