### PR TITLE
openjdk25-corretto: update to 25.0.4.8.1

### DIFF
--- a/java/openjdk25-corretto/Portfile
+++ b/java/openjdk25-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.4.7.1
+version      ${feature}.0.4.8.1
 revision     0
 
 # Support calendar: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  06130fcfa562c09bd784d717f980ad6e35a84ae7 \
-                 sha256  840b857016f2ab1a60a2aa5a68584b1da55f4ab953c1e2a207bde0a5114f683d \
-                 size    221008402
+    checksums    rmd160  eb6fb098db06b25549224b0e7b2a9d18e650d4ea \
+                 sha256  ae63ba7c8beb5a3669fcce4a2eb1261505a468fe7223e6c45df98c86eb52b5ee \
+                 size    220999407
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  7a5cb2490219836d645bad071b327011a2e2a713 \
-                 sha256  41e185be6b230cff4e9c85d33f9b092274a32e42113087f26d3b2e4f7909ab78 \
-                 size    218317899
+    checksums    rmd160  fb1f0081654faf9ab12438971b061a993d22dbd4 \
+                 sha256  b3040e5db181d09c79499728c86d250773f7f5018a3e4c124a0b08b96a75c42b \
+                 size    218316666
 } else {
     set corretto_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 25.0.4.8.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?