### PR TITLE
openjdk21: update to 21.0.12.1

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -9,8 +9,8 @@ set feature 21
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk21u/tags for the latest '*-ga' tag and its corresponding build number
-set openjdk_version ${feature}.0.12
-set build 8
+set openjdk_version ${feature}.0.12.1
+set build 1
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
 github.tarball_from archive
 version             ${openjdk_version}
@@ -30,9 +30,9 @@ long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementa
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  45247f59edfdde19422dbdf52c264eb337fe8720 \
-                    sha256  4061da54ee3b69a7b95a5403f3b170e1f6a08b192bde995a5cf607626c839626 \
-                    size    114155298
+checksums           rmd160  0bf6861db362ef23db6a2b6dfafa133cad004903 \
+                    sha256  c2c2f5c17619ead8652b10318e77eb1bacab5fc8496e8523b5b7e58330566370 \
+                    size    114151340
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.12.1.

###### Type(s)

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?