### PR TITLE
openjdk25-temurin: update to 25.0.4.1

### DIFF
--- a/java/openjdk25-temurin/Portfile
+++ b/java/openjdk25-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=25&os=mac
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.4
-set build    7
+version      ${feature}.0.4.1
+set build    1
 revision     0
 
 # End of availability: https://adoptium.net/support
@@ -33,14 +33,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  e697b25f62fd814caa3d3b9c10fe47bbb00ec1bf \
-                 sha256  a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7 \
-                 size    120249038
+    checksums    rmd160  028ce6351a9bad4b1909996aa29eaf7ede993cc4 \
+                 sha256  e6229d9504f7922053ab31821b9e6bee8761daf7b026a3476d1a027563009880 \
+                 size    120256199
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  7b7babfad7762c3233d8f212896238741eb7a4d2 \
-                 sha256  5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd \
-                 size    136352956
+    checksums    rmd160  66f953d66aba2a40cc69dba42edb91eed28b8a4d \
+                 sha256  61979887f7506a24a57439ff99adb8b3a7fc89977d9cfe3b8984f58a981b7b9d \
+                 size    136355078
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 25.0.4.1.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?