### PR TITLE
kiln: drop the worksrcdir workaround, fixing the build

### DIFF
--- a/www/kiln/Portfile
+++ b/www/kiln/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            git.sr.ht/~adnano/kiln 0.4.1
+go.toolchain_min    1.20
 revision            0
 categories          www devel
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -13,8 +14,6 @@ description         A simple static site generator
 long_description    {*}${description}
 
 go.package          git.sr.ht/~adnano/kiln
-
-worksrcdir          ${name}
 
 checksums           ${distname}${extract.suffix} \
                         rmd160  073ab4ce0ad9d5afe20498d1d40cb9b8e0cc1cb1 \


### PR DESCRIPTION
#### Description

Fixes `kiln`, which does not build at all on master.

`worksrcdir` named a directory that never exists: the source is placed under
`gopath/src/git.sr.ht/~adnano/kiln`, while the build ran in `work/kiln`.

The golang portgroup now restores the GOPATH `worksrcdir` after applying
`sourcehut-1.0` (see 8cd0a559753 on master), so dropping the line is all that is
needed here. No revision bump, as there is no working build to invalidate.

Closes: https://trac.macports.org/ticket/68440

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`; confirmed it does *not* build without this change
- [ ] tested basic functionality of all binary files?
