### PR TITLE
podofo: fix legacy support

### DIFF
--- a/graphics/podofo/Portfile
+++ b/graphics/podofo/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
 github.setup        podofo podofo 1.1.1
@@ -36,6 +37,22 @@ depends_lib-append  port:freetype \
 
 compiler.cxx_standard 2017
 compiler.thread_local_storage yes
+
+# 13.3, to_chars
+legacysupport.newest_darwin_requires_legacy \
+                    22
+if {${os.platform} eq "darwin" && ${os.major} <= 22} {
+    # TODO when macports-libcxx is bumped to clang 17, this is not needed
+    # clang 16 and lower lacks to_chars in the libc++ dylibs
+    depends_lib-append \
+                    port:clang-17
+    configure.ldflags-append \
+                    -L${prefix}/libexec/llvm-17/lib/libc++
+    configure.cppflags-append \
+                    -nostdinc++ \
+                    -isystem${prefix}/libexec/llvm-17/include/c++/v1 \
+                    -D_LIBCPP_DISABLE_AVAILABILITY=1
+}
 
 configure.args-append \
                     -DPODOFO_WANT_LCMS2=TRUE \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
fixes build on osx 10.9 by using clang-17 libcxx, closes issues noted in the commit comment

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
