### PR TITLE
GPXSee: update to 16.13

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake6 1.0
 
-github.setup        tumic0 GPXSee 16.12
+github.setup        tumic0 GPXSee 16.13
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  4d1c5502999789146fd09e20110218d4a7d8d780 \
-                    sha256  2c25f884348807813776d3a05ce4ee5fe28ab28c1cf87e27b87ab79bcfe09dbd \
-                    size    6471515
+checksums           rmd160  82790543e5e756dfbe27323e371d648d9bc2d2cc \
+                    sha256  b6ac500415db7595c70a6a985a838ca88d172e0bc79f21057210a6bb15169d90 \
+                    size    6471609
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
