### PR TITLE
Python3{10..12}: conflict_build libuuid

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup clang_dependency 1.0
+PortGroup           conflicts_build 1.0
 
 name                python310
 
@@ -39,6 +40,7 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     patchfiles-append  patch-threadid-older-systems.diff
 }
 
+conflicts_build     libuuid
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \

--- a/lang/python311/Portfile
+++ b/lang/python311/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup           conflicts_build 1.0
 
 name                python311
 
@@ -45,6 +46,7 @@ if {${configure.build_arch} in "ppc ppc64"} {
     configure.ldflags-append -Wl,-force_cpusubtype_ALL
 }
 
+conflicts_build     libuuid
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \

--- a/lang/python312/Portfile
+++ b/lang/python312/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup           conflicts_build 1.0
 
 name                python312
 
@@ -38,6 +39,7 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     patchfiles-append  patch-threadid-older-systems.diff
 }
 
+conflicts_build     libuuid
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \


### PR DESCRIPTION
#### Description
When building python 3{10..12} from source, I get these errors
```
$=> grep -C 3 'error:' python312_install.log
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/hfs/hfs_format.h:807:2: error: unknown type name 'uuid_string_t'; did you mean 'io_string_t'?
  807 |         uuid_string_t   ext_jnl_uuid;
      |         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/device/device_types.h:89:33: note: 'io_string_t' declared here
--
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/hfs/hfs_format.h:809:20: error: use of undeclared identifier 'uuid_string_t'
  809 |         char            reserved[JIB_RESERVED_SIZE];
      |                                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/hfs/hfs_format.h:800:61: note: expanded from macro 'JIB_RESERVED_SIZE'
```
when `libuuid` is active


###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
```
Model Identifier: MacPro5,1                 Model Identifier: Macmini6,1
macOS macOS 15.7.8 24G824 x86_64            macOS 10.15.8 19H2036 x86_64
Xcode 26.3 17C529                           Xcode 12.4 12D4e
Command Line Tools 26.3.0.0.1.1771626560    Command Line Tools 12.4.0.0.1.1610135815
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?


