### PR TITLE
claude-code: update to 2.1.235

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.234
+version             2.1.235
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  83d387c83af378832ea80de9f96c5f7588f66164 \
-                 sha256  1a7b2e8948609f1f732a6498cd17b805b5c5187d74a99adc61ebaa5a29efc34c \
-                 size    319452208
+    checksums    rmd160  033181a8c6c407445d3b98152c0f4f193437ac8e \
+                 sha256  325a2dbc166ba8361a913ce588dce4a236789502060239acea52072bb51a54f1 \
+                 size    321995248
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  3f4f6baac1016b404e52c265f11a3fbaa60695cc \
-                 sha256  08d8700313697cbe730a25420c908a299ce52d56f0eb2cf4fac94cab5109bc57 \
-                 size    310740672
+    checksums    rmd160  691e03dc3d599655bd3968226fcc396eddc94b70 \
+                 sha256  83b8f806f6f2eea316cfe246628e6c23374711d868f1fd0409db551b877b7748 \
+                 size    313334608
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.235.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?