### PR TITLE
pkgconf: Update to 3.0.6

### DIFF
--- a/devel/pkgconf/Portfile
+++ b/devel/pkgconf/Portfile
@@ -8,7 +8,7 @@ PortGroup                   meson 1.0
 legacysupport.newest_darwin_requires_legacy 13
 
 name                        pkgconf
-version                     3.0.5
+version                     3.0.6
 revision                    0
 categories                  devel
 license                     ISC
@@ -20,9 +20,9 @@ long_description            pkgconf is ${description}. \
 homepage                    https://github.com/pkgconf/pkgconf
 master_sites                https://distfiles.ariadne.space/pkgconf/
 
-checksums                   rmd160  89caa8fc038682fda04ee2017f10877dbf4be473 \
-                            sha256  d0d2ebdb3c7bfa3ae6e879d80b60dfe1dd482cce9f8be8fd8651149d396a4c49 \
-                            size    624066
+checksums                   rmd160  e50625d3675dc9b6dbf337e386dbb0074a586ca2 \
+                            sha256  01da06de506241a124faa7ba0a34b5ad549b49df8d280337d42d00e78ac37d5d \
+                            size    625431
 
 # both ports install ${prefix}/share/aclocal/pkg.m4
 conflicts                   pkgconfig


### PR DESCRIPTION
#### Description

Update pkgconf to 3.0.6

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
