### PR TITLE
libjodycode: legacy compat fix, jdupes: fix build by adding a break

### DIFF
--- a/devel/libjodycode/Portfile
+++ b/devel/libjodycode/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           codeberg 1.0
+PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 codeberg.setup      jbruchon libjodycode 4.1.2 v
@@ -20,6 +21,10 @@ long_description    ${name} is a software code library containing code \
                     and zeromerge.
 
 compiler.c_standard 2011
+
+# 10.11, sys/clonefile.h
+legacysupport.newest_darwin_requires_legacy \
+                    15
 
 # Disable use of Intel extensions, as they also require aligned_alloc.
 # And latter only available for 10.14+ x86_64 anyway.

--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -20,7 +20,8 @@ long_description    ${name} is a powerful duplicate file finder and an \
 depends_lib-append \
                     port:libjodycode
 
-patchfiles          filestat.patch
+patchfiles          act_linkfiles.diff \
+                    filestat.patch
 
 compiler.c_standard 2011
 

--- a/sysutils/jdupes/files/act_linkfiles.diff
+++ b/sysutils/jdupes/files/act_linkfiles.diff
@@ -1,0 +1,11 @@
+--- act_linkfiles.c.orig
++++ act_linkfiles.c
+@@ -363,6 +363,7 @@
+ void linkfiles(file_t *files, const int linktype, const int only_current)
+                 dupelist[x]->flags |= FF_HASHDB_DIRTY | (srcfile->flags & (FF_HASH_PARTIAL | FF_HASH_FULL));
+                 add_hashdb_entry(NULL, 0, dupelist[x], 1);
+               default:
++                break;
+             }
+           }
+ #endif


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
libjodycode: fixes compat on 10.11 and lower (tested on 10.9) by using legacysupport portgroup
jdupes: fixes build by adding a `break;` after `default:` in act_linkfiles.c

both changes closes a ticket. see the commit message for the referenced tickets

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
