### PR TITLE
openjdk17-sap: update to 17.0.20.1

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.20
+version      ${feature}.0.20.1
 revision     0
 
 description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  118a148b682b2b9eee746d2b1efc08adf42b5877 \
-                 sha256  e7e7d0615056573ebcd60820d138fa2f05e1f1b03d491e5080eaf9d89c2f1b1b \
-                 size    189884660
+    checksums    rmd160  8708f9220b772071b50d730a75502996a6d55230 \
+                 sha256  899eb65d02cd22e773b0415234322a733eb8863c05ef301392a8f0e6b2dc5247 \
+                 size    189914223
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  bfb70698cfdefa4a854c861fbbaa0134f9737231 \
-                 sha256  9c84d766eeb257208ccbb852b00ed3a88b5a92cc5ead6796266ba4d60ebbc574 \
-                 size    187830758
+    checksums    rmd160  f9d57d3741a8ec5297ea81c60f748ca3e35029c6 \
+                 sha256  74f8acefb6d7ba833953761a78bf22ffa44dbeedf7a28f93d7addf9329b8b9d1 \
+                 size    187830354
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.20.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?