### PR TITLE
whichllm: update to 0.5.16

### DIFF
--- a/llm/whichllm/Portfile
+++ b/llm/whichllm/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    whichllm
-version                 0.5.15
+version                 0.5.16
 revision                0
 
 categories              llm python
@@ -17,9 +17,9 @@ long_description        Find the local LLM that actually runs and performs best 
                         Auto-detects your GPU/CPU/RAM and ranks the top models from HuggingFace that fit your system. \
                         Ranked by real, recency-aware benchmarks, not parameter count.
 
-checksums               rmd160  e5e09c0a8446f9a183219b1395018c822a9af327 \
-                        sha256  40a94e7495ceb9f730f57b5ebf4988bdd45e5e57b22c9f058b500fa4fbdeb180 \
-                        size    1103123
+checksums               rmd160  e284cbf419fe3f456407a0fcb6b5b72de5aac9e3 \
+                        sha256  2ab5ceb33f2bcfb23b43e38ce7f94abee9df1dd2dd9dda7e29ae605262427481 \
+                        size    1105965
 
 python.default_version  314
 python.pep517_backend   hatch


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
