### PR TITLE
testdisk: update to 7.2, fix build with Xcode 26

### DIFF
--- a/sysutils/testdisk/Portfile
+++ b/sysutils/testdisk/Portfile
@@ -3,10 +3,9 @@
 PortSystem     1.0
 
 name            testdisk
-version         7.1
-revision        1
+version         7.2
+revision        0
 categories      sysutils
-platforms       darwin
 maintainers     nomaintainer
 license         GPL-2+
 description     TestDisk is a powerful free data recovery utility.
@@ -35,9 +34,9 @@ use_bzip2       yes
 homepage        http://www.cgsecurity.org/wiki/TestDisk
 master_sites    http://www.cgsecurity.org/
 
-checksums           rmd160  481f3ec24e3d2ed3b15a8efb038abf88db9bc55d \
-                    sha256  1413c47569e48c5b22653b943d48136cb228abcbd6f03da109c4df63382190fe \
-                    size    742006
+checksums           rmd160  8285e51dc999cae954cccc0cdaf833108977d3bf \
+                    sha256  f8343be20cb4001c5d91a2e3bcd918398f00ae6d8310894a5a9f2feb813c283f \
+                    size    855781
 
 configure.cppflags-append   -I${prefix}/include/ossp
 
@@ -46,8 +45,12 @@ configure.args-append   --with-ncurses-lib=${prefix}/lib \
                         --with-iconv-lib=${prefix}/lib \
                         --with-iconv-includes=${prefix}/include
 
-# needed for testdisk 6.11's configure script
-configure.cflags-append -fnested-functions
+# configure restores LIBS (dropping -lewf) before the AC_CHECK_FUNCS that probes
+# for libewf_handle_{read,write}_buffer_at_offset, so those probes never link and
+# always report "no". The code then falls back to libewf_handle_{read,write}_random,
+# which libewf 2 removed.
+# https://github.com/cgsecurity/testdisk/issues/209
+configure.libs-append   -lewf
 
 livecheck.type  regex
 livecheck.regex {href="/wiki/TestDisk_Download".*>([0-9.]+)<}

--- a/sysutils/testdisk/Portfile
+++ b/sysutils/testdisk/Portfile
@@ -31,8 +31,8 @@ universal_variant no
 
 use_bzip2       yes
 
-homepage        http://www.cgsecurity.org/wiki/TestDisk
-master_sites    http://www.cgsecurity.org/
+homepage        https://www.cgsecurity.org/wiki/TestDisk
+master_sites    https://www.cgsecurity.org/
 
 checksums           rmd160  8285e51dc999cae954cccc0cdaf833108977d3bf \
                     sha256  f8343be20cb4001c5d91a2e3bcd918398f00ae6d8310894a5a9f2feb813c283f \


### PR DESCRIPTION
#### Description

`testdisk` currently fails to build on macOS 26 / Xcode 26. This updates the port to 7.2 and fixes three separate issues:

1. **`-fnested-functions` breaks all linking.** The Portfile appended it for testdisk 6.11's configure script. Clang translates the flag into a linker `-allow_stack_execute`, which Apple's linker as of Xcode 26 no longer accepts, so even configure's trivial "can the compiler create executables" probe fails:

   ```
   ld: unknown options: -allow_stack_execute
   configure: error: C compiler cannot create executables
   ```

2. **ntfs-3g `ioctl` signature mismatch.** Current ntfs-3g declares the `ioctl` device op's `request` parameter as `unsigned long`. testdisk 7.1 uses `int`, and clang 16+ treats the resulting function pointer mismatch as a hard error. Upstream 7.2 selects the correct signature itself, so the version update fixes this with no downstream patch.

3. **libewf 2 detection is broken upstream.** `configure` restores `LIBS` (dropping `-lewf`) before the `AC_CHECK_FUNCS` that probes for `libewf_handle_{read,write}_buffer_at_offset`, so those probes never link and always report "no". `ewf.c` then falls back to `libewf_handle_{read,write}_random`, which libewf 2 removed. Passing `LIBS=-lewf` makes the probes succeed and the libewf 2 code path compile.

Also drops the redundant `platforms` line to satisfy `port lint`.

Note on (3): this is an upstream bug, worked around here at the Portfile level. Patching `configure` directly would also work and would avoid an autoreconf — happy to switch if that is preferred. Worth being aware that on platforms where the fallback still compiles, this bug silently disables EWF support rather than failing loudly.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5 25F71 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`? (see note on trace mode below)
- [x] tested basic functionality of all binary files?

`port lint --nitpick` reports 0 errors and 0 warnings. No existing Trac ticket was found for this issue, so there is nothing to reference.

A full verbose source install (`sudo port -vs upgrade -n --force testdisk`) completes cleanly, ending in `No broken files found. / No broken ports found.`

Trace mode (`-t`) could not be included: on this system MacPorts 2.12.4 ships `darwintrace.dylib` as `x86_64 arm64`, while the macOS 26 system binaries it must inject into (`/usr/bin/gzip`, `/usr/bin/tar`, `/bin/sh`) are `x86_64 arm64e`. `DYLD_INSERT_LIBRARIES` therefore fails and any traced build aborts on signal 6 during extract. This is independent of this port — the first traced dependency fails the same way — so `-t` was omitted rather than worked around.

All three installed binaries were exercised:

- `testdisk` and `photorec` report all optional features enabled — `ntfs lib: libntfs-3g, ewf lib: 20230212, libjpeg: libjpeg-turbo-3.1.4.1, curses lib: ncurses 6.6, zlib: 1.3.2, iconv support: yes`
- `fidentify` correctly identifies a JPEG
- `photorec` carved a JPEG out of a synthetic 8 MB raw disk image and recovered it byte-identical to the source, confirming the libjpeg and carving paths work end to end

The port defines no test phase and upstream ships no `check` target, so `sudo port test` is not applicable. The port has no variants.
