### PR TITLE
commons-logging: update to 1.4.0

### DIFF
--- a/java/commons-logging/Portfile
+++ b/java/commons-logging/Portfile
@@ -1,51 +1,41 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           maven 1.0
 
 name                commons-logging
-version             1.3.6
+github.setup        apache ${name} 1.4.0 rel/${name}-
+github.tarball_from archive
 
 categories          java
 license             Apache-2
 maintainers         nomaintainer
-platforms           darwin
+platforms           any
+supported_archs     noarch
 
 description         Apache Commons-Logging
 long_description    Commons-Logging is a wrapper around a variety of \
                     logging API implementations.
 homepage            https://commons.apache.org/logging/
 
-distname            ${name}-${version}-src
-master_sites        apache:commons/logging/source/
-checksums           rmd160  e4269ac100b8ee2951d7e7d90fbab6465f5f486a \
-                    sha256  9f479865de3e1235e7e0c64ef466f8690a47faecfd397b2d23e20cb561b063e0 \
-                    size    197037
+checksums           rmd160  f17ad7bfa1f3f7e8c797c35f7e1c80cd96fb667e \
+                    sha256  be9e34dbcfb42c131a749933556e2cb3be8eb06f0149e7605360039e3e715418 \
+                    size    268502
 
-depends_build       bin:mvn3:maven3
+java.version        1.8+
+java.fallback       openjdk11
 
-use_configure       no
-set maven_local_repository ${worksrcpath}/.m2/repository
+destroot {
+    set targetdir   ${worksrcpath}/target
+    set destjavadir ${destroot}${prefix}/share/java/${name}
 
-pre-build {
-    file mkdir ${maven_local_repository}
+    xinstall -d -m 755 ${destjavadir}
+
+    xinstall -m 644 ${targetdir}/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+    xinstall -m 644 ${targetdir}/${name}-${version}-api.jar \
+        ${destjavadir}/${name}-api.jar
+    xinstall -m 644 ${targetdir}/${name}-${version}-adapters.jar \
+        ${destjavadir}/${name}-adapters.jar
 }
-
-build.cmd           mvn3
-build.target        "package"
-build.pre_args-append \
-                    -Dmaven.repo.local=${maven_local_repository} \
-                    -DskipTests \
-                    -Drat.skip=true
-
-destroot    {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/target/commons-logging-${version}.jar \
-        ${destroot}${prefix}/share/java/commons-logging.jar
-    xinstall -m 644 ${worksrcpath}/target/commons-logging-${version}-api.jar \
-        ${destroot}${prefix}/share/java/commons-logging-api.jar
-    xinstall -m 644 ${worksrcpath}/target/commons-logging-${version}-adapters.jar \
-        ${destroot}${prefix}/share/java/commons-logging-adapters.jar
-}
-
-livecheck.type  regex
-livecheck.url   https://commons.apache.org/proper/commons-logging/download_logging.cgi
-livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"


### PR DESCRIPTION
#### Description

Update the `commons-logging` port to version 1.4.0 and polish up the Portfile.

May be related to [ticket 58389](https://trac.macports.org/ticket/58389)?  If it removes the dependency on `servlet23-api`, then it is related and I will edit the commit message to include the ticket.  But I cannot tell where the dependency was added or if it still persists after this update.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vs install`?