### PR TITLE
cosign: update to 3.1.3, declare the Go it needs

### DIFF
--- a/security/cosign/Portfile
+++ b/security/cosign/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/sigstore/cosign 3.1.1 v
+go.setup            github.com/sigstore/cosign 3.1.3 v
+go.toolchain_min    1.26
 revision            0
 
 categories          security
@@ -15,9 +16,9 @@ long_description    \
     Container Signing, Verification and Storage in an OCI registry. Cosign \
     aims to make signatures invisible infrastructure.
 
-checksums           rmd160  2d0b73763d89979d058917d34e687e024161128c \
-                    sha256  2b44374321cd19b0eb27026ee16e519393139edd7ffe01860c2d78d6084c68eb \
-                    size    973653
+checksums           rmd160  d0407363804d174f8bbcc0a991f0241490030e13 \
+                    sha256  ab8fcb8e0b4c0b8d01aefa37790cdd5ad099366b2efb8636b7a0250915b93362 \
+                    size    962331
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 go.offline_build no


### PR DESCRIPTION
#### Description

Updates `cosign` to 3.1.3. `go.mod` requires go 1.26.0, so `go.toolchain_min` is
declared. No other changes: `cmd/cosign` is still the main package and the
installed docs are unchanged.

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`
