### PR TITLE
mariadb-{LTS} : update to latest versions

### DIFF
--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -7,12 +7,12 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.11
 set name_mysql      ${name}
-version             10.11.18
+version             10.11.19
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 1
+set revision_client 0
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
@@ -41,9 +41,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  96da148f4584b810b3efb62de8cccdfc207a302f \
-                    sha256  a46852c68075be7c31c7b33fee233c5b5a00c8c28117f5204d124e4f2fd56fa8 \
-                    size    114604451
+    checksums       rmd160  2ff4ad3229efdbcc7e93827264b255a62830a92d \
+                    sha256  b8e543ee69d380fb1cfd563226f49e0fe96e4d67e7b7a9045ee514a168ed2066 \
+                    size    114812324
 
     cmake.build_type    Release
 

--- a/databases/mariadb-10.6/Portfile
+++ b/databases/mariadb-10.6/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.6
 set name_mysql      ${name}
-version             10.6.27
+version             10.6.28
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
@@ -41,9 +41,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  322309910d7b45979a1ac3b09db723db70b87e74 \
-                    sha256  8eb76ad3b1b3d14c56611ccc910428141fe56160043819e6474160385f69665e \
-                    size    109060020
+    checksums       rmd160  f6efaaf9403e33a94550303d652db97f92dc3c39 \
+                    sha256  13d9330f3120c739757b215a3220a9c9e2ddf3c3c1b8beff5cd43942868f3d72 \
+                    size    109119525
 
     cmake.build_type    Release
 

--- a/databases/mariadb-11.4/Portfile
+++ b/databases/mariadb-11.4/Portfile
@@ -7,12 +7,12 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-11.4
 set name_mysql      ${name}
-version             11.4.12
+version             11.4.13
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 1
+set revision_client 0
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
@@ -41,9 +41,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  82fa1c138647c4cdfcd49ce0cbe44841002d26a8 \
-                    sha256  5ab7883db519bfcebfdd2aac09bc5544a12ce328f39edd46d0bf01690615ef6c \
-                    size    118865084
+    checksums       rmd160  f0f272a7fe9f95268ae216940eae553e2ef47568 \
+                    sha256  1bb254b106d0a7ca871cfa18fa6e18d4b80a7430f9ec9d1571ec4271a13def96 \
+                    size    221118336
 
     cmake.build_type    Release
 

--- a/databases/mariadb-11.8/Portfile
+++ b/databases/mariadb-11.8/Portfile
@@ -7,12 +7,12 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-11.8
 set name_mysql      ${name}
-version             11.8.8
+version             11.8.9
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 1
+set revision_client 0
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
@@ -41,9 +41,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  f16d4bd7c84016e08323337a23ab03c593b61f75 \
-                    sha256  bd023a4959faf012db7f0ebfc0d276729e67e5443df193163f98d80fdfc524c9 \
-                    size    119402982
+    checksums       rmd160  c47e5f6f3d8e1bf894d7769bed4e922218593b3e \
+                    sha256  2e015b7e91004142eda8b3a20d3ceb875cf2ae55e72603e7222cd497d4e56fc6 \
+                    size    221699796
 
     cmake.build_type    Release
 

--- a/databases/mariadb-12.3/Portfile
+++ b/databases/mariadb-12.3/Portfile
@@ -7,13 +7,13 @@ legacysupport.newest_darwin_requires_legacy     15
 
 name                    mariadb-12.3
 set name_mysql          ${name}
-version                 12.3.2
+version                 12.3.3
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 1
-set revision_server 0
+set revision_client     0
+set revision_server     0
 categories              databases
 homepage                https://mariadb.org/
 maintainers             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
@@ -41,9 +41,9 @@ if {$subport eq $name} {
 
     master_sites        https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname            mariadb-${version}
-    checksums           rmd160  152a4bea361abdaa3fa263407fc0e8a90bb99a4c \
-                        sha256  82798714baf2f3456ed2f311fc803dc120f2bf3b82358e773847d628cdb4b670 \
-                        size    120615576
+    checksums           rmd160  d6ecf45d363b43183e7efaf9622830cd021c98b7 \
+                        sha256  e99d739fd4a55f9a11dea7bd2287a262673e287550af3071c8469dd2bec0c163 \
+                        size    222927580
 
     cmake.build_type    Release
 


### PR DESCRIPTION
#### Description

```
mariadb-12.3           : update to 12.3.3
mariadb-11.8           : update to 11.8.9
mariadb-11.4           : update to 11.4.13
mariadb-10.6           : update to 10.6.28
mariadb-10.11          : update to 10.11.19
```

###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560
```

