### PR TITLE
ImageMagick7: Update to 7.1.2-30

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -20,13 +20,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.2-27
+github.setup        ImageMagick ImageMagick 7.1.2-30
 github.tarball_from releases
 revision            0
 use_xz              yes
-checksums           rmd160  07c5256f79bc3d3002305a996a73a631458c02af \
-                    sha256  f65773f1f465c730f1c025c92a2524966f772ebeb77de0d817c336e1f565e9ef \
-                    size    10889824
+checksums           rmd160  43e16101dabcb07ac37ebe925646a18beb4832f3 \
+                    sha256  55100ca72b2332df6b2df4769bc153afcfcf588753dfc49b6fb8afa8ead59b23 \
+                    size    10215380
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

Update ImageMagick7 7.1.2-27 --> 7.1.2-30.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?