### PR TITLE
nnn: update to 5.3

### DIFF
--- a/sysutils/nnn/Portfile
+++ b/sysutils/nnn/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               makefile 1.0
 
-github.setup            jarun nnn 5.2 v
+github.setup            jarun nnn 5.3 v
 github.tarball_from     archive
 revision                0
 categories              sysutils
@@ -14,9 +14,9 @@ maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description             tiny, lightning fast, feature-packed file manager
 long_description        ${name} is a tiny, lightning fast, feature-packed file manager.
 
-checksums               rmd160  9a84cb162ac1df09625bff9df87966ec6963fd65 \
-                        sha256  f166eda5093ac8dcf8cbbc6224123a32c53cf37b82c5c1cb48e2e23352754030 \
-                        size    270059
+checksums               rmd160  8edce7325c3da6cc0fe7e65bd6c77553aa2b05dc \
+                        sha256  79ee69f3ced7c0778d207df76b4d4d680636975ccda002eeb19d0917fcba3d36 \
+                        size    287765
 
 installs_libs           no
 


### PR DESCRIPTION
#### Description
https://github.com/jarun/nnn/releases/tag/v5.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
