### PR TITLE
py-hypothesis: remove noarch, uses native code

### DIFF
--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -9,7 +9,6 @@ revision            0
 
 categories-append   devel
 platforms           {darwin any}
-supported_archs     noarch
 license             MPL-2
 maintainers         {khindenburg @kurthindenburg} \
                     openmaintainer

--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-hypothesis
 version             6.164.0
-revision            0
+revision            1
 
 categories-append   devel
 platforms           {darwin any}


### PR DESCRIPTION
#### Description

removes noarch on py-hypothesis, port has native code, fixed this error:
```ImportError: dlopen(/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/hypothesis/_native.cpython-312-darwin.so, 0x0002): tried: '/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/hypothesis/_native.cpython-312-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64e.v1' or 'arm64' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/hypothesis/_native.cpython-312-darwin.so' (no such file), '/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/hypothesis/_native.cpython-312-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64e.v1' or 'arm64' or 'arm64'))```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
