### PR TITLE
butane: Update to 0.29.0

### DIFF
--- a/sysutils/butane/Portfile
+++ b/sysutils/butane/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/coreos/butane 0.26.0 v
+go.setup            github.com/coreos/butane 0.29.0 v
+go.toolchain_min    1.24
 github.tarball_from archive
 revision            0
 categories          sysutils
@@ -18,9 +19,9 @@ long_description    Butane translates human-readable Butane Configs into \
                     operating systems that use Ignition, such as Fedora CoreOS.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  d532fcee52fa27096317b61a4707e6af4c0d426a \
-                        sha256  4294b92ab18cecfad3758100017d4fa3af6da131b3ae1ce1074c5c0e836fa9bd \
-                        size    692637
+                        rmd160  dddaac56d059f90f223c0021580de06187ba6585 \
+                        sha256  fb53732f08479a8057f60e7d7535e3717ecd013e362d65f474272b44374e0f97 \
+                        size    764045
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -47,11 +48,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  eb2e68c61d88ce1e22cf4b75b31de9815ee375b5 \
                         sha256  8e29e9893c782030a639e4e1ff4442cef352fa54b64aaa11c35163d550ce10dd \
                         size    63166 \
-                    github.com/rogpeppe/go-internal \
-                        lock    v1.9.0 \
-                        rmd160  acb8f644e5634bdae632cdb61ea736422aeb88f0 \
-                        sha256  65b0852e5c78fa920fef2176fa17180bf1f7f32a1163baacb44c2aa480845a16 \
-                        size    133682 \
                     github.com/pmezard/go-difflib \
                         lock    5d4384ee4fb2 \
                         rmd160  18b381fb63f46047dcc373a07a40e026b1ce1732 \
@@ -67,11 +63,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  401559c8d2db7a6becabf583dca6843e5cd3c5ac \
                         sha256  e6cbd00eca63c91837cd094e89bda52d067163dc5b5db12758b8995c75fd3377 \
                         size    9936 \
-                    github.com/kr/text \
-                        lock    v0.2.0 \
-                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
-                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
-                        size    8702 \
                     github.com/kr/pretty \
                         lock    v0.3.1 \
                         rmd160  8c08579b4c56cdc958794e77afe3413e80aa67c3 \
@@ -87,16 +78,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  ce50f5a16806c19ec5ce7e58695a445952099ba0 \
                         sha256  4e2946623d69565882a1c64186c555ddb7fe8069ed02df551921180131d4a1b4 \
                         size    15983 \
-                    github.com/coreos/ignition \
-                        lock    v2.25.0 \
-                        rmd160  67f3f3f93dcc1668bef9c5139b73286262238e41 \
-                        sha256  190e724512fa84b300d94cada187a413596f20e415d19f7142d0fee6f0b9bff4 \
-                        size    8478151 \
-                    github.com/coreos/go-systemd \
-                        lock    v22.6.0 \
-                        rmd160  fd75e74feab84fc7936013921d93d53e19a2522d \
-                        sha256  6152c7044505009ef79156aa19b44613ef60412c0becbfdd8ab61fbc2ee91e5d \
-                        size    77945 \
+                    github.com/coreos/ignition/v2 \
+                        lock    v2.26.0 \
+                        rmd160  d6c4a564159e532b978a44b84efb850f5aaa89d1 \
+                        sha256  9a3d515a691c334e7a04b1ec70afb3dcc8f8b154a1357eea125a4f1d0ad19f26 \
+                        size    8521096 \
+                    github.com/coreos/go-systemd/v22 \
+                        lock    v22.7.0 \
+                        rmd160  90e3fe046541c630b4cda53e2b1f9e23f20b7ecb \
+                        sha256  78ca13cea535f445427f2ecf7bd8e61a86b16034c7d367884f6570adb2aa83b0 \
+                        size    79663 \
                     github.com/coreos/go-semver \
                         lock    v0.3.1 \
                         rmd160  b88448b88ac26286ebac14c2145a520d414ff6bb \
@@ -113,13 +104,13 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  2ac6fe410345d7c3dc01a8680e44064c36e9742938f419e1aad78915a4f9953f \
                         size    188635 \
                     github.com/aws/aws-sdk-go-v2 \
-                        lock    v1.40.1 \
-                        rmd160  00baa7e60c2ab1f16f5fa66691b2845322aa0f36 \
-                        sha256  89c6f6a4f40931aa0e06afb4356ad7daf08961af771bfa9494cbc7c2e0e450f4 \
-                        size    57406314
+                        lock    v1.41.1 \
+                        rmd160  79133ccc1405ab34b89900da6514348780401fd3 \
+                        sha256  f8f250145526a3337f108a2d596cd7003eeb8e7deb2bd48a2ade943cb5bebe15 \
+                        size    57707293
 
-build.args          -o ${name} \
-                    -ldflags -X\\ github.com/coreos/butane/internal/version.Raw=${version} \
+build.args-append   -o ${name} \
+                    -ldflags \"-X ${go.package}/internal/version.Raw=${version}\" \
                     internal/main.go
 
 destroot {


### PR DESCRIPTION
#### Description

Update butane to 0.29.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
