### PR TITLE
openjdk8-zulu: update to 8.96.0.205

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      ${feature}.96.0.19
+version      ${feature}.96.0.205
 revision     0
 
-set openjdk_version ${feature}.0.502
+set openjdk_version ${feature}.0.504
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until December 2030)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  abf681716daf7f0113dd3415a3f86e3811e055e4 \
-                 sha256  b29088ddb00f81db1e01d6d5bfddd44a58e46ef44b50c372cff3eb1bf5b23173 \
-                 size    106163060
+    checksums    rmd160  757cf2856838c416bc74b2b947aa19a7c1a5010b \
+                 sha256  e35bc8a4401193aa670146762bbad132bf0651fee5e3f16acbb3a5db0e0b0cff \
+                 size    106151769
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  c923c58d8366fd6548e4eb71a93305cafa9c4e6e \
-                 sha256  9f9e5038c638e415e507e8b5118a774822f553a56e76bdf4b042c3fbe7b69083 \
-                 size    103713081
+    checksums    rmd160  534aba01e85cec76bb6164ee4e6893150b7322ee \
+                 sha256  58bb3c08f2aa63d9743cf31899fa4b8c6c9effefce9479e7288c26621c3bb21b \
+                 size    103714410
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.96.0.205.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?