### PR TITLE
dcmtk: Use GitHub for livecheck (breaking anti-bot challenge upstream)

### DIFF
--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -171,6 +171,4 @@ test.run                yes
 test.cmd                env DYLD_LIBRARY_PATH=${cmake.build_dir}/lib make
 test.target             -j 1 test
 
-livecheck.type          regex
-livecheck.url           https://dicom.offis.de/en/dcmtk/dcmtk-software-development/
 livecheck.regex         ${name}-(\[0-9._\]+)${extract.suffix}


### PR DESCRIPTION
Maintainer update.

After recent CVE publicity, a bot-protection check has been added to the DCMTK homepage. This breaks livechecks using the homepage; switch to GitHub.

No changes to installed port; no bump.