### PR TITLE
ImageMagick, p5-perlmagick: Update to 6.9.13-55

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -14,19 +14,20 @@ legacysupport.newest_darwin_requires_legacy 11
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-github.setup                ImageMagick ImageMagick6 6.9.13-52
+github.setup                ImageMagick ImageMagick6 6.9.13-55
 revision                    0
 
 github.tarball_from         releases
 distname                    ${name}-${version}
 use_xz                      yes
 
-checksums                   rmd160  d255f948705898e3d63afd0c26a8ed534b8402f5 \
-                            sha256  0e313e1a4d3bcac8bdce22fcaa31589ccb5450a17966e7ce8d22c407b04b437b \
-                            size    9727724
+checksums                   rmd160  9da27be27a945f3fc6b81e155962fe831addc7c9 \
+                            sha256  2dcd82487604d061f0190553d05cb66af51b912851e5fe1daa5f63b0da8c9f82 \
+                            size    8656728
 
 categories                  graphics devel
-maintainers                 {ryandesign @ryandesign} \
+maintainers                 {@Dave-Allured noaa.gov:dave.allured} \
+                            {ryandesign @ryandesign} \
                             openmaintainer
 license                     Apache-2
 

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -8,8 +8,8 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.13-52
-github.setup        ImageMagick ImageMagick6 6.9.13-52
+perl5.setup         PerlMagick 6.9.13-55
+github.setup        ImageMagick ImageMagick6 6.9.13-55
 revision            0
 
 set my_name         ImageMagick
@@ -17,11 +17,12 @@ github.tarball_from releases
 distname            ${my_name}-${version}
 use_xz              yes
 
-checksums           rmd160  d255f948705898e3d63afd0c26a8ed534b8402f5 \
-                    sha256  0e313e1a4d3bcac8bdce22fcaa31589ccb5450a17966e7ce8d22c407b04b437b \
-                    size    9727724
+checksums           rmd160  9da27be27a945f3fc6b81e155962fe831addc7c9 \
+                    sha256  2dcd82487604d061f0190553d05cb66af51b912851e5fe1daa5f63b0da8c9f82 \
+                    size    8656728
 
-maintainers         {ryandesign @ryandesign} \
+maintainers         {@Dave-Allured noaa.gov:dave.allured} \
+                    {ryandesign @ryandesign} \
                     openmaintainer
 description         Perl extension for calling ImageMagick's libMagick methods
 long_description    {*}${description}
@@ -62,6 +63,6 @@ use_parallel_build  no
 
 livecheck.type      none
 } else {
-livecheck.url       ${github.homepage}/tags
-livecheck.regex     archive/refs/tags/[join ${github.livecheck.regex}]\\.tar\\.gz
+livecheck.url       https://github.com/ImageMagick/ImageMagick6/tags
+livecheck.regex     archive/refs/tags/(\[^"\]+)\.tar\.gz
 }


### PR DESCRIPTION
#### Description

* Update ImageMagick 6.9.13-52 --> 6.9.13-55.
* Keep p5-perlmagick in sync.
* Add self as co-maintainer.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?