### PR TITLE
libavif: Another legacy fix for <= 10.10

### DIFF
--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -3,6 +3,10 @@
 PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               github 1.0
+PortGroup               legacysupport 1.1
+
+# static_assert
+legacysupport.newest_darwin_requires_legacy 14
 
 github.setup            AOMediaCodec libavif 1.4.2 v
 revision                1


### PR DESCRIPTION
#### Description

* Add legacy support, fix builds on 10.6-10.10.
* Fixes "error: expected parameter declarator" due to new C11 assertions "static_assert" in upstream release.
* No rev bump.  Legacy build fixes only.
* Maybe closes https://trac.macports.org/ticket/74300 for real this time.  Wait and see.
* From analysis by @ryandesign at https://trac.macports.org/ticket/74324#comment:7
* This works by providing an updated "assert.h" which includes a C11 "static_assert" macro definition, missing from some older system "assert.h" headers.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.
* Wait for merge to check legacy builder results.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?