### PR TITLE
libtorrent-rasterbar: Create dist-info, and new subports.

### DIFF
--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -54,6 +54,23 @@ cmake.build_type    Release
 universal_variant   no
 
 conflicts_build     ${name}
+subport libtorrent-rasterbar1 {
+    conflicts                   ${name} ${name}21
+    github.setup                arvidn libtorrent 1.2.20 v
+    distname                    libtorrent-rasterbar-${version}
+    boost.version               1.81
+
+    
+    checksums                   rmd160  0cde59c0554be067f5e674dab3c1d61123714258 \
+                                sha256  ccbf8e8c21dc81635de95166b498922b4725f9725a23b2cfe2a6b2fead6fb9fc \
+                                size    4227996
+
+    patchfiles-replace          patch-create-dist-info.patch \
+                                lt1-dist-info.patch
+
+    depends_lib-replace         path:lib/libssl.dylib:openssl \
+                                path:lib/libssl.dylib:openssl11
+}
 
 
 variant python310 conflicts python311 python312 python313 python314 description {Build bindings for Python 3.10} {

--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -53,7 +53,8 @@ cmake.build_type    Release
 
 universal_variant   no
 
-conflicts_build     ${name}
+conflicts           ${name}1 ${name}21
+
 subport libtorrent-rasterbar1 {
     conflicts                   ${name} ${name}21
     github.setup                arvidn libtorrent 1.2.20 v
@@ -72,6 +73,37 @@ subport libtorrent-rasterbar1 {
                                 path:lib/libssl.dylib:openssl11
 }
 
+subport libtorrent-rasterbar21 {
+    conflicts                   ${name} ${name}1
+    github.setup                arvidn libtorrent 2.1.1 v
+    distname                    libtorrent-rasterbar-${version}
+
+    # I am leaving most of this logic commented out, because, although it was fixed since I began work on the PR, upstream very commonly forgets to upload the source archive including submodules.
+
+    #    set try_signal_commit       105cce59972f925a33aa6b1c3109e4cd3caf583d
+    #    master_sites-append         https://github.com/arvidn/try_signal/archive/:try_signal
+    #    distfiles-append            ${try_signal_commit}${extract.suffix}:try_signal
+
+    checksums                   rmd160 7a967dc30640afdddc68d03c4ef40536dfd260a0 \
+                                sha256 0f163516ecef2e3331500266751de3098835a3c3ae0c2290448046c632bc0e93 \
+                                size    6667546
+
+    #                                ${try_signal_commit}${extract.suffix} \
+    #                                rmd160  ec03ef3e60546f448387b21d3e64a0541bac1985 \
+    #                                sha256  6f111b0d77429a8051be4faed06cf23fb03cf6ee233967c84fdd9d8d3b42ba8e \
+    #                                size    8008
+    #    extract.only                ${distname}${extract.suffix}
+
+    #    post-extract {
+    #        system -W ${worksrcpath} \
+    #        "tar -C '${worksrcpath}/deps/try_signal/' \
+    #        --strip-components 1 \
+    #        -xf '${distpath}/${try_signal_commit}${extract.suffix}'"
+    #    }
+
+    compiler.cxx_standard           2017
+    compiler.blacklist-append       {*gcc-[34].*} {macports-gcc-[56]} {clang < 1000.11.45.2}
+}
 
 variant python310 conflicts python311 python312 python313 python314 description {Build bindings for Python 3.10} {
         require_active_variants boost[boost::version_nodot] python310

--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -34,24 +34,20 @@ checksums           rmd160  e31bf9d8d6b3a918bc1ac7aa7320bf87d66707d6 \
                     size    4765282
 
 depends_lib-append  path:lib/libssl.dylib:openssl
+patchfiles-append   patch-create-dist-info.patch
 
-patchfiles          patch-python-use-the-right-compiler.diff
-
-# Apple clang less than 900.0.39.2 fails to build
-# build using C++14 for binary compatibility with C++14 dependents
 compiler.cxx_standard 2014
-compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 900.0.39.2}
-
-# ensure that compiler is using C++14 mode
-configure.cxxflags-append -std=c++14
+compiler.blacklist-append {*gcc-[34].*} {clang < 900.0.39.2}
 
 configure.args-append \
                     -DBoost_LIBRARY_DIR_RELEASE=[boost::lib_dir] \
                     -Dencryption=ON \
-                    -DCMAKE_CXX_STANDARD=14 \
                     -Dlogging=OFF \
                     -Dpython-bindings=ON \
-                    -Dpython-install-system-dir=ON
+                    -Ddeprecated-functions=ON \
+                    -Dpython-install-system-dir=ON \
+                    -Dpython-dist-info=ON \
+                    -Dwebtorrent=OFF
 
 cmake.build_type    Release
 
@@ -62,6 +58,7 @@ conflicts_build     ${name}
 
 variant python310 conflicts python311 python312 python313 python314 description {Build bindings for Python 3.10} {
         require_active_variants boost[boost::version_nodot] python310
+        depends_build-append port:py310-setuptools
         depends_lib-append port:python310
         configure.args-append \
                 -DPython3_EXECUTABLE=${prefix}/bin/python3.10 \
@@ -70,6 +67,7 @@ variant python310 conflicts python311 python312 python313 python314 description 
 
 variant python311 conflicts python310 python312 python313 python314 description {Build bindings for Python 3.11} {
         require_active_variants boost[boost::version_nodot] python311
+        depends_build-append port:py311-setuptools
         depends_lib-append port:python311
         configure.args-append \
                 -DPython3_EXECUTABLE=${prefix}/bin/python3.11 \
@@ -78,6 +76,7 @@ variant python311 conflicts python310 python312 python313 python314 description 
 
 variant python312 conflicts python310 python311 python313 python314 description {Build bindings for Python 3.12} {
         require_active_variants boost[boost::version_nodot] python312
+        depends_build-append port:py312-setuptools
         depends_lib-append port:python312
         configure.args-append \
                 -DPython3_EXECUTABLE=${prefix}/bin/python3.12 \
@@ -86,6 +85,7 @@ variant python312 conflicts python310 python311 python313 python314 description 
 
 variant python313 conflicts python310 python311 python312 python314 description {Build bindings for Python 3.13} {
         require_active_variants boost[boost::version_nodot] python313
+        depends_build-append port:py313-setuptools
         depends_lib-append port:python313
         configure.args-append \
                 -DPython3_EXECUTABLE=${prefix}/bin/python3.13 \
@@ -94,6 +94,7 @@ variant python313 conflicts python310 python311 python312 python314 description 
 
 variant python314 conflicts python310 python311 python312 python313 description {Build bindings for Python 3.14} {
         require_active_variants boost[boost::version_nodot] python314
+        depends_build-append port:py314-setuptools
         depends_lib-append port:python314
         configure.args-append \
                 -DPython3_EXECUTABLE=${prefix}/bin/python3.14 \

--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -98,7 +98,7 @@ variant python314 conflicts python310 python311 python312 python313 description 
         depends_lib-append port:python314
         configure.args-append \
                 -DPython3_EXECUTABLE=${prefix}/bin/python3.14 \
-                -DBoost_PYTHON313_LIBRARY_RELEASE=[boost::lib_dir]/libboost_python314-mt.dylib
+                -DBoost_PYTHON314_LIBRARY_RELEASE=[boost::lib_dir]/libboost_python314-mt.dylib
 }
 
 variant error_logging description {Enable logging of errors to disk} {

--- a/net/libtorrent-rasterbar/files/lt1-dist-info.patch
+++ b/net/libtorrent-rasterbar/files/lt1-dist-info.patch
@@ -1,0 +1,47 @@
+diff --git CMakeLists.txt.orig CMakeLists.txt
+index ff9d60a..b65576c 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -679,7 +679,7 @@ feature_option(build_tests "build tests" OFF)
+ feature_option(build_examples "build examples" OFF)
+ feature_option(build_tools "build tools" OFF)
+ feature_option(python-bindings "build python bindings" OFF)
+-feature_option(python-egg-info "generate python egg info" OFF)
++feature_option(python-dist-info "generate python dist info" OFF)
+ feature_option(python-install-system-dir "Install python bindings to the system installation directory rather than the CMake installation prefix" OFF)
+ 
+ feature_option(iconv "build libtorrent with iconv support" ON)
+
+diff --git bindings/python/CMakeLists.txt.orig bindings/python/CMakeLists.txt
+index eb87438..39443bd 100644
+--- bindings/python/CMakeLists.txt
++++ bindings/python/CMakeLists.txt
+@@ -105,7 +105,7 @@ message(STATUS "Python 3 extension suffix: ${Python3_SOABI}")
+ 
+ install(TARGETS python-libtorrent DESTINATION "${_PYTHON3_SITE_ARCH}")
+ 
+-if (python-egg-info)
++if (python-dist-info)
+ 	set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
+ 	set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
+ 	set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
+@@ -114,13 +114,15 @@ if (python-egg-info)
+ 	configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
+ 
+ 	add_custom_command(OUTPUT ${OUTPUT}
+-		COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} build -b "${CMAKE_CURRENT_SOURCE_DIR}"
+-		COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} egg_info -b "${CMAKE_CURRENT_SOURCE_DIR}"
++		COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${Python3_EXECUTABLE} ${SETUP_PY} dist_info
++		COMMAND echo 'libtorrent' > "${CMAKE_CURRENT_BINARY_DIR}/libtorrent-${CMAKE_PROJECT_VERSION}.dist-info/top_level.txt"
+ 		COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
+ 		DEPENDS ${DEPS}
+ 	)
+ 
+-	add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
++	if (NOT TARGET python_bindings)
++		add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
++	endif()
+ 
+-	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
++	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent-${CMAKE_PROJECT_VERSION}.dist-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
+ endif()

--- a/net/libtorrent-rasterbar/files/patch-create-dist-info.patch
+++ b/net/libtorrent-rasterbar/files/patch-create-dist-info.patch
@@ -1,0 +1,46 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 63f903c..71c494b 100644
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -730,7 +730,7 @@ feature_option(build_tests "build tests" OFF)
+ feature_option(build_examples "build examples" OFF)
+ feature_option(build_tools "build tools" OFF)
+ feature_option(python-bindings "build python bindings" OFF)
+-feature_option(python-egg-info "generate python egg info" OFF)
++feature_option(python-dist-info "generate python dist info" OFF)
+ feature_option(python-install-system-dir "Install python bindings to the system installation directory rather than the CMake installation prefix" OFF)
+ 
+ # these options require existing target
+
+diff --git bindings/python/CMakeLists.txt bindings/python/CMakeLists.txt
+index 689c274..f9c5906 100644
+--- bindings/python/CMakeLists.txt.orig
++++ bindings/python/CMakeLists.txt
+@@ -110,7 +110,7 @@ message(STATUS "Python 3 extension suffix: ${Python3_SOABI}")
+ 
+ install(TARGETS python-libtorrent DESTINATION "${_PYTHON3_SITE_ARCH}")
+ 
+-if (python-egg-info)
++if (python-dist-info)
+ 	set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
+ 	set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
+ 	set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
+@@ -119,12 +119,15 @@ if (python-egg-info)
+ 	configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
+ 
+ 	add_custom_command(OUTPUT ${OUTPUT}
+-		COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} egg_info
++		COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${Python3_EXECUTABLE} ${SETUP_PY} dist_info
++		COMMAND echo 'libtorrent' > "${CMAKE_CURRENT_BINARY_DIR}/libtorrent-${CMAKE_PROJECT_VERSION}.dist-info/top_level.txt"
+ 		COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
+ 		DEPENDS ${DEPS}
+ 	)
+ 
+-	add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
++	if (NOT TARGET python_bindings)
++		add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
++	endif()
+ 
+-	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
++	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent-${CMAKE_PROJECT_VERSION}.dist-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
+ endif()


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This PR fixes a couple things with libtorrent:

1) Updates the main port to the latest release.
2) Adds subports for the latest libtorrent 1.2 , as well as the latest in the 2.0 branches. The reason for this is that they represent breaking API changes and there are clients and users who might want to use each of those versions.
3) Fixes a broken variant, and fixes the libtorrent conflicting with itself thing which was fixed upstream god knows how long ago.
4) Includes a patch to create dist-info instead of egg-info, which will make builds of libtorrent play nice with other python packages that might want to use it. I'm working on getting that merged upstream.

Some notes: 
 - Libtorrent 2.1 explicitly raised the c++ standard to c++17; I haven't tested the new compiler blacklist entries but rather I made them by looking into the reported compatibilities of each of the versions I listed.
 - I had to use `fetch.type git` for 2.0.14 because that particular release is broken and missing the source file archive that includes submodules.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.7.8 22H730 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

