### PR TITLE
openjdk21-zulu: update to 21.52.203

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      ${feature}.52.15
+version      ${feature}.52.203
 revision     0
 
-set openjdk_version ${feature}.0.12
+set openjdk_version ${feature}.0.12.1
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until December 2030)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  80c2a02a1ad6ade9f858f49e24f7c5b2d9cd1b65 \
-                 sha256  14e05cb1299c27cd26d3c5c6815723f63018df548dc7278c810767607902b4f4 \
-                 size    208133820
+    checksums    rmd160  6e852417dba749606c50646e15763772d9e11aaa \
+                 sha256  6edaf4b72ec6c23d86a46d8b88d0cfed2aaf81645fee13fd852d37af23c4b9fb \
+                 size    208142948
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  69c58dd9519fa241d637e4ea2991e1789c51b59f \
-                 sha256  84d38c4bf04f73d585bd319b949758d00abde50149a9522c2d9deef46b9a3ec6 \
-                 size    205915901
+    checksums    rmd160  b4174d3a5548c4edba4f6199208f1f67a7bfb746 \
+                 sha256  042093e0895c940a02d68e727bc37b59f3958e58aa1463ec9080845d77af0a45 \
+                 size    205923685
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 21.52.203.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?