### PR TITLE
abendrot: new port

### DIFF
--- a/aqua/abendrot/Portfile
+++ b/aqua/abendrot/Portfile
@@ -1,9 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+PortGroup           xcodeversion 1.0
 
-name                abendrot
-version             1.0.8
+github.setup        matthewrball abendrot 1.0.8 v
+github.tarball_from archive
 revision            0
 
 categories          aqua sysutils
@@ -16,29 +19,104 @@ long_description    Abendrot is a free, open-source Mac screen warmer that cuts 
                     sunset so your evenings aren't lit up like daytime.
 
 homepage            https://abendrot.app
-master_sites        https://github.com/matthewrball/abendrot/releases/download/v${version}/
-
-distname            Abendrot-${version}
-use_dmg             yes
-
-checksums           rmd160  cfbeec7754c7d504bfaffa266727b93a77996292 \
-                    sha256  5667d6f550a7a20031430e6c0af6186df3232f16333f7353c3e6529d2b019f1f \
-                    size    9319846
-
-supported_archs     arm64 x86_64
 platforms           {darwin >= 23}
+supported_archs     arm64 x86_64
+universal_variant   no
+macosx_deployment_target \
+                    14.0
+minimum_xcodeversions \
+                    {23 16.0 24 16.0}
 
-use_configure       no
+set source_commit   353a968fc6013fadead8658bb3d00f346983a2eb
+set keyboardshortcuts_version \
+                    2.4.0
+set swift_log_version \
+                    1.13.2
+set argument_parser_version \
+                    1.8.2
 
-build {}
+set main_distfile   ${distfiles}
+set keyboardshortcuts_distfile \
+                    KeyboardShortcuts-${keyboardshortcuts_version}${extract.suffix}
+set swift_log_distfile \
+                    swift-log-${swift_log_version}${extract.suffix}
+set argument_parser_distfile \
+                    swift-argument-parser-${argument_parser_version}${extract.suffix}
+
+master_sites-append https://github.com/sindresorhus/KeyboardShortcuts/archive/refs/tags/${keyboardshortcuts_version}${extract.suffix}?dummy=:keyboardshortcuts \
+                    https://github.com/apple/swift-log/archive/refs/tags/${swift_log_version}${extract.suffix}?dummy=:swift_log \
+                    https://github.com/apple/swift-argument-parser/archive/refs/tags/${argument_parser_version}${extract.suffix}?dummy=:argument_parser
+
+distfiles-append    ${keyboardshortcuts_distfile}:keyboardshortcuts \
+                    ${swift_log_distfile}:swift_log \
+                    ${argument_parser_distfile}:argument_parser
+
+checksums           ${main_distfile} \
+                    rmd160  88a41d89e9fe93d3e8abef48d2214c2afe8985e3 \
+                    sha256  ce446c7d0fb1ae1fa37a538489c99b1693e295a5eb9229f5bf2067642dc4caff \
+                    size    4285803 \
+                    ${keyboardshortcuts_distfile} \
+                    rmd160  f60fd3ceb5bb2107fca74a878bc0fd5b8e4ac469 \
+                    sha256  ff53e65840357372a4764cc645a390d677a680eb4142f587533dd633b489db65 \
+                    size    158789 \
+                    ${swift_log_distfile} \
+                    rmd160  5135bde2d7c4135d1a4e779a04f42217f375bc75 \
+                    sha256  67cd40237c1eac2fbe154a3de577ffa01aeed88b53192c98a37aebe05a02bd47 \
+                    size    92080 \
+                    ${argument_parser_distfile} \
+                    rmd160  acc20eae3c5200131c7748631a762ed77424dc6d \
+                    sha256  62bb12fb84d07d7f9ebbbbae205d32f941bcfecdcebdd09889f6e7f7f96f04ac \
+                    size    709666
+
+depends_build       port:xcodegen
+patchfiles          patch-disable-sparkle.diff
+
+post-extract {
+    xinstall -d ${worksrcpath}/Vendor
+    move ${workpath}/KeyboardShortcuts-${keyboardshortcuts_version} \
+        ${worksrcpath}/Vendor/KeyboardShortcuts
+    move ${workpath}/swift-log-${swift_log_version} \
+        ${worksrcpath}/Vendor/swift-log
+    move ${workpath}/swift-argument-parser-${argument_parser_version} \
+        ${worksrcpath}/Vendor/swift-argument-parser
+}
+
+pre-build {
+    delete ${worksrcpath}/Abendrot.xcodeproj
+    delete ${worksrcpath}/cli/Package.resolved
+    system -W ${worksrcpath} "${prefix}/bin/xcodegen generate --spec project.yml"
+}
+
+use_xcode           yes
+xcode.project       Abendrot.xcodeproj
+xcode.scheme        Abendrot
+xcode.configuration Release
+xcode.build.settings-append \
+                    SDKROOT=macosx \
+                    DEVELOPMENT_TEAM= \
+                    CODE_SIGN_IDENTITY= \
+                    CODE_SIGNING_REQUIRED=NO \
+                    CODE_SIGNING_ALLOWED=NO \
+                    SWIFT_ACTIVE_COMPILATION_CONDITIONS=ABENDROT_MACPORTS \
+                    ABENDROT_SOURCE_COMMIT=${source_commit}
+
+post-build {
+    set cli_args "--package-path cli --configuration release --disable-sandbox --arch ${configure.build_arch}"
+    system -W ${worksrcpath} \
+        "env MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} /usr/bin/swift build ${cli_args}"
+    set cli_bindir [string trim [exec /usr/bin/swift build \
+        --package-path ${worksrcpath}/cli --configuration release \
+        --disable-sandbox --arch ${configure.build_arch} --show-bin-path]]
+    xinstall -d ${worksrcpath}/build/Release/Abendrot.app/Contents/Helpers
+    xinstall -m 0755 ${cli_bindir}/abendrot \
+        ${worksrcpath}/build/Release/Abendrot.app/Contents/Helpers/abendrot
+}
 
 destroot {
-    copy ${worksrcpath}/Abendrot.app ${destroot}${applications_dir}
+    xinstall -d ${destroot}${applications_dir}
+    copy ${worksrcpath}/build/Release/Abendrot.app \
+        ${destroot}${applications_dir}
     xinstall -d ${destroot}${prefix}/bin
     ln -s ${applications_dir}/Abendrot.app/Contents/Helpers/abendrot \
         ${destroot}${prefix}/bin/abendrot
 }
-
-livecheck.type      regex
-livecheck.url       https://github.com/matthewrball/abendrot/releases
-livecheck.regex     {Abendrot-(\d+(?:\.\d+)*)\.dmg}

--- a/aqua/abendrot/Portfile
+++ b/aqua/abendrot/Portfile
@@ -97,6 +97,9 @@ xcode.build.settings-append \
                     CODE_SIGN_IDENTITY= \
                     CODE_SIGNING_REQUIRED=NO \
                     CODE_SIGNING_ALLOWED=NO \
+                    OTHER_SWIFT_FLAGS=-disable-sandbox \
+                    -IDEPackageSupportDisableManifestSandbox=1 \
+                    -IDEPackageSupportDisablePluginExecutionSandbox=1 \
                     SWIFT_ACTIVE_COMPILATION_CONDITIONS=ABENDROT_MACPORTS \
                     ABENDROT_SOURCE_COMMIT=${source_commit}
 

--- a/aqua/abendrot/Portfile
+++ b/aqua/abendrot/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                abendrot
+version             1.0.8
+revision            0
+
+categories          aqua sysutils
+license             MIT
+maintainers         {abendrot.app:support @matthewrball} openmaintainer
+
+description         Screen warmer that cuts nighttime blue light on every display
+long_description    Abendrot is a free, open-source Mac screen warmer that cuts \
+                    nighttime blue light. It warms every display around your local \
+                    sunset so your evenings aren't lit up like daytime.
+
+homepage            https://abendrot.app
+master_sites        https://github.com/matthewrball/abendrot/releases/download/v${version}/
+
+distname            Abendrot-${version}
+use_dmg             yes
+
+checksums           rmd160  cfbeec7754c7d504bfaffa266727b93a77996292 \
+                    sha256  5667d6f550a7a20031430e6c0af6186df3232f16333f7353c3e6529d2b019f1f \
+                    size    9319846
+
+supported_archs     arm64 x86_64
+platforms           {darwin >= 23}
+
+use_configure       no
+
+build {}
+
+destroot {
+    copy ${worksrcpath}/Abendrot.app ${destroot}${applications_dir}
+    xinstall -d ${destroot}${prefix}/bin
+    ln -s ${applications_dir}/Abendrot.app/Contents/Helpers/abendrot \
+        ${destroot}${prefix}/bin/abendrot
+}
+
+livecheck.type      regex
+livecheck.url       https://github.com/matthewrball/abendrot/releases
+livecheck.regex     {Abendrot-(\d+(?:\.\d+)*)\.dmg}

--- a/aqua/abendrot/files/patch-disable-sparkle.diff
+++ b/aqua/abendrot/files/patch-disable-sparkle.diff
@@ -1,0 +1,139 @@
+--- project.yml.orig
++++ project.yml
+@@ -45,8 +45,5 @@
+   WarmthKit:
+     path: WarmthKit
+-  Sparkle:
+-    url: https://github.com/sparkle-project/Sparkle
+-    revision: b6496a74a087257ef5e6da1c5b29a447a60f5bd7 # Sparkle 2.9.4
+ 
+ targets:
+   Abendrot:
+@@ -65,8 +62,6 @@
+       # DTOs) the app uses to observe + apply CLI/AI control messages and write state.json.
+       - package: WarmthKit
+         product: AbendrotControl
+-      - package: Sparkle
+-        product: Sparkle
+     info:
+       path: App/Resources/Info.plist
+       properties:
+--- App/Sources/Abendrot/Services/UpdateManager.swift.orig
++++ App/Sources/Abendrot/Services/UpdateManager.swift
+@@ -1,7 +1,11 @@
+-import AppKit
+-import Sparkle
+ import SwiftUI
+ 
++#if !ABENDROT_MACPORTS
++import AppKit
++import Sparkle
++#endif
++
++#if !ABENDROT_MACPORTS
+ @MainActor
+ final class UpdateManager: ObservableObject {
+     static let shared = UpdateManager()
+@@ -132,6 +136,27 @@
+     }
+ }
+ 
++#else
++
++@MainActor
++final class UpdateManager: ObservableObject {
++    static let shared = UpdateManager()
++
++    @Published private(set) var canCheckForUpdates = false
++    @Published private(set) var automaticallyDownloadsUpdates = false
++    let updaterUnavailableReason: String? = "Updates are managed by MacPorts."
++
++    private init() {}
++
++    func checkForUpdates() {}
++
++    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {}
++
++    func refresh() {}
++}
++
++#endif
++
+ @MainActor
+ struct CheckForUpdatesView: View {
+     @ObservedObject private var updates: UpdateManager
+--- App/Sources/Abendrot/Theme/GlassSurface.swift.orig
++++ App/Sources/Abendrot/Theme/GlassSurface.swift
+@@ -62,22 +62,32 @@
+             // Ember-tinted SOLID fallback — warm, never grey (critical a11y/brand fix).
+             // (The screenshot harness forces this too — see `abendrotShootingSolidGlass`.)
+             content.background(solidFallback)
+-        } else if #available(macOS 26.0, *) {
+-            // Native Liquid Glass material.
+-            content
+-                .background {
+-                    shape
+-                        .fill(glassTintOverlay)
+-                }
+-                .glassEffect(glassStyle, in: shape)
+         } else {
++#if compiler(>=6.2)
++            if #available(macOS 26.0, *) {
++                // Native Liquid Glass material.
++                content
++                    .background {
++                        shape
++                            .fill(glassTintOverlay)
++                    }
++                    .glassEffect(glassStyle, in: shape)
++            } else {
++                // Pre-Tahoe fallback for the app's macOS 14 deployment floor.
++                content
++                    .background(.ultraThinMaterial, in: shape)
++                    .overlay(shape.fill(glassTintOverlay).allowsHitTesting(false))
++            }
++#else
+             // Pre-Tahoe fallback for the app's macOS 14 deployment floor.
+             content
+                 .background(.ultraThinMaterial, in: shape)
+                 .overlay(shape.fill(glassTintOverlay).allowsHitTesting(false))
++#endif
+         }
+     }
+ 
++#if compiler(>=6.2)
+     @available(macOS 26.0, *)
+     private var glassStyle: Glass {
+         // Interactive on the transient popover; plain (calmer) on the Settings frost.
+@@ -86,6 +96,7 @@
+         case .frost: return .regular
+         }
+     }
++#endif
+ 
+     /// A faint warm tint laid over the system glass so the material reads as ember,
+     /// not neutral system glass. Subtle by design (the real recipe lives in tokens).
+--- WarmthKit/Package.swift.orig
++++ WarmthKit/Package.swift
+@@ -32,8 +32,8 @@
+     dependencies: [
+         // Carbon RegisterEventHotKey wrapper — true-global hotkey, no Accessibility
+         // permission, exposes keyDown AND keyUp (exact fit for hold-to-reveal).
+-        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.2.0"),
++        .package(path: "../Vendor/KeyboardShortcuts"),
+         // Structured logging (bridged to OSLog at the app boundary).
+-        .package(url: "https://github.com/apple/swift-log", from: "1.6.0"),
++        .package(path: "../Vendor/swift-log"),
+     ],
+     targets: [
+--- cli/Package.swift.orig
++++ cli/Package.swift
+@@ -21,7 +21,7 @@
+         .macOS("14.0"),
+     ],
+     dependencies: [
+-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
++        .package(path: "../Vendor/swift-argument-parser"),
+         .package(path: "../WarmthKit"),
+     ],
+     targets: [

--- a/aqua/abendrot/files/patch-disable-sparkle.diff
+++ b/aqua/abendrot/files/patch-disable-sparkle.diff
@@ -6,7 +6,7 @@
 -  Sparkle:
 -    url: https://github.com/sparkle-project/Sparkle
 -    revision: b6496a74a087257ef5e6da1c5b29a447a60f5bd7 # Sparkle 2.9.4
- 
+
  targets:
    Abendrot:
 @@ -65,8 +62,6 @@
@@ -24,7 +24,7 @@
 -import AppKit
 -import Sparkle
  import SwiftUI
- 
+
 +#if !ABENDROT_MACPORTS
 +import AppKit
 +import Sparkle
@@ -37,7 +37,7 @@
 @@ -132,6 +136,27 @@
      }
  }
- 
+
 +#else
 +
 +@MainActor
@@ -100,7 +100,7 @@
 +#endif
          }
      }
- 
+
 +#if compiler(>=6.2)
      @available(macOS 26.0, *)
      private var glassStyle: Glass {
@@ -110,7 +110,7 @@
          }
      }
 +#endif
- 
+
      /// A faint warm tint laid over the system glass so the material reads as ember,
      /// not neutral system glass. Subtle by design (the real recipe lives in tokens).
 --- WarmthKit/Package.swift.orig


### PR DESCRIPTION
#### Description

New port for Abendrot, a free MIT-licensed macOS screen warmer.

Installs the signed/notarized GitHub release DMG (same artifact as the existing Homebrew cask) and links the bundled `abendrot` CLI.

- Homepage: https://abendrot.app
- Source: https://github.com/matthewrball/abendrot
- Version: 1.0.8
- Requires macOS 14+ (darwin 23+)

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Checksums computed from the v1.0.8 release DMG (sha256 matches the published digest). Full `port -vst install` not run here; CI should extract the DMG and copy `Abendrot.app`.

###### Verification

- [x] Have you followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] Have you squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] Have you referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] Have you checked your Portfile with `port lint`?
- [ ] Have you tried existing tests with `sudo port test`?
- [ ] Have you tried a full install with `sudo port -vst install`?
- [ ] Have you tested basic functionality of all binary files?
