### PR TITLE
openspec: update to 1.9.0

### DIFF
--- a/llm/openspec/Portfile
+++ b/llm/openspec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                openspec
-version             1.8.0
+version             1.9.0
 revision            0
 
 categories          llm
@@ -23,6 +23,6 @@ homepage            https://openspec.dev
 npm.rootname        @fission-ai/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  1bce57b96797b4abc569e37666bcb4df7af8b2b8 \
-                    sha256  e6f049442659eba493a130220faecfc4cb7b001b300af069ae5d535e744348c4 \
-                    size    433287
+checksums           rmd160  21ff6c72d41d1090b54188e35f6598535cd00cf1 \
+                    sha256  c31b792d1437a62b94fbff7b33889b4a6411d086fa2c1fe550aa14f77c515b2c \
+                    size    449077


### PR DESCRIPTION
#### Description

Update to OpenSpec 1.9.0.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?