### PR TITLE
openjdk25: update to 25.0.4.1

### DIFF
--- a/_resources/port1.0/group/metal-1.0.tcl
+++ b/_resources/port1.0/group/metal-1.0.tcl
@@ -13,12 +13,14 @@
 use_xcode   yes
 
 pre-configure {
+    set xcrun_command "xcrun"
+
     set sdkroot [option configure.sdkroot]
     if {$sdkroot ne ""} {
-        set metal_check_command "env SDKROOT=[shellescape $sdkroot] xcrun metal --version"
-    } else {
-        set metal_check_command "xcrun metal --version"
+        set xcrun_command "env SDKROOT=[shellescape $sdkroot] $xcrun_command"
     }
+
+    set metal_check_command "$xcrun_command metal --version"
 
     if {[catch {system ${metal_check_command}}]} {
         # The Metal toolchain is not set up correctly, let's see what we can do or recommend
@@ -32,7 +34,7 @@ pre-configure {
 
         # The Metal toolchain check could be failing due to a corrupt xcrun cache
         # Let's kill the xcrun cache to see if this fixes the problem
-        system "xcrun --kill-cache"
+        system "$xcrun_command --kill-cache"
 
         if {[catch {system ${metal_check_command}}]} {
             return -code error "Required Metal toolchain not set up properly for use with MacPorts. \

--- a/java/openjdk25/Portfile
+++ b/java/openjdk25/Portfile
@@ -12,8 +12,8 @@ name                openjdk${feature}
 set boot_feature 24
 
 # See https://github.com/openjdk/jdk25u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.4
-set build 7
+set openjdk_version ${feature}.0.4.1
+set build 1
 revision            0
 
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
@@ -30,9 +30,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  5cd4ecaf14b8ddac4f1641870c1aa8aab9dddda8 \
-                    sha256  7ac9dc76bc201e1a03e8a7bff750fb226cd7373182293bc1860c33317d47b2df \
-                    size    119678926
+checksums           rmd160  cbdaaac747c03b0d51735ceb9855dd9459cdc826 \
+                    sha256  1dd5567b315e19cf4cfb2c32931e535fd65b326960a8770f351d7655439b1eb8 \
+                    size    119680316
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 25.0.4.1.

Also make sure that all `xcrun` commands are run with `SDKROOT` set or for instance `xcrun --kill-cache` won't work as expected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?