### PR TITLE
openjdk21-corretto: update to 21.0.12.9.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      ${feature}.0.12.8.1
+version      ${feature}.0.12.9.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6d61f1447378370e3b2d7863d3802c590a669d1d \
-                 sha256  a018ae6221babf065f770479b1bf0ab0d23bea78ed18f236c40bb5d4736612ff \
-                 size    202985567
+    checksums    rmd160  85b984676d50b1d78a491bd84fa668529294985a \
+                 sha256  203b3d37c16b388db2b2f3cabe9d37189bac09294848737a26f7dc9063331cb8 \
+                 size    202991079
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  937bbc688ae6d9e5398b36f2661f9892a5e09008 \
-                 sha256  cb230d7ac82784a4438663cdaf91d0d04037a9b4fb99ea41e138d88ce1224ab7 \
-                 size    200624726
+    checksums    rmd160  0bb17f7b6158754705fe3e56036bd763fc7e81e5 \
+                 sha256  2c03e806a8fb634b9fa21013f9de43ed4ec7fc6e6487144d2af5e2d4c126dfdd \
+                 size    200627351
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.12.9.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?