### PR TITLE
mars: migrate to java PortGroup

### DIFF
--- a/java/mars/Portfile
+++ b/java/mars/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           java 1.0
 
 name                mars
 version             4.5.1
@@ -41,7 +42,8 @@ checksums           Mars4_5.jar \
                     sha256  49bd31b90d41b1afd2d0e47636fea2461f5d16c2a55e0147fd82d77305514151 \
                     size    37008
 
-depends_lib         bin:java:kaffe
+java.version        1.5+
+java.fallback       openjdk11
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Use the `java` PortGroup to remove the dependency on `kaffe` for ticket [60206](https://trac.macports.org/ticket/60206).  Also use this opportunity to close tickets [66531](https://trac.macports.org/ticket/66531) and [66533](https://trac.macports.org/ticket/66533), which should have been closed by commit ef86185d761c81bd4464f4a5f020560fcfd958d1.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
