### PR TITLE
sysutils/tmux: fix 3.7c configure failure (must give --enable/--disable-jemalloc)

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -6,7 +6,7 @@ PortGroup       legacysupport 1.1
 
 github.setup    tmux tmux 3.7c
 if {${subport} eq ${name}} {
-    revision        0
+    revision        1
     conflicts       tmux-devel
 }
 subport tmux-devel {
@@ -96,6 +96,20 @@ post-destroot {
 
 variant sixel description {Support SIXEL graphics} {
     configure.args-append   --enable-sixel
+}
+
+variant jemalloc description {Use jemalloc instead of the system allocator (works around macOS calloc(3) bug, tmux/tmux#4777)} {
+    depends_lib-append      port:jemalloc
+    configure.args-append   --enable-jemalloc
+}
+
+if {${subport} eq ${name}} {
+    # Only the 3.7c release configure hard-requires an explicit
+    # --enable-jemalloc/--disable-jemalloc; the tmux-devel snapshot's
+    # configure.ac has no such check and treats jemalloc as fully optional.
+    if {![variant_isset jemalloc]} {
+        configure.args-append   --disable-jemalloc
+    }
 }
 
 default_variants-append +sixel


### PR DESCRIPTION
## Summary

tmux 3.7c's `configure` now hard-requires an explicit `--enable-jemalloc` or
`--disable-jemalloc` flag on darwin:

```
configure: 	   macOS calloc(3) appears not to correctly
configure: 	   zero allocations in some circumstances;
configure: 	   to avoid this, configuring with
configure: 	   --enable-jemalloc is recommended. To build
configure: 	   without anyway, use --disable-jemalloc

configure: error: must give --enable-jemalloc or --disable-jemalloc
```

The current Portfile passes neither flag, so **tmux 3.7c currently fails to
configure on every macOS host** (`port install tmux` / `port upgrade tmux`
both fail).

This is documented upstream as tmux/tmux#4777 (macOS `calloc(3)` under-zeroing
in some cases, causing crashes e.g. in copy mode on Apple Silicon).

## Changes

- Bump `revision` 0 → 1 for the `tmux` subport only (`tmux-devel` untouched;
  its snapshot's `configure.ac` has no such requirement — verified against
  the pinned commit, only `--enable/--disable-utf8proc` is hard-required
  there).
- Add an opt-in `variant jemalloc` (`depends_lib-append port:jemalloc`,
  `--enable-jemalloc`), matching upstream's own recommendation for the fix.
- When `-jemalloc`, pass `--disable-jemalloc` explicitly, satisfying
  configure's requirement without adding a new default dependency.
- Left `default_variants` unchanged (`+sixel` only) — jemalloc stays opt-in
  rather than becoming a default dependency for every user, since
  `--disable-jemalloc` alone is sufficient to fix the configure failure.

## Test plan

- [x] `port lint sysutils/tmux` — 0 errors, 0 warnings
- [x] `port install tmux +jemalloc` — builds and installs cleanly
      (`tmux @3.7c_1+jemalloc+sixel`), links `libjemalloc.2.dylib`
- [x] `port install tmux -jemalloc` — builds and installs cleanly
      (`tmux @3.7c_1+sixel`), confirming the `--disable-jemalloc` fallback
      path also configures successfully
- [x] `tmux -V` reports `tmux 3.7c`; verified a real session starts and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)