### PR TITLE
claude-code: update to 2.1.238

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.237
+version             2.1.238
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  25155440ef415f61bfd643041e237b7b585fbfeb \
-                 sha256  9f00789754a7b95febc6d4e37a3b6523d4d9c4c2333a2ce4bd596ad82186224e \
-                 size    325793008
+    checksums    rmd160  6a3c0c22e3cf4f2f56a93b22c304c8db20cf45d8 \
+                 sha256  d10bc7bb1720435f8830aa3ee74085f09348d2b1a2a152bdee251b770d76cc73 \
+                 size    329970544
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  0f27308f29fa55abb62ff69de8a5a9b8ab885644 \
-                 sha256  338901351d4ff17495738c67fc3e12a32c1b506738ac5e012eb782d3d8b5be43 \
-                 size    317110288
+    checksums    rmd160  15a7e8a6dd2854823d70ba661b408050f7c9c9d0 \
+                 sha256  1c196c456373b57818ae87df84aecee96cb659448c0d6a6bbb401ac5758431b2 \
+                 size    321263536
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.238.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?