### PR TITLE
claude-code: update to 2.1.233

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.232
+version             2.1.233
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6a14fe16bdd0ff9f61c30ff8b76d0a165df05c91 \
-                 sha256  aa3d606d7bf0ea9739a6d0de11810e72a662e7a4e5061d67ee7f8bc47c8890f9 \
-                 size    314779248
+    checksums    rmd160  acd8cfdb4545e5ab00cf3e3dec90b2f6af92e766 \
+                 sha256  8b3ae18df411098ce55705c4bb151e9c97e34df55fe379c7b6b3122a69f0ea74 \
+                 size    315654448
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e7a27ca6fee580dada0a498165ab07d3239c7f24 \
-                 sha256  7b39c1588df919d001dea3ffd5651adb682f2451b5a0e18d42d4233296b53cc7 \
-                 size    306111312
+    checksums    rmd160  09cf2898ed31f12f72416c3f7f30218d9bf6d065 \
+                 sha256  bc466b6cde63edafc773f471a1fb98787fabb31f52240c8616ce7e1f587b212d \
+                 size    306981408
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.233.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?