### PR TITLE
mise: Update to 2026.8.8

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.8.0 v
+github.setup        jdx mise 2026.8.8 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7cd0d07e2f767eb25d6b82c2a99f73aaad88ed2f \
-                    sha256  c053fb4f4373712e72505b3b1e2a3088a8fa165e621fd50882dc231feb659a0b \
-                    size    12949941
+                    rmd160  38cf2a4a4d00e41b5e21e552165259d65a633432 \
+                    sha256  f4053c5f98801ea6e35fc0050033ecbeb1c5d6c2142b61e07abbc262f8cccbaa \
+                    size    13552538
 
 depends_build-append \
                     port:bin/cmake:cmake
@@ -106,7 +106,7 @@ cargo.crates \
     age-core                            0.11.0  e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99 \
     age-core                            0.12.0  01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656 \
     ahash                               0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
-    aho-corasick                         1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    aho-corasick                         1.1.5  c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba \
     alloc-no-stdlib                      2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
     alloc-stdlib                         0.2.4  0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195 \
     allocator-api2                      0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
@@ -133,57 +133,58 @@ cargo.crates \
     astral_async_zip                    0.0.20  bd939d79959c3f49a648a1d7857d63cc62548725a6b060b8dbf0ea5c92470b63 \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes           0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
-    async-compression                   0.4.42  e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac \
+    async-compression                   0.4.43  3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8 \
     async-fd-lock                        0.2.0  7569377d7062165f6f7834d9cb3051974a2d141433cc201c2f94c149e993cccf \
     async-once-cell                      0.5.4  4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
     async-trait                         0.1.91  ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    aube                                1.37.0  1adc6f39cc5afd58a6cc578dfcb4dafcab9fe14fb6dbcaa2d50a530aa6ed558e \
-    aube-codes                          1.37.0  57b802f0a009c344d3a493c4f9f67f50e0012522db7eea32c53086bfbe231a4b \
-    aube-linker                         1.37.0  2e7dfa60c4ad71e79dc811119ea8d53f5a17b5b2ad812e141002639e3fef3be1 \
-    aube-lockfile                       1.37.0  0ce5c79419dada6ec1a6c4dcd5a5306684f6436b4517224e11adf699c4c357cd \
-    aube-manifest                       1.37.0  e47a036bd03aaeeab293e6be73faf9139b6edbb303bfbddfdf84d5069205751c \
-    aube-registry                       1.37.0  a3e472bea7624c2caae172603f855a6124bc434b4e132fb89e0e7eda22dc3ce3 \
-    aube-resolver                       1.37.0  681fd4570c2e8ccf5b45516ca1c4c8c951eebaf2e1ce2a4e68335e315ea7885f \
-    aube-runtime                        1.37.0  8fe29236d34f652cfdedc5fcb04f73ebc9589431e375ffa6caebd03c4f4df738 \
-    aube-scripts                        1.37.0  7e4e9804d041c81c6ab7c7382d64e1630480088adab0aede900dc3da90f7ddae \
-    aube-settings                       1.37.0  fc67ab05335c6cf84dd02aa7ee411e519d6a2a2b4b765f0183f8dbb45f7a8efe \
-    aube-store                          1.37.0  de2e17b61820b71eef2d09594bfd580a6d3f813be4e036d22704fb2181be9fcc \
-    aube-util                           1.37.0  e4dd6e9f42aa3bd013c823a5a0da673ece1e17cd667a8c73a5941d3abd85921c \
-    aube-workspace                      1.37.0  675be8ee8f9d4b485581774218c76f9c6ce8e1e86309594ea1f103a23da6f3d0 \
+    aube                                1.41.0  96f32e8b165cd44d00394a0ff19f578a92c99b2cc7ca14575df0da2db69f9eef \
+    aube-codes                          1.41.0  7e4970f4e74d441f91ba6a4a0ac8fd6e46658fe65e12ad7ebfe4873b580aff24 \
+    aube-linker                         1.41.0  162c3a9ff8ee6be148ed9abf3f8b274fe4b2442a54247b258395e69f4a96d7b5 \
+    aube-lockfile                       1.41.0  7f0bb9d924f35f07ccb1ead685e7f45f3a6f488df9b03562e5fbb8ec075d6290 \
+    aube-manifest                       1.41.0  75090ee2a1539bb4130d22f6410c2ab835381dee709913f5fb12c205148a37f0 \
+    aube-registry                       1.41.0  3f8b7bcdbfde52d4ce96c363b99e577ac73093e82f7ea40a23ed680ffda521ce \
+    aube-resolver                       1.41.0  deeda8571e6340e6f9bb8ca3ba39f163463260a8c0e6d8411d84f846fa4101f9 \
+    aube-runtime                        1.41.0  70f9172dbd650d35e6a9b54276998179c9b8a776fc11e0696de2b2a6c1f46110 \
+    aube-scripts                        1.41.0  2526895539b06b2abe99e4e77ed3e37ea54e6aaabf5d3a0d84348ed25d84978e \
+    aube-settings                       1.41.0  5f08726d73039e2fc9407715b3e6c2f97d72a4dbc85256c5ed21fe7b66d0dbaf \
+    aube-store                          1.41.0  f40eaeec4efdf07458340bcd405ec9c4f0034d48f6fbd9af765cc1d81aaae3cd \
+    aube-util                           1.41.0  ac99c4c1451782b818dbd0f197925352362caded0d798214a0e9dc809a146d3e \
+    aube-workspace                      1.41.0  dd585c4e04b176043622fd08a60b3a8f33a0245fa485787d2b01b9747da62d3d \
     autocfg                              1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
-    aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
-    aws-credential-types                1.2.13  6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0 \
-    aws-lc-fips-sys                    0.13.16  37b00953a69b2cfb471d13d72538d2e66930832340b0f31deadd404b48c573c5 \
-    aws-lc-rs                           1.17.3  00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1 \
-    aws-lc-sys                          0.43.0  43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c \
-    aws-runtime                          1.7.1  ede2ddc593e6c8acc6ce3358c28d6677a6dc49b65ba4b37a2befe14a11297e75 \
-    aws-sdk-s3                         1.119.0  1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c \
-    aws-sdk-sso                         1.95.0  00c5ff27c6ba2cbd95e6e26e2e736676fdf6bcf96495b187733f521cfe4ce448 \
-    aws-sdk-ssooidc                     1.97.0  4d186f1e5a3694a188e5a0640b3115ccc6e084d104e16fd6ba968dca072ffef8 \
-    aws-sdk-sts                         1.99.0  9acba7c62f3d4e2408fa998a3a8caacd8b9a5b5549cf36e2372fbdae329d5449 \
-    aws-sigv4                            1.4.1  37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9 \
-    aws-smithy-async                    1.2.13  5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13 \
-    aws-smithy-checksums               0.63.12  87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae \
-    aws-smithy-eventstream             0.60.19  1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79 \
-    aws-smithy-http                     0.62.6  826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b \
-    aws-smithy-http                     0.63.5  d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7 \
-    aws-smithy-http-client              1.1.11  00ccbb08c10f6bcf912f398188e42ee2eab5f1767ce215a02a73bc5df1bbdd95 \
-    aws-smithy-json                     0.61.9  49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551 \
-    aws-smithy-json                     0.62.4  27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb \
-    aws-smithy-observability             0.2.5  4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b \
-    aws-smithy-query                   0.60.14  05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0 \
-    aws-smithy-runtime                  1.10.2  22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf \
-    aws-smithy-runtime-api              1.11.5  b4af6e5def28be846479bbeac55aa4603d6f7986fc5da4601ba324dd5d377516 \
-    aws-smithy-types                     1.4.5  8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3 \
-    aws-smithy-xml                     0.60.14  b53543b4b86ed43f051644f704a98c7291b3618b67adf057ee77a366fa52fcaa \
-    aws-types                           1.3.13  0470cc047657c6e286346bdf10a8719d26efd6a91626992e0e64481e44323e96 \
+    aws-config                          1.8.18  e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275 \
+    aws-credential-types                1.2.14  8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7 \
+    aws-lc-fips-sys                     0.14.1  118303cd75f63d1933a90c2ceb7e697281ac6acbdbcc490b46419f25a527ab90 \
+    aws-lc-rs                           1.18.0  ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e \
+    aws-lc-sys                          0.44.0  f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483 \
+    aws-runtime                          1.7.5  6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39 \
+    aws-sdk-s3                         1.137.0  c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874 \
+    aws-sdk-sso                        1.102.0  8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b \
+    aws-sdk-ssooidc                    1.104.0  321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913 \
+    aws-sdk-sts                        1.107.0  3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560 \
+    aws-sigv4                            1.4.5  bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71 \
+    aws-smithy-async                    1.2.14  2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc \
+    aws-smithy-checksums                0.64.8  e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a \
+    aws-smithy-eventstream             0.60.21  78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706 \
+    aws-smithy-http                     0.63.6  ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231 \
+    aws-smithy-http-client              1.1.13  5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3 \
+    aws-smithy-json                     0.62.7  701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa \
+    aws-smithy-observability             0.2.6  a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c \
+    aws-smithy-query                   0.60.15  1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd \
+    aws-smithy-runtime                  1.11.3  b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182 \
+    aws-smithy-runtime-api              1.12.3  9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c \
+    aws-smithy-runtime-api-macros        1.0.0  8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7 \
+    aws-smithy-schema                    0.1.0  7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5 \
+    aws-smithy-types                     1.5.0  32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85 \
+    aws-smithy-xml                     0.60.15  0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3 \
+    aws-types                           1.3.16  d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531 \
     backtrace                           0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
     backtrace-ext                        0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
     base16ct                             0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
     base64                              0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                              0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    base64                              0.23.1  ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5 \
     base64-simd                          0.8.0  339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195 \
     base64ct                             1.8.3  2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06 \
     basic-toml                          0.1.10  ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a \
@@ -222,7 +223,7 @@ cargo.crates \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                               1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
     bytes-utils                          0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
-    bytesize                             2.4.2  3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e \
+    bytesize                             2.7.0  7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b \
     bzip2                                0.6.1  f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c \
     cache_control                        0.2.0  1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
@@ -230,7 +231,7 @@ cargo.crates \
     camellia                             0.1.0  3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30 \
     cast5                               0.11.1  26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                   1.4.0  5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9 \
+    cc                                   1.4.2  5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfb-mode                             0.8.2  738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
@@ -245,13 +246,13 @@ cargo.crates \
     ci_info                            0.14.15  7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23 \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     cipher                               0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
-    clang-sys                            1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                                 4.6.4  d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7 \
+    clang-sys                            1.9.1  157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a \
+    clap                                 4.6.5  301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf \
     clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
-    clap_builder                         4.6.2  f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b \
+    clap_builder                         4.6.5  94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078 \
     clap_derive                          4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
     clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
-    clap_usage                           4.0.0  46d067625f5704e5722fe7e46407fef7e79680d6dfd045d29036149d90ec044b \
+    clap_usage                           5.0.0  c3671e15a3e8444d399658989389a0eca99bee6f4aca10b836aad27882d4c4d7 \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
     clx                                  3.0.2  03a65674abcd65c2846d6bfc4c9816ab9177b15277a18a78aa1691683ce63095 \
     cmac                                 0.7.2  8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa \
@@ -267,7 +268,7 @@ cargo.crates \
     colorchoice                          1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     colored                              3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
     combine                              4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
-    comfy-table                          7.2.2  958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47 \
+    comfy-table                          8.0.0  136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2 \
     compression-codecs                  0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
     compression-core                    0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
     configparser                         3.2.0  b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4 \
@@ -277,7 +278,7 @@ cargo.crates \
     const-oid                            0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const-oid                           0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     constant_time_eq                     0.4.2  3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b \
-    contracts                            0.6.8  1be22136880ccef017b6b3d2e2ab23ba62755b308093862bad6b6e78d26d5e46 \
+    contracts                           0.6.10  80771e396e09e4d428c6d034440a3fc62f3927334b66e13c8b8689d3f8785e42 \
     convert_case                        0.10.0  633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
     cookie                              0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
     cookie-factory                       0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
@@ -289,9 +290,7 @@ cargo.crates \
     cpubits                              0.1.1  15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae \
     cpufeatures                         0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     cpufeatures                          0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
-    crc                                  3.4.0  5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
-    crc-catalog                          2.5.0  217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
-    crc-fast                             1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
+    crc-fast                            1.10.0  e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5 \
     crc24                                0.1.6  fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0 \
     crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crmf                                 0.2.0  36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92 \
@@ -304,7 +303,7 @@ cargo.crates \
     crypto-bigint                        0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    ctor                                1.0.11  e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209 \
+    ctor                                1.0.12  2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -347,7 +346,7 @@ cargo.crates \
     directories                          6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs                                 6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                             0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    displaydoc                           0.2.6  1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
+    displaydoc                           0.2.7  c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8 \
     document-features                   0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                             0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     dsa                                  0.6.3  48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689 \
@@ -388,7 +387,7 @@ cargo.crates \
     file_url                             0.3.2  5e68d9ad067554ef18d79494f0e0bcddaf263f41b0126eb7a937f9e942fcbbd8 \
     filetime                            0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
-    find-msvc-tools                      0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    find-msvc-tools                     0.1.10  26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de \
     fixedbitset                          0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
     flagset                              0.4.7  b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe \
     flate2                               1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
@@ -414,15 +413,15 @@ cargo.crates \
     fslock                               0.2.1  04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb \
     funty                                2.0.0  e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c \
     futures                             0.3.33  a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218 \
-    futures-channel                     0.3.33  262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae \
-    futures-core                        0.3.33  2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7 \
+    futures-channel                     0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
+    futures-core                        0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
     futures-executor                    0.3.33  6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458 \
-    futures-io                          0.3.33  4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a \
+    futures-io                          0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
     futures-lite                         2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
-    futures-macro                       0.3.33  2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b \
-    futures-sink                        0.3.33  e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307 \
-    futures-task                        0.3.33  b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109 \
-    futures-util                        0.3.33  a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa \
+    futures-macro                       0.3.34  9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44 \
+    futures-sink                        0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                        0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-util                        0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
     fuzzy-matcher                        0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
     generator                            0.7.5  5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e \
     generic-array                       0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
@@ -489,7 +488,7 @@ cargo.crates \
     gix-worktree-stream                 0.35.0  3b088c8724e7be120c4798dd86925cf05332c9d356a463542578600c50c7a549 \
     gix-zlib                             0.1.0  3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c \
     glob                                 0.3.4  e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
-    globset                             0.4.19  e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd \
+    globset                             0.4.20  07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988 \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     group                               0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
     h2                                  0.4.15  6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155 \
@@ -510,7 +509,7 @@ cargo.crates \
     homedir                              0.3.6  68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527 \
     hpke                                0.12.0  4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11 \
     http                                0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
-    http                                 1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
+    http                                 1.5.0  918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0 \
     http-auth                           0.1.10  150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822 \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                            1.1.0  ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
@@ -524,7 +523,7 @@ cargo.crates \
     humansize                            2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                            2.4.0  15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
     hybrid-array                         0.2.3  f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9 \
-    hybrid-array                        0.4.13  818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c \
+    hybrid-array                        0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
     hyper                               1.11.0  d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72 \
     hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
@@ -548,7 +547,7 @@ cargo.crates \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                         1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
-    ignore                              0.4.31  7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83 \
+    ignore                              0.4.33  00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f \
     impl-tools                          0.11.4  0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208 \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
@@ -564,7 +563,7 @@ cargo.crates \
     inventory                           0.3.24  a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b \
     io-close                             0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
     io_tee                               0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
-    ipnet                               2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
+    ipnet                               2.12.1  6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78 \
     is_ci                                1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill                1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                           0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
@@ -592,21 +591,20 @@ cargo.crates \
     keccak                               0.1.6  cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653 \
     kem                            0.3.0-pre.0  2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
-    landlock                             0.4.6  aa9b598524037d06d8466ec364866121281a2398c343ae8640b28bbe7be50cdb \
-    lazy-regex                           3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
-    lazy-regex-proc_macros               3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
+    landlock                             0.4.7  4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1 \
+    lazy-regex                           3.6.1  4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9 \
+    lazy-regex-proc_macros               3.6.1  fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libbz2-rs-sys                        0.2.5  34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c \
     libc                               0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                            0.1.18  c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652 \
+    libredox                            0.1.19  2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa \
     libyaml-rs                           0.3.0  2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777 \
     libz-ng-sys                         1.1.29  879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469 \
-    line-index                           0.1.2  3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2 \
-    link-section                        0.19.1  8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1 \
-    linktime-proc-macro                  0.2.0  8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee \
+    link-section                        0.19.2  5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4 \
+    linktime-proc-macro                  0.2.2  348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -616,7 +614,7 @@ cargo.crates \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
-    lru                                 0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
+    lru                                 0.16.4  7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39 \
     lru-slab                             0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     lua-src                            550.1.1  75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949 \
     luajit-src                 210.7.2+b925b3e  920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6 \
@@ -649,7 +647,6 @@ cargo.crates \
     nix                                 0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
     node-semver                          2.2.0  3b1a233ea5dc37d2cfba31cfc87a5a56cc2a9c04e3672c15d179ca118dae40a7 \
     nodejs-semver                        5.0.0  364dd919c4d6feef8c3a3f3e2b64af729187902156e17481618622cbbf1353a1 \
-    nohash-hasher                        0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
     nom                                  7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nom                                  8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
     nom-language                         0.1.0  2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29 \
@@ -661,7 +658,7 @@ cargo.crates \
     num-bigint-dig                       0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
     num-complex                          0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                             0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
-    num-integer                         0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-integer                         0.1.47  7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b \
     num-iter                            0.1.46  c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b \
     num-rational                         0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
@@ -739,9 +736,9 @@ cargo.crates \
     prettyplease                        0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     primeorder                          0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
     proc-macro-error-attr2               2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
-    proc-macro-error-attr3               3.0.3  be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1 \
+    proc-macro-error-attr3               3.1.0  b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7 \
     proc-macro-error2                    2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro-error3                    3.0.3  dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c \
+    proc-macro-error3                    3.1.0  0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50 \
     proc-macro2                        1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     prodash                             31.0.0  962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c \
     proptest                            1.11.0  4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744 \
@@ -769,20 +766,20 @@ cargo.crates \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_pcg                            0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.47.1  417e0f429d4c0f849d8e862c6d522efb35c6cb48cb6fb9e34a9a26fb6b70850f \
-    rattler_cache                       0.10.3  1e608aa1824f88fbdf0839ed2e5d5a762692cad6aa864a725b44844d79e28c8e \
-    rattler_conda_types                 0.48.1  f38273db000680207c48aa39ae1bcca9babf430c0f4dfb80b7dea9376592ddad \
+    rattler                             0.48.2  61bfdcb39e1719edbb27e562d40405c1a8130eb3fff8b11b489672b642a488af \
+    rattler_cache                       0.10.5  b1ea7ff3474f2c5aceb5fe741061ad744f164e050de40dc25608c5ae0e66753c \
+    rattler_conda_types                 0.49.1  058c739d6ea6b3f429443f9d7117022330049bdb1cdde7b46622662463bd5cc0 \
     rattler_digest                       1.3.2  56538779701395adba456293b22fda6598b079f30c24d9a22c2bb15271bd67f3 \
     rattler_macros                       1.1.2  bc1bde42798a908a8a2609836a062f01117b83a3fba6f8f6be3eb8c1d07bfdf2 \
-    rattler_menuinst                    0.2.70  b99d32612f64644cbcaf39caf83fb89409477b579985735930996fe1f71b0cf2 \
-    rattler_networking                  0.30.2  a79426b2af3db171d23fba74bfa9abf832367af610bbee76f979d47f9a094f2a \
-    rattler_package_streaming           0.26.8  4db3af7641d6c40af2f8f2be0a494ad4d04c3825dc5ed1e7957d3c019637b5b2 \
-    rattler_pty                         0.2.15  ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328 \
+    rattler_menuinst                    0.2.73  b6269634b94b5a9be52cf45bf9368819b33268a4372e76f9c8f9c64c9275a64a \
+    rattler_networking                  0.30.4  e668ff6375b364d8835cf15d51179ac7366aced2a39d60877041d099a421fd06 \
+    rattler_package_streaming           0.27.0  e7ca685c8e3a5ffecd6ad1e9c938753993ed05220c050a070a847ae541797a2e \
+    rattler_pty                         0.2.16  c4bb899b6b8d316efe26fe43e003073ef93d230d9009a41d630e22473368c0e4 \
     rattler_redaction                    0.2.2  068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177 \
-    rattler_repodata_gateway            0.30.1  7b18c19b2e44e3c29840a73cb76bf741bd844b777f5a9d19dabb522ea99bcbb8 \
-    rattler_shell                      0.27.10  40e36d0927ce8ee7cc7648be7060f8d1bbda9ac0afeb24e280af644d21d6ba28 \
-    rattler_solve                        7.2.2  766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3 \
-    rattler_virtual_packages             3.0.4  af8a387e540318781c3805871c02f4652da75c5440a8b6adea63a2de63dffec6 \
+    rattler_repodata_gateway            0.32.0  466a4335b63701b2eeb0888e66c82e034589998007ee68eceb30f75d5bc643b7 \
+    rattler_shell                      0.27.13  27e6d9e4b73759112b0560c85c3fe3c9619386ed11700daa7b068d02fcd0a766 \
+    rattler_solve                        9.0.1  15139fa95d92a22fe4ba6b00ee89ed6b2375550f1c51036b202c51f771c0d29a \
+    rattler_virtual_packages             5.0.0  3fbade435086e26b977cd2e2a06afa6e5815de03c34af6b39e5a309cbc731196 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
@@ -791,7 +788,7 @@ cargo.crates \
     ref-cast-impl                       1.0.26  2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c \
     reflink-copy                        0.1.30  d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b \
     regex                               1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
-    regex-automata                      0.4.16  8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad \
+    regex-automata                      0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-lite                           0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     regex-syntax                        0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
@@ -805,8 +802,8 @@ cargo.crates \
     ripemd                               0.1.3  bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f \
     rkyv                                0.8.17  815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874 \
     rkyv_derive                         0.8.17  c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c \
-    rmcp                                 2.2.0  14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af \
-    rmcp-macros                          2.2.0  783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3 \
+    rmcp                                 3.1.0  ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695 \
+    rmcp-macros                          3.1.0  41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
@@ -822,12 +819,12 @@ cargo.crates \
     rustc_version                        0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                             0.23.42  3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138 \
+    rustls                             0.23.43  0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06 \
     rustls-native-certs                  0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
     rustls-pki-types                    1.15.1  2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
-    rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
+    rustls-webpki                     0.103.14  0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a \
     rustversion                         1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     ryu                                 1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
@@ -919,19 +916,19 @@ cargo.crates \
     sonic-number                         0.1.2  3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32 \
     sonic-rs                             0.5.8  d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f \
     sonic-simd                           0.1.4  f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4 \
+    spdx                                0.13.5  081670c233dfbed55690cc0cd38424e0e24ac1b2673d0b408b3f7b684738dfa9 \
     spin                                 0.9.9  3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e \
+    spin                                0.10.1  023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3 \
     spki                                 0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     spki                                 0.8.0  1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f \
     stable_deref_trait                   1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                    1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
-    streaming-iterator                   0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strip-ansi-escapes                   0.2.1  2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025 \
     strsim                              0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                               0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
     strum                               0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                        0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     strum_macros                        0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
-    subfeature                          1.28.0  f6be2c63b5abd9caec364547309f51653179b216193c7be5e70dcf0c1c84d418 \
     subtle                               2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     superslice                           1.0.0  ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f \
     supports-color                       3.0.2  c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6 \
@@ -967,7 +964,7 @@ cargo.crates \
     thiserror-impl                      1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                      2.0.19  43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
     thread_local                        1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
-    time                                0.3.54  3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244 \
+    time                                0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
     time-core                            0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
     time-macros                         0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
     tinystr                              0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
@@ -976,14 +973,14 @@ cargo.crates \
     tls_codec                            0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
     tls_codec_derive                     0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
     tokio                               1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
-    tokio-macros                         2.7.1  6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba \
+    tokio-macros                         2.7.2  78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e \
     tokio-native-tls                     0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                        0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                        0.1.19  a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b \
     tokio-util                          0.7.19  494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52 \
     toml                                0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                                0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
-    toml                      1.1.3+spec-1.1.0  53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c \
+    toml                      1.1.4+spec-1.1.0  3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5 \
     toml_datetime                       0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
     toml_datetime             1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
     toml_edit                          0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
@@ -1002,10 +999,6 @@ cargo.crates \
     tracing-log                          0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-serde                        0.2.0  704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1 \
     tracing-subscriber                  0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
-    tree-sitter                        0.26.11  af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df \
-    tree-sitter-iter                    1.27.0  0cbef0ee83b87916292355e78f4fdee268d719ececa729be8914882428ca86b0 \
-    tree-sitter-language                 0.1.7  009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782 \
-    tree-sitter-yaml                     0.7.2  53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97 \
     try-lock                             0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     twofish                              0.7.1  a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013 \
     type-map                             0.5.1  cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90 \
@@ -1037,7 +1030,7 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            4.0.0  b60d4043943b220cc7269576a383ff2d62ab00f208f10d94b2496791729f8b02 \
+    usage-lib                            5.1.0  12698ad30baf6deeaf269f22385352c52dfadc27526e886a07b077e6fb25d17e \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -1140,8 +1133,6 @@ cargo.crates \
     xx                                   2.6.1  f8aff208388ac09afbb2bd20c3db8f7d253c9fbed7076e3618d598bb3deef2c5 \
     xz2                                  0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yaml_serde                          0.10.4  08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975 \
-    yamlpatch                           1.26.1  919764173d845c2b685a44ca9a028534ef1127bcf713edc6b69787430f18b030 \
-    yamlpath                            1.27.0  1362068e6e34bf985c39ee42ee8d410fcc398fedbd5f9303602616db26f542b5 \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                 0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \


### PR DESCRIPTION
#### Description

mise: Update to 2026.8.8


##### Tested on

macOS 26.5.2 25F84 arm64
Xcode 26.6 17F113


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
