### PR TITLE
claude-code: update to 2.1.241

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.239
+version             2.1.241
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  311fb3757b690b4bb37984d63d0713fc7ab3305c \
-                 sha256  17426fd63e66cb0dfaeae34763e1836855a444850f1256c4e94ae7d6d2280ba7 \
-                 size    333702256
+    checksums    rmd160  622cad6e9e1ab31b68483855a524649fb22b7d11 \
+                 sha256  cf01b8cace66485ef5b476f14d96f69af61194a38c3df8412a80eb8f1316c10d \
+                 size    333784816
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  270ae0f19917114ad4762f502a08f1ecc57be0e0 \
-                 sha256  2b4f7aafdaa65bcc2335f56a4b276317837203f2c5587b1f2a17ca78ad14e36f \
-                 size    324973552
+    checksums    rmd160  eef513fcabaa327ff36c81cbe8388bf68adf3efd \
+                 sha256  1495eb7c42d3b4451f5f1cd38b6d498d22a4a38c802bc2be5c1cf1795e64820d \
+                 size    325055632
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.241.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?