### PR TITLE
pdfbox: update to 3.0.8

### DIFF
--- a/java/pdfbox/Portfile
+++ b/java/pdfbox/Portfile
@@ -1,40 +1,57 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           maven 1.0
 
-name                pdfbox
-version             0.7.3
+github.setup        apache pdfbox 3.0.8
+github.tarball_from archive
+
 categories          java print
 maintainers         nomaintainer
+license             Apache-2
+platforms           any
+supported_archs     noarch
+
 description         PDFBox is a Java PDF Library
 long_description    PDFBox is a Java PDF Library. This project will allow \
                     access to all of the components in a PDF document.
 
 homepage            https://pdfbox.apache.org/
-master_sites        sourceforge
-distname            PDFBox-${version}
-checksums           md5     b8d01eb03b409ba288aba3fb0194589f \
-                    rmd160  f2ac644ee0195cfc5405bb56548a01de419f5069 \
-                    sha256  5c6f6c87cdbf247ff29d0ce691ab977c2e869070d54cf1bd6305e0fd84e7373d \
-                    size    22769102
-use_zip             yes
+checksums           rmd160  6fe6737463277136d3cdb7d1fae4c2c6c77f5769 \
+                    sha256  8ce71e5082466ea2705356c4196ab8f52b5ea28e4ee873b46ad66f3119f23c30 \
+                    size    16607274
 
-depends_build       bin:ant:apache-ant
-depends_lib         bin:java:kaffe
+java.version        1.8+
+java.fallback       openjdk11
 
-post-extract    {
-    file mkdir ${worksrcpath}/Config
-}
+destroot {
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
 
-use_configure       no
+    xinstall -d ${destdocdir} ${destjavadir}
 
-build.cmd           ant
-build.target        package javadoc
+    xinstall -m 644 \
+        ${worksrcpath}/KEYS \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/NOTICE.txt \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/RELEASE-NOTES.txt \
+        ${destdocdir}
 
-destroot    {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java/ \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/lib/PDFBox-${version}.jar \
-        ${destroot}${prefix}/share/java/pdfbox.jar
-    file copy ${worksrcpath}/docs/javadoc ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 \
+        ${worksrcpath}/${name}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+    xinstall -m 644 \
+        ${worksrcpath}/app/target/${name}-app-${version}.jar \
+        ${destjavadir}/${name}-app.jar
+    xinstall -m 644 \
+        ${worksrcpath}/examples/target/${name}-examples-${version}.jar \
+        ${destjavadir}/${name}-examples.jar
+    xinstall -m 644 \
+        ${worksrcpath}/io/target/${name}-io-${version}.jar \
+        ${destjavadir}/${name}-io.jar
+    xinstall -m 644 \
+        ${worksrcpath}/tools/target/${name}-tools-${version}.jar \
+        ${destjavadir}/${name}-tools.jar
 }

--- a/java/pdfbox/Portfile
+++ b/java/pdfbox/Portfile
@@ -1,38 +1,40 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			pdfbox
-version			0.7.3
-categories		java print
-maintainers		nomaintainer
-description		PDFBox is a Java PDF Library
-long_description	PDFBox is a Java PDF Library. This project will allow \
-					access to all of the components in a PDF document.
+PortSystem          1.0
 
-homepage		https://pdfbox.apache.org/
-master_sites	sourceforge
-distname		PDFBox-${version}
-checksums		md5     b8d01eb03b409ba288aba3fb0194589f \
-                rmd160  f2ac644ee0195cfc5405bb56548a01de419f5069 \
-                sha256  5c6f6c87cdbf247ff29d0ce691ab977c2e869070d54cf1bd6305e0fd84e7373d \
-                size    22769102
-use_zip			yes
+name                pdfbox
+version             0.7.3
+categories          java print
+maintainers         nomaintainer
+description         PDFBox is a Java PDF Library
+long_description    PDFBox is a Java PDF Library. This project will allow \
+                    access to all of the components in a PDF document.
 
-depends_build	bin:ant:apache-ant
-depends_lib		bin:java:kaffe
+homepage            https://pdfbox.apache.org/
+master_sites        sourceforge
+distname            PDFBox-${version}
+checksums           md5     b8d01eb03b409ba288aba3fb0194589f \
+                    rmd160  f2ac644ee0195cfc5405bb56548a01de419f5069 \
+                    sha256  5c6f6c87cdbf247ff29d0ce691ab977c2e869070d54cf1bd6305e0fd84e7373d \
+                    size    22769102
+use_zip             yes
 
-post-extract	{
-	file mkdir ${worksrcpath}/Config
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
+
+post-extract    {
+    file mkdir ${worksrcpath}/Config
 }
 
-use_configure	no
+use_configure       no
 
-build.cmd		ant
-build.target	package javadoc
+build.cmd           ant
+build.target        package javadoc
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java/ \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/lib/PDFBox-${version}.jar \
-		${destroot}${prefix}/share/java/pdfbox.jar
-	file copy ${worksrcpath}/docs/javadoc ${destroot}${prefix}/share/doc/${name}
+destroot    {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java/ \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/lib/PDFBox-${version}.jar \
+        ${destroot}${prefix}/share/java/pdfbox.jar
+    file copy ${worksrcpath}/docs/javadoc ${destroot}${prefix}/share/doc/${name}
 }


### PR DESCRIPTION
#### Description

Tidy up `pdfbox`'s Portfile and update it to version 3.0.8.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?