### PR TITLE
apr-util: fix expansion of conflicting variants

### DIFF
--- a/devel/apr-util/Portfile
+++ b/devel/apr-util/Portfile
@@ -114,7 +114,7 @@ variant mysql55 requires mysql57 description "Legacy compatibility variant" {}
 variant mysql56 requires mysql57 description "Legacy compatibility variant" {}
 foreach v ${mysql_vers} mysql_name ${mysql_names} {
     variant ${mysql_name} \
-            conflicts [ldelete ${db_vers} ${mysql_name}] \
+            conflicts {*}[ldelete ${db_vers} ${mysql_name}] \
             description "Use MySQL ${v} libraries" "
         depends_lib-append      port:${mysql_name}
         configure.args-replace --without-mysql --with-mysql
@@ -127,7 +127,7 @@ foreach v ${mysql_vers} mysql_name ${mysql_names} {
 variant mariadb requires mariadb10 description "Legacy compatibility variant" {}
 foreach v ${mariadb_vers} mariadb_name ${mariadb_names} {
     variant ${mariadb_name} \
-            conflicts [ldelete ${db_vers} ${mariadb_name}] \
+            conflicts {*}[ldelete ${db_vers} ${mariadb_name}] \
             description "Use MariaDB ${v} libraries" "
         depends_lib-append      port:mariadb-${v}
         configure.args-replace --without-mysql --with-mysql


### PR DESCRIPTION
#### Description

made a 🥩 in the `conflicts {*}[ldelete ${db_vers} ${mysql_name}] \` : forgot the `{*}`

###### Type(s)


- [x] bugfix
- [ ] enhancement
- [ ] security fix

