### PR TITLE
php-rrd: update @2.0.4 : PECL -> GitHub

### DIFF
--- a/php/php-rrd/Portfile
+++ b/php/php-rrd/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
+PortGroup                       github 1.0
 PortGroup                       php 1.1
 
 name                            php-rrd
@@ -8,29 +9,33 @@ categories-append               net devel
 maintainers                     {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license                         BSD
 
-php.branches                    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4
-php.pecl                        yes
+php.branches                    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5
 
 description                     PHP rrdtool extension
 long_description \
     ${name} is a procedural and simple object-oriented wrapper for PHP for using rrdtool—data \
     logging and graphing system for time series data.
 
+github.tarball_from             archive
+
 if {[vercmp ${php.branch} >= 7.0]} {
-    version                     2.0.3
-    revision                    1
-    checksums                   rmd160  8cffdcd5ee196c4d187d7c014edbcc817c31537f \
-                                sha256  a42161e58cdc8a853b72cff298989dcbde82b0f76456dd59ce02854c92b730f7 \
-                                size    19178
+    github.setup                php pecl-processing-rrd 2.0.4 rrd-
+    revision                    0
+    checksums                   rmd160  f8895399aea8b4e3eeb1410d9b67e50ee6c2cecf \
+                                sha256  b4f0ca4df248c6b9dac2e63635ea5aadb299f3afa6c177d154d2b5fc57d4e6a7 \
+                                size    18331
 } else {
-    version                     1.1.3
+    github.setup                php pecl-processing-rrd 1.1.2 rrd-
     revision                    2
-    checksums                   rmd160  dbef0cf56fc081f768f85d46fd185a750a42cef5 \
-                                sha256  0415ac51e09fe2e7a999d155d10d6af42ddf40ab0b4847a63ed1f9458533858e \
-                                size    19229
+    checksums                   rmd160  06804a991fa7a722cbd5973cc75e959c7834de5a \
+                                sha256  a3384c382a080ab805599afd5c59f62feb974aca6cc6487992fe2e09c32b3bf7 \
+                                size    17784
 }
 
 if {${name} ne ${subport}} {
+    # remove w/ next update
+    dist_subdir                 ${name}/${version}_1
+
     if {[vercmp ${php.branch} >= 7.0]} {
         depends_build-append    path:bin/pkg-config:pkgconfig
     }

--- a/php/php-rrd/Portfile
+++ b/php/php-rrd/Portfile
@@ -1,44 +1,42 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           php 1.1
+PortSystem                      1.0
+PortGroup                       php 1.1
 
-name                php-rrd
-categories-append   net devel
-maintainers         {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
-license             BSD
+name                            php-rrd
+categories-append               net devel
+maintainers                     {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+license                         BSD
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4
-php.pecl            yes
+php.branches                    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4
+php.pecl                        yes
+
+description                     PHP rrdtool extension
+long_description \
+    ${name} is a procedural and simple object-oriented wrapper for PHP for using rrdtool—data \
+    logging and graphing system for time series data.
 
 if {[vercmp ${php.branch} >= 7.0]} {
-    version         2.0.3
-    revision        1
-    checksums       rmd160  8cffdcd5ee196c4d187d7c014edbcc817c31537f \
-                    sha256  a42161e58cdc8a853b72cff298989dcbde82b0f76456dd59ce02854c92b730f7 \
-                    size    19178
+    version                     2.0.3
+    revision                    1
+    checksums                   rmd160  8cffdcd5ee196c4d187d7c014edbcc817c31537f \
+                                sha256  a42161e58cdc8a853b72cff298989dcbde82b0f76456dd59ce02854c92b730f7 \
+                                size    19178
 } else {
-    version         1.1.3
-    revision        2
-    checksums       rmd160  dbef0cf56fc081f768f85d46fd185a750a42cef5 \
-                    sha256  0415ac51e09fe2e7a999d155d10d6af42ddf40ab0b4847a63ed1f9458533858e \
-                    size    19229
+    version                     1.1.3
+    revision                    2
+    checksums                   rmd160  dbef0cf56fc081f768f85d46fd185a750a42cef5 \
+                                sha256  0415ac51e09fe2e7a999d155d10d6af42ddf40ab0b4847a63ed1f9458533858e \
+                                size    19229
 }
-
-description         PHP rrdtool extension
-
-long_description    ${name} is a procedural and simple object-oriented wrapper \
-                    for PHP for using rrdtool—data logging and graphing system \
-                    for time series data.
 
 if {${name} ne ${subport}} {
     if {[vercmp ${php.branch} >= 7.0]} {
-        depends_build-append \
-                        path:bin/pkg-config:pkgconfig
+        depends_build-append    path:bin/pkg-config:pkgconfig
     }
 
-    depends_lib-append  port:rrdtool \
-                        port:libffi
+    depends_lib-append          port:rrdtool \
+                                port:libffi
 
-    configure.args      --with-rrd=${prefix}
+    configure.args              --with-rrd=${prefix}
 }


### PR DESCRIPTION
#### Description

Switched from PECL to GitHub due to PECL being deprecated
 Fix build on PHP 8.4 and 8.5: php_smart_string.h moved to Zend/zend_smart_string.h - thanks Remi
###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

