### PR TITLE
libewf: Fix build

### DIFF
--- a/security/libewf/Portfile
+++ b/security/libewf/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           openssl 1.0
 
 github.setup        libyal libewf 20230212
-revision            0
+revision            1
 categories          security
 maintainers         nomaintainer
 license             LGPL-3+
@@ -26,12 +26,14 @@ checksums           rmd160  2c23bdeb7f703c142d8b4412a952c08aace9500c \
                     sha256  d22eecbd962c3d7d646ccfba131fc3c07e6a07da37dc163b6ecbb1348db16101 \
                     size    2638562
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig \
+                    port:gettext
 
 openssl.branch      3
 
-depends_lib         port:bzip2 \
-                    port:gettext \
+depends_lib-append  port:bzip2 \
+                    port:gettext-runtime \
                     port:libiconv \
                     port:zlib
 
@@ -66,11 +68,10 @@ configure.args      --with-bzip2=${prefix} \
                     --without-libuuid
 
 if {${configure.build_arch} in [list arm64 x86_64]} {
-    depends_lib-append \
-                    path:lib/pkgconfig/fuse.pc:macfuse
+    PortGroup       fuse 1.0
 
     configure.args-replace \
-                   --without-libfuse --with-libfuse=${prefix}
+                    --without-libfuse --with-libfuse=${prefix}
 
     # osxfuse is not universal
     universal_variant   no


### PR DESCRIPTION
#### Description

Fix building libewf by using the fuse PG to use the correct fuse dependency on legacy systems (which had `macfuse` forced on them).

Found through [#34088](https://github.com/macports/macports-ports/pull/34088) when trying to build testdisk on the platforms listed below; `macfuse` shouldn't be a dependency for anything < macOS 10.12.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
