### PR TITLE
oasdiff: Update to 1.29.1

### DIFF
--- a/devel/oasdiff/Portfile
+++ b/devel/oasdiff/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Tufin/oasdiff 1.27.0 v
+go.setup            github.com/Tufin/oasdiff 1.29.1 v
 go.offline_build    no
 go.toolchain_min    1.26
 revision            0
@@ -21,9 +21,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  97d30d67a009f39ef9e9b3b34fd8b925560729a7 \
-                    sha256  e0790896f57d2e8d812353a4b2811944b86ed9cad19b791a09d06854e7f7c6da \
-                    size    696922
+                    rmd160  672e98aee997c7b7ef19aa196918f683ff6ee02e \
+                    sha256  50cc87718af4f052cae19b9929b3a454bf60b6fb9573aa026d3c0490d894b363 \
+                    size    712055
 
 post-build {
     system -W ${worksrcpath} "./${name} completion bash > ${name}.bash"


### PR DESCRIPTION
#### Description

oasdiff: Update to 1.29.1


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
