### PR TITLE
ble.sh: Depend on gawk at runtime

### DIFF
--- a/sysutils/ble.sh/Portfile
+++ b/sysutils/ble.sh/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        akinomyoga ble.sh 0.4.0-devel3 v
+revision            1
 fetch.type          git
 
 description         Bash Line Editor (${name}) is a command line editor written in pure Bash which replaces the default GNU Readline.
@@ -19,6 +20,9 @@ post-fetch {
 }
 
 depends_build-append \
+                    port:gawk
+# There seem to be some encoding and charset problems with /usr/bin/awk
+depends_run-append \
                     port:gawk
 
 use_configure       no


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
