### PR TITLE
certgraph: Update to 0.1.2

### DIFF
--- a/net/certgraph/Portfile
+++ b/net/certgraph/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lanrat/certgraph 20220513
+go.setup            github.com/lanrat/certgraph 0.1.2 v
+go.toolchain_min    1.23.0
 revision            0
 
 description         \
@@ -29,37 +30,39 @@ license             GPL-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
+build.args-append   -ldflags \"-X main.version=${version}\"
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  ae159562723fe707a992e3bd0c5f2a878ece9ee7 \
-                        sha256  739c7a7d29de354814a8799d6c5ce4ba2236aee16ab7be980203bc7780769b47 \
-                        size    39109
+                        rmd160  42a72e7c3930e9350b4170ff57673cf2907f767c \
+                        sha256  233b6bf6c081d88c63ed26b2d11d09a74e55f3dfc860823fdf946dc455a1d135 \
+                        size    48260
 
 go.vendors          golang.org/x/text \
-                        lock    v0.3.7 \
-                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
-                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
-                        size    8356115 \
+                        lock    v0.27.0 \
+                        rmd160  3e107b85875c286ddcfc1b54394511131beacef8 \
+                        sha256  e17d0f44e43c08335322047d9310665e8cb0b4f796aff6efb5d2e6f89a9ee7a6 \
+                        size    8974673 \
                     golang.org/x/sync \
-                        lock    036812b2e83c \
-                        rmd160  f42be6eb3565d2ed3d1066ea1a7f69437c8bb1e6 \
-                        sha256  6f1daceb16cd75bdbf35da6c50aa352d1995d68ccd0049851d27686f451fad92 \
-                        size    18756 \
+                        lock    v0.16.0 \
+                        rmd160  68d9738ce548abe5fee7f08d9a7ce87c6a3c56a8 \
+                        sha256  490f41af712f24ebdd058f7b66666645800c32c66697c3f3878bc985a2cdac16 \
+                        size    18193 \
                     golang.org/x/net \
-                        lock    2871e0cb64e4 \
-                        rmd160  b0ca718c4ad52ea0d357f63842977fa62a407742 \
-                        sha256  ab2d7170f99614779cc9e16c8b0f217c66570fc5a1ab9fdb4a0f0cc147a423f1 \
-                        size    1229632 \
+                        lock    v0.42.0 \
+                        rmd160  6fa0b8351464db25d1033c94a352d5776a063b53 \
+                        sha256  3eb38644e1166af6362d1128cff5a62c43640df97142513bb9e7b0eabc0490fe \
+                        size    1504674 \
                     github.com/weppos/publicsuffix-go \
-                        lock    v0.15.0 \
-                        rmd160  97fcca60d21acf072a33f32a40f25e377a28f3e6 \
-                        sha256  805310d5cba65744c549afb5616791f1dff844142eecc581118ba61d21fe4bce \
-                        size    62703 \
+                        lock    v0.40.2 \
+                        rmd160  e17b6696d5cb2e22b1b00291ec45e42311f28289 \
+                        sha256  d437b07f7cfe36107c1108d68eed6dc0a1d4a3e08ee4af8be69ca921ee559e1a \
+                        size    71904 \
                     github.com/lib/pq \
-                        lock    v1.10.5 \
-                        rmd160  4752298d4213564b073d74b25601c2598f7a9b51 \
-                        sha256  758344045f26275ebc9a4f05f475d7b2443e0a6eed72b1e4cdbde1b5774fe275 \
-                        size    108336
+                        lock    v1.10.9 \
+                        rmd160  beb0e233773f49d8d08ee991abf23bc8febf69d0 \
+                        sha256  08610bf0370b202bee369b7303c3085e02c7f6fdfd42a3f58e8f033088151eea \
+                        size    114528


### PR DESCRIPTION
#### Description

Update certgraph to 0.1.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
