### PR TITLE
json-c: Update to 0.19

### DIFF
--- a/textproc/json-c/Portfile
+++ b/textproc/json-c/Portfile
@@ -5,7 +5,8 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
-github.setup        json-c json-c 0.18 json-c- -20240915
+github.setup        json-c json-c 0.19 json-c- -20260627
+github.tarball_from releases
 revision            0
 license             MIT
 categories          textproc devel
@@ -18,16 +19,21 @@ long_description    JSON-C implements a reference counting object model that all
                     formatted strings and parse JSON formatted strings back into \
                     the C representation of JSON objects.
 
-master_sites        https://s3.amazonaws.com/json-c_releases/releases/
+master_sites-append https://s3.amazonaws.com/${name}_releases/releases/
 distfiles           ${name}-${version}-nodoc${extract.suffix}
-checksums           md5 e795aadd85376623777ff0fd259bebab \
-                    rmd160 c563f362ba81d831d9b1ab1abd6f0d9e70881b85 \
-                    sha256 602cdefc1d2aab8318fc0814b7ce7d59e72514d4276ca3eff92f35f86cf1c160
+checksums           rmd160  e93f6f68fb2794102b8c6fad2002ae989dfc0b3c \
+                    sha256  704927172443309a8efeb162060bb215548e1286e5568514007dd2cc35a0a164 \
+                    size    232738
 
-cmake.out_of_source yes
+# These are never installed
+# See: https://github.com/json-c/json-c/blob/json-c-0.19-20260627/apps/CMakeLists.txt#L119-L121
+configure.args-append \
+                    -DBUILD_APPS=OFF
 
 # disable warnings as errors, fixes:
 # cc1: warnings being treated as errors
 # json_object.c:73: warning: 'cold' attribute directive ignored
 # make[2]: *** [CMakeFiles/json-c.dir/build.make:125: CMakeFiles/json-c.dir/json_object.c.o] Error 1
 configure.args-append -DDISABLE_WERROR=ON
+
+livecheck.regex     {releases/tag/json-c-([0-9.]+)(?:[_-]\d{6,8})}


### PR DESCRIPTION
#### Description

Update json-c to 0.19, fixing the livecheck of the port for later updates.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
