### PR TITLE
hut: update to 0.8.0, drop the worksrcdir workaround

### DIFF
--- a/devel/hut/Portfile
+++ b/devel/hut/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            git.sr.ht/~xenrox/hut 0.7.0 v
+go.setup            git.sr.ht/~xenrox/hut 0.8.0 v
 revision            0
 
 description         A CLI tool for sr.ht.
@@ -18,18 +18,17 @@ license             AGPL-3
 maintainers         {woolsweater.net:macports @woolsweater} \
                     openmaintainer
 
-checksums           rmd160  a83badd9d13aa599d63dcb60623fe2ea189cfdc5 \
-                    sha256  5975f940740dd816057ab3cf20cebde3ece3250891952a566f8555f73fb67b21 \
-                    size    149392
+checksums           rmd160  95352b9d77caefefe1d9b76a0d17762dc2868b1c \
+                    sha256  f7994375673f253705ed7499f44b712b2d9fcec8a5a42f1d0408002552b7d0e7 \
+                    size    161225
 
 depends_build-append \
                     port:scdoc
 
-# Tarball contents name conflicts with the default work dir name
-worksrcdir          ${name}-${version}-${epoch}
-
 # Allow Go to fetch dependencies at build time
 go.offline_build no
+
+go.toolchain_min    1.24
 
 build.cmd           \
     ${build.cmd} -ldflags \" \


### PR DESCRIPTION
#### Description

Updates `hut` to 0.8.0 and removes its `worksrcdir` workaround.

The golang portgroup now restores the GOPATH `worksrcdir` after applying
`sourcehut-1.0` (see 8cd0a559753 on master), so the port no longer has to name
the directory itself. Build and destroot are unchanged, hence no revision bump.

`go.mod` moved its floor from 1.18 to 1.24.0, so `go.toolchain_min` is declared.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`
- [ ] tested basic functionality of all binary files?
