### PR TITLE
uriparser: Update to 1.0.2

### DIFF
--- a/devel/uriparser/Portfile
+++ b/devel/uriparser/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        uriparser uriparser 0.9.9 uriparser-
+github.setup        uriparser uriparser 1.0.2 uriparser-
 revision            0
-checksums           rmd160  8a417a6579e40517a577b2cad1c3d2e013238c56 \
-                    sha256  027b923c0ce89786d8cf7a842ef77dcfff3a6a097c0e67d241b447d1eae8db4c \
-                    size    215434
+checksums           rmd160  0d60592814e536a55566b4eb7c62a22e54dcba1a \
+                    sha256  dd2e4843f43de6f5aedf430e530f1e2d159eba8ca4d64c2787af1c20f707a9e4 \
+                    size    222489
 
 categories          devel www
 maintainers         {ryandesign @ryandesign} openmaintainer


### PR DESCRIPTION
#### Description

Update uriparser to 1.0.2. No revbumps needed.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
