### PR TITLE
goimapnotify: update to 2.5.8

### DIFF
--- a/mail/goimapnotify/Portfile
+++ b/mail/goimapnotify/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/shackra/goimapnotify 2.4-rc4
+go.setup            gitlab.com/shackra/goimapnotify 2.5.8
+revision            0
 categories          mail
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-3 MIT BSD
@@ -15,81 +16,31 @@ description         \
 long_description    {*}${description}
 
 go.package          gitlab.com/shackra/goimapnotify
+go.toolchain_min    1.23
 
 use_bzip2           no
 extract.suffix      .tar.gz
 extract.cmd         gzip
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  2945dccc8bb05aae71a55df337555ac8b096d1cc \
-                        sha256  e414e14b48bd5624a8a8db529cb2d391218a9f4c0fbc7276446bccf1437beeea \
-                        size    27115
+                        rmd160  4e7e3b33144af865909696776eeed2a68db08e40 \
+                        sha256  616aae1f48fbe4e2afffd968e7c393d32075365a0a94aa7654ab7abe4b4ac1c6 \
+                        size    2371498
 
-go.vendors          gopkg.in/yaml.v3 \
-                        lock    496545a6307b \
-                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
-                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
-                        size    90145 \
-                    gopkg.in/check.v1 \
-                        lock    20d25e280405 \
-                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
-                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
-                        size    30360 \
-                    golang.org/x/text \
-                        lock    v0.3.2 \
-                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
-                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
-                        size    7168458 \
-                    golang.org/x/sys \
-                        lock    39ccf1dd6fa6 \
-                        rmd160  f5d7a5e0ba099b8249d4e64f9452d6fadc6b8749 \
-                        sha256  3c9360b11a9070150711969632f591134d1de5762ac6f78dba5dd2cdeee15702 \
-                        size    1211469 \
-                    github.com/stretchr/testify \
-                        lock    v1.7.0 \
-                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
-                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
-                        size    91096 \
-                    github.com/sirupsen/logrus \
-                        lock    v1.8.1 \
-                        rmd160  aeb4e5f2ea8112e787a72fba611605c4c87f42b5 \
-                        sha256  931c31f624d05136760b41a63f6bc146b79ac91776b4642cbd2026c2792e3aca \
-                        size    47184 \
-                    github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
-                    github.com/emersion/go-textwrapper \
-                        lock    d0e65e56babe \
-                        rmd160  ef26d9541c9c955095a1226ea84e2c07a4556d94 \
-                        sha256  66bda58d5b25c55bc1f46d0441140959f4a7ef18f2dc1b7f952dfea4519aa2be \
-                        size    2173 \
-                    github.com/emersion/go-sasl \
-                        lock    7bfe0ed36a21 \
-                        rmd160  145a810700dd640b3bc44342e9308fcdfec687fd \
-                        sha256  5835e6fb1169dec85f1e87a6c16074f5bdf3dd85f6ff50ec9d455f429ef8a28e \
-                        size    7110 \
-                    github.com/emersion/go-message \
-                        lock    v0.9.1 \
-                        rmd160  d6702b4d01defbca834a8e4a1368d2a6ee5f84fb \
-                        sha256  499ba5d75d1f91dc161c6287a917c6a54ad1a07758f9d88fb566303ced7f3c63 \
-                        size    14773 \
-                    github.com/emersion/go-imap-idle \
-                        lock    2af93776db6b \
-                        rmd160  c66a62448bbc7176de8997742c57b8c32c11bc63 \
-                        sha256  d755d205025ba8f7591d7e53f53c4c23d148aa8748727885bc013e3fdb6ac5aa \
-                        size    3656 \
-                    github.com/emersion/go-imap \
-                        lock    b7db4a2bc5cc \
-                        rmd160  422156eb878efbb2f4ca6e45d1fc902b4f027d0a \
-                        sha256  5f37a5ccf4993aade5184d94f8bef2ad9c05bc591877c027370962b82a3ecae2 \
-                        size    88637 \
-                    github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171
+# 2.5.x ships a complete vendor directory, so no go.vendors block is needed --
+# the build resolves every dependency from vendor/ with GOPROXY=off.
+#
+# main moved to ./cmd/goimapnotify in 2.5.0.
+#
+# Upstream's Makefile stamps main.commit and main.branch from git, which is not
+# available here; gittag is the one that matters, as it feeds both -version and
+# the imap client's version string. The Makefile also passes -gcflags '-N -l',
+# which disables optimization and inlining -- that is a debug build, not
+# something to reproduce here.
+build.pre_args-append \
+                    -ldflags \" -X main.gittag=${version} \"
+
+build.args-append   -o ${name} ./cmd/${name}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Updates `goimapnotify` from 2.4-rc4 to 2.5.8, moving off a release candidate.

2.5.x restructured the project, so this is more than a version bump:

- `package main` moved to `./cmd/goimapnotify`, so that is built rather than the
  repository root, which now holds no Go files. Without this the build fails with
  `no Go files in .../src/gitlab.com/shackra/goimapnotify`.
- The tarball now ships a complete `vendor/` directory (28 modules), so the
  `go.vendors` block is removed. Every dependency resolves from `vendor/` with
  `GOPROXY=off`, verified by building with an empty module cache and no network.
  The list no longer needs regenerating on each update.
- `main.gittag` is now stamped. It feeds both `-version` and the imap client's
  version string, and was previously left empty.

Upstream's Makefile also passes `-gcflags '-N -l'`, which disables optimization
and inlining; that is a debug build and is deliberately not reproduced here. It
stamps `main.commit` and `main.branch` from `git`, which a release tarball
cannot supply, so those are left unset.

`go.mod` moved its floor from 1.20 to 1.23.

Dropping `go.vendors` is a structural change to the port, so I would rather it
got a look than be assumed harmless — happy to restore the block if you prefer
it kept.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`
- [x] tested basic functionality of all binary files? — `-version` reports 2.5.8
