### PR TITLE
google-cloud-sdk: update to 581.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             580.0.0
+version             581.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  02edacbb937a406aba71bd67138be55faf9277a2 \
-                    sha256  43090b89de9487291d20815b343a9a383250da5d662c0373fda442a3b4528159 \
-                    size    60119483
+    checksums       rmd160  b966cb72b71058f888f202272e750e35f08968cc \
+                    sha256  1ea341bda45b8b63ae51886d1b0b79198bde296b96306394f0d5f5ff6c7ac83f \
+                    size    60562945
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  ff08c32f2d34b306b684d1cf7176c96d49bb1305 \
-                    sha256  9688006c182a95b83a21c0246216b2f5439fb71eb7d70b526a9f480dd9ce1317 \
-                    size    61774587
+    checksums       rmd160  8d8c8508aecb911c638131c2ca44fb83c3478500 \
+                    sha256  0a1d266f4785977dba578a6cd2e3dce551d82dedf14b1ce1cb8d3728d5e0ee94 \
+                    size    62222458
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  81d506e65e5dad64c693a9b2f7b6d5574a093191 \
-                    sha256  4f704fd6e2f918c667da53c96304fa4c831a8a4e84f3c24c4b27ad0880d8f3af \
-                    size    61679977
+    checksums       rmd160  40aae42285803e9daaa29fbeba19675915263d49 \
+                    sha256  5d5b79fc28c302ebbdffb83cddb50a138b3d364edccd70dfafee8969d3c44bdd \
+                    size    62128574
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 581.0.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?