### PR TITLE
postgresqls: fix JIT compiler selection

### DIFF
--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -161,13 +161,14 @@ variant llvm description {add support for JIT compilation} {
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set clang_port_ver [string range ${clang} 5 6]
+            set clang_port_ver [string range ${clang} 5 end]
             set llvm_ver ${clang_port_ver}
         }
     }
 
     depends_lib-append      port:llvm-${llvm_ver}
+    depends_build-append    port:clang-${llvm_ver}
     configure.args-append   --with-llvm
     configure.env-append    LLVM_CONFIG=${prefix}/libexec/llvm-${llvm_ver}/bin/llvm-config \
-                            CLANG=${configure.cc}
+                            CLANG=${prefix}/libexec/llvm-${llvm_ver}/bin/clang
 }

--- a/databases/postgresql15/Portfile
+++ b/databases/postgresql15/Portfile
@@ -154,13 +154,14 @@ variant llvm description {add support for JIT compilation} {
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set clang_port_ver [string range ${clang} 5 6]
+            set clang_port_ver [string range ${clang} 5 end]
             set llvm_ver ${clang_port_ver}
         }
     }
 
     depends_lib-append      port:llvm-${llvm_ver}
+    depends_build-append    port:clang-${llvm_ver}
     configure.args-append   --with-llvm
     configure.env-append    LLVM_CONFIG=${prefix}/libexec/llvm-${llvm_ver}/bin/llvm-config \
-                            CLANG=${configure.cc}
+                            CLANG=${prefix}/libexec/llvm-${llvm_ver}/bin/clang
 }

--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -173,13 +173,14 @@ variant llvm description {add support for JIT compilation} {
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set clang_port_ver [string range ${clang} 5 6]
+            set clang_port_ver [string range ${clang} 5 end]
             set llvm_ver ${clang_port_ver}
         }
     }
 
     depends_lib-append      port:llvm-${llvm_ver}
+    depends_build-append    port:clang-${llvm_ver}
     configure.args-append   --with-llvm
     configure.env-append    LLVM_CONFIG=${prefix}/libexec/llvm-${llvm_ver}/bin/llvm-config \
-                            CLANG=${configure.cc}
+                            CLANG=${prefix}/libexec/llvm-${llvm_ver}/bin/clang
 }

--- a/databases/postgresql17/Portfile
+++ b/databases/postgresql17/Portfile
@@ -172,13 +172,14 @@ variant llvm description {add support for JIT compilation} {
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set clang_port_ver [string range ${clang} 5 6]
+            set clang_port_ver [string range ${clang} 5 end]
             set llvm_ver ${clang_port_ver}
         }
     }
 
     depends_lib-append      port:llvm-${llvm_ver}
+    depends_build-append    port:clang-${llvm_ver}
     configure.args-append   --with-llvm
     configure.env-append    LLVM_CONFIG=${prefix}/libexec/llvm-${llvm_ver}/bin/llvm-config \
-                            CLANG=${configure.cc}
+                            CLANG=${prefix}/libexec/llvm-${llvm_ver}/bin/clang
 }

--- a/databases/postgresql18/Portfile
+++ b/databases/postgresql18/Portfile
@@ -97,7 +97,8 @@ configure.universal_args-delete --disable-dependency-tracking
 # building psql with clang from Xcode prior to 4.4 causes segfault on query; see #31717
 compiler.blacklist-append {clang < 421}
 compilers.choose          cc cxx
-compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang90 -clang13
+compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang90 \
+                          -clang11 -clang12 -clang13
 notes "To use the postgresql server as a startup item install the ${name}-server port."
 
 if {${universal_possible} && [variant_isset universal]} {
@@ -172,13 +173,14 @@ variant llvm description {add support for JIT compilation} {
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set clang_port_ver [string range ${clang} 5 6]
+            set clang_port_ver [string range ${clang} 5 end]
             set llvm_ver ${clang_port_ver}
         }
     }
 
     depends_lib-append      port:llvm-${llvm_ver}
+    depends_build-append    port:clang-${llvm_ver}
     configure.args-append   --with-llvm
     configure.env-append    LLVM_CONFIG=${prefix}/libexec/llvm-${llvm_ver}/bin/llvm-config \
-                            CLANG=${configure.cc}
+                            CLANG=${prefix}/libexec/llvm-${llvm_ver}/bin/clang
 }


### PR DESCRIPTION
#### Description

This forces the +llvm variant to use the same clang as the selected LLVM version, but you can still change both by setting both +llvm and +clangNN.

Also, a few unsupported clangs are blacklisted in newer versions.

No revbump because these invalid combinations could never be built anyway.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
