### PR TITLE
openjdk17-zulu: update to 17.68.203

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.68.17
+version      ${feature}.68.203
 revision     0
 
-set openjdk_version ${feature}.0.20
+set openjdk_version ${feature}.0.20.1
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until September 2029)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  cce7d390570cd77915749141ba429f0c87057920 \
-                 sha256  b5bace4a346a7af0fe4f50904c46770e66d4b465800b038693c35e5d5b9bd52a \
-                 size    193762657
+    checksums    rmd160  8671192c527d403c984771cf3539628f7bb66a9a \
+                 sha256  ec1f9c98a9c1304230af23c565a3592c48314409e82ead75e3a98ee4fc94336f \
+                 size    193763519
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  12b42026e5c4f0b05ff8f3f778b23e9f6e849296 \
-                 sha256  0da52534760b74ba8a42660384b2f4e44311a47ae52faa45fcbd829b2797b244 \
-                 size    191676948
+    checksums    rmd160  e92f51b990652dc63001a6c1dce53124660a3008 \
+                 sha256  ed54397260c5994b2fc4e31c780f480b947e6532bc6a5ac7754355d5dd4c127d \
+                 size    191677926
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.68.203.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?