### PR TITLE
mp3rgain: update to 3.3.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.2.0 v
+github.setup        M-Igashi mp3rgain 3.3.0 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  178f33789f9028674cdf5655229eb5ff38b64988 \
-                    sha256  67a6c44e773099aff526614c558196c0aeb70d1852c8958c16404445a16bf8a5 \
-                    size    551671
+                    rmd160  3f24ec0f105afd78658d5e73e8f3264f2d227f60 \
+                    sha256  b438621bbc83ba3fe3b4bea0f6e206268b0e9a6d73277366dc1c0f51131b541a \
+                    size    560376
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -75,17 +75,17 @@ cargo.crates \
     serde_json                   1.0.151          c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     simd-adler32                 0.3.9            703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     smallvec                     1.15.1           67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    symphonia                    0.6.0            1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a \
-    symphonia-bundle-mp3         0.6.0            350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546 \
-    symphonia-codec-aac          0.6.0            f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76 \
-    symphonia-common             0.6.0            8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55 \
-    symphonia-core               0.6.0            95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1 \
-    symphonia-format-isomp4      0.6.0            2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e \
-    symphonia-metadata           0.6.0            a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681 \
+    symphonia                    0.6.1            a7edef6a96b696d4e0cab5ee9ebb7ca155ed95f30a6b45bbb8b97d2727f02424 \
+    symphonia-bundle-mp3         0.6.1            98ea5ffc8716bff677dfb3b01b420c7b758de901a72b8c330bf2040ab74b4add \
+    symphonia-codec-aac          0.6.1            f5bf8e39552d34a3c4c98333370e62f48c92456d2e814f273b5c3ad7c4a5f45c \
+    symphonia-common             0.6.1            2acc3fcc18ec9b8cdd48614e259c4cf0d27b71d41e5d9b120b42c5adab12d7c4 \
+    symphonia-core               0.6.1            01c412864d599d4750d0c3d684d7e093ec05e5309681ef5252cc1096a437f6e0 \
+    symphonia-format-isomp4      0.6.1            0e681a70e1870d34e02abf1dbc51e4267c3f1827801474e8870be8c689fc4dc3 \
+    symphonia-metadata           0.6.1            83713a97705d77bdef7cdbc0768fd6e5a54e4cd7e48d60a806ae85639e2c87c6 \
     syn                          2.0.117          e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     syn                          3.0.3            53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
-    thiserror                    2.0.19           09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
-    thiserror-impl               2.0.19           43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
+    thiserror                    2.0.20           ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
+    thiserror-impl               2.0.20           bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
     unicode-ident                1.0.24           e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-width                0.2.2            b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unit-prefix                  0.5.2            81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3 \


### PR DESCRIPTION
Updates `audio/mp3rgain` to 3.3.0.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.3.0

Notable in this version:
- `--true-peak`, an opt-in true-peak meter (BS.1770-4 Annex 2) for the `--rg2` / `--r128` modes.
- Fixed a gain-step rounding error that made post-apply ReplayGain tags drift by roughly 0.005 dB per applied step.

Portfile changes:
- `github.setup` bumped to 3.3.0 and `revision` reset to 0.
- Distfile `rmd160` / `sha256` / `size` recomputed from the release tarball.
- `cargo.crates` regenerated from `Cargo.lock`; the only movement is symphonia 0.6.0 -> 0.6.1 and thiserror 2.0.19 -> 2.0.20 (64 crates, unchanged count).

The GUI (mp3rgui) is not packaged here, so this covers the CLI only.