### PR TITLE
claude-code: update to 2.1.234

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.233
+version             2.1.234
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  acd8cfdb4545e5ab00cf3e3dec90b2f6af92e766 \
-                 sha256  8b3ae18df411098ce55705c4bb151e9c97e34df55fe379c7b6b3122a69f0ea74 \
-                 size    315654448
+    checksums    rmd160  83d387c83af378832ea80de9f96c5f7588f66164 \
+                 sha256  1a7b2e8948609f1f732a6498cd17b805b5c5187d74a99adc61ebaa5a29efc34c \
+                 size    319452208
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  09cf2898ed31f12f72416c3f7f30218d9bf6d065 \
-                 sha256  bc466b6cde63edafc773f471a1fb98787fabb31f52240c8616ce7e1f587b212d \
-                 size    306981408
+    checksums    rmd160  3f4f6baac1016b404e52c265f11a3fbaa60695cc \
+                 sha256  08d8700313697cbe730a25420c908a299ce52d56f0eb2cf4fac94cab5109bc57 \
+                 size    310740672
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.234.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?