### PR TITLE
openjdk11: update to 11.0.32.1

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -7,8 +7,8 @@ set feature 11
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.32
-set build 9
+set openjdk_version ${feature}.0.32.1
+set build 1
 revision            0
 
 github.setup        openjdk jdk${feature}u ${openjdk_version}+${build} jdk-
@@ -25,9 +25,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  ef82229667e4cff5c07a49ea33e72ae819b11181 \
-                    sha256  483c10fe5702c921daae632653214c3909485fb1569310d1f10f15c67dbf5eb3 \
-                    size    116741115
+checksums           rmd160  238a310e327ed7a4beaa858bcca9583539c43e49 \
+                    sha256  d9a11caf637121ac7a034d882443da4119ae32c4d5b192a2350d51167ad98008 \
+                    size    116738269
 
 depends_lib         port:freetype \
                     port:libiconv


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.32.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?