### PR TITLE
qemu: fix build on macOS 11 and earlier

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 11.1.0
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -76,6 +76,31 @@ patchfiles-append       patch-qemu-block-file-posix.diff
 
 # SDL2 GL workaround
 patchfiles-append       patch-qemu-ui-sdl2.diff
+
+# APIs newer than the SDK or the deployment target.  Constants are guarded on
+# MAC_OS_X_VERSION_MAX_ALLOWED, functions and Objective-C methods on
+# MAC_OS_X_VERSION_MIN_REQUIRED; see each patch header.
+
+# pthread_jit_write_protect_np: macOS 11
+patchfiles-append       patch-qemu-osdep-pthread-jit.diff
+
+# IOMainPort: macOS 12 rename of IOMasterPort
+patchfiles-append       patch-qemu-block-file-posix-iomainport.diff
+
+# kAudioObjectPropertyElementMain: macOS 12 rename of ...Master
+patchfiles-append       patch-qemu-coreaudio-element-main.diff
+
+# NSScreen safeAreaInsets: macOS 12
+patchfiles-append       patch-qemu-cocoa-safeareainsets.diff
+
+# HV_DENIED: added to hv_return_t in the macOS 11 SDK
+patchfiles-append       patch-qemu-hvf-hv-denied.diff
+
+# HV_DEADLINE_FOREVER (macOS 11) and hv_vcpu_run_until() (macOS 10.15)
+patchfiles-append       patch-qemu-hvf-i386-old-sdk.diff
+
+# timespec_get()/TIME_UTC: C11, reached macOS in 10.15
+patchfiles-append       patch-qemu-uftrace-timespec-get.diff
 
 # 11.1.0 added HVF nested virtualization and an in-kernel vGIC, which use
 # Hypervisor.framework APIs and constants (HV_SYS_REG_*_EL2, hv_gic_*,
@@ -172,6 +197,14 @@ configure.args-append   --smbd=${prefix}/sbin/smbd
 # Hypervisor.framework introduced in 10.10
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     configure.args-replace --enable-hvf --disable-hvf
+}
+
+# vmnet's isolation / network-identifier keys and VMNET_SHARING_SERVICE_BUSY
+# are all API_AVAILABLE(macos(11.0)) and absent from earlier SDKs.  meson's
+# probe only checks for VMNET_BRIDGED_MODE, which older SDKs do have, so it
+# auto-enables vmnet and then fails to compile net/vmnet-*.
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    configure.args-append   --disable-vmnet
 }
 
 # pthread_fchdir_np introduced in 10.12

--- a/emulators/qemu/files/patch-qemu-block-file-posix-iomainport.diff
+++ b/emulators/qemu/files/patch-qemu-block-file-posix-iomainport.diff
@@ -1,0 +1,25 @@
+IOMainPort() is the macOS 12 rename of IOMasterPort(); older SDKs declare only
+the latter, so qemu 11.1.0 fails on macOS 11 and earlier.
+
+The signatures are identical, so aliasing suffices.  The guard tests
+MAC_OS_X_VERSION_MIN_REQUIRED rather than MAX_ALLOWED: a binary deployed to
+macOS 11 must not call a macOS 12 symbol even when built against a newer SDK.
+
+See https://trac.macports.org/ticket/72042
+
+--- block/file-posix.c.orig
++++ block/file-posix.c
+@@ -58,6 +58,13 @@
+ #include <IOKit/storage/IOCDMedia.h>
+ //#include <IOKit/storage/IOCDTypes.h>
+ #include <IOKit/storage/IODVDMedia.h>
++
++/* IOMainPort is the macOS 12 rename of IOMasterPort; older SDKs (e.g. 10.15)
++ * declare only the latter.  Same signature, so alias it. */
++#if !defined(MAC_OS_VERSION_12_0) || \
++    MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_12_0
++#define IOMainPort IOMasterPort
++#endif
+ #include <CoreFoundation/CoreFoundation.h>
+ #endif
+ 

--- a/emulators/qemu/files/patch-qemu-cocoa-safeareainsets.diff
+++ b/emulators/qemu/files/patch-qemu-cocoa-safeareainsets.diff
@@ -1,0 +1,30 @@
+The NSScreen safeAreaInsets property is macOS 12.  Older SDKs do not declare
+it, so the message returns id and qemu 11.1.0 fails with an incompatible
+initialisation of NSEdgeInsets.
+
+Screens without a notch report zero insets, so substituting zeros preserves
+behaviour.  The guard tests MAC_OS_X_VERSION_MIN_REQUIRED, not MAX_ALLOWED:
+this is a runtime message send, so building against a macOS 12 SDK while
+targeting an older system must still take the fallback.  Note that +cocoa is a
+default variant only at darwin >= 18, so this is reached on 10.14 and 10.15 but
+not below.
+
+See https://trac.macports.org/ticket/70482
+
+--- ui/cocoa.m.orig
++++ ui/cocoa.m
+@@ -489,7 +489,14 @@
+ - (NSSize) screenSafeAreaSize
+ {
+     NSSize size = [[[self window] screen] frame].size;
++    /* -[NSScreen safeAreaInsets] is macOS 12+; older SDKs do not declare it.
++     * Screens without a notch have zero insets, so this is a no-op there. */
++#if defined(MAC_OS_VERSION_12_0) && \
++    MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_0
+     NSEdgeInsets insets = [[[self window] screen] safeAreaInsets];
++#else
++    NSEdgeInsets insets = NSEdgeInsetsMake(0, 0, 0, 0);
++#endif
+     size.width -= insets.left + insets.right;
+     size.height -= insets.top + insets.bottom;
+     return size;

--- a/emulators/qemu/files/patch-qemu-coreaudio-element-main.diff
+++ b/emulators/qemu/files/patch-qemu-coreaudio-element-main.diff
@@ -1,0 +1,25 @@
+kAudioObjectPropertyElementMain is the macOS 12 rename of
+kAudioObjectPropertyElementMaster; older SDKs declare only the latter, so qemu
+11.1.0 fails on macOS 11 and earlier with an undeclared identifier.
+
+This is an enum constant, so the question is purely whether the SDK declares
+it; the guard therefore tests MAC_OS_X_VERSION_MAX_ALLOWED.  Contrast the
+IOMainPort patch, where the symbol is a function and the deployment target is
+what matters.
+
+--- audio/coreaudio.m.orig
++++ audio/coreaudio.m
+@@ -24,6 +24,13 @@
+ 
+ #include "qemu/osdep.h"
+ #include <CoreAudio/CoreAudio.h>
++
++/* kAudioObjectPropertyElementMain is the macOS 12 rename of
++ * kAudioObjectPropertyElementMaster; older SDKs declare only the latter. */
++#if !defined(MAC_OS_VERSION_12_0) || \
++    MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_12_0
++#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
++#endif
+ #include <pthread.h>            /* pthread_X */
+ 
+ #include "qemu/main-loop.h"

--- a/emulators/qemu/files/patch-qemu-hvf-hv-denied.diff
+++ b/emulators/qemu/files/patch-qemu-hvf-hv-denied.diff
@@ -1,0 +1,26 @@
+HV_DENIED was added to Hypervisor.framework's hv_return_t in the macOS 11 SDK;
+the 10.15 SDK stops at HV_UNSUPPORTED.  qemu 11.1.0 uses it in a diagnostic
+string table and in a comparison against hvf_arch_vm_create().
+
+The value (err_common_hypervisor | 0x07) is taken verbatim from the 11.1 SDK's
+Hypervisor/hv_error.h, so the runtime comparison stays correct rather than
+merely compiling.
+
+--- accel/hvf/hvf-all.c.orig
++++ accel/hvf/hvf-all.c
+@@ -9,6 +9,15 @@
+  */
+ 
+ #include "qemu/osdep.h"
++
++/* HV_DENIED was added to Hypervisor.framework's hv_return_t in the macOS 11
++ * SDK; the 10.15 SDK stops at HV_UNSUPPORTED.  Value taken verbatim from the
++ * 11.1 SDK's hv_error.h so the runtime comparison stays correct. */
++#if !defined(MAC_OS_VERSION_11_0) || \
++    MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_11_0
++#include <Hypervisor/hv_error.h>
++#define HV_DENIED (err_common_hypervisor | 0x07)
++#endif
+ #include "qemu/error-report.h"
+ #include "qapi/error.h"
+ #include "qapi/qapi-visit-common.h"

--- a/emulators/qemu/files/patch-qemu-hvf-i386-old-sdk.diff
+++ b/emulators/qemu/files/patch-qemu-hvf-i386-old-sdk.diff
@@ -1,0 +1,51 @@
+Two related gaps in target/i386/hvf on older SDKs.
+
+HV_DEADLINE_FOREVER was added in the macOS 11 SDK; its value (~0ull) is taken
+verbatim from the 11.1 SDK's Hypervisor/hv.h.
+
+hv_vcpu_run_until() is annotated __HV_10_15, so below 10.15 the function itself
+is absent and no #define can help.  Its guard tests
+MAC_OS_X_VERSION_MIN_REQUIRED, since it is a function; the HV_DEADLINE_FOREVER
+guard above tests MAC_OS_X_VERSION_MAX_ALLOWED, since a constant only needs to
+be declared by the SDK.  Apple's macOS 11 header deprecates
+hv_vcpu_run() with "Use hv_vcpu_run_until(..., HV_DEADLINE_FOREVER) instead",
+establishing the two as equivalent for an infinite deadline, and that is the
+only deadline qemu passes.  The shim preserves semantics and keeps HVF
+available below 10.15 rather than falling back to TCG.
+
+Compile-verified on 10.14; not exercised by a running guest.
+
+--- target/i386/hvf/hvf.c.orig
++++ target/i386/hvf/hvf.c
+@@ -47,6 +47,31 @@
+  */
+ 
+ #include "qemu/osdep.h"
++
++#include <Hypervisor/hv.h>
++
++/* HV_DEADLINE_FOREVER was added to Hypervisor.framework in the macOS 11 SDK.
++ * Value taken verbatim from the 11.1 SDK's hv.h. */
++#if !defined(MAC_OS_VERSION_11_0) || \
++    MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_11_0
++#define HV_DEADLINE_FOREVER (~0ull)
++#endif
++
++/* hv_vcpu_run_until() is annotated __HV_10_15, so it is absent from the 10.14
++ * and older SDKs, which provide only hv_vcpu_run().  Apple documents the two
++ * as equivalent for an infinite deadline: the macOS 11 header deprecates
++ * hv_vcpu_run() with "Use hv_vcpu_run_until(..., HV_DEADLINE_FOREVER)
++ * instead".  HV_DEADLINE_FOREVER is the only deadline qemu ever passes, so
++ * this shim preserves semantics rather than degrading them, and keeps HVF
++ * acceleration available below 10.15 instead of falling back to TCG. */
++#if !defined(MAC_OS_X_VERSION_10_15) || \
++    MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_15
++static inline hv_return_t hv_vcpu_run_until(hv_vcpuid_t vcpu, uint64_t deadline)
++{
++    assert(deadline == HV_DEADLINE_FOREVER);
++    return hv_vcpu_run(vcpu);
++}
++#endif
+ #include "qemu/error-report.h"
+ #include "qemu/memalign.h"
+ #include "qapi/error.h"

--- a/emulators/qemu/files/patch-qemu-osdep-pthread-jit.diff
+++ b/emulators/qemu/files/patch-qemu-osdep-pthread-jit.diff
@@ -1,0 +1,24 @@
+pthread_jit_write_protect_np() is macOS 11 and is not declared by earlier SDKs,
+so qemu 11.1.0 fails on 10.15 and older with a call to an undeclared function.
+
+The call toggles W^X on MAP_JIT pages, an Apple silicon requirement that is a
+no-op on Intel, so upstream's existing #else branch is already correct on older
+systems.  Guarding on the deployment target rather than on architecture leaves
+behaviour unchanged anywhere the symbol can actually be called.
+
+See https://trac.macports.org/ticket/70694
+
+--- include/qemu/osdep.h.orig
++++ include/qemu/osdep.h
+@@ -844,7 +844,10 @@
+  * Toggle write/execute on the pages marked MAP_JIT
+  * for the current thread.
+  */
+-#ifdef __APPLE__
++/* pthread_jit_write_protect_np() is macOS 11; older SDKs do not declare it.
++ * Keep calling it wherever the SDK provides it so behaviour matches upstream. */
++#if defined(__APPLE__) && defined(MAC_OS_VERSION_11_0) && \
++    MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_11_0
+ static inline void qemu_thread_jit_execute(void)
+ {
+     pthread_jit_write_protect_np(true);

--- a/emulators/qemu/files/patch-qemu-uftrace-timespec-get.diff
+++ b/emulators/qemu/files/patch-qemu-uftrace-timespec-get.diff
@@ -1,0 +1,25 @@
+timespec_get() and TIME_UTC are C11 and only reached macOS in 10.15, so qemu
+11.1.0 fails on 10.14 and earlier.
+
+clock_gettime() has been available since 10.12 and TIME_UTC designates the
+realtime clock, so CLOCK_REALTIME is the direct equivalent.  The guard tests
+MAC_OS_X_VERSION_MIN_REQUIRED so that building against a newer SDK while
+targeting 10.14 still takes the fallback.
+
+--- contrib/plugins/uftrace.c.orig
++++ contrib/plugins/uftrace.c
+@@ -144,7 +144,14 @@
+ #else
+     /* We need nanosecond precision for short lived functions. */
+     struct timespec ts;
++    /* timespec_get() is C11 and only reached macOS in 10.15; older SDKs
++     * provide clock_gettime(), for which TIME_UTC's clock is CLOCK_REALTIME. */
++#if defined(__APPLE__) && (!defined(MAC_OS_X_VERSION_10_15) || \
++    MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_15)
++    clock_gettime(CLOCK_REALTIME, &ts);
++#else
+     timespec_get(&ts, TIME_UTC);
++#endif
+     uint64_t now_ns = ts.tv_sec * NANOSECONDS_PER_SECOND + ts.tv_nsec;
+ #endif
+     return now_ns;


### PR DESCRIPTION
# qemu 11.1.0: unbreak building on macOS below 12

`emulators/qemu` fails on **every buildbot below macOS 12**: 10.6 (x86_64 and
i386), 10.7, 10.8, 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.15, and 11 on
both arches. From 12 onwards all are green except `12_arm64`, which fails for
an unrelated arm64 reason (see the caveats). The cutoff for the x86_64 line
sits exactly where Apple's macOS 11 and 12 API additions and
inclusive-language renames landed.

Of those red builders, 10.7 and 10.10 through 11 fail at `install-port`, i.e.
compiling qemu itself — that is what this change addresses. 10.6, 10.8 and 10.9
fail earlier, at `install-dependencies`, and are a separate problem not touched
here.

This is **not** a compiler-selection problem. The port already sets
`compiler.blacklist {clang < 1500}`, so it is already building with
macports-clang; every failure below is a symbol the older SDK does not declare.

The port declares **no floor** and is actively engineered for old systems
(`legacysupport.newest_darwin_requires_legacy 16`, `-femulated-tls` below
darwin 11, `--disable-hvf` below darwin 14, `--disable-virtfs` below darwin 16,
`+cocoa` defaulted only at darwin >= 18). These are regressions, not
unsupported configurations.

## Fixes

Seven patchfiles plus one Portfile gate. Every threshold was read out of
Apple's own SDK headers on the target machines, not from documentation or
recall.

| # | patchfile | symbol | added in | file |
|---|---|---|---|---|
| 1 | `patch-qemu-osdep-pthread-jit.diff` | `pthread_jit_write_protect_np` | macOS 11 | `include/qemu/osdep.h` |
| 2 | `patch-qemu-block-file-posix-iomainport.diff` | `IOMainPort` (rename of `IOMasterPort`) | macOS 12 | `block/file-posix.c` |
| 3 | `patch-qemu-coreaudio-element-main.diff` | `kAudioObjectPropertyElementMain` (rename of `…Master`) | macOS 12 | `audio/coreaudio.m` |
| 4 | `patch-qemu-cocoa-safeareainsets.diff` | `-[NSScreen safeAreaInsets]` | macOS 12 | `ui/cocoa.m` |
| 5 | `patch-qemu-hvf-hv-denied.diff` | `HV_DENIED` | macOS 11 | `accel/hvf/hvf-all.c` |
| 6 | `patch-qemu-hvf-i386-old-sdk.diff` | `HV_DEADLINE_FOREVER` + `hv_vcpu_run_until()` | macOS 11 / 10.15 | `target/i386/hvf/hvf.c` |
| 7 | `patch-qemu-uftrace-timespec-get.diff` | `timespec_get` / `TIME_UTC` | macOS 10.15 | `contrib/plugins/uftrace.c` |
| 8 | *(Portfile)* | vmnet auto-detection | — | `--disable-vmnet` below darwin 20 |

### Notes on the non-obvious ones

**#6 is two problems in one file.** `HV_DEADLINE_FOREVER` is simply absent
before the macOS 11 SDK; its value `(~0ull)` is taken verbatim from the 11.1
SDK's `hv.h`. But `hv_vcpu_run_until()` itself is annotated `__HV_10_15`, so on
10.14 and older the *function* is missing too, and a `#define` cannot fix that.
The shim falls back to `hv_vcpu_run()`, which Apple's own macOS 11 header
documents as equivalent — it deprecates `hv_vcpu_run()` with "Use
`hv_vcpu_run_until(..., HV_DEADLINE_FOREVER)` instead", and
`HV_DEADLINE_FOREVER` is the only deadline qemu ever passes. This keeps HVF
acceleration working below 10.15 rather than dropping those hosts to TCG.

An exhaustive diff of every `HV_*` constant and `hv_*` function qemu's HVF code
uses against the 10.15 SDK found exactly these two constants missing and no
missing functions, so the Hypervisor surface is fully covered.

**#8 is an upstream detection bug, not a missing symbol.** meson probes with:

    Header "vmnet/vmnet.h" has symbol "VMNET_BRIDGED_MODE" ... YES

`VMNET_BRIDGED_MODE` exists in the 10.15 SDK, so vmnet is auto-enabled — but
`net/vmnet-*.{c,m}` then reference `vmnet_enable_isolation_key`,
`vmnet_network_identifier_key` and `VMNET_SHARING_SERVICE_BUSY`, all
`API_AVAILABLE(macos(11.0))` and absent from earlier SDKs. The feature test
checks a 10.15-era symbol while the code needs macOS 11 ones. Disabling matches
how the port already gates `hvf` and `virtfs`; a proper upstream fix would
probe for one of the symbols actually used.

**Guard macro choice follows what the symbol is.** A compile-time entity — an
enum constant or macro — only needs the SDK to declare it, so those guards test
`MAC_OS_X_VERSION_MAX_ALLOWED` (`HV_DENIED`, `HV_DEADLINE_FOREVER`,
`kAudioObjectPropertyElementMain`). A runtime entity — a function or an
Objective-C method — must not be referenced when the deployment target predates
it, even if a newer SDK declares it, so those guards test
`MAC_OS_X_VERSION_MIN_REQUIRED` (`IOMainPort`, `pthread_jit_write_protect_np`,
`hv_vcpu_run_until`, `timespec_get`, `safeAreaInsets`). Building against a newer
SDK than the deployment target is a real configuration, so the distinction
matters.

**#1 guards on availability, not architecture.** An earlier revision gated
on `__aarch64__` — which works, since the call is an Apple-silicon W^X
mechanism and a no-op on Intel — but that would have changed behaviour on every
modern x86_64 macOS. The availability guard keeps upstream behaviour wherever
the symbol can actually be called and only no-ops where it cannot.

## Verification

Built from a clean tree on real hardware, three OS versions, four toolchain
configurations. Each build is a full `port build qemu` to completion.

| | 10.14.6 | 10.15.7 | 11.7.10 | 11.7.10 (pinned) |
|---|---|---|---|---|
| Apple clang | 11.0.0 | 12.0.0 | 13.0.0 | 13.0.0 |
| SDK | 10.14.5 | 10.15.6 | 12.1 | 11.3 |
| build | 3590/3590 ✓ | 3590/3590 ✓ | 3596/3596 ✓ | 3596/3596 ✓ |
| patch failures | 0 | 0 | 0 | 0 |
| accelerators | tcg, hvf | tcg, hvf | tcg, hvf | tcg, hvf |
| vmnet | disabled | disabled | enabled | enabled |
| `pthread_jit` | no-op | no-op | real call | real call |
| `hv_vcpu_run_until` | **shim** | native | native | native |
| `timespec_get` | **shim** | native | native | native |
| macOS-12 guards | fire | fire | mixed (see below) | fire (`!defined`) |

The 3596-vs-3590 target difference is the `net/vmnet-*` files: the gate changes
what is compiled, not merely what parses.

Symbol selection was confirmed against the built binaries with `nm -u` rather
than by reading the source. On 10.15: `IOMasterPort` 1, `IOMainPort` 0,
`pthread_jit_write_protect_np` 0, `hv_vcpu_run_until` 1, and no vmnet netdev
backends. On 11 with the 11.3 SDK: `IOMasterPort` 1, `IOMainPort` 0,
`pthread_jit_write_protect_np` 1, `hv_vcpu_run_until` 1.

The fourth column exists because the macOS 11 test host carried an **SDK 12.1**,
newer than its OS — a configuration where the two availability macros diverge.
There the runtime-symbol guards (`IOMainPort`, `safeAreaInsets`) fire on
`MIN_REQUIRED`, while the constant guard (`kAudioObjectPropertyElementMain`)
correctly does not, since that SDK declares the symbol. A stock macOS 11
install takes the `!defined(...)` clause for all of them; pinning
`configure.sdkroot` to an 11.3 SDK also present on that host exercises that
path. The pin is a test artefact and is not part of this change.

**The builds above were run before the guard-macro correction described under
"Fixes".** On 10.14, 10.15 and the 11.3-pinned build the SDK and deployment
target match, so `MIN_REQUIRED` and `MAX_ALLOWED` evaluate identically and those
results are unaffected. Only the SDK 12.1 column changes: `safeAreaInsets` and
`kAudioObjectPropertyElementMain` now select the other branch. Both branches are
known to compile, since each is exercised by another column, but that exact
configuration has not been rebuilt since the correction.

## Tickets closed

Each has been open since qemu 9.x with a report and no patch.

- #70694 — *"implicit declaration of function `pthread_jit_write_protect_np`"*
  (new, `legacy-os`) → patch 1
- #72042 — *"call to undeclared function `IOMainPort`"* (assigned) → patch 2
- #70482 — *"initializing `NSEdgeInsets` … with an expression of incompatible
  type `id`"* (assigned, tagged `catalina`) → patch 4

## Caveats

- **Not tested below 10.14.** 10.7 and 10.10–10.13 fail at `install-port` and
  may well be fixed by these patches, but that is unverified. 10.6, 10.8 and
  10.9 fail earlier at `install-dependencies` and are certainly not addressed.
- **`12_arm64` is not addressed.** It is the one red builder at or above
  macOS 12; its failure is arm64-specific and unrelated to the SDK-symbol
  issues fixed here.
- **Runtime testing is shallow.** `-accel hvf` was confirmed to initialise and
  reach CPU feature negotiation on each host, but no guest was booted. The
  `hv_vcpu_run()` fallback in patch 6 is compile-verified and argued from
  Apple's documented equivalence — it has not been exercised by a running VM.
- **Test host SDKs vary and were not uniform.** The macOS 11 host carried an
  SDK newer than its OS (12.1), which is why the fourth column exists. The
  10.15 host was checked directly and is contemporaneous (SDK 10.15.6 on
  10.15.7). The 10.14 host reported SDK 10.14.5, which likewise reads as
  contemporaneous, but that one was not independently confirmed.
- **`arm64` untested.** All builds were x86_64.
- `plutil` could not read `SDKSettings.plist` from the 11.3 SDK
  (`<unknown error>`), though the SDK is otherwise complete and its availability
  macros are internally consistent at `110300`. Unexplained.
