### PR TITLE
gost: Update to 3.2.6

### DIFF
--- a/net/gost/Portfile
+++ b/net/gost/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ginuerzh/gost 2.12.0 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/go-gost/gost 3.2.6 v
+go.toolchain_min    1.26.3
 revision            0
 
 categories          net
@@ -14,17 +13,36 @@ maintainers         {judaew @judaew} openmaintainer
 
 description         GO Simple Tunnel - a simple tunnel written in golang.
 long_description    ${description}
-homepage            https://docs.ginuerzh.xyz/gost/en
+homepage            https://gost.run/en/
 
-checksums           rmd160  55e6628753d2d311e1cf4caf34f28a57deea002e \
-                    sha256  8e96a75fac7d49e52206ed8890fd796ce3230769c86999c73d0e9069616bea31 \
-                    size    184935
+checksums           rmd160  2c4c39920514bf57592eda81d674226114a3c05a \
+                    sha256  79874354530b899576dd4866d3b1400651d0b17c1e7a90ad30c44686a0642600 \
+                    size    31234
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
-go.offline_build no
+go.offline_build    no
 
 build.args          -o ${name} ./cmd/gost
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0644 ${worksrcpath}/${name}.yml ${destroot}${prefix}/etc/${name}.yml.example
 }
+
+startupitem.create  yes
+startupitem.name    ${name}
+startupitem.logfile ${prefix}/var/log/${name}.log
+startupitem.start   "${prefix}/bin/${name} -C ${prefix}/etc/${name}.yml"
+startupitem.stop    "kill \$(cat ${prefix}/var/run/${name}.pid)"
+startupitem.pidfile auto ${prefix}/var/run/${name}.pid
+
+notes-append "
+A configuration must be created at
+    ${prefix}/etc/${name}.yml
+
+An example configuration is located at
+    ${prefix}/etc/${name}.yml.example
+"
+
+# Ignore nightly releases
+livecheck.url       ${github.homepage}/releases


### PR DESCRIPTION
#### Description

Update gost to 3.2.6. Add a startupitem entry to launch gost as a daemon.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
