### PR TITLE
expat: Update to 2.8.3

### DIFF
--- a/textproc/expat/Portfile
+++ b/textproc/expat/Portfile
@@ -6,11 +6,11 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                expat
-version             2.8.2
+version             2.8.3
 revision            0
-checksums           rmd160  60d9b52208da31a3aff01c63bbc7f04cc2a75b76 \
-                    sha256  69e7f52417d85b1c2b7fe855e176eec55d0b2d7d92d691372d833a1c7df7923b \
-                    size    660292
+checksums           rmd160  cc320cb65f982cd2388b7b94fab9d292ba225387 \
+                    sha256  b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670 \
+                    size    663048
 
 categories          textproc devel
 platforms           darwin freebsd
@@ -24,7 +24,7 @@ long_description    Expat is an XML parser library written in C. It is a \
                     registers handlers for things the parser might find \
                     in the XML document (like start tags).
 
-homepage            http://www.libexpat.org/
+homepage            https://libexpat.github.io/
 master_sites        sourceforge:project/${name}/${name}/${version}
 # Don't use a compression format that necessitates a dependency on another
 # port since that causes a dependency cycle on older OS versions since
@@ -41,6 +41,14 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 configure.args      --without-docbook
 
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # macOS 10.12+ provides getentropy but expat provides a fallback
+    # utilizing /dev/urandom, negating linking with legacysupport
+    configure.args-append \
+                    --with-dev-urandom \
+                    --without-getentropy
+}
+
 if {${os.platform} eq "darwin" && ${os.major} < 13} {
     configure.args-append \
                     --without-tests
@@ -56,11 +64,11 @@ post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}
     set examplesdir ${destroot}${prefix}/share/examples/${name}
     xinstall -m 0755 -d ${examplesdir} ${docdir}/html
-    
+
     xinstall -m 0644 -W ${worksrcpath} COPYING Changes README.md ${docdir}
     xinstall -m 0644 {*}[glob -directory ${worksrcpath}/doc *.css *.html] \
         ${docdir}/html
-    
+
     xinstall -m 0644 {*}[glob -directory ${worksrcpath}/examples *.c] \
         ${examplesdir}
 }


### PR DESCRIPTION
#### Description

Update expat to 2.8.3. Avoid implicit function errors when configuring the port on macOS 10.11 and lower due to lack of getentropy and update homepage.

No revbumps needed.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
