### PR TITLE
vega: update to 6.4.0

### DIFF
--- a/graphics/vega/Portfile
+++ b/graphics/vega/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                vega
-version             6.3.0
+version             6.4.0
 revision            0
 
 npm.rootname        vega-cli
@@ -25,9 +25,9 @@ long_description    Vega is a visualization grammar, a declarative language for 
 
 homepage            https://vega.github.io/vega/
 
-checksums           rmd160  ac7e536b8be48a984929225b3a44c629e1f0b22f \
-                    sha256  db42f7bb7f2d3032430eb44a6c01de216c91867db2c67997b95cbdff01127f4f \
-                    size    4154
+checksums           rmd160  4a39e995cd5609f2fa68d701306b9e619f6f1343 \
+                    sha256  73c6b758a222298dba1319a2d9408e85e09a65083e214801d1f6674029c2eb2f \
+                    size    4361
 
 platform darwin {
     if {${os.major} >= 22} {


### PR DESCRIPTION
Update `vega` from 6.3.0 to 6.4.0.

Upstream release: https://github.com/vega/vega/releases/tag/v6.4.0

Verified locally:
- `port lint --nitpick` passes
- `port test` passes