### PR TITLE
senpai: fix livecheck, drop the worksrcdir workaround

### DIFF
--- a/irc/senpai/Portfile
+++ b/irc/senpai/Portfile
@@ -5,6 +5,7 @@ PortGroup               golang 1.0
 
 name                    senpai
 go.setup                git.sr.ht/~delthas/senpai 0.5.0
+go.toolchain_min        1.21
 revision                0
 categories              irc net
 installs_libs           no
@@ -14,8 +15,10 @@ license                 ICS
 
 master_sites            https://git.sr.ht/~delthas/senpai/refs/download/v${version}
 
-# Tarball contents name conflicts with the default work dir name
-worksrcdir              ${name}-v${version}
+# The release tags carry a v prefix but the tarballs do not, so go.setup is
+# left without one to keep distname right, and the tag prefix is reapplied
+# here for livecheck alone.
+livecheck.regex         {refs/v([0-9][^<]+)</guid>}
 
 go.offline_build        no
 


### PR DESCRIPTION
#### Description

Fixes `senpai`'s livecheck and removes its `worksrcdir` workaround.

livecheck matched nothing and errored with `regex didn't match`. The golang
portgroup builds its livecheck regex from the tag prefix, and `go.setup` carries
none, because the release tarballs are named without the `v` that the tags use
(`senpai-0.5.0.tar.gz` for tag `v0.5.0`). Adding the prefix to `go.setup` would
fix livecheck but rename `distname` to a URL that 404s, so the regex is set
directly instead. `senpai` is confirmed current at 0.5.0.

The golang portgroup now restores the GOPATH `worksrcdir` after applying
`sourcehut-1.0` (see 8cd0a559753 on master), so the port no longer has to name
the directory itself. Build and destroot are unchanged, hence no revision bump.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`
- [ ] tested basic functionality of all binary files?
