### PR TITLE
vercel-fx: new port, tiny native coding agent in Zig

### DIFF
--- a/llm/vercel-fx/Portfile
+++ b/llm/vercel-fx/Portfile
@@ -1,0 +1,103 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           zig_toolchain 1.0
+
+name                vercel-fx
+github.setup        vercel-labs fx 0.0.3 v
+github.tarball_from archive
+revision            0
+
+homepage            https://fx.sh
+
+categories          llm
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Tiny, open, embeddable, native coding agent
+
+long_description    fx is a coding agent harness and CLI written in Zig, \
+                    optimized for research and embeddability as part of \
+                    larger systems. It focuses on minimalism and performance \
+                    across the board, from system prompt design to its tools, \
+                    feature set, and binary size, and its output style aims to \
+                    be closer to a Unix shell than a heavy terminal IDE. It is \
+                    model-agnostic and suitable for both local and cloud \
+                    inference.
+
+checksums           rmd160  e8c4d9216fc962706ec4f5ae268ca63bed9785d3 \
+                    sha256  eb0f9b8877db2764c083e0620b1f0fb60a90345367bc8a6fe81af3682facd337 \
+                    size    5110944
+
+# The series build.zig.zon names as minimum_zig_version. An exact pin, not a
+# floor: Zig breaks the language and standard library at every minor release.
+set zig_series      0.16
+
+# Inherited from the Zig toolchain, which is the only thing here that will not
+# build further back.
+platforms           "darwin >= [zig_toolchain.min_darwin ${zig_series}]"
+
+# The Zig toolchain is only packaged for these, and Zig does not take the
+# -arch flags a universal build would hand it.
+supported_archs     arm64 x86_64
+universal_variant   no
+
+depends_build-append \
+                    port:zig-${zig_series}
+
+# The agent shells out to git to enumerate tracked files and to drive `fx pr`
+# and `fx issue`.
+depends_run-append  path:bin/git:git
+
+# Both install a `fx` binary.
+conflicts           fx
+
+use_configure       no
+
+build.cmd           [zig_toolchain.bin ${zig_series}]
+build.target        build
+build.args          -Doptimize=ReleaseFast \
+                    -j${build.jobs} \
+                    --global-cache-dir ${workpath}/zig-global-cache \
+                    --cache-dir ${workpath}/zig-local-cache
+
+test.run            yes
+test.cmd            ${worksrcpath}/zig-out/bin/fx
+test.target
+test.args           --version
+
+destroot {
+    xinstall -d ${destroot}${prefix}/libexec/${name}
+    xinstall -m 0755 ${worksrcpath}/zig-out/bin/fx \
+        ${destroot}${prefix}/libexec/${name}/fx
+
+    # fx starts a background thread that checks for a new release every thirty
+    # minutes and swaps the running binary out for it. That is this port's job,
+    # so the wrapper turns it off through fx's own opt-out, while still letting
+    # someone who wants the upstream behaviour set FX_AUTO_UPGRADE themselves.
+    set wrapper [open ${destroot}${prefix}/bin/fx w 0755]
+    puts $wrapper "#!/bin/sh"
+    puts $wrapper ": \"\$\{FX_AUTO_UPGRADE:=0\}\""
+    puts $wrapper "export FX_AUTO_UPGRADE"
+    puts $wrapper "exec ${prefix}/libexec/${name}/fx \"\$@\""
+    close $wrapper
+}
+
+notes "
+fx's built-in self-updater is disabled: this port keeps ${prefix}/bin/fx up to\
+date, and 'fx upgrade' cannot write there anyway. Run 'sudo port selfupdate &&\
+sudo port upgrade ${name}' instead.
+
+Sign in with 'fx login', or configure an AI Gateway API key with 'fx setup'.
+"
+
+# Releases are ordered by date rather than by version: the 0.4.x tags predate
+# the 0.0.x ones, which upstream restarted from on 2026-08-17. Reading the
+# first entry of the feed (regexm stops at one match) gets the current release;
+# a tag listing would report v0.4.5 forever.
+livecheck.type      regexm
+livecheck.url       ${github.homepage}/releases.atom
+livecheck.regex     <id>tag:\[^<\]*/v(\[0-9.\]+)</id>


### PR DESCRIPTION
#### Description

New port for [vercel-labs/fx](https://github.com/vercel-labs/fx), a coding agent CLI written in Zig. Builds against `zig-0.16`; `build.zig.zon` declares no dependencies, so nothing is fetched during the build.

Three things worth a reviewer's attention:

- **Named `vercel-fx`** because `sysutils/fx` (the terminal JSON viewer) holds the `fx` name. The binary is still `fx`, so the two `conflicts`. The reciprocal `conflicts vercel-fx` on `sysutils/fx` is not in this PR.
- **`bin/fx` is a wrapper.** fx starts a background thread that checks for a new release every 30 minutes and swaps the running binary out. The wrapper sets fx's own `FX_AUTO_UPGRADE=0` opt-out, using `:=` so a user can still override it.
- **Livecheck reads the releases feed, not the tag list.** Upstream's `v0.4.x` tags predate the current `v0.0.x` ones (they restarted versioning on 2026-08-17), so a tag listing reports `v0.4.5` forever. `github.livecheck.regex` can't fix this: it only swaps the capture group inside `livecheck.type regex`, which always picks the highest version found.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification

- [x] checked your Portfile with `port lint --nitpick` (0 errors, 0 warnings)
- [x] verified livecheck resolves to the current release (0.0.3)
- [x] built with `zig-0.16 build -Doptimize=ReleaseFast` and ran the resulting binary
- [ ] `sudo port test` / `sudo port -vst install` — **not yet run**; the build and binary were verified outside the port phases, so destroot and the wrapper still need exercising