### PR TITLE
openjdk26: update to 26.0.2.1

### DIFF
--- a/java/openjdk26/Portfile
+++ b/java/openjdk26/Portfile
@@ -12,8 +12,8 @@ name                openjdk${feature}
 set boot_feature 25
 
 # See https://github.com/openjdk/jdk26u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set build 10
-github.setup        openjdk jdk${feature}u ${feature}.0.2 jdk- +${build}
+set build 1
+github.setup        openjdk jdk${feature}u ${feature}.0.2.1 jdk- +${build}
 revision            0
 github.tarball_from archive
 
@@ -27,9 +27,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  560ba09160c8141066d2daa11d1b057eccef32a8 \
-                    sha256  dc7301511e010b22b28f2953c005b1e5bd7845c025440396f940c5c73d4b73d0 \
-                    size    121699515
+checksums           rmd160  6bd3102388b0b382baea5ef9a4a3a4520d69b6c1 \
+                    sha256  334810683c6beafe00e4945d95b398f0d93ae09fe483c7b30f0c3f9d32403416 \
+                    size    121696934
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 26.0.2.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?