### PR TITLE
glab: update to 1.114.0, declare the Go it needs

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/cli 1.107.0 v
+go.setup            gitlab.com/gitlab-org/cli 1.114.0 v
+go.toolchain_min    1.26
 name                glab
 revision            0
 categories          devel
@@ -16,9 +17,9 @@ long_description    ${name} is an open source GitLab CLI tool \
                     you are already working with git and your code.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fea975b549e2d16effad3673ad16b9b1aeae2009 \
-                    sha256  10b7acef12221dda93901b125c4502cfb5594820216faf40880b8f079acd48d8 \
-                    size    17712714
+                    rmd160  5cd212d44524a3be04ba0c01ead35046ddbe412d \
+                    sha256  07b81d85963f5d05c58c3259a85b0530b1e11485944eb5916ac8b60c79301919 \
+                    size    17815095
 
 # If not set, it states that it's a developer build
 # Suppress build date for reproducible builds


### PR DESCRIPTION
#### Description

Updates `glab` to 1.114.0.

`go.mod` requires go 1.26.5, so `go.toolchain_min` is declared. Note that
`go.toolchain_min` compares by series, so this does not by itself guarantee the
1.26.5 patch level.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`
- [ ] tested basic functionality of all binary files?
