### PR TITLE
servlet2[34]-api: remove dependencies on kaffe

### DIFF
--- a/java/servlet23-api/Portfile
+++ b/java/servlet23-api/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 PortGroup java 1.0
 PortGroup deprecated 1.0
@@ -13,7 +15,8 @@ version         1
 categories      java
 license         Apache-2
 maintainers     nomaintainer
-platforms       darwin
+platforms       any
+supported_archs noarch
 
 description     Java Servlet API 2.3 and JSP 1.2 API.
 long_description \
@@ -28,7 +31,9 @@ master_sites    macports:jberry
 checksums       md5 2a32a1c8e148b4f6533eda9c1e698e50
 
 depends_build   bin:ant:apache-ant
-depends_lib     bin:java:kaffe
+
+java.version    1.2+
+java.fallback   openjdk11
 
 use_configure   no
 

--- a/java/servlet24-api/Portfile
+++ b/java/servlet24-api/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 PortGroup java 1.0
 PortGroup deprecated 1.0
@@ -32,7 +34,9 @@ checksums       md5     73cd758f32dff07e7d26817b50d3448d \
 
 
 depends_build   bin:ant:apache-ant
-depends_lib     bin:java:kaffe
+
+java.version    1.2+
+java.fallback   openjdk11
 
 worksrcdir      ${distname}/build
 
@@ -51,6 +55,4 @@ destroot {
         ${destroot}${prefix}/share/java/servlet24-api.jar
 }
 
-livecheck.type  regex
-livecheck.url   ${homepage}/download-55.cgi
-livecheck.regex "apache-tomcat-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.type  none


### PR DESCRIPTION
See: https://trac.macports.org/ticket/60206

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?

(Though `port lint` gives a few warnings due to the Portfiles being old; not much I can do to fix those.)