### PR TITLE
saxpath: obsolete port

### DIFF
--- a/java/saxpath/Portfile
+++ b/java/saxpath/Portfile
@@ -1,44 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem      1.0
+PortGroup       obsolete 1.0
 
 name            saxpath
 version         1.0
+revision        1
 categories      java devel textproc
 license         Apache-1.1
-platforms       darwin
-maintainers     nomaintainer
-description     simple Java API for XPath
-
-long_description \
-    The SAXPath project is a Simple API for XPath. SAXPath is analogous to SAX \
-    in that the API abstracts away the details of parsing and provides a \
-    simple event based callback interface.
-
 homepage        http://saxpath.sourceforge.net/
-master_sites    sourceforge
 
-checksums       md5 cc95ecc7dfb689a29bd42323490ee702
-
-depends_build   bin:ant:apache-ant
-depends_lib     bin:java:kaffe
-
-set worksrcdir  ${worksrcdir}-FCS
-
-post-extract {
-    file mkdir ${worksrcpath}/src/conf
-    file copy ${filespath}/MANIFEST.MF ${worksrcpath}/src/conf
-}
-
-use_configure   no
-
-build.cmd       ant
-build.target    package
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/build/saxpath.jar \
-        ${destroot}${prefix}/share/java/
-    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
-}
-
-livecheck.regex {saxpath (\d+(?:\.\d+)*) FCS}
+replaced_by     jaxen
+obsolete.note   SAXPath has been merged into the Jaxen codebase and is \
+                no longer being maintained separately.

--- a/java/saxpath/files/MANIFEST.MF
+++ b/java/saxpath/files/MANIFEST.MF
@@ -1,9 +1,0 @@
-Manifest-Version: 1.0
-Extension-Name: org.saxpath
-Specification-Title: saxpth
-Specification-Version: 1.0 FCS
-Specification-Vendor: werken digital.
-Created-By: Ant 1.4.1
-Implementation-Vendor:  werken digital.
-Implementation-Version: 1.0
-Implementation-Title: saxpath


### PR DESCRIPTION
#### Description

Upstream was merged into the `jaxen` project and has since been [unmaintained](https://sourceforge.net/projects/saxpath/) as a separate project.  The port itself has remained untouched for a decade and has no dependents.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?