### PR TITLE
cloc: Update to 2.10

### DIFF
--- a/textproc/cloc/Portfile
+++ b/textproc/cloc/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           perl5 1.0
 PortGroup           makefile 1.0
 
-github.setup        AlDanial cloc 2.08 v
+github.setup        AlDanial cloc 2.10 v
 github.tarball_from archive
 revision            0
 perl5.branches      5.34
@@ -20,9 +20,9 @@ long_description    cloc counts blank lines, comment lines, and physical \
                     Given two versions of a code base, cloc can compute \
                     differences in blank, comment, and source lines.
 
-checksums           rmd160  c1362af39659673a85ee3338d13ff41782227178 \
-                    sha256  8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5 \
-                    size    763505
+checksums           rmd160  890a016cd7706a29bc5a5afaa1729a9fdda00262 \
+                    sha256  a8fac35f4cf42728765580ba11afc2568ad205509a22204663f526169548436d \
+                    size    778538
 
 depends_run-append  port:perl${perl5.major} \
                     port:p${perl5.major}-algorithm-diff \


### PR DESCRIPTION
#### Description

Update cloc to 2.10

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
