### PR TITLE
jdk21: update to 21.0.12.1

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      ${feature}.0.12
+version      ${feature}.0.12.1
 revision     0
 
 description  Oracle Java SE Development Kit ${feature}
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  07289a4700d691c4e9f3d6dafc034ca67fba87e5 \
-                 sha256  73943c130e0e064a7d4674f81e397b097f1a6bf2f35b5db6a4123d6d1f17b703 \
-                 size    194032563
+    checksums    rmd160  870e76a76a1325e9cf80f145fe8fceb4865df3a8 \
+                 sha256  36dc94414d59891390df14a494df32f4237c1ca0a8064eca7791cb2f676e16b8 \
+                 size    194033138
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  e7031e4d9a9fffda35a7873611b960e9d6969339 \
-                 sha256  64377c2dab9b5df4be5648d84ba54174b46add6ca2bec86aa2716e5b3bddac62 \
-                 size    191716493
+    checksums    rmd160  75f3461928f4224ec25fb926bbfefc21e9b590a0 \
+                 sha256  f1f319f81b5c82c4980bf5dab294e382d2d168b4d7c9c9bdc1bd81e994491d01 \
+                 size    191720321
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Oracle JDK 21.0.12.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?