### PR TITLE
openjdk21-temurin: update to 21.0.12.1

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  a33a6eee48be29498d63afa3809dbf4a10b1779d \
-                 sha256  6b85c260eea574a995eacd0b3ee23c8042aa93b23a08e6478edafca0a0333d7f \
-                 size    194309619
+    checksums    rmd160  bab123c017a9164d4c9a954964f7f76b259092c0 \
+                 sha256  44db0f08196daf19a47f90d13388b0c943b67663cb537f998fe29e836fa842ce \
+                 size    194316575
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f53e512c7a08cd6a4780818114124e6376c132b7 \
-                 sha256  021d629349ebc12a409faa517b837ec80ceee8f58a5ac85c788ecad07ca6881c \
-                 size    200069721
+    checksums    rmd160  47d2a0ed11e801eb3c125f5e42d059b6d429d1a6 \
+                 sha256  3623232f33a9c3baadf304480b2535f9a3cba8a58d42ecbb438ba267315d9998 \
+                 size    200073404
 } else {
     set arch_classifier unsupported_arch
 }

--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=21&os=mac
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.12
-set build    8
+version      ${feature}.0.12.1
+set build    1
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least December 2029)


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.12.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?