### PR TITLE
openjdk11-microsoft: update to 11.0.32.1

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.32
-set build    9
+version      ${feature}.0.32.1
+set build    1
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d540841f58e754bc32a1daaa46f3dae344a25cc4 \
-                 sha256  f4c6d69692e27b33ed39b89d096cfcfb2dae0d5bbce78c5dc3123d507bd7d049 \
-                 size    191105486
+    checksums    rmd160  c56b9fafdfc9614366bef0e199ee37277616d90e \
+                 sha256  96088abf8d4a483cfc1f7e1f68d5f9e01e396b5903571f087efb35867497d390 \
+                 size    191105166
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  966ccb8428bbf74742134d5f331c2a590fa06993 \
-                 sha256  5b56e9658e4f08b0ed5aa9c914213b5214de299c85e8668892d169c37ba134bc \
-                 size    185242316
+    checksums    rmd160  40195993d00986362f8e966a88e7a7b2e55921d9 \
+                 sha256  05161b4b839beafcb361a49c8bfda07f06923562d91c2271dbf511ae48d07314 \
+                 size    185211488
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 11.0.32.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?