### PR TITLE
openjdk17-temurin: update to 17.0.20.1

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.20
-set build    8
+version      ${feature}.0.20.1
+set build    1
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  0169266b27f1d433435fa5b76b7f3af08d2e7180 \
-                 sha256  3710c3131c5d7c090582b357f1310133a90bf701183d065223f1a0b90b9ed5ae \
-                 size    180581753
+    checksums    rmd160  978b841d7a5d8dba04bf25faa22cf190b6e89274 \
+                 sha256  c01975da12ed4235250ff891fe8bba73a9e73037d444b269c9d0922b5dbc8e0a \
+                 size    180578248
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  2e5d13cf0ebd9a013f0c6f3b04026497429dadd1 \
-                 sha256  524850138c742324fb21fca4ff6ef68ea25f25bf59366a864e45b4a0c45ed0df \
-                 size    185860079
+    checksums    rmd160  550e73fd369f150f4ded87c4fa91c15443b4ba1c \
+                 sha256  196d13ba5f10414bef7f6a05a9b3f00edacb18ebacef2b99485db9e2ee18f0e8 \
+                 size    185851019
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.20.1.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?