### PR TITLE
tmd: update/add port at 0.0.18

### DIFF
--- a/textproc/tmd/Portfile
+++ b/textproc/tmd/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                tmd
+version             0.0.18
+categories          textproc devel
+platforms           darwin
+supported_archs     arm64 x86_64
+license             AGPL-3
+maintainers         {github:intelligent-username}
+description         Convert files to token-efficient Markdown for LLM prompts
+long_description    {*}${description}. Supports PDF, DOCX, PPTX, XLSX, ODT, \
+                    EPUB, MOBI, HTML, JSON, CSV, LaTeX, e-mail, subtitles, \
+                    Jupyter notebooks, and whole code repositories.
+homepage            https://github.com/intelligent-username/tokens.md
+
+distfiles           tmd-macos-arm64
+if {${build_arch} eq "x86_64"} {
+    distfiles       tmd-macos-x64
+}
+
+master_sites        https://github.com/intelligent-username/tokens.md/releases/download/v${version}/
+checksums           tmd-macos-arm64 \
+                        sha256  23c994329e4fdeb5f39c0fde788af6c60da4da6976640f954345d496bb41ba65 \
+                    tmd-macos-x64 \
+                        sha256  bf9d5aee1b415ad6fe5e9711455bd2b88c5059acfe21b2c8a84065262727cf90
+
+use_configure       no
+build               {}
+
+destroot {
+    if {${build_arch} eq "x86_64"} {
+        file copy ${worksrcpath}/tmd-macos-x64 ${destroot}${prefix}/bin/tmd
+    } else {
+        file copy ${worksrcpath}/tmd-macos-arm64 ${destroot}${prefix}/bin/tmd
+    }
+    file attributes ${destroot}${prefix}/bin/tmd -permissions 0755
+}
+
+test.run            yes
+test.cmd            ${prefix}/bin/tmd
+test.args           --version             0.0.18


### PR DESCRIPTION
Updates/adds `tmd` Portfile to version 0.0.18. Native binary distribution for macOS (x86_64 and arm64).