### PR TITLE
openjdk25-zulu: update to 25.36.205

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25&package=jdk#zulu
-version      ${feature}.36.15
+version      ${feature}.36.205
 revision     0
 
-set openjdk_version ${feature}.0.4
+set openjdk_version ${feature}.0.4.1
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until September 2033)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  1d8afd067eaa38a8c038c834501da452c4a97e56 \
-                 sha256  63273c6b9e2d9b250a0009ffdaa6d9f27af6ba98772516c391276106fb9f2820 \
-                 size    226258616
+    checksums    rmd160  6c9bdeb01dac8fd633fa68665f862b9c50cca10a \
+                 sha256  dc5c05d44b89fe753fb25e559cbc71b341b95d593aeb08a294afd61ff0dd3262 \
+                 size    226262746
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  3700af6d0f53598ac30850d147bfc34084ec4e32 \
-                 sha256  c422f22713510992c764a7d577ae4f5add223529ab356993f38f8df2d4b247bd \
-                 size    223708386
+    checksums    rmd160  7712572908833a9541ebdea6fb093f5628d3e156 \
+                 sha256  c2e610d1689ead4bbd860d1ee8634ffb0b61f3bd62b5573df315ce8fc00bc068 \
+                 size    223713114
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.36.205.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?