### PR TITLE
openjdk21-microsoft: update to 21.0.12.1

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.12
-set build    8
+version      ${feature}.0.12.1
+set build    1
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  15f90671cb1ca7bddfe42ff289b78bb27804e52b \
-                 sha256  9b06efd99de047f2aba42ea0804854e51b69ed633e995730aef049adac62cb98 \
-                 size    202450530
+    checksums    rmd160  5effc9f56e8508e5ae0696df20240f6ab1ce71aa \
+                 sha256  7a27a750ad4aadd9256565c6b92f30befc58e8562f5d2d0e3a86fdf7695bebfc \
+                 size    202449572
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  4c8c26b0a8a54fd4ec901d9094c348922651ed68 \
-                 sha256  56f338a3c6af071649047e78f2d31a2ca97c57be6c1b2c213823acb016463ee1 \
-                 size    200091378
+    checksums    rmd160  2cfd71d34988f1c25e2983832a188e487fc8fa83 \
+                 sha256  6704f1372a02fabcc9e1efec84f63fcf4d9c1c904e2b8e29b04bed2fb62f7e6e \
+                 size    200089913
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 21.0.12.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?