### PR TITLE
slf4j: update to 2.0.18

### DIFF
--- a/java/slf4j/Portfile
+++ b/java/slf4j/Portfile
@@ -1,54 +1,56 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			slf4j
-version			1.5.6
+PortSystem          1.0
 
-categories		java
-maintainers		nomaintainer
-platforms		darwin
+name                slf4j
+version             1.5.6
 
-description		Simple Logging Facade for Java (SLF4J)
-long_description	The Simple Logging Facade for Java or (SLF4J) is \
-			intended to serve as a simple facade for various \
-			logging APIs allowing to the end-user to plug in \
-			the desired implementation at deployment time.  \
-			SLF4J also supports a bridging legacy APIs as \
-			well as a source code migration tool.  SLF4J API \
-			offers an advanced abstraction of various logging \
-			systems, including JDK 1.4 logging, log4j and \
-			logback.  Features include parameterized logging \
-			and MDC support.
-homepage		http://www.slf4j.org/
+categories          java
+maintainers         nomaintainer
+platforms           darwin
 
-master_sites		${homepage}dist/
-checksums		md5 967db737f5d748aa36d79c69dceeaa27 \
-			sha1 a73c602cab0d3c3bd7239de9d89a37eb5b251e03 \
-			rmd160 e3e2a0bda4d144c8fa83fac4f62706657c48ad61
+description         Simple Logging Facade for Java (SLF4J)
+long_description    The Simple Logging Facade for Java or (SLF4J) is \
+                    intended to serve as a simple facade for various \
+                    logging APIs allowing to the end-user to plug in \
+                    the desired implementation at deployment time.  \
+                    SLF4J also supports a bridging legacy APIs as \
+                    well as a source code migration tool.  SLF4J API \
+                    offers an advanced abstraction of various logging \
+                    systems, including JDK 1.4 logging, log4j and \
+                    logback.  Features include parameterized logging \
+                    and MDC support.
+homepage            http://www.slf4j.org/
 
-depends_lib		bin:java:kaffe
+master_sites        ${homepage}dist/
+checksums           md5     967db737f5d748aa36d79c69dceeaa27 \
+                    sha1    a73c602cab0d3c3bd7239de9d89a37eb5b251e03 \
+                    rmd160  e3e2a0bda4d144c8fa83fac4f62706657c48ad61
 
-use_configure		no
+depends_lib         bin:java:kaffe
+
+use_configure       no
 
 build {}
 
 destroot {
-	# Ensure needed directories
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc/${name}
+    # Ensure needed directories
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc/${name}
 
-	foreach f {	jcl-over-slf4j jul-to-slf4j log4j-over-slf4j slf4j-api
-			slf4j-ext slf4j-jcl slf4j-jdk14 slf4j-log4j12 
-			slf4j-migrator slf4j-nop slf4j-simple} {
-		file copy ${worksrcpath}/${f}-${version}.jar \
-			${destroot}${prefix}/share/java/${f}.jar
-	}
+    foreach f { jcl-over-slf4j jul-to-slf4j log4j-over-slf4j slf4j-api
+            slf4j-ext slf4j-jcl slf4j-jdk14 slf4j-log4j12 
+            slf4j-migrator slf4j-nop slf4j-simple} {
+        file copy ${worksrcpath}/${f}-${version}.jar \
+            ${destroot}${prefix}/share/java/${f}.jar
+    }
 
-	file copy ${worksrcpath}/LICENSE.txt \
-		${destroot}${prefix}/share/doc/${name}
-	file copy ${worksrcpath}/site/apidocs \
-		${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/LICENSE.txt \
+        ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/site/apidocs \
+        ${destroot}${prefix}/share/doc/${name}
 }
 
-livecheck.type		regex
-livecheck.url		${homepage}download.html
-livecheck.regex		slf4j-(\[0-9.\]+)\\.tar\\.gz
+livecheck.type      regex
+livecheck.url       ${homepage}download.html
+livecheck.regex     slf4j-(\[0-9.\]+)\\.tar\\.gz

--- a/java/slf4j/Portfile
+++ b/java/slf4j/Portfile
@@ -1,13 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           maven 1.0
 
-name                slf4j
-version             1.5.6
+github.setup        qos-ch slf4j 2.0.18 v_
+github.tarball_from archive
+
+# Prevent *-alpha* tags from counting as new versions
+github.livecheck.regex \
+                    {([0-9.]+)}
 
 categories          java
 maintainers         nomaintainer
-platforms           darwin
+platforms           any
+supported_archs     noarch
+license             MIT
 
 description         Simple Logging Facade for Java (SLF4J)
 long_description    The Simple Logging Facade for Java or (SLF4J) is \
@@ -20,37 +28,49 @@ long_description    The Simple Logging Facade for Java or (SLF4J) is \
                     systems, including JDK 1.4 logging, log4j and \
                     logback.  Features include parameterized logging \
                     and MDC support.
-homepage            http://www.slf4j.org/
 
-master_sites        ${homepage}dist/
-checksums           md5     967db737f5d748aa36d79c69dceeaa27 \
-                    sha1    a73c602cab0d3c3bd7239de9d89a37eb5b251e03 \
-                    rmd160  e3e2a0bda4d144c8fa83fac4f62706657c48ad61
+homepage            https://www.slf4j.org/
+checksums           rmd160  f9a7252ca8b541bf097d5dd30a17e8ec87fb444c \
+                    sha256  13562c210eb5d31d795bd906839886b59caa866bc07b2f8666c3bdc958f66765 \
+                    size    384556
 
-depends_lib         bin:java:kaffe
-
-use_configure       no
-
-build {}
+java.version        11+
+java.fallback       openjdk11
 
 destroot {
-    # Ensure needed directories
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc/${name}
-
-    foreach f { jcl-over-slf4j jul-to-slf4j log4j-over-slf4j slf4j-api
-            slf4j-ext slf4j-jcl slf4j-jdk14 slf4j-log4j12 
-            slf4j-migrator slf4j-nop slf4j-simple} {
-        file copy ${worksrcpath}/${f}-${version}.jar \
-            ${destroot}${prefix}/share/java/${f}.jar
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set docs {
+        LICENSE.txt
+        README.md
+        SECURITY.md
     }
 
-    file copy ${worksrcpath}/LICENSE.txt \
-        ${destroot}${prefix}/share/doc/${name}
-    file copy ${worksrcpath}/site/apidocs \
-        ${destroot}${prefix}/share/doc/${name}
-}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
+    set modules {
+        jcl-over-slf4j
+        jul-to-slf4j
+        log4j-over-slf4j
+        osgi-over-slf4j
+        slf4j-api
+        slf4j-ext
+        slf4j-jdk-platform-logging
+        slf4j-jdk14
+        slf4j-migrator
+        slf4j-nop
+        slf4j-reload4j
+        slf4j-simple
+    }
 
-livecheck.type      regex
-livecheck.url       ${homepage}download.html
-livecheck.regex     slf4j-(\[0-9.\]+)\\.tar\\.gz
+    # Ensure needed directories
+    xinstall -d -m 755 ${destdocdir} ${destjavadir}
+
+    foreach doc ${docs} {
+        xinstall -m 644 ${worksrcpath}/${doc} ${destdocdir}
+    }
+
+    foreach module ${modules} {
+        xinstall -m 644 \
+            ${worksrcpath}/${module}/target/${module}-${version}.jar \
+            ${destjavadir}/${module}.jar
+    }
+}


### PR DESCRIPTION
#### Description

Update `slf4j` to the latest stable release 2.0.18.  Also fix up and polish the Portfile.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vs install`?