### PR TITLE
dmux: fix build with Rust >= 1.53

### DIFF
--- a/sysutils/dmux/Portfile
+++ b/sysutils/dmux/Portfile
@@ -7,7 +7,13 @@ PortGroup           cargo 1.0
 github.setup        zdcthomas dmux 0.6.2 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
+
+# The bundled Cargo.lock pins lexical-core 0.6.2, whose Limb::BITS (usize)
+# collides with the inherent BITS (u32) const the integer types gained in Rust
+# 1.53, breaking the build.  0.6.8 fixes this and satisfies nom 5.1.1's ^0.6
+# requirement, so re-resolve the lock against the vendored crates.
+cargo.update        yes
 
 description         A tmux workspace manager
 
@@ -67,7 +73,7 @@ cargo.crates \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
     itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    lexical-core                     0.6.2  d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890 \
+    lexical-core                     0.6.8  233853dfa6b87c7c00eb46a205802069263ab27e16b6bdd1b08ddf91a855e30c \
     libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
     linked-hash-map                  0.3.0  6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd \
     linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \


### PR DESCRIPTION
`dmux` fails to build with Rust >= 1.53.

The `Cargo.lock` bundled in the v0.6.2 tarball pins `lexical-core 0.6.2`, which defines its own `Limb::BITS` as `usize`. Rust 1.53 gave the primitive integer types an inherent `BITS: u32` associated const, which now wins the lookup:

```
error[E0308]: mismatched types
    --> lexical-core-0.6.2/src/atof/algorithm/math.rs:2071:27
2071 |     let rs = Limb::BITS - s;
     |                           ^ expected `u32`, found `usize`
```

The dependency chain is `dmux` → `config 0.10.1` → `nom 5.1.1` → `lexical-core ^0.6`.

This bumps the vendored crate to `lexical-core 0.6.8`, which fixes the collision and still satisfies `nom 5.1.1`'s `^0.6` requirement, and sets `cargo.update yes`.

`cargo.update` is required because `cargo.crates` only controls what gets vendored into the directory source replacing crates.io — it does not touch the bundled lock, so the default `--frozen` build still fails:

```
error: failed to select a version for the requirement `lexical-core = "^0.6.0"` (locked to 0.6.2)
candidate versions found which didn't match: 0.6.8
```

Setting it runs `cargo --offline update` in post-extract. The vendor directory holds exactly one version of each crate, so the re-resolve is fully constrained and moves only `lexical-core`.

Upstream's newest release is still v0.6.2 (September 2020), so this is a lockfile fix rather than an upgrade.

Built and destrooted on macOS 26 arm64 with rustc 1.97.1; the resulting binary runs. `port lint --nitpick` reports 0 errors.

Fixes: https://trac.macports.org/ticket/74315