### PR TITLE
mcp-inspector: update to 2.3.0

### DIFF
--- a/llm/mcp-inspector/Portfile
+++ b/llm/mcp-inspector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                mcp-inspector
-version             2.2.0
+version             2.3.0
 revision            0
 
 categories          llm
@@ -20,9 +20,9 @@ homepage            https://modelcontextprotocol.io/docs/tools/inspector
 npm.rootname        @modelcontextprotocol/inspector
 distname            inspector-${version}
 
-checksums           rmd160  9cebb2b691740056b72fc45e9f45f8fd7febc9f7 \
-                    sha256  0604ec5f00eee023f9821f372462f6ed76e39c6b9c8edb50661e7f61c4c9e6e3 \
-                    size    1244322
+checksums           rmd160  c25415d0f23e694f896315621d4494503a3492bf \
+                    sha256  e1f8609e6773d7e06e9293d900eaefac5e9f331e6c8709f6a86e1f727be9255c \
+                    size    1292058
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to MCP Inspector 2.3.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?