### PR TITLE
openjdk17: update to 17.0.20.1

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -8,8 +8,8 @@ set feature 17
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.20
-set build 8
+set openjdk_version ${feature}.0.20.1
+set build 1
 revision            0
 
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
@@ -27,9 +27,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  99c835aaca0f5703ac5cff6607717c4e7ecefa97 \
-                    sha256  553420058f849043d7bf7715771a5851046043e7d977626d43ee0e3a67b23ddf \
-                    size    108344766
+checksums           rmd160  1c3ffd4060890a0282c6f8c6d374c0eba982c077 \
+                    sha256  c5dde86a6f9790411fde5449b7e42984c52b1c1fceb3a27ef7910c9dea0621b6 \
+                    size    108348221
 
 set port_jdk_build  openjdk${feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.20.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?