### PR TITLE
openjdk11-corretto: update to 11.0.32.10.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      ${feature}.0.32.9.1
+version      ${feature}.0.32.10.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d926f0fc19a007ee80ec37ce2cd01ab2bd124375 \
-                 sha256  399ff66c80c4f55024c8ba36bfdefbcd4ac180934d147a30b9f66d6970b055e7 \
-                 size    187859804
+    checksums    rmd160  d54ef1fddf4587c565c38439cd95247aea17c44a \
+                 sha256  b2dc525aed2dc78e0b7ebda1fd5fa37b40d184699ba27fb5d6edd13b8cf84531 \
+                 size    187860352
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  0652f999174947bed23e7c1ea060e9487b632723 \
-                 sha256  569ef802134a63d026b9a0215c2c61e49a077ce896462334b63668cdd644b1f6 \
-                 size    185351709
+    checksums    rmd160  acfb4f85da1034d595adc98ffaa999366af2cd32 \
+                 sha256  878b362d1942a4e4e553f1237ca3534a88b246dc200bbb13f2dc1712fb5602f4 \
+                 size    185357466
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.32.10.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?