### PR TITLE
openjdk26-zulu: update to 26.32.203

### DIFF
--- a/java/openjdk26-zulu/Portfile
+++ b/java/openjdk26-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-26&package=jdk#zulu
-version      ${feature}.32.13
+version      ${feature}.32.203
 revision     0
 
-set openjdk_version ${feature}.0.2
+set openjdk_version ${feature}.0.2.1
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2026)
@@ -34,14 +34,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5749cac0c4db53153c1625ac6f2d534e808e33e5 \
-                 sha256  3a96262cd9ac0a606959d246fcdedbc5d96081670325cc44aede3bf5690e386c \
-                 size    231522832
+    checksums    rmd160  307073116cae1ec128e93787e7ca6454f4479d61 \
+                 sha256  4074a99b7487ba0b82eecb6086ef1ae6f2992bf48510d4610bb1ee22e1ea060f \
+                 size    231523376
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  7c2d7e7a0957d4bfae4a964d49f024c057e9f188 \
-                 sha256  4e9958fc459d8dd72fc51b21314b20b678132fc542915d9faa88d10a4a137ba2 \
-                 size    228897043
+    checksums    rmd160  11a1a5799079778736f2811a5ac496c9cadc78df \
+                 sha256  f638bd1bb4c9fc4e8f59da10d21d14d7f281e1fb72006ab6427d1704bf3529d7 \
+                 size    228895377
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Azul Zulu 26.32.203.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?