### PR TITLE
llama.cpp: Add spirv-headers as build dep to +vulkan

### DIFF
--- a/llm/llama.cpp/Portfile
+++ b/llm/llama.cpp/Portfile
@@ -94,7 +94,8 @@ variant metal description {Enable Metal support} {
 
 variant vulkan description {Enable Vulkan support via MoltenVK} conflicts metal {
     depends_build-append \
-                        port:vulkan-headers
+                        port:vulkan-headers \
+                        port:spirv-headers
     depends_lib-append \
                         path:lib/libMoltenVK.dylib:MoltenVK-latest \
                         path:bin/glslc:shaderc \


### PR DESCRIPTION
#### Description

Add spirv-headers as a build-dep for the +vulkan variant of llama.cpp. Apologies for missing this in the last PR.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.1 25G76 x86_64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
