### PR TITLE
claude-code: update to 2.1.236

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.235
+version             2.1.236
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  033181a8c6c407445d3b98152c0f4f193437ac8e \
-                 sha256  325a2dbc166ba8361a913ce588dce4a236789502060239acea52072bb51a54f1 \
-                 size    321995248
+    checksums    rmd160  1f1df564511778e760ba5cbfc6f6462d726b9d65 \
+                 sha256  3ce6a8e016fcae45ad3f2dc78f1980600d3908c302355396a0d6bc17b5d43333 \
+                 size    325726960
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  691e03dc3d599655bd3968226fcc396eddc94b70 \
-                 sha256  83b8f806f6f2eea316cfe246628e6c23374711d868f1fd0409db551b877b7748 \
-                 size    313334608
+    checksums    rmd160  9e087a1b3dfcee778860cc5ac3026042467dee10 \
+                 sha256  6bc4ba992d2786cbf0237c4453ca53c1fdf0c3b3d83ffa0025c0d8190ed27848 \
+                 size    317044624
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.236.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?