### PR TITLE
go-1.25, go-1.26, go-devel: update; go_toolchain: record 1.27's floor

### DIFF
--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -124,8 +124,8 @@
 # (https://go.dev/wiki/MinimumRequirements): 10.13 from 1.17, 10.15 from 1.21,
 # 11 from 1.23, 12 from 1.25, 13 from 1.27. Those state what upstream
 # supports. min_darwin records something narrower and testable: where the
-# binaries still start. The two agree for 1.18 through 1.20 and again from
-# 1.25, and part company for 1.21 through 1.24.
+# binaries still start. The two agree for 1.18 through 1.20, 1.25 and 1.26, and
+# differ for 1.21 through 1.24 and for 1.27.
 #
 # What ends a Go binary is an unresolved symbol. crypto/x509 reaches
 # Security.framework through //go:cgo_import_dynamic even when CGO is
@@ -141,18 +141,24 @@
 # later only, and older systems abort before main. That substitution is the
 # entire cliff, and it is what #73086 hits.
 #
+# 1.26 and 1.27 import the same set as 1.25. 1.27 adds seven CoreFoundation
+# imports, but they are in runtime/sys_ios_arm64, which darwin builds do not
+# compile: its shipped darwin/amd64 and darwin/arm64 binaries have the same
+# undefined symbols as 1.26's.
+#
 # LC_BUILD_VERSION is not the limit: 1.24.8 declares minos 11.0 and ran on
 # 10.13 through 11 for the nine months MacPorts shipped it, because macOS dyld
 # loads a binary whose minos exceeds the running system. Only the missing
-# symbol is fatal, which is why these tables follow the imports.
+# symbol is fatal, which is why these tables follow the imports. 1.27rc3
+# declares minos 13.0 and imports nothing newer than macOS 12.
 #
 # See https://trac.macports.org/ticket/73086.
 
 # The oldest darwin major version each Go series runs on.
 #
 # An entry is needed for any series that has a port, and for any series that
-# is the newest runnable on some version of macOS. 1.17 and 1.27 are the two
-# values not established by the imports above; both are noted below.
+# is the newest runnable on some version of macOS. 1.17 is not established by
+# the imports above; it and 1.27 are noted below.
 set go_toolchain.min_darwin(1.17)   11  ;# 10.7  Lion          (see below)
 set go_toolchain.min_darwin(1.18)   17  ;# 10.13 High Sierra
 set go_toolchain.min_darwin(1.19)   17  ;# 10.13 High Sierra
@@ -163,7 +169,7 @@ set go_toolchain.min_darwin(1.23)   17  ;# 10.13 High Sierra
 set go_toolchain.min_darwin(1.24)   17  ;# 10.13 High Sierra
 set go_toolchain.min_darwin(1.25)   21  ;# 12    Monterey
 set go_toolchain.min_darwin(1.26)   21  ;# 12    Monterey
-set go_toolchain.min_darwin(1.27)   22  ;# 13    Ventura      (see below)
+set go_toolchain.min_darwin(1.27)   21  ;# 12    Monterey     (see below)
 
 # The oldest darwin major version from which a series may be chosen as the
 # default Go. Absent means min_darwin, the usual case: a release that runs
@@ -189,14 +195,13 @@ set go_toolchain.min_darwin(1.27)   22  ;# 13    Ventura      (see below)
 # is the limit of that: 10.6 cannot build it, because its dsymutil aborts on
 # the debug information Go's linker emits. See lang/go-1.17.
 #
-# 1.27 is upstream's support floor, carried over unchecked. Its imports have
-# not been read, and on the evidence above its real floor may well be darwin
-# 21, the same as 1.25 and 1.26.
+# 1.27 is read from the prerelease, and is below upstream's floor of 13
+# Ventura. Its imports are those of 1.25 and 1.26, the newest being
+# SecTrustCopyCertificateChain, which macOS 12 provides. Reread them at 1.27.0.
 #
-# The value is not idle in the meantime: setup derives go-devel's platforms
-# from it, so go-devel is offered only on 13 Ventura and later. It is never
-# returned as a ceiling, being the newest series here, so nothing else is
-# affected. Read the imports before packaging a go-1.27.
+# This entry decides where go-devel is offered, setup deriving its platforms
+# from it. It is never returned as a ceiling, being the newest series here, and
+# `go` never selects an unpackaged series, so nothing else depends on it.
 
 # The series MacPorts packages as go-1.NN ports.
 #

--- a/lang/go-1.25/Portfile
+++ b/lang/go-1.25/Portfile
@@ -3,19 +3,19 @@
 PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
-go_toolchain.setup  1.25.12
-revision            2
+go_toolchain.setup  1.25.13
+revision            0
 
 checksums           \
-                    go1.25.12.src.tar.gz \
-                    rmd160  25fa8850c2264cf7dff1c56b66b501ec1932da8b \
-                    sha256  f90dcee4bd023fa376374ea0a5a6ebe553537b39c426ffd8c689469b45519932 \
-                    size    32013699 \
-                    go1.25.12.darwin-arm64.tar.gz \
-                    rmd160  19c5bb66bbb7b43444d5778c3e04a03f73e0106d \
-                    sha256  fa2c88bbcf64bd3b2aef355f026cfec6d3a4a01c132f999c8f8c964eb767164f \
-                    size    58121109 \
-                    go1.25.12.darwin-amd64.tar.gz \
-                    rmd160  509e1916781165250d0bc85cf66d6b1c4145e446 \
-                    sha256  00a2e743b82bccec03c51c4b0f7e46d5fec52184075fd6c5183c3bb39ae9fb00 \
-                    size    60594502
+                    go1.25.13.src.tar.gz \
+                    rmd160  04cd83229d314a86d8e38697b1393b8aa46ad071 \
+                    sha256  1d7e2f70b1ee9b93c7df8efcca71f5adcc6a59797a4336c2d10171bd4c174614 \
+                    size    32023100 \
+                    go1.25.13.darwin-arm64.tar.gz \
+                    rmd160  eab20a7f1168ed4f2c9cb343dd12f293bc524d4f \
+                    sha256  916fe61a2bc78dd516b3629ee3428b06e17141b85a70f1986c260149a3d2ffbd \
+                    size    58124139 \
+                    go1.25.13.darwin-amd64.tar.gz \
+                    rmd160  259090b3b97df4e14376229f9457295312e897fd \
+                    sha256  d742b7a53f8c8be5e02d75263883482cebabbe14ec9308cb056dd8aebeb040df \
+                    size    60622938

--- a/lang/go-1.26/Portfile
+++ b/lang/go-1.26/Portfile
@@ -3,19 +3,19 @@
 PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
-go_toolchain.setup  1.26.5
-revision            2
+go_toolchain.setup  1.26.6
+revision            0
 
 checksums           \
-                    go1.26.5.src.tar.gz \
-                    rmd160  37919c04f4a80d411d21e8244b455359ddfc38ec \
-                    sha256  495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42 \
-                    size    34140216 \
-                    go1.26.5.darwin-arm64.tar.gz \
-                    rmd160  67ab77955564e690647cdff5fdbfc4222acf84b4 \
-                    sha256  efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a \
-                    size    64738542 \
-                    go1.26.5.darwin-amd64.tar.gz \
-                    rmd160  d71b04c25734257bd78ee97f4ad017ba43741c4a \
-                    sha256  6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725 \
-                    size    67836304
+                    go1.26.6.src.tar.gz \
+                    rmd160  4931359123a8d2f3bca0390147f032a4727924af \
+                    sha256  a0721c54c688901448d77ad9b3ec7ea7c474730755ff891382e92ecb93ff2cb1 \
+                    size    34151057 \
+                    go1.26.6.darwin-arm64.tar.gz \
+                    rmd160  54ec507ae3b5daa2f78927e1975e862658c04a84 \
+                    sha256  2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204 \
+                    size    64772321 \
+                    go1.26.6.darwin-amd64.tar.gz \
+                    rmd160  fd6a8f8cd806a54ae65d378272c48428825d8c6e \
+                    sha256  08b65a63f244115121ced6c3b55ad38d801a7442acad5c949a17aad84ae6d684 \
+                    size    67851334

--- a/lang/go-devel/Portfile
+++ b/lang/go-devel/Portfile
@@ -3,19 +3,19 @@
 PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
-go_toolchain.setup  1.27rc2 devel
-revision            3
+go_toolchain.setup  1.27rc3 devel
+revision            0
 epoch               3
 
-checksums           go1.27rc2.src.tar.gz \
-                    rmd160  1cc5569eef2cdb0fccf11813e44cc903d9d49c12 \
-                    sha256  860fd7a30b285ee16a2ae0ec5d4441cb47c48872a0a30cb60cae348947f48a25 \
-                    size    35062886 \
-                    go1.27rc2.darwin-arm64.tar.gz \
-                    rmd160  cc53993dc9b1ca123be7f1ebfd93c06be63ebb06 \
-                    sha256  b543bf435ed266d66b275efba433dbe64904be607fe365494cf72f7ad4e91b63 \
-                    size    68280741 \
-                    go1.27rc2.darwin-amd64.tar.gz \
-                    rmd160  15fc884257b1524493471445502d76e0f17f2a6d \
-                    sha256  1145766e0b510cf2f0185b83dddfaa7c3a67f036b2fd4601d996fac2157135b6 \
-                    size    71693163
+checksums           go1.27rc3.src.tar.gz \
+                    rmd160  2753cfd7e0ac25cf0270e6a9ed08fda802d3eccc \
+                    sha256  e9e20edd1720095f9109696e963a66069d3f6d48d00eb9388c888ce06631df5c \
+                    size    35077555 \
+                    go1.27rc3.darwin-arm64.tar.gz \
+                    rmd160  a7f7a4f4ddd10d521df8a87627d4d724b448691a \
+                    sha256  205d5695db35df32fdd88ea6fa420dfb5f7d98feae5a9061a88b4f6308f61c5f \
+                    size    68300849 \
+                    go1.27rc3.darwin-amd64.tar.gz \
+                    rmd160  09dbaa93aef932d0f36922443871894e7371113d \
+                    sha256  b0ecf4d29bdef8743be5d7938d8bee3367102d58ccbae81fd5e781e9256f377f \
+                    size    71681032


### PR DESCRIPTION
Go 1.25.13, 1.26.6 and 1.27rc3, plus the 1.27 entry in the go_toolchain PortGroup.

- `go-1.25`: 1.25.12 → 1.25.13
- `go-1.26`: 1.26.5 → 1.26.6
- `go-devel`: 1.27rc2 → 1.27rc3
- `go_toolchain`: `min_darwin(1.27)` 22 → 21

The 1.27 entry was upstream's supported floor of 13 Ventura, carried over without reading the release. 1.27rc3 imports what 1.25 and 1.26 do, the newest being `SecTrustCopyCertificateChain`, which macOS 12 provides. The seven CoreFoundation imports it adds are in `runtime/sys_ios_arm64`, which darwin builds do not compile, and its shipped darwin/amd64 and darwin/arm64 binaries have the same undefined symbols as 1.26's. It declares `minos 13.0`, which does not gate loading.

1.27 is not packaged, so `go` never selects it and no ceiling moves: on darwin 21 `ceiling` now answers `{}` rather than `1.26`, and both resolve to 1.26 through the newest packaged series. The one effect is `go-devel`, whose platforms become `darwin >= 21`.

Checksums verified against the sha256 and size values go.dev publishes. `port lint` is clean on all three ports.