### PR TITLE
openjdk8-corretto: update to 8.504.01.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.502.07.1
+version      ${feature}.504.01.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  c9dfa011cfd9e14298579f28509e6b732b525b41 \
-                 sha256  ab6c714f54388f67bce204cea9f40b2a5ea8fed3263e425520efbc970e6c1f6f \
-                 size    102825410
+    checksums    rmd160  18696941ba80706cd17d3ea926b03271ba2a54fb \
+                 sha256  6763f63fd4ffab020fefc54b96d29e02a82b8745a6e87aaccb9af92f3c33d5da \
+                 size    102834322
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  d77abdd5c3ea0b718fbdc8e4c6bd907dfe22ac3d \
-                 sha256  81a172ff2dfb3f408eca5b0a0dfaf84657cb68f9a0cc94818d562e144b3f199f \
-                 size    102923569
+    checksums    rmd160  19afa886c2d17538a9c7f7a75c0893b6403e1556 \
+                 sha256  425eaab72289ffb346fae3d904de7301dc9fcb70ae9dc095fac2ea1b1c621bea \
+                 size    102920269
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.504.01.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?