### PR TITLE
yodl: fix build on x86_64

### DIFF
--- a/textproc/yodl/Portfile
+++ b/textproc/yodl/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                yodl
 version             3.05.01
+revision            1
 categories          textproc
 platforms           darwin
 license             GPL-3
@@ -32,7 +33,8 @@ checksums           rmd160  712337201e8b899fd4ee513004e89db12fd9e540 \
 
 patchfiles          avoid-c++11.patch \
                     use-macports-compilers.patch \
-                    use-macports-locations.patch
+                    use-macports-locations.patch \
+                    include-stdarg.patch
 post-patch {
     reinplace -W ${worksrcpath} s|__MP_CC__|${configure.cc}| INSTALL.im
     reinplace -W ${worksrcpath} s|__MP_CXX__|${configure.cxx}| INSTALL.im

--- a/textproc/yodl/files/include-stdarg.patch
+++ b/textproc/yodl/files/include-stdarg.patch
@@ -1,0 +1,18 @@
+Index: src/root/root.h
+===================================================================
+--- src/root/root.h.orig
++++ src/root/root.h
+@@ -78,6 +78,13 @@
+ #  define ATTRIBUTE_FORMAT_PRINTF(a,b)
+ #endif
+ 
++/* va_copy is defined by <stdarg.h>, which root.h did not include.  As
++   root.h is included ahead of <stdarg.h> (e.g. by src/string/string.h),
++   the fallback below used to override a perfectly good compiler-provided
++   va_copy with a plain assignment, which is invalid wherever va_list is
++   an array type (x86_64 System V, among others). */
++#include <stdarg.h>
++
+ /* va_copy is C99; try to deal with systems that lack it. */
+ #ifndef va_copy
+ #  ifdef __va_copy


### PR DESCRIPTION
`yodl` fails to build on x86_64. The build stops in `src/string`:

```
stringvformat.c:13:5: error: array type 'va_list' (aka '__builtin_va_list') is not assignable
   13 |     va_copy(copy, list);
      |     ^       ~~~~
./../root/root.h:86:42: note: expanded from macro 'va_copy'
   86 | #    define va_copy(dest, src) do { dest = src; } while (0)
      |                                     ~~~~ ^
1 error generated.
```

`src/root/root.h` carries a fallback for platforms lacking `va_copy`, but never
includes `<stdarg.h>` — and it is included *ahead* of `<stdarg.h>` by its
consumers (`src/string/string.h:10` includes `../root/root.h`, then `<stdarg.h>`
at line 12). So neither `va_copy` nor `__va_copy` is defined when the guard is
evaluated, and the fallback replaces the compiler's own `va_copy` with a plain
assignment.

That assignment is invalid wherever `va_list` is an array type. On x86_64 it is
`__builtin_va_list`, an array type, so this is a hard error; on arm64 Darwin
`va_list` is a plain `char *`, which is assignable — which is why the port
builds on Apple Silicon and fails only on Intel.

This adds `files/include-stdarg.patch`, which includes `<stdarg.h>` ahead of the
guard so the compiler's `va_copy` is visible, plus a `revision` bump.

### Verification

Applied to a pristine `yodl_3.05.01.orig.tar.gz` extraction with the three
existing patchfiles, built with the port's own flags (`CFLAGS='-Os -arch x86_64'`,
no workaround flags):

- `./build programs` — rc=0
- `./build macros` — rc=0
- `./build man` — rc=0
- 0 `error:` lines across all three phase logs
- `yodl --version` → `yodl version 3.05.01`
- smoke test: processed a small `article` document to text output correctly

Without the patch the same tree fails at `stringvformat.c` as above.

Tested on macOS 15.7.8 (24G824) x86_64, Apple clang 17.0.0, MacPorts 2.12.99.

### Note on the maintainer

The Portfile names `{larryv @larryv}`, but #56651 (*[Port Abandoned] Ports
abandoned by larryv*, closed `wontfix`) lists `yodl` among the abandoned ports
and the maintainer line was never updated. Happy to add a `nomaintainer` /
`openmaintainer` change here if that is preferred.

Closes: https://trac.macports.org/ticket/74329
