### PR TITLE
libp11: Update to 0.4.20

### DIFF
--- a/security/libp11/Portfile
+++ b/security/libp11/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               openssl 1.0
 
-github.setup            OpenSC libp11 0.4.18 libp11-
+github.setup            OpenSC libp11 0.4.20 libp11-
 github.tarball_from     releases
 revision                0
 categories              security
@@ -14,19 +15,20 @@ description             Interface to access PKCS#11 objects.
 long_description        libp11 is a library implementing a thin layer on top of PKCS#11 API \
                         to make using PKCS#11 implementations easier.
 
-checksums               rmd160  622c810b865365d308c4b28fcb573087bfa83f33 \
-                        sha256  9292de67ca73aba1deacf577c9086b595765f36ef47712cfeb49fa31f6e772fb \
-                        size    578268
+checksums               rmd160  748473f6cc09fecf6b93e04dab772662a076fb5c \
+                        sha256  a125e0310ff10c189fc1b32a9652101486ea94a6b07c677a30e90e3638d2db48 \
+                        size    680288
 
-depends_build           port:docbook-xsl-nons \
-                        port:gengetopt \
-                        port:help2man \
-                        port:libxslt \
-                        port:pkgconfig
-depends_lib             path:lib/libcrypto.dylib:openssl
+depends_build-append    path:bin/pkg-config:pkgconfig
+depends_test-append     port:opensc \
+                        port:softhsm
 
 # p11_attr.c:167: error: 'for' loop initial declaration used outside C99 mode
 compiler.c_standard     2011
 
 test.run                yes
 test.target             check
+
+post-destroot {
+    xinstall -m 644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

Update libp11 to 0.4.20

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
