### PR TITLE
micronaut: update to 5.1.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.1.0 v
+github.setup    micronaut-projects micronaut-starter 5.1.1 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  9d41588f50424dc5ebb94b828583c7f0aa9f4e49 \
-                 sha256  cb2569db41a58c3927d56efacc59a409d876c8d4a8dfc990d0ae7a57737d3578 \
-                 size    34082121
+    checksums    rmd160  b05391ab25d1075a7d7815bca583687c690f7a56 \
+                 sha256  2342c3616a231b0158cf0723521b5527225819bfb1d9eb6b0a31011cc7840076 \
+                 size    34122622
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  e70e0168be026e37da4bd988914825686f7866b8 \
-                 sha256  a76fd1185379727bb7e6d8085524911838443e6c6ce8d1d727d439b31154dd61 \
-                 size    39179166
+    checksums    rmd160  13264f88819b36870ab47de9b9f99915af8f45f7 \
+                 sha256  2d48f1274910164b44246659c8c2e86d18390067227b6f478e7363be7c4d873f \
+                 size    39157596
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.1.1.

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?