### PR TITLE
py-blosc2: Update to 4.11.0

### DIFF
--- a/python/py-blosc2/Portfile
+++ b/python/py-blosc2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-blosc2
-version             4.1.2
+version             4.11.0
 revision            0
 
 categories-append   archivers devel
@@ -17,9 +17,9 @@ long_description    A Python wrapper for the extremely fast Blosc2 \
 
 homepage            https://pypi.python.org/pypi/blosc2/
 
-checksums           rmd160 733c89366fd4e4d780d1648c704b1e818383897a \
-                    sha256 c127342d976de44fee242137e83660097e0b072779f4164a34e149ac9f693c8a \
-                    size 4341120
+checksums           rmd160  1306cf4efef2aad15747e959c8bd15d5cdee5f3f \
+                    sha256  3c610b076ad0422d861ff10732013c7c3461135968c3c442630542e71249a4a2 \
+                    size    6820440
 
 python.versions     310 311 312 313 314
 


### PR DESCRIPTION
#### Description

Update py-blosc2 to 4.11.0, as part of fixing linking issues following [#33983](https://github.com/macports/macports-ports/pull/33983).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
