### PR TITLE
openjdk26-corretto: update to 26.0.2.11.1

### DIFF
--- a/java/openjdk26-corretto/Portfile
+++ b/java/openjdk26-corretto/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-# https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.2.10.1
+# https://github.com/corretto/corretto-26/releases
+version      ${feature}.0.2.11.1
 revision     0
 
 # Support calendar: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  fe263397774c809f2455c66d09b289ce2a2ff58a \
-                 sha256  3c136216dac0b9d1616ae4d6fa2faa317d9af7843be0853dbe7a93154fbd99a9 \
-                 size    226273685
+    checksums    rmd160  6f8a2fa4013abc05e61853361b0d2b75bdb85a51 \
+                 sha256  92b080fe3d1de305dcc2bcc6d1b938e4ee1e79a749a31757e5d68434093c588a \
+                 size    226283499
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  ed55c17eafb6172233e471bfcf2068ed5b0f13af \
-                 sha256  005e867168437be5c12ce704b5310e1ad40e122bef0108634cac70790b5bd6f8 \
-                 size    223486567
+    checksums    rmd160  9becb70cb4a928ac98527733bca886af681038d2 \
+                 sha256  328c25729dda95fdb5caead2cf39f997877acefbde356c6ce55ff2d1585d6ec5 \
+                 size    223490899
 } else {
     set corretto_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 26.0.2.11.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?