### PR TITLE
libuuid: move uuid.h two levels deeper in order to avoid configure conflicts

### DIFF
--- a/devel/libuuid/Portfile
+++ b/devel/libuuid/Portfile
@@ -1,14 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       github 1.0
 PortGroup                       meson 1.0
 
 conflicts                       ossp-uuid
 
 name                            libuuid
-version                         2.42.1
-revision                        1
+version                         2.42.2
+revision                        0
 categories                      devel
 maintainers                     nomaintainer
 license                         BSD
@@ -22,9 +21,9 @@ distname                        util-linux-${version}
 
 use_xz                          yes
 
-checksums                       rmd160  ac28aa535cde2b0789aea5bee394c7ca2d1c6972 \
-                                sha256  82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f \
-                                size    10639396
+checksums                       rmd160  e60976e7e26874e7df17443875e4ff5b193d3ab3 \
+                                sha256  03a05d3adf9602ef128f2da05b84b3205ce60c351e5737c0370f74000679ce8a \
+                                size    10658220
 
 configure.args                  -Dauto_features=disabled \
                                 -Dbuild-libuuid=enabled \

--- a/devel/libuuid/Portfile
+++ b/devel/libuuid/Portfile
@@ -1,36 +1,36 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           meson 1.0
+PortSystem                      1.0
+PortGroup                       github 1.0
+PortGroup                       meson 1.0
 
-conflicts           ossp-uuid
+conflicts                       ossp-uuid
 
-name                libuuid
-version             2.42.1
-revision            1
-categories          devel
-maintainers         nomaintainer
-license             BSD
+name                            libuuid
+version                         2.42.1
+revision                        1
+categories                      devel
+maintainers                     nomaintainer
+license                         BSD
 
-description         Portable uuid C library
-long_description    {*}${description}
+description                     Portable uuid C library
+long_description                {*}${description}
 
-set branch          [join [lrange [split ${version} .] 0 1] .]
-master_sites        https://www.kernel.org/pub/linux/utils/util-linux/v${branch}/
-distname            util-linux-${version}
+set branch                      [join [lrange [split ${version} .] 0 1] .]
+master_sites                    https://www.kernel.org/pub/linux/utils/util-linux/v${branch}/
+distname                        util-linux-${version}
 
-use_xz              yes
+use_xz                          yes
 
-checksums           rmd160  ac28aa535cde2b0789aea5bee394c7ca2d1c6972 \
-                    sha256  82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f \
-                    size    10639396
+checksums                       rmd160  ac28aa535cde2b0789aea5bee394c7ca2d1c6972 \
+                                sha256  82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f \
+                                size    10639396
 
-configure.args      -Dauto_features=disabled \
-                    -Dbuild-libuuid=enabled \
-                    -Dprogram-tests=false
+configure.args                  -Dauto_features=disabled \
+                                -Dbuild-libuuid=enabled \
+                                -Dprogram-tests=false
 
-patchfiles-append   patch-libuuid_meson.build.diff
+patchfiles-append               patch-libuuid_meson.build.diff
 
-livecheck.url       https://github.com/util-linux/util-linux/tags
-livecheck.regex     {v([0-9.]+)}
+livecheck.url                   https://github.com/util-linux/util-linux/tags
+livecheck.regex                 {v([0-9.]+)}

--- a/devel/libuuid/Portfile
+++ b/devel/libuuid/Portfile
@@ -8,6 +8,7 @@ conflicts           ossp-uuid
 
 name                libuuid
 version             2.42.1
+revision            1
 categories          devel
 maintainers         nomaintainer
 license             BSD
@@ -28,6 +29,8 @@ checksums           rmd160  ac28aa535cde2b0789aea5bee394c7ca2d1c6972 \
 configure.args      -Dauto_features=disabled \
                     -Dbuild-libuuid=enabled \
                     -Dprogram-tests=false
+
+patchfiles-append   patch-libuuid_meson.build.diff
 
 livecheck.url       https://github.com/util-linux/util-linux/tags
 livecheck.regex     {v([0-9.]+)}

--- a/devel/libuuid/files/patch-libuuid_meson.build.diff
+++ b/devel/libuuid/files/patch-libuuid_meson.build.diff
@@ -1,0 +1,14 @@
+--- libuuid/meson.build.orig	2026-04-28 19:11:39
++++ libuuid/meson.build	2026-08-22 18:57:47
+@@ -53,9 +53,9 @@
+ if build_libuuid
+   pkgconfig.generate(lib_uuid,
+                      description : 'Universally unique id library',
+-                     subdirs : 'uuid',
++                     subdirs : 'libuuid/include/uuid',
+                      version : pc_version)
+-  install_headers('src/uuid.h', subdir : 'uuid')
++  install_headers('src/uuid.h', subdir : 'libuuid/include/uuid')
+   if meson.version().version_compare('>=0.54.0')
+     meson.override_dependency('uuid', uuid_dep)
+   endif

--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
+PortGroup                       github 1.0
 PortGroup                       php 1.1
 
 name                            php-uuid
@@ -9,27 +10,30 @@ maintainers                     {ryandesign @ryandesign} {mathiesen.info:macinto
 license                         LGPL-2.1+
 
 php.branches                    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
-php.pecl                        yes
 
 description                     A wrapper around libuuid from the ext2utils project.
-
 long_description                ${description}
 
+github.tarball_from             archive
+
 if {[vercmp ${php.branch} >= 7.0]} {
-    version                     1.3.0
+    github.setup                php pecl-networking-uuid 1.3.0 v
     revision                    0
-    checksums                   rmd160  4d7cfa161e193436850b48e3579c6156694fc2ad \
-                                sha256  b7af055e2c409622f8c5e6242d1c526c00e011a93c39b10ca28040b908da3f37 \
-                                size    17385
+    checksums                   rmd160  409d420fd371e805edc59f7f3ade7d626da2d9ab \
+                                sha256  c8f69109da9faf06778e6a5c576d4df7fa26520bc862c8e178608b66172297d0 \
+                                size    24218
 } elseif {[vercmp ${php.branch} >= 5.3]} {
-    version                     1.0.5
+    github.setup                php pecl-networking-uuid 1.0.5 uuid-
     revision                    1
-    checksums                   rmd160  c9e5fdfe7ccb56c19d4309cadac4eeaa26f8b463 \
-                                sha256  f762c53cfdc408f015384188c174b503a734b59d7be82738b89ec3ffd3e6b8f4 \
-                                size    14946
+    checksums                   rmd160  136dceee627f18e6ad786990247e7005bb42aa89 \
+                                sha256  e808accf3cdf952beee998b94674ebf97a20fbf7d6920578807956bd09c3885d \
+                                size    20704
 }
 
 if {${name} ne ${subport}} {
+    # remove w/ next update
+    dist_subdir                 ${name}/${version}_1
+
     depends_lib-append          port:libuuid
 
     configure.args              --with-uuid=${prefix}/include/libuuid

--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -29,10 +29,8 @@ if {[vercmp ${php.branch} >= 7.0]} {
                         size    14946
 }
 
-use_parallel_build      yes
-
 if {${name} ne ${subport}} {
     depends_lib-append  port:libuuid
 
-    configure.args      --with-uuid=${prefix}
+    configure.args      --with-uuid=${prefix}/include/libuuid
 }

--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -1,36 +1,36 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               php 1.1
+PortSystem                      1.0
+PortGroup                       php 1.1
 
-name                    php-uuid
-categories-append       net www
-maintainers             {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
-license                 LGPL-2.1+
+name                            php-uuid
+categories-append               net www
+maintainers                     {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
+license                         LGPL-2.1+
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
-php.pecl                yes
+php.branches                    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
+php.pecl                        yes
 
-description             A wrapper around libuuid from the ext2utils project.
+description                     A wrapper around libuuid from the ext2utils project.
 
-long_description        ${description}
+long_description                ${description}
 
 if {[vercmp ${php.branch} >= 7.0]} {
-    version             1.3.0
-    revision            0
-    checksums           rmd160  4d7cfa161e193436850b48e3579c6156694fc2ad \
-                        sha256  b7af055e2c409622f8c5e6242d1c526c00e011a93c39b10ca28040b908da3f37 \
-                        size    17385
+    version                     1.3.0
+    revision                    0
+    checksums                   rmd160  4d7cfa161e193436850b48e3579c6156694fc2ad \
+                                sha256  b7af055e2c409622f8c5e6242d1c526c00e011a93c39b10ca28040b908da3f37 \
+                                size    17385
 } elseif {[vercmp ${php.branch} >= 5.3]} {
-    version             1.0.5
-    revision            1
-    checksums           rmd160  c9e5fdfe7ccb56c19d4309cadac4eeaa26f8b463 \
-                        sha256  f762c53cfdc408f015384188c174b503a734b59d7be82738b89ec3ffd3e6b8f4 \
-                        size    14946
+    version                     1.0.5
+    revision                    1
+    checksums                   rmd160  c9e5fdfe7ccb56c19d4309cadac4eeaa26f8b463 \
+                                sha256  f762c53cfdc408f015384188c174b503a734b59d7be82738b89ec3ffd3e6b8f4 \
+                                size    14946
 }
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:libuuid
+    depends_lib-append          port:libuuid
 
-    configure.args      --with-uuid=${prefix}/include/libuuid
+    configure.args              --with-uuid=${prefix}/include/libuuid
 }


### PR DESCRIPTION
#### Description

If `libuuid` is installed, at least `llvm-*` & `python3{10..12}` fail to configure, as they get hold of the MacPorts `libuuid` instead of the system `libuuid`. @jmroot suggested moving MP `libuuid` to a subdirectory in `${prefix}/includes`, but a default install of `libuuid` allready does that, leading every Port looking for `libuuid` & using `pkg-config` to find the wrong `libuuid`. My final solutions was to move the `uuid.h` file two levels deeper.
```
#=> port contents libuuid               #=> port contents libuuid
Port libuuid @2.42.1_0 contains:        Port libuuid @2.42.1_1 contains:
  /opt/local/bin/uuidgen                  /opt/local/bin/uuidgen
  /opt/local/include/uuid/uuid.h          /opt/local/include/libuuid/include/uuid/uuid.h
  /opt/local/lib/libuuid.1.dylib          /opt/local/lib/libuuid.1.dylib
  /opt/local/lib/libuuid.dylib            /opt/local/lib/libuuid.dylib
  /opt/local/lib/pkgconfig/uuid.pc        /opt/local/lib/pkgconfig/uuid.pc
```
MacPorts only has 3 Ports dependent on `libuuid` : `erofs-utils`, `p5-alien-libuuid` & `php-uuid`
1. `php-uuid` uses `--with-uuid=<path>`
2. `erofs-utils` & `p5-alien-libuuid` has to have a path added to `cpplags` as they are using `pkg-config`

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

Resolves : 
- #34079 
- https://trac.macports.org/ticket/73620

###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560
```

