### PR TITLE
openjdk21-sap: update to 21.0.12.1

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      ${feature}.0.12
+version      ${feature}.0.12.1
 revision     0
 
 description  SAP Machine ${feature}
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  eeeb8f8c93f9df32eb70f611eb8b2b2d5e069bef \
-                 sha256  16ee0108ba14f7d36609fd8cc0677286ed566ef95f708256ce11ff4dbd2a42b3 \
-                 size    204091618
+    checksums    rmd160  75b712c44681b7289ebb662cf76df76661a32965 \
+                 sha256  8f0270257539ef464215e2bda4427f5b4593124664c1f07b08ed291acfa08a75 \
+                 size    204103681
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  221769aea685ceb0b52454882eea56415b675588 \
-                 sha256  3102ea90b1c6e7ded54d48eb1b56f18f36d02c5b3b54ea9ec6106685036fdb63 \
-                 size    201791590
+    checksums    rmd160  78743af0daafff93a711b8dfc5e9b8a1a5d4f749 \
+                 sha256  dd04e7790c44c44cee15216792eb0521532e4b23f9620535c5901202c49847eb \
+                 size    201809689
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.12.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?