### PR TITLE
openjdk17-corretto: update to 17.0.20.10.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.20.8.1
+version      ${feature}.0.20.10.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  4186fa6ae6b57dfab53a49b0318e386e70fc8fdd \
-                 sha256  36b2e4f270e8b70aafe8c1ec8c254cc323675fd911d1d3f49981e3f18f73e638 \
-                 size    188738226
+    checksums    rmd160  d0bb76802ab8d1d05ae46fd1c52f26d4f6670824 \
+                 sha256  3e328eaf6e82c5a95afc5bdfa8b65b387e18836f57e95bde31c0ad476678edf9 \
+                 size    188745962
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  10ff16eaa128d2f21c86bb3abb759afbdeb4ee7c \
-                 sha256  786a9bbb94d2d077ca5618a80eec4c1a909595fbe24b617d57f50d360f96990e \
-                 size    186696102
+    checksums    rmd160  74f898fa09c69b23d08b55d9a4386118c2662383 \
+                 sha256  44e16fd802661560640fc04209f72a61816bae3b02aae9fa7668ee23228b22f6 \
+                 size    186697528
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.20.10.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?