### PR TITLE
castor: update to 1.4.1

### DIFF
--- a/java/castor/Portfile
+++ b/java/castor/Portfile
@@ -1,40 +1,42 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			castor
-version			0.9.9
-categories		java
-platforms		darwin
-maintainers		nomaintainer
-description		data binding framework for Java
-long_description	Castor is an Open Source data binding framework for \
-				Java(tm). It's the shortest path between Java objects, XML \
-				documents and relational tables. Castor provides Java-to-XML \
-				binding, Java-to-SQL persistence, and more.
+PortSystem      1.0
 
-homepage		https://castor-data-binding.github.io/castor/
-master_sites	http://dist.codehaus.org/castor/${version}/
-distfiles		${distname}-src.tgz
-checksums		md5 4ae9cf49a93ee93ac743041ed5f0f4d3
+name            castor
+version         0.9.9
+categories      java
+platforms       darwin
+maintainers     nomaintainer
+description     data binding framework for Java
+long_description    Castor is an Open Source data binding framework for \
+                Java(tm). It's the shortest path between Java objects, XML \
+                documents and relational tables. Castor provides Java-to-XML \
+                binding, Java-to-SQL persistence, and more.
 
-depends_lib		bin:java:kaffe
+homepage        https://castor-data-binding.github.io/castor/
+master_sites    http://dist.codehaus.org/castor/${version}/
+distfiles       ${distname}-src.tgz
+checksums       md5 4ae9cf49a93ee93ac743041ed5f0f4d3
 
-use_configure	no
+depends_lib     bin:java:kaffe
 
-set classpath	lib/ant-1.6.jar:lib/ant-1.6-launcher.jar:lib/xerces-J_1.4.0.jar:build/classes
-build.cmd		java -classpath ${classpath} -Dant.home=lib org.apache.tools.ant.Main "$@" -buildfile src/build.xml
-build.target	jar
+use_configure   no
+
+set classpath   lib/ant-1.6.jar:lib/ant-1.6-launcher.jar:lib/xerces-J_1.4.0.jar:build/classes
+build.cmd       java -classpath ${classpath} -Dant.home=lib org.apache.tools.ant.Main "$@" -buildfile src/build.xml
+build.target    jar
 
 destroot {
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/dist/castor-0.9.9-xml.jar \
-		${destroot}${prefix}/share/java/castor-xml.jar
-	xinstall -m 644 ${worksrcpath}/dist/castor-0.9.9.jar \
-		${destroot}${prefix}/share/java/castor.jar
-	file copy ${worksrcpath}/src/doc ${destroot}${prefix}/share/doc/${name}
-	file copy ${worksrcpath}/src/examples ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/dist/castor-0.9.9-xml.jar \
+        ${destroot}${prefix}/share/java/castor-xml.jar
+    xinstall -m 644 ${worksrcpath}/dist/castor-0.9.9.jar \
+        ${destroot}${prefix}/share/java/castor.jar
+    file copy ${worksrcpath}/src/doc ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/src/examples ${destroot}${prefix}/share/doc/${name}
 }
 
-livecheck.type	regex
-livecheck.url	http://dist.codehaus.org/castor/
-livecheck.regex	{>([0-9.]+)/<}
+livecheck.type  regex
+livecheck.url   http://dist.codehaus.org/castor/
+livecheck.regex {>([0-9.]+)/<}

--- a/java/castor/Portfile
+++ b/java/castor/Portfile
@@ -1,11 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       github 1.0
+PortGroup       maven 1.0
 
-name            castor
-version         0.9.9
+github.setup    castor-data-binding castor 1.4.1
+github.tarball_from archive
+
 categories      java
-platforms       darwin
+license         Apache-2 BSD
+platforms       any
+supported_archs noarch
 maintainers     nomaintainer
 description     data binding framework for Java
 long_description    Castor is an Open Source data binding framework for \
@@ -14,29 +19,45 @@ long_description    Castor is an Open Source data binding framework for \
                 binding, Java-to-SQL persistence, and more.
 
 homepage        https://castor-data-binding.github.io/castor/
-master_sites    http://dist.codehaus.org/castor/${version}/
-distfiles       ${distname}-src.tgz
-checksums       md5 4ae9cf49a93ee93ac743041ed5f0f4d3
+checksums       rmd160  d8d605a71f16c54c86e91cd2be5758328c31df14 \
+                sha256  f3c3f21596825a83c022ce6abb26d4536f36a82434eaa6ca0d2db7fd6df0e1fe \
+                size    6142391
 
-depends_lib     bin:java:kaffe
+java.version    1.8+
+java.fallback   openjdk11
 
-use_configure   no
-
-set classpath   lib/ant-1.6.jar:lib/ant-1.6-launcher.jar:lib/xerces-J_1.4.0.jar:build/classes
-build.cmd       java -classpath ${classpath} -Dant.home=lib org.apache.tools.ant.Main "$@" -buildfile src/build.xml
-build.target    jar
+patchfiles      fix-maven-build.diff
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/dist/castor-0.9.9-xml.jar \
-        ${destroot}${prefix}/share/java/castor-xml.jar
-    xinstall -m 644 ${worksrcpath}/dist/castor-0.9.9.jar \
-        ${destroot}${prefix}/share/java/castor.jar
-    file copy ${worksrcpath}/src/doc ${destroot}${prefix}/share/doc/${name}
-    file copy ${worksrcpath}/src/examples ${destroot}${prefix}/share/doc/${name}
-}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
 
-livecheck.type  regex
-livecheck.url   http://dist.codehaus.org/castor/
-livecheck.regex {>([0-9.]+)/<}
+    xinstall -d ${destjavadir}
+
+    xinstall -m 644 \
+        ${worksrcpath}/anttask/target/${name}-anttasks-${version}.jar \
+        ${destjavadir}/anttasks.jar
+    xinstall -m 644 \
+        ${worksrcpath}/codegen/target/${name}-codegen-${version}.jar \
+        ${destjavadir}/codegen.jar
+    xinstall -m 644 \
+        ${worksrcpath}/codegen-testcase-archetype/target/${name}-archetype-codegen-testcase-${version}.jar \
+        ${destjavadir}/archetype-codegen-testcase.jar
+    xinstall -m 644 \
+        ${worksrcpath}/core/target/${name}-core-${version}.jar \
+        ${destjavadir}/core.jar
+    xinstall -m 644 \
+        ${worksrcpath}/diff/target/${name}-xml-diff-${version}.jar \
+        ${destjavadir}/xml-diff.jar
+    xinstall -m 644 \
+        ${worksrcpath}/maven-plugins/target/${name}-maven-plugins-${version}.jar \
+        ${destjavadir}/maven-plugins.jar
+    xinstall -m 644 \
+        ${worksrcpath}/schema/target/${name}-xml-schema-${version}.jar \
+        ${destjavadir}/xml-schema.jar
+    xinstall -m 644 \
+        ${worksrcpath}/xml/target/${name}-xml-${version}.jar \
+        ${destjavadir}/xml.jar
+    xinstall -m 644 \
+        ${worksrcpath}/xml-annotations/target/${name}-xml-annotations-${version}.jar \
+        ${destjavadir}/xml-annotations.jar
+}

--- a/java/castor/files/fix-maven-build.diff
+++ b/java/castor/files/fix-maven-build.diff
@@ -1,0 +1,17 @@
+As of at least version 3.9.16, Maven refuses to build the project due to
+it specifying Java 7, which Maven considers too old.  Bump up the Java
+version slightly to Java 8 to please Maven.
+
+--- parent/pom.xml.orig	2016-05-16 01:17:25
++++ parent/pom.xml	2026-08-18 21:08:12
+@@ -73,8 +73,8 @@
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+-                  <source>1.7</source>
+-                  <target>1.7</target>
++                  <source>1.8</source>
++                  <target>1.8</target>
+                </configuration>
+             </plugin>
+             <plugin>


### PR DESCRIPTION
#### Description

Also migrate to the github and maven PortGroups, and add a patch to allow more recent versions of Maven to build the project.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?