### PR TITLE
syncthing-macos: fix SwiftPM cache path

### DIFF
--- a/net/syncthing-macos/Portfile
+++ b/net/syncthing-macos/Portfile
@@ -32,8 +32,32 @@ post-patch {
 use_configure           no
 use_xcode               yes
 
+pre-build {
+    file mkdir ${workpath}/tmp
+    file mkdir ${workpath}/home/Library/Caches
+    file mkdir ${workpath}/spm-cache
+
+    # SPM sandboxes its manifest-loading subprocesses via sandbox-exec, but
+    # macOS rejects nested sandbox_apply calls when the process is already
+    # sandboxed by MacPorts.
+    append portsandbox_profile " (allow process-exec (literal \"/usr/bin/sandbox-exec\") (with no-profile))"
+}
+
+build.env-append        TMPDIR=${workpath}/tmp \
+                        HOME=${workpath}/home \
+                        CFFIXED_USER_HOME=${workpath}/home
+
 build {
-    system -W ${build.dir} "make release"
+    system -W ${build.dir} "env TMPDIR=${workpath}/tmp HOME=${workpath}/home \
+        CFFIXED_USER_HOME=${workpath}/home \
+        xcodebuild -workspace syncthing.xcworkspace \
+        -derivedDataPath ${build.dir} \
+        -clonedSourcePackagesDirPath ${build.dir}/SourcePackages \
+        -packageCachePath ${workpath}/spm-cache \
+        -disablePackageRepositoryCache \
+        -skipPackageUpdates \
+        -configuration Release \
+        -scheme syncthing"
 }
 
 destroot {


### PR DESCRIPTION
Fix the Xcode/SwiftPM cache paths for syncthing-macos.