### PR TITLE
wxgtk-3.2: new port

### DIFF
--- a/_resources/port1.0/group/wxWidgets-1.0.tcl
+++ b/_resources/port1.0/group/wxWidgets-1.0.tcl
@@ -59,6 +59,8 @@
 #   If you already want to provide a special variant for your port with
 #   'wxWidgtes-3.2', you might only need a revbump after the switch to 3.2
 #
+# * 'wxGTK-3.2'
+#   Modern wx for legacy systems, and also for development purposes.
 #
 # You should note an important aspect of 'wxWidgets.use' though:
 # it does not actually do anything useful yet other than failing during
@@ -170,6 +172,7 @@ option_proc wxWidgets.use wxWidgets._set
 ## - wxPython-3.0
 ## - wxWidgets-3.0-cxx11
 ## - wxWidgets-3.2
+## - wxGTK-3.2
 proc wxWidgets._set {option action args} {
     global prefix frameworks_dir os.major
     global wxWidgets.name wxWidgets.version wxWidgets.prefix wxWidgets.wxdir
@@ -257,6 +260,10 @@ proc wxWidgets._set {option action args} {
                 return -code error "incompatible macOS version"
             }
         }
+    } elseif {${args} eq "wxGTK-3.2"} {
+        wxWidgets.name      "wxGTK"
+        wxWidgets.version   "3.2"
+        wxWidgets.port      "wxgtk-3.2"
     } else {
         # throw an error
         ui_error "invalid parameter for wxWidgets.use; use one of:\n\twxWidgets-2.8/wxGTK-2.8/wxWidgets-3.0/wxGTK-3.0/wxPython-3.0/wxWidgets-3.2"

--- a/graphics/wxgtk-3.2/Portfile
+++ b/graphics/wxgtk-3.2/Portfile
@@ -1,0 +1,287 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           cmake           1.1
+PortGroup           github          1.0
+PortGroup           legacysupport   1.1
+PortGroup           select          1.0
+PortGroup           wxWidgets       1.0
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
+
+github.setup        wxWidgets wxWidgets 3.2.11 v
+revision            0
+
+set branch          [join [lrange [split ${version} .] 0 1] .]
+
+name                wxgtk-${branch}
+
+set installname     wxGTK
+set wxtype          gtk3
+wxWidgets.use       wxGTK-${branch}
+
+categories          graphics devel
+license             wxwidgets-3.1
+maintainers         {@barracuda156 macos-powerpc.org:barracuda} openmaintainer
+
+description         C++ framework for cross-platform GUI development
+long_description    wxWidgets ${branch} is an open-source cross-platform C++ \
+                    GUI framework for Mac OS, Unix, Linux, Windows.
+
+homepage            https://www.wxwidgets.org
+
+distname            wxWidgets-${version}
+use_bzip2           yes
+
+checksums           rmd160  0c23bdcf0758bcb7dc4b8007325d4a2b82f47470 \
+                    sha256  6a129015bce2e914e4bf61ec4411854ad962801d47e92f2eb8340adb6a90af08 \
+                    size    27561301
+github.tarball_from releases
+
+dist_subdir         wxWidgets/${version}
+
+set selectdir       ${workpath}/select
+select.group        wxWidgets
+select.file         ${selectdir}/${subport}
+
+compiler.c_standard   2011
+compiler.cxx_standard 2011
+compiler.thread_local_storage yes
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
+                    port:curl \
+                    port:expat \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:jbigkit \
+                    port:libGLU \
+                    port:libiconv \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:libmspack \
+                    port:libpng \
+                    port:libsdl2 \
+                    port:libsdl2_mixer \
+                    port:mesa \
+                    port:pcre2 \
+                    port:tiff \
+                    port:xorg-libice \
+                    port:xorg-libsm \
+                    port:zlib
+
+require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
+require_active_variants gtk3 x11
+
+depends_run         port:wxWidgets-common \
+                    port:wxWidgets_select
+
+post-patch {
+    file mkdir ${selectdir}
+    system "echo \"${wxWidgets.wxdir}/wx-config\n${wxWidgets.wxdir}/wxrc-${branch}\" > ${select.file}"
+}
+
+# Enabled precomp results in weird errors, at least on powerpc:
+# https://github.com/wxWidgets/wxWidgets/pull/25321
+configure.args-append \
+                    -DCMAKE_INSTALL_PREFIX=${wxWidgets.prefix} \
+                    -DwxBUILD_COMPATIBILITY=3.0 \
+                    -DwxBUILD_MONOLITHIC=OFF \
+                    -DwxBUILD_OPTIMISE=ON \
+                    -DwxBUILD_PRECOMP=OFF \
+                    -DwxBUILD_SHARED=ON \
+                    -DwxBUILD_TESTS=OFF \
+                    -DwxCXX_STANDARD_DEFAULT=11 \
+                    -DwxBUILD_TOOLKIT=gtk3 \
+                    -DwxUSE_AUI=ON \
+                    -DwxUSE_CAIRO_DEFAULT=ON \
+                    -DwxUSE_COMPILER_TLS=ON \
+                    -DwxUSE_DEBUGREPORT=OFF \
+                    -DwxUSE_DISPLAY=ON \
+                    -DwxUSE_EXPAT=sys \
+                    -DwxUSE_GEOMETRY=ON \
+                    -DwxUSE_GLCANVAS_EGL=OFF \
+                    -DwxUSE_GUI=ON \
+                    -DwxUSE_HTML=ON \
+                    -DwxUSE_INTL=ON \
+                    -DwxUSE_JOYSTICK=OFF \
+                    -DwxUSE_LIBICONV=sys \
+                    -DwxUSE_LIBJPEG=sys \
+                    -DwxUSE_LIBLZMA=OFF \
+                    -DwxUSE_LIBNOTIFY=OFF \
+                    -DwxUSE_LIBPNG=sys \
+                    -DwxUSE_LIBSDL=OFF \
+                    -DwxUSE_LIBTIFF=sys \
+                    -DwxUSE_MEDIACTRL=OFF \
+                    -DwxUSE_MIMETYPE=ON \
+                    -DwxUSE_OPENGL=OFF \
+                    -DwxUSE_POSTSCRIPT=ON \
+                    -DwxUSE_PRINTF_POS_PARAMS=ON \
+                    -DwxUSE_REGEX=sys \
+                    -DwxUSE_REPRODUCIBLE_BUILD=OFF \
+                    -DwxUSE_RICHTEXT=ON \
+                    -DwxUSE_SECRETSTORE=ON \
+                    -DwxUSE_SOCKETS=ON \
+                    -DwxUSE_SPELLCHECK=OFF \
+                    -DwxUSE_STC=ON \
+                    -DwxUSE_STDPATHS=ON \
+                    -DwxUSE_THREADS=ON \
+                    -DwxUSE_UNICODE=ON \
+                    -DwxUSE_UNSAFE_WXSTRING_CONV=ON \
+                    -DwxUSE_WEBREQUEST=ON \
+                    -DwxUSE_WEBREQUEST_CURL=ON \
+                    -DwxUSE_WEBREQUEST_URLSESSION=OFF \
+                    -DwxUSE_WEBVIEW=OFF \
+                    -DwxUSE_XLOCALE=ON \
+                    -DwxUSE_XRC=ON \
+                    -DwxUSE_ZLIB=sys
+
+patch.pre_args-replace -p0 -p1
+
+platform darwin {
+    # These are backports from upstream now.
+    patchfiles-append \
+                    0001-uilocale-stdpaths.patch \
+                    0002-dirctrlg.cpp-fix.patch \
+                    0003-display-fix.patch \
+                    0004-evtloop_cf-fix.patch \
+                    0005-defs.h-fix.patch \
+                    0006-cfstring-fix.patch \
+                    0008-utilsunx-no-memset_s-before-10.9.patch \
+                    0009-utils_base.mm-fix.patch \
+                    0010-Install-forgotten-stdpaths.h.patch
+
+    # Temporary fix for https://github.com/wxWidgets/wxWidgets/issues/25490
+    # TODO: must be reviewed and then updated to what the upstream settles on.
+    patchfiles-append \
+                    0011-volume.mm-support-building-on-10.7-and-with-gcc.patch \
+                    0012-Move-volume.mm-in-place-for-macOS.patch
+
+    # Broken in 3.2.x at the moment (fixed in the master):
+    # https://github.com/wxWidgets/wxWidgets/issues/25873
+    # Might have been fixed in https://github.com/wxWidgets/wxWidgets/pull/25919
+#    if {${os.major} > 12} {
+#        configure.args-replace \
+#                    -DwxUSE_WEBREQUEST_CURL=ON -DwxUSE_WEBREQUEST_CURL=OFF \
+#                    -DwxUSE_WEBREQUEST_URLSESSION=OFF -DwxUSE_WEBREQUEST_URLSESSION=ON
+#    }
+    # Temporary fix to actually enable webrequest:
+    # https://github.com/wxWidgets/wxWidgets/issues/26471
+    patchfiles-append \
+                    0013-unbreak-webrequest.patch
+
+    patchfiles-append \
+                    0001-osx-evtloopsrc.h-install-always-on-macOS.patch \
+                    0003-mimetypes-fixes.patch \
+                    0004-Fix-Cocoa-stuff.patch
+
+    # Workaround to support wxPython build:
+    patchfiles-append \
+                    0006-wx-mediactrl.h-a-hack-to-install-it.patch
+
+    # Workaround, may not be needed for 3.3, verify when updating:
+    patchfiles-append \
+                    0007-powercmn.cpp.patch
+
+    # A hack to support 10.5:
+    if {${os.major} < 10} {
+        patchfiles-append \
+                    patch-leopard.diff
+    }
+
+    if {${os.major} < 12} {
+        configure.cxxflags-append \
+                    -F/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks
+    }
+}
+
+platform darwin powerpc {
+    if {![catch {sysctl hw.vectorunit} result] && $result > 0} {
+        configure.cxxflags-append -faltivec
+        configure.cflags-append -faltivec
+    }
+}
+
+post-destroot {
+    foreach dylib [ exec find ${destroot}${wxWidgets.prefix}/lib -name "\*.dylib" ] {
+            regsub ":$" ${dylib} "" destroot_dylib_path
+            regsub ${destroot} ${destroot_dylib_path} "" dylib_path
+            system "install_name_tool -id ${dylib_path} ${destroot_dylib_path}"
+
+            system "install_name_tool -change ${prefix}/lib/libwx_baseu-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_baseu-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_baseu_net-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_baseu_net-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_baseu_xml-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_baseu_xml-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_adv-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_adv-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_aui-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_aui-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_core-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_core-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_html-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_html-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_propgrid-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_propgrid-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_ribbon-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_ribbon-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_richtext-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_richtext-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+            system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_xrc-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_xrc-${branch}.0.dylib \
+                ${destroot_dylib_path}"
+
+            if {[variant_isset gstreamer]} {
+                system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_media-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_media-${branch}.0.dylib \
+                    ${destroot_dylib_path}"
+            }
+
+            if {[variant_isset opengl]} {
+                system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_gl-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_gl-${branch}.0.dylib \
+                    ${destroot_dylib_path}"
+            }
+
+            if {[variant_isset qa]} {
+                system "install_name_tool -change ${prefix}/lib/libwx_gtk3u_qa-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_gtk3u_qa-${branch}.0.dylib \
+                    ${destroot_dylib_path}"
+            }
+
+            system "install_name_tool -change ${prefix}/lib/libwx_baseu-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_baseu-${branch}.0.dylib \
+                ${destroot}${wxWidgets.prefix}/bin/wxrc-${branch}"
+            system "install_name_tool -change ${prefix}/lib/libwx_baseu_xml-${branch}.0.dylib ${wxWidgets.prefix}/lib/libwx_baseu_xml-${branch}.0.dylib \
+                ${destroot}${wxWidgets.prefix}/bin/wxrc-${branch}"
+    }
+
+    set confscript ${wxWidgets.prefix}/lib/wx/config/${wxtype}-unicode-${branch}
+    ln -sf ${confscript} ${destroot}${wxWidgets.prefix}/bin/wx-config
+}
+
+variant gstreamer description "Enable GStreamer" {
+    depends_lib-append \
+            port:gstreamer1 \
+            port:gstreamer1-gst-plugins-bad
+
+    configure.args-replace \
+            -DwxUSE_MEDIACTRL=OFF -DwxUSE_MEDIACTRL=ON
+}
+
+variant opengl description "Enable GL" {
+    configure.args-replace \
+            -DwxUSE_OPENGL=OFF -DwxUSE_OPENGL=ON
+}
+
+variant qa description "Enable DebugReport class" {
+    configure.args-replace \
+            -DwxUSE_DEBUGREPORT=OFF -DwxUSE_DEBUGREPORT=ON
+}
+
+# media library is needed by some dependents.
+default_variants-append     +gstreamer
+
+if {${os.platform} ne "darwin" || ${os.major} < 20} {
+    default_variants-append +opengl
+}
+
+github.livecheck.regex  {([0-9.]+)}

--- a/graphics/wxgtk-3.2/files/0001-osx-evtloopsrc.h-install-always-on-macOS.patch
+++ b/graphics/wxgtk-3.2/files/0001-osx-evtloopsrc.h-install-always-on-macOS.patch
@@ -1,0 +1,32 @@
+From bd228176a6f3d6f509b50e95643a5bfd3f2a0be1 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 30 Nov 2025 18:08:43 +0800
+Subject: [PATCH 1/5] osx/evtloopsrc.h: install always on macOS
+
+---
+ build/cmake/files.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/cmake/files.cmake b/build/cmake/files.cmake
+index a416e6956f..b6b53cbbfb 100644
+--- a/build/cmake/files.cmake
++++ b/build/cmake/files.cmake
+@@ -135,6 +135,7 @@ set(BASE_COREFOUNDATION_HDR
+     wx/osx/core/joystick.h
+     wx/osx/core/mimetype.h
+     wx/osx/core/dataview.h
++    wx/osx/evtloopsrc.h
+ )
+ 
+ set(BASE_OSX_SHARED_SRC
+@@ -2423,7 +2424,6 @@ set(OSX_SHARED_HDR
+     wx/osx/dirdlg.h
+     wx/osx/dnd.h
+     wx/osx/evtloop.h
+-    wx/osx/evtloopsrc.h
+     wx/osx/filedlg.h
+     wx/osx/font.h
+     wx/osx/fontdlg.h
+-- 
+2.24.3 (Apple Git-128)
+

--- a/graphics/wxgtk-3.2/files/0001-uilocale-stdpaths.patch
+++ b/graphics/wxgtk-3.2/files/0001-uilocale-stdpaths.patch
@@ -1,0 +1,153 @@
+From bd64f536503feba0f8893dc063220f263e4341a9 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 1 Dec 2025 15:04:37 +0800
+Subject: [PATCH 3/5] uilocale-related backports
+
+548e1ac17bec16ea0a3be394d1da3d96a442c3f8
+924fdbfc161d1bc6057b0e46eb756752d850413f
+8cf2920e3632ed776004d7ea8a1cb0013474bcc1
+b57b9cbe121bf39a410669b6d10cf95ddcc95882
+ed9869733dedbccd28fa449b70a1df61c2afe569
+---
+ build/bakefiles/files.bkl | 6 +++---
+ build/cmake/files.cmake   | 6 +++---
+ build/files               | 6 +++---
+ src/unix/uilocale.cpp     | 5 +++++
+ 4 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/build/bakefiles/files.bkl b/build/bakefiles/files.bkl
+index be5b539168..8ec455431c 100644
+--- a/build/bakefiles/files.bkl
++++ b/build/bakefiles/files.bkl
+@@ -97,6 +97,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
+ <set var="BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC" hints="files">
+     $(BASE_UNIX_AND_DARWIN_SRC)
+     src/unix/mimetype.cpp
++    src/unix/uilocale.cpp
+ </set>
+ 
+ <set var="BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR" hints="files">
+@@ -115,7 +116,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
+     src/unix/fswatcher_inotify.cpp
+     src/unix/stdpaths.cpp
+     src/unix/secretstore.cpp
+-    src/unix/uilocale.cpp
+ </set>
+ <set var="BASE_UNIX_HDR" hints="files">
+     $(BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR)
+@@ -189,7 +189,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
+     src/osx/core/strconv_cf.cpp
+     src/osx/cocoa/utils_base.mm
+     src/osx/core/secretstore.cpp
+-    src/osx/core/uilocale.mm
++    src/osx/cocoa/stdpaths.mm
+ </set>
+ <set var="BASE_COREFOUNDATION_HDR" hints="files">
+     wx/osx/core/cfdataref.h
+@@ -215,7 +215,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
+     $(BASE_COREFOUNDATION_SRC)
+     $(BASE_UNIX_AND_DARWIN_SRC)
+     src/osx/fswatcher_fsevents.cpp
+-    src/osx/cocoa/stdpaths.mm
++    src/osx/core/uilocale.mm
+ </set>
+ <set var="BASE_OSX_SHARED_HDR" hints="files">
+     $(BASE_COREFOUNDATION_HDR)
+diff --git a/build/cmake/files.cmake b/build/cmake/files.cmake
+index b6b53cbbfb..0c8671947c 100644
+--- a/build/cmake/files.cmake
++++ b/build/cmake/files.cmake
+@@ -35,6 +35,7 @@ set(BASE_UNIX_AND_DARWIN_HDR
+ set(BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC
+     ${BASE_UNIX_AND_DARWIN_SRC}
+     src/unix/mimetype.cpp
++    src/unix/uilocale.cpp
+ )
+ 
+ set(BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR
+@@ -47,7 +48,6 @@ set(BASE_UNIX_SRC
+     src/unix/fswatcher_inotify.cpp
+     src/unix/secretstore.cpp
+     src/unix/stdpaths.cpp
+-    src/unix/uilocale.cpp
+ )
+ 
+ set(BASE_UNIX_HDR
+@@ -116,7 +116,7 @@ set(BASE_COREFOUNDATION_SRC
+     src/osx/core/secretstore.cpp
+     src/osx/core/strconv_cf.cpp
+     src/osx/cocoa/utils_base.mm
+-    src/osx/core/uilocale.mm
++    src/osx/cocoa/stdpaths.mm
+ )
+ 
+ set(BASE_COREFOUNDATION_HDR
+@@ -141,9 +141,9 @@ set(BASE_COREFOUNDATION_HDR
+ set(BASE_OSX_SHARED_SRC
+     src/osx/core/mimetype.cpp
+     src/osx/fswatcher_fsevents.cpp
+-    src/osx/cocoa/stdpaths.mm
+     ${BASE_COREFOUNDATION_SRC}
+     ${BASE_UNIX_AND_DARWIN_SRC}
++    src/osx/core/uilocale.mm
+ )
+ 
+ set(BASE_OSX_SHARED_HDR
+diff --git a/build/files b/build/files
+index e92a5d7432..9eaddb8002 100644
+--- a/build/files
++++ b/build/files
+@@ -57,6 +57,7 @@ BASE_UNIX_AND_DARWIN_HDR =
+ BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC =
+     $(BASE_UNIX_AND_DARWIN_SRC)
+     src/unix/mimetype.cpp
++    src/unix/uilocale.cpp
+ 
+ BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR =
+     $(BASE_UNIX_AND_DARWIN_HDR)
+@@ -71,7 +72,6 @@ BASE_UNIX_SRC =
+     src/unix/fswatcher_inotify.cpp
+     src/unix/secretstore.cpp
+     src/unix/stdpaths.cpp
+-    src/unix/uilocale.cpp
+ 
+ BASE_UNIX_HDR =
+     $(BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR)
+@@ -141,7 +141,7 @@ BASE_COREFOUNDATION_SRC =
+     src/osx/core/evtloop_cf.cpp
+     src/osx/core/secretstore.cpp
+     src/osx/core/strconv_cf.cpp
+-    src/osx/core/uilocale.mm
++    src/osx/cocoa/stdpaths.mm
+     src/osx/cocoa/utils_base.mm
+ 
+ BASE_COREFOUNDATION_HDR =
+@@ -164,8 +164,8 @@ BASE_COREFOUNDATION_HDR =
+ # Base files used by OS X ports (not Carbon)
+ BASE_OSX_SHARED_SRC =
+     src/osx/core/mimetype.cpp
++    src/osx/core/uilocale.mm
+     src/osx/fswatcher_fsevents.cpp
+-    src/osx/cocoa/stdpaths.mm
+     $(BASE_COREFOUNDATION_SRC)
+     $(BASE_UNIX_AND_DARWIN_SRC)
+ 
+diff --git a/src/unix/uilocale.cpp b/src/unix/uilocale.cpp
+index 4aaebee4a5..b05d77ca85 100644
+--- a/src/unix/uilocale.cpp
++++ b/src/unix/uilocale.cpp
+@@ -21,6 +21,11 @@
+ #if wxUSE_INTL
+ 
+ #include <locale.h>
++
++#ifdef HAVE_XLOCALE_H
++    #include <xlocale.h>
++#endif
++
+ #ifdef HAVE_LANGINFO_H
+     #include <langinfo.h>
+ #endif
+-- 
+2.24.3 (Apple Git-128)
+

--- a/graphics/wxgtk-3.2/files/0002-dirctrlg.cpp-fix.patch
+++ b/graphics/wxgtk-3.2/files/0002-dirctrlg.cpp-fix.patch
@@ -1,0 +1,22 @@
+From 741c14478b814392e06d55fd58471fc65790e8cb Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 26 Jul 2024 11:45:25 +0800
+Subject: [PATCH] dirctrlg.cpp: fix
+
+---
+ src/generic/dirctrlg.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/generic/dirctrlg.cpp b/src/generic/dirctrlg.cpp
+index 364b0fc36c..f0295dc5aa 100644
+--- a/src/generic/dirctrlg.cpp
++++ b/src/generic/dirctrlg.cpp
+@@ -98,7 +98,7 @@ size_t wxGetAvailableDrives(wxArrayString &paths, wxArrayString &names, wxArrayI
+ {
+ #if defined(wxHAS_FILESYSTEM_VOLUMES) || defined(__APPLE__)
+ 
+-#if (defined(__WIN32__) || defined(__WXOSX__)) && wxUSE_FSVOLUME
++#if (defined(__WIN32__) || defined(__APPLE__)) && wxUSE_FSVOLUME
+     // TODO: this code (using wxFSVolumeBase) should be used for all platforms
+     //       but unfortunately wxFSVolumeBase is not implemented everywhere
+     const wxArrayString as = wxFSVolumeBase::GetVolumes();

--- a/graphics/wxgtk-3.2/files/0003-display-fix.patch
+++ b/graphics/wxgtk-3.2/files/0003-display-fix.patch
@@ -1,0 +1,36 @@
+From d2109a772ed650ea76f31bb285952f8efee75ff1 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 17 Feb 2025 10:52:21 +0800
+Subject: [PATCH] display: fix
+
+---
+ src/osx/core/display.cpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/osx/core/display.cpp b/src/osx/core/display.cpp
+index 6b8004da4c..8878ceb51b 100644
+--- a/src/osx/core/display.cpp
++++ b/src/osx/core/display.cpp
+@@ -31,6 +31,8 @@
+ 
+ #include "wx/osx/private.h"
+ 
++#ifdef __WXMAC__
++
+ // ----------------------------------------------------------------------------
+ // common helpers compiled even in wxUSE_DISPLAY==0 case
+ // ----------------------------------------------------------------------------
+@@ -441,4 +443,13 @@ protected:
+     return new wxDisplayFactorySingleMacOSX;
+ }
+ 
++#else
++
++/* static */ wxDisplayFactory *wxDisplay::CreateFactory()
++{
++    return new wxDisplayFactorySingle;
++}
++
++#endif
++
+ #endif // wxUSE_DISPLAY

--- a/graphics/wxgtk-3.2/files/0003-mimetypes-fixes.patch
+++ b/graphics/wxgtk-3.2/files/0003-mimetypes-fixes.patch
@@ -1,0 +1,130 @@
+From d6cc82958cc2d63642bd26f64b10652da49083ef Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 1 Dec 2025 15:11:20 +0800
+Subject: [PATCH 5/5] mimetypes fixes
+
+---
+ build/cmake/files.cmake   |  5 +++--
+ include/wx/gtk/mimetype.h | 10 ++++++----
+ src/gtk/mimetype.cpp      |  4 ++--
+ 3 files changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/build/cmake/files.cmake b/build/cmake/files.cmake
+index 4ca5db08fc..425f15617b 100644
+--- a/build/cmake/files.cmake
++++ b/build/cmake/files.cmake
+@@ -34,7 +34,6 @@ set(BASE_UNIX_AND_DARWIN_HDR
+ 
+ set(BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC
+     ${BASE_UNIX_AND_DARWIN_SRC}
+-    src/unix/mimetype.cpp
+     src/unix/uilocale.cpp
+ )
+ 
+@@ -46,6 +45,7 @@ set(BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR
+ set(BASE_UNIX_SRC
+     ${BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC}
+     src/unix/fswatcher_inotify.cpp
++    src/unix/mimetype.cpp
+     src/unix/secretstore.cpp
+     src/unix/stdpaths.cpp
+ )
+@@ -53,6 +53,7 @@ set(BASE_UNIX_SRC
+ set(BASE_UNIX_HDR
+     ${BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR}
+     wx/unix/fswatcher_inotify.h
++    wx/unix/mimetype.h
+     wx/unix/stdpaths.h
+ )
+ 
+@@ -113,6 +114,7 @@ set(BASE_WIN32_HDR
+ set(BASE_COREFOUNDATION_SRC
+     src/osx/core/cfstring.cpp
+     src/osx/core/evtloop_cf.cpp
++    src/osx/core/mimetype.cpp
+     src/osx/core/secretstore.cpp
+     src/osx/core/strconv_cf.cpp
+     src/osx/cocoa/utils_base.mm
+@@ -140,7 +142,6 @@ set(BASE_COREFOUNDATION_HDR
+ )
+ 
+ set(BASE_OSX_SHARED_SRC
+-    src/osx/core/mimetype.cpp
+     src/osx/fswatcher_fsevents.cpp
+     ${BASE_COREFOUNDATION_SRC}
+     ${BASE_UNIX_AND_DARWIN_SRC}
+diff --git a/include/wx/gtk/mimetype.h b/include/wx/gtk/mimetype.h
+index ed645c6de3..e33143a7e1 100644
+--- a/include/wx/gtk/mimetype.h
++++ b/include/wx/gtk/mimetype.h
+@@ -12,10 +12,12 @@
+ 
+ #include "wx/defs.h"
+ 
+-#if defined(__UNIX__)
+-#include "wx/unix/mimetype.h"
++#if defined(__DARWIN__)
++    #include "wx/osx/mimetype.h"
++#elif defined(__UNIX__)
++    #include "wx/unix/mimetype.h"
+ #elif defined(__WINDOWS__)
+-#include "wx/msw/mimetype.h"
++    #include "wx/msw/mimetype.h"
+ #endif
+ 
+ #if wxUSE_MIMETYPE
+@@ -23,7 +25,7 @@
+ class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerImpl : public wxMimeTypesManagerImpl
+ {
+ protected:
+-#if defined(__UNIX__)
++#if defined(__UNIX__) && !defined(__DARWIN__)
+     wxString GetIconFromMimeType(const wxString& mime) wxOVERRIDE;
+ #endif
+ };
+diff --git a/src/gtk/mimetype.cpp b/src/gtk/mimetype.cpp
+index 99f5aa19a0..d203e672f4 100644
+--- a/src/gtk/mimetype.cpp
++++ b/src/gtk/mimetype.cpp
+@@ -18,7 +18,7 @@
+ #include "wx/gtk/private/string.h"
+ #include "wx/gtk/private/object.h"
+ 
+-#if defined(__UNIX__)
++#if defined(__UNIX__) && !defined(__DARWIN__)
+ wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
+ {
+     wxString icon;
+@@ -57,7 +57,7 @@ wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
+ #endif // GTK_CHECK_VERSION(2,14,0)
+     return icon;
+ }
+-#endif // defined(__UNIX__)
++#endif // defined(__UNIX__) && !defined(__DARWIN__)
+ 
+ wxMimeTypesManagerImpl *wxGTKMimeTypesManagerFactory::CreateMimeTypesManagerImpl()
+ {
+
+diff --git a/src/osx/core/mimetype.cpp b/src/osx/core/mimetype.cpp
+index 9f878b0ab3..d4801d1618 100644
+--- a/src/osx/core/mimetype.cpp
++++ b/src/osx/core/mimetype.cpp
+@@ -427,7 +427,17 @@ void wxMimeTypesManagerImpl::LoadDisplayDataForUti(const wxString& uti)
+     wxCFStringRef ext = UTTypeCopyPreferredTagWithClass( cfuti, kUTTagClassFilenameExtension );
+ 
+     // Look up the preferred application
+-    wxCFRef<CFURLRef> appUrl = LSCopyDefaultApplicationURLForContentType( cfuti, kLSRolesAll, NULL);
++    wxCFRef<CFURLRef> appUrl;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 101000
++    CFURLRef aurl;
++    // THIS FUNCTION, DESPITE ITS NAME, RETAINS THE URL REFERENCE ON BEHALF OF THE CALLER.
++    OSStatus status = LSGetApplicationForInfo( kLSUnknownType, kLSUnknownCreator, ext, kLSRolesAll, nullptr, &aurl );
++    if( status != noErr )
++        return;
++    appUrl.reset(aurl);
++#else
++    appUrl.reset(LSCopyDefaultApplicationURLForContentType( cfuti, kLSRolesAll, nullptr));
++#endif
+ 
+     if( !appUrl )
+         return;

--- a/graphics/wxgtk-3.2/files/0004-Fix-Cocoa-stuff.patch
+++ b/graphics/wxgtk-3.2/files/0004-Fix-Cocoa-stuff.patch
@@ -1,0 +1,141 @@
+From 3c352c0647538a0975b442734ce4a3518329b856 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 1 Dec 2025 15:51:23 +0800
+Subject: [PATCH 6/6] Fix Cocoa stuff
+
+---
+ include/wx/defs.h        | 46 +++++++++++-----------------------------
+ include/wx/osx/private.h |  8 ++++++-
+ 2 files changed, 19 insertions(+), 35 deletions(-)
+
+diff --git a/include/wx/defs.h b/include/wx/defs.h
+index 86eb04b194..560f54ea4a 100644
+--- a/include/wx/defs.h
++++ b/include/wx/defs.h
+@@ -2941,7 +2941,7 @@ typedef HIShapeRef WXHRGN;
+ 
+ #endif // __WXMAC__
+ 
+-#if defined(__WXMAC__)
++#ifdef __DARWIN__
+ 
+ /* Objective-C type declarations.
+  * These are to be used in public headers in lieu of NSSomething* because
+@@ -2982,26 +2982,30 @@ typedef struct objc_object *WX_##klass
+ #endif /*  (defined(__GNUC__) && defined(__APPLE__)) */
+ 
+ DECLARE_WXCOCOA_OBJC_CLASS(NSArray);
++DECLARE_WXCOCOA_OBJC_CLASS(NSBitmapImageRep);
++DECLARE_WXCOCOA_OBJC_CLASS(NSColor);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSData);
++DECLARE_WXCOCOA_OBJC_CLASS(NSFont);
++DECLARE_WXCOCOA_OBJC_CLASS(NSFontDescriptor);
++DECLARE_WXCOCOA_OBJC_CLASS(NSImage);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSMutableArray);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSString);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSObject);
++DECLARE_WXCOCOA_OBJC_CLASS(NSSound);
++DECLARE_WXCOCOA_OBJC_CLASS(NSString);
++DECLARE_WXCOCOA_OBJC_CLASS(NSThread);
++
++typedef WX_NSImage WXImage;
+ 
+ #if wxOSX_USE_COCOA
+ 
+ DECLARE_WXCOCOA_OBJC_CLASS(NSApplication);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSBitmapImageRep);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSBox);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSButton);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSColor);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSColorPanel);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSControl);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSCursor);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSEvent);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSFont);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSFontDescriptor);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSFontPanel);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSImage);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSLayoutManager);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSMenu);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSMenuExtra);
+@@ -3010,14 +3014,12 @@ DECLARE_WXCOCOA_OBJC_CLASS(NSNotification);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSPanel);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSResponder);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSScrollView);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSSound);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSStatusItem);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSTableColumn);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSTableView);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSTextContainer);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSTextField);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSTextStorage);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSThread);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSWindow);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSView);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSOpenGLContext);
+@@ -3034,41 +3036,17 @@ DECLARE_WXCOCOA_OBJC_CLASS(WKWebView);
+ 
+ typedef WX_NSWindow WXWindow;
+ typedef WX_NSView WXWidget;
+-typedef WX_NSImage WXImage;
+ typedef WX_NSMenu WXHMENU;
+ typedef WX_NSOpenGLPixelFormat WXGLPixelFormat;
+ typedef WX_NSOpenGLContext WXGLContext;
+ typedef WX_NSPasteboard OSXPasteboard;
+ typedef WX_WKWebView OSXWebViewPtr;
+ 
+-#elif wxOSX_USE_IPHONE
+-
+-DECLARE_WXCOCOA_OBJC_CLASS(UIMenu);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIMenuItem);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIWindow);
+-DECLARE_WXCOCOA_OBJC_CLASS(UImage);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIView);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIFont);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIImage);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIEvent);
+-DECLARE_WXCOCOA_OBJC_CLASS(NSSet);
+-DECLARE_WXCOCOA_OBJC_CLASS(EAGLContext);
+-DECLARE_WXCOCOA_OBJC_CLASS(UIPasteboard);
+-
+-typedef WX_UIWindow WXWindow;
+-typedef WX_UIView WXWidget;
+-typedef WX_UIImage WXImage;
+-typedef WX_UIMenu WXHMENU;
+-typedef WX_EAGLContext WXGLContext;
+-typedef WX_NSString WXGLPixelFormat;
+-typedef WX_UIPasteboard WXOSXPasteboard;
+-
+ #endif
+ 
++#endif /* __DARWIN__ */
+ 
+ 
+-#endif /* __WXMAC__ */
+-
+ /* ABX: check __WIN32__ instead of __WXMSW__ for the same MSWBase in any Win32 port */
+ #if defined(__WIN32__)
+ 
+diff --git a/include/wx/osx/private.h b/include/wx/osx/private.h
+index 23fd0025fb..af32d8564a 100644
+--- a/include/wx/osx/private.h
++++ b/include/wx/osx/private.h
+@@ -7,8 +7,14 @@
+     #include "wx/osx/iphone/private.h"
+ #elif wxOSX_USE_COCOA
+     #include "wx/osx/cocoa/private.h"
+-#elif wxUSE_GUI
++#elif wxUSE_GUI && defined(__WXOSX__)
+     #error "Must include wx/defs.h first"
++#else
++    #include <ApplicationServices/ApplicationServices.h>
++
++    #ifdef __OBJC__
++        #import <Cocoa/Cocoa.h>
++    #endif
+ #endif
+ 
+ #endif
+-- 
+2.24.3 (Apple Git-128)
+

--- a/graphics/wxgtk-3.2/files/0004-evtloop_cf-fix.patch
+++ b/graphics/wxgtk-3.2/files/0004-evtloop_cf-fix.patch
@@ -1,0 +1,29 @@
+From d90086469eaebc2c3111776bec92a5d535fcd114 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 17 Feb 2025 10:55:23 +0800
+Subject: [PATCH] evtloop_cf: fix
+
+---
+ src/osx/core/evtloop_cf.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/osx/core/evtloop_cf.cpp b/src/osx/core/evtloop_cf.cpp
+index 9004763836..1e18ddbf8e 100644
+--- a/src/osx/core/evtloop_cf.cpp
++++ b/src/osx/core/evtloop_cf.cpp
+@@ -31,7 +31,14 @@
+ 
+ #include "wx/scopedptr.h"
+ 
+-#include "wx/osx/private.h"
++#ifdef __WXMAC__
++    #include "wx/osx/private.h"
++#else
++    #include <CoreFoundation/CoreFoundation.h>
++    #include <Carbon/Carbon.h>
++    #include "wx/osx/core/cfstring.h"
++#endif
++
+ #include "wx/osx/core/cfref.h"
+ #include "wx/thread.h"
+ 

--- a/graphics/wxgtk-3.2/files/0005-defs.h-fix.patch
+++ b/graphics/wxgtk-3.2/files/0005-defs.h-fix.patch
@@ -1,0 +1,34 @@
+From d0b5a8ed8e524f63a1c91383823c7af44adc0574 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 26 Jul 2024 12:01:50 +0800
+Subject: [PATCH 05/13] defs.h: fix
+
+---
+ include/wx/defs.h | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/include/wx/defs.h b/include/wx/defs.h
+index 39ce129477..ebb75ebd07 100644
+--- a/include/wx/defs.h
++++ b/include/wx/defs.h
+@@ -2811,10 +2811,6 @@ typedef int (* LINKAGEMODE wxListIterateFunction)(void *current);
+ #define DECLARE_WXOSX_OPAQUE_CFREF( name ) typedef struct __##name* name##Ref;
+ #define DECLARE_WXOSX_OPAQUE_CONST_CFREF( name ) typedef const struct __##name* name##Ref;
+ 
+-#endif
+-
+-#ifdef __WXMAC__
+-
+ #define WX_OPAQUE_TYPE( name ) struct wxOpaque##name
+ 
+ typedef void*       WXHCURSOR;
+@@ -2832,7 +2828,9 @@ typedef unsigned short  WXWORD;
+ 
+ typedef WX_OPAQUE_TYPE(PicHandle ) * WXHMETAFILE ;
+ 
++#if !defined(__WXX11__) && !defined(__WXGTK__)
+ typedef void*       WXDisplay;
++#endif
+ 
+ /*
+  * core frameworks

--- a/graphics/wxgtk-3.2/files/0006-cfstring-fix.patch
+++ b/graphics/wxgtk-3.2/files/0006-cfstring-fix.patch
@@ -1,0 +1,61 @@
+From 613ddb7e3c912185037a6e4687d564393fea26da Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 26 Jul 2024 03:38:45 +0800
+Subject: [PATCH 11/13] cfstring: fix
+
+---
+ include/wx/osx/core/cfstring.h | 8 ++++----
+ src/osx/core/cfstring.cpp      | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/wx/osx/core/cfstring.h b/include/wx/osx/core/cfstring.h
+index 6468713139..cf744d0b0b 100644
+--- a/include/wx/osx/core/cfstring.h
++++ b/include/wx/osx/core/cfstring.h
+@@ -66,11 +66,10 @@ public:
+ 
+     static wxString AsString( CFStringRef ref, wxFontEncoding encoding = wxFONTENCODING_DEFAULT ) ;
+     static wxString AsStringWithNormalizationFormC( CFStringRef ref, wxFontEncoding encoding = wxFONTENCODING_DEFAULT ) ;
+-#ifdef __WXMAC__
++#ifdef __OBJC__
+     static wxString AsString( WX_NSString ref, wxFontEncoding encoding = wxFONTENCODING_DEFAULT ) ;
+     static wxString AsStringWithNormalizationFormC( WX_NSString ref, wxFontEncoding encoding = wxFONTENCODING_DEFAULT ) ;
+-#endif
+-#ifdef __OBJC__
++
+     WX_NSString AsNSString() const { return (WX_OSX_BRIDGE WX_NSString)(CFStringRef) *this; }
+ #endif
+ private:
+@@ -87,7 +86,7 @@ inline wxCFStringRef wxCFStringRefFromGet(CFStringRef p)
+     return wxCFStringRef(wxCFRetain(p));
+ }
+ 
+-#ifdef __WXMAC__
++#ifdef __OBJC__
+ /*! @function   wxCFStringRefFromGet
+     @abstract   Factory function to create wxCFStringRefRef from a NSString* obtained from a Get-rule function
+     @param  p           The NSString pointer to retain and create a wxCFStringRefRef from.  May be NULL.
+@@ -98,6 +97,7 @@ inline wxCFStringRef wxCFStringRefFromGet(NSString *p)
+ {
+     return wxCFStringRefFromGet((WX_OSX_BRIDGE CFStringRef)p);
+ }
++
+ #endif
+ 
+ #endif //__WXCFSTRINGHOLDER_H__
+diff --git a/src/osx/core/cfstring.cpp b/src/osx/core/cfstring.cpp
+index 977b316282..23153fbb36 100644
+--- a/src/osx/core/cfstring.cpp
++++ b/src/osx/core/cfstring.cpp
+@@ -688,7 +688,7 @@ wxString wxCFStringRef::AsString(wxFontEncoding encoding) const
+     return AsString( get(), encoding );
+ }
+ 
+-#ifdef __WXMAC__
++#ifdef __OBJC__
+ 
+ wxString wxCFStringRef::AsString( NSString* ref, wxFontEncoding encoding )
+ {
+-- 
+2.49.0
+

--- a/graphics/wxgtk-3.2/files/0006-wx-mediactrl.h-a-hack-to-install-it.patch
+++ b/graphics/wxgtk-3.2/files/0006-wx-mediactrl.h-a-hack-to-install-it.patch
@@ -1,0 +1,24 @@
+From cd39ef946d691a00de3d5f4ee6bbe6da6f1e0e99 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 1 Dec 2025 19:29:08 +0800
+Subject: [PATCH 8/8] wx/mediactrl.h: a hack to install it
+
+---
+ build/cmake/files.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build/cmake/files.cmake b/build/cmake/files.cmake
+index 425f15617b..0fc1fd924c 100644
+--- a/build/cmake/files.cmake
++++ b/build/cmake/files.cmake
+@@ -568,6 +568,7 @@ set(BASE_CMN_HDR
+     wx/log.h
+     wx/longlong.h
+     wx/math.h
++    wx/mediactrl.h
+     wx/memconf.h
+     wx/memory.h
+     wx/memtext.h
+-- 
+2.24.3 (Apple Git-128)
+

--- a/graphics/wxgtk-3.2/files/0007-powercmn.cpp.patch
+++ b/graphics/wxgtk-3.2/files/0007-powercmn.cpp.patch
@@ -1,0 +1,20 @@
+--- a/src/common/powercmn.cpp	2025-05-26 00:15:56
++++ b/src/common/powercmn.cpp	2025-11-24 21:03:44
+@@ -39,7 +39,7 @@
+ #endif
+ 
+ // Provide stubs for systems without power resource management functions
+-#if !defined(__WINDOWS__) && !defined(__APPLE__)
++#if !defined(__WINDOWS__)
+ 
+ bool
+ wxPowerResource::Acquire(wxPowerResourceKind WXUNUSED(kind),
+@@ -52,7 +52,7 @@
+ {
+ }
+ 
+-#endif // !(__WINDOWS__ || __APPLE__)
++#endif // !(__WINDOWS__)
+ 
+ // provide stubs for the systems not implementing these functions
+ #if !defined(__WINDOWS__)

--- a/graphics/wxgtk-3.2/files/0008-utilsunx-no-memset_s-before-10.9.patch
+++ b/graphics/wxgtk-3.2/files/0008-utilsunx-no-memset_s-before-10.9.patch
@@ -1,0 +1,30 @@
+From 29660016a25a8374cbe4b423a9660edd22b9648f Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 17 Feb 2025 11:10:15 +0800
+Subject: [PATCH] utilsunx: no memset_s before 10.9
+
+---
+ src/unix/utilsunx.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/unix/utilsunx.cpp b/src/unix/utilsunx.cpp
+index 8a944cd626..7d384705d1 100644
+--- a/src/unix/utilsunx.cpp
++++ b/src/unix/utilsunx.cpp
+@@ -150,6 +150,7 @@
+ 
+ #if defined(__DARWIN__)
+     #include <sys/sysctl.h>
++    #include <AvailabilityMacros.h>
+ #endif
+ 
+ // ----------------------------------------------------------------------------
+@@ -225,7 +226,7 @@ void wxSecureZeroMemory(void* v, size_t n)
+     // but may be found in a non-standard header file, or in a library that is
+     // not linked by default.
+     explicit_bzero(v, n);
+-#elif defined(__DARWIN__) || defined(__STDC_LIB_EXT1__)
++#elif (defined(__DARWIN__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)) || defined(__STDC_LIB_EXT1__)
+     // memset_s() is available since OS X 10.9, and may be available on
+     // other platforms.
+     memset_s(v, n, 0, n);

--- a/graphics/wxgtk-3.2/files/0009-utils_base.mm-fix.patch
+++ b/graphics/wxgtk-3.2/files/0009-utils_base.mm-fix.patch
@@ -1,0 +1,144 @@
+From be228c5a1590694c53d4ec70d7006f2d1a036772 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 17 Feb 2025 11:01:28 +0800
+Subject: [PATCH] utils_base.mm: fix
+
+---
+ src/osx/cocoa/utils_base.mm | 63 ++++++++++++++++++++++++++++++++++---
+ 1 file changed, 58 insertions(+), 5 deletions(-)
+
+diff --git a/src/osx/cocoa/utils_base.mm b/src/osx/cocoa/utils_base.mm
+index c7c253363d..71ea57b9df 100644
+--- a/src/osx/cocoa/utils_base.mm
++++ b/src/osx/cocoa/utils_base.mm
+@@ -24,6 +24,13 @@
+ #include "wx/osx/private.h"
+ #include "wx/osx/private/available.h"
+ 
++#if (defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101000) \
++    || (defined(__WXOSX_IPHONE__) && defined(__IPHONE_8_0))
++    #define wxHAS_NSPROCESSINFO 1
++#endif
++
++#include <AppKit/AppKit.h>
++
+ #if wxUSE_SOCKETS
+ // global pointer which lives in the base library, set from the net one (see
+ // sockosx.cpp) and used from the GUI code (see utilsexc_cf.cpp) -- ugly but
+@@ -36,6 +43,7 @@ wxSocketManager *wxOSXSocketManagerCF = NULL;
+ // our OS version is the same in non GUI and GUI cases
+ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
+ {
++#if wxHAS_NSPROCESSINFO
+     NSOperatingSystemVersion osVer = [NSProcessInfo processInfo].operatingSystemVersion;
+ 
+     if ( verMaj != NULL )
+@@ -46,18 +54,42 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
+ 
+     if ( verMicro != NULL )
+         *verMicro = osVer.patchVersion;
++#else
++    SInt32 maj, min, micro;
++
++    Gestalt(gestaltSystemVersionMajor, &maj);
++    Gestalt(gestaltSystemVersionMinor, &min);
++    Gestalt(gestaltSystemVersionBugFix, &micro);
++
++    if ( verMaj != NULL )
++        *verMaj = maj;
+ 
++    if ( verMin != NULL )
++        *verMin = min;
++
++    if ( verMicro != NULL )
++        *verMicro = micro;
++#endif
+     return wxOS_MAC_OSX_DARWIN;
+ }
+ 
+ bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
+ {
++#if wxHAS_NSPROCESSINFO
+     NSOperatingSystemVersion osVer;
+     osVer.majorVersion = majorVsn;
+     osVer.minorVersion = minorVsn;
+     osVer.patchVersion = microVsn;
+ 
+     return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:osVer] != NO;
++#else
++    int majorCur, minorCur, microCur;
++    wxGetOsVersion(&majorCur, &minorCur, &microCur);
++
++    return majorCur > majorVsn
++        || (majorCur == majorVsn && minorCur >= minorVsn)
++        || (majorCur == majorVsn && minorCur == minorVsn && microCur >= microVsn);
++#endif
+ }
+ 
+ wxString wxGetOsDescription()
+@@ -77,6 +109,25 @@ wxString wxGetOsDescription()
+     {
+         switch (minorVer)
+         {
++            case 5:
++                osName = "Leopard";
++                osBrand = "Mac OS X";
++                break;
++            case 6:
++                osName = "Snow Leopard";
++                osBrand = "Mac OS X";
++                break;
++            case 7:
++                osName = "Lion";
++                // 10.7 was the last version where the "Mac" prefix was used
++                osBrand = "Mac OS X";
++                break;
++            case 8:
++                osName = "Mountain Lion";
++                break;
++            case 9:
++                osName = "Mavericks";
++                break;
+             case 10:
+                 osName = "Yosemite";
+                 break;
+@@ -223,16 +274,16 @@ bool wxCocoaLaunch(const char* const* argv, pid_t &pid)
+     }
+ 
+     NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+-    
+-    
++
++
+     NSRunningApplication *app = nil;
+-    
++
+     if ( [params count] > 0 )
+         app = [ws openURLs:params withApplicationAtURL:url
+                    options:NSWorkspaceLaunchAsync
+              configuration:[NSDictionary dictionary]
+                      error:&error];
+-    
++
+     if ( app == nil )
+     {
+         app = [ws launchApplicationAtURL:url
+@@ -252,15 +303,17 @@ bool wxCocoaLaunch(const char* const* argv, pid_t &pid)
+             }
+         }
+     }
+-    
++
+     [params release];
+ 
+     if( app != nil )
+         pid = [app processIdentifier];
+     else
+     {
++#ifdef __WXMAC__
+         wxString errorDesc = wxCFStringRef::AsString([error localizedDescription]);
+         wxLogDebug( "wxCocoaLaunch failure: error is %s", errorDesc );
++#endif
+         return false;
+     }
+     return true;

--- a/graphics/wxgtk-3.2/files/0010-Install-forgotten-stdpaths.h.patch
+++ b/graphics/wxgtk-3.2/files/0010-Install-forgotten-stdpaths.h.patch
@@ -1,0 +1,29 @@
+From af7d8af9ba546cc60c5d225201335f288f607277 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 21 Apr 2025 15:05:13 +0800
+Subject: [PATCH] Install forgotten stdpaths.h
+
+---
+ build/cmake/files.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/cmake/files.cmake b/build/cmake/files.cmake
+index e9db2dfcc5..de268ce716 100644
+--- a/build/cmake/files.cmake
++++ b/build/cmake/files.cmake
+@@ -119,6 +119,7 @@ set(BASE_COREFOUNDATION_SRC
+ 
+ set(BASE_COREFOUNDATION_HDR
+     wx/osx/carbon/region.h
++    wx/osx/cocoa/stdpaths.h
+     wx/osx/core/cfdataref.h
+     wx/osx/core/cfref.h
+     wx/osx/core/cfstring.h
+@@ -2217,7 +2218,6 @@ set(OSX_COCOA_HDR
+     wx/osx/cocoa/chkconf.h
+     wx/osx/cocoa/evtloop.h
+     wx/osx/cocoa/private.h
+-    wx/osx/cocoa/stdpaths.h
+     wx/generic/region.h
+     wx/osx/activityindicator.h
+     wx/osx/datectrl.h

--- a/graphics/wxgtk-3.2/files/0011-volume.mm-support-building-on-10.7-and-with-gcc.patch
+++ b/graphics/wxgtk-3.2/files/0011-volume.mm-support-building-on-10.7-and-with-gcc.patch
@@ -1,0 +1,119 @@
+From 8807264378dfcc69d5142fbbb2007e19a28fb62a Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 2 Jun 2025 21:23:51 +0800
+Subject: [PATCH] volume.mm: support building on <10.7 and with gcc
+
+---
+ src/osx/volume.mm | 48 +++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 46 insertions(+), 2 deletions(-)
+
+diff --git a/src/osx/volume.mm b/src/osx/volume.mm
+index 4e8a163c02..d8f10993d2 100644
+--- a/src/osx/volume.mm
++++ b/src/osx/volume.mm
+@@ -22,6 +22,11 @@
+ 
+ #include "wx/volume.h"
+ 
++// gcc does not yet support modern Apple ObjC++ syntax.
++#ifndef __clang__
++#define USE_LEGACY_OBJC
++#endif
++
+ #ifndef WX_PRECOMP
+     #if wxUSE_GUI
+         #include "wx/icon.h"
+@@ -35,17 +40,34 @@
+ #import <Foundation/NSFileManager.h>
+ #import <Foundation/NSURL.h>
+ 
++// Fallbacks for legacy systems
++#ifndef NSURLVolumeLocalizedNameKey
++#define NSURLVolumeLocalizedNameKey @"NSURLVolumeLocalizedNameKey"
++#endif
++#ifndef NSURLVolumeIsLocalKey
++#define NSURLVolumeIsLocalKey @"NSURLVolumeIsLocalKey"
++#endif
++#ifndef NSURLVolumeIsReadOnlyKey
++#define NSURLVolumeIsReadOnlyKey @"NSURLVolumeIsReadOnlyKey"
++#endif
++#ifndef NSURLVolumeIsRemovableKey
++#define NSURLVolumeIsRemovableKey @"NSURLVolumeIsRemovableKey"
++#endif
++
+ //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ // wxFSVolume
+ //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 
+ wxArrayString wxFSVolumeBase::GetVolumes(int flagsSet, int flagsUnset)
+ {
++#ifdef USE_LEGACY_OBJC
++    NSArray* nativeVolumes = [[NSFileManager defaultManager]
++#else
+     auto nativeVolumes = [[NSFileManager defaultManager]
++#endif
+                           mountedVolumeURLsIncludingResourceValuesForKeys:nil
+                           options:NSVolumeEnumerationSkipHiddenVolumes];
+ 
+-
+     wxArrayString volumePaths;
+     if ( nativeVolumes == nil )
+     {
+@@ -56,9 +78,17 @@ wxArrayString wxFSVolumeBase::GetVolumes(int flagsSet, int flagsUnset)
+     }
+     else
+     {
++#ifdef USE_LEGACY_OBJC
++        for (NSUInteger i = 0; i < [nativeVolumes count]; ++i)
++        {
++            NSURL* url = [nativeVolumes objectAtIndex:i];
++            const char* path = [[url path] fileSystemRepresentation];
++            wxFSVolumeBase volume(path);
++#else
+         for (NSURL* url in nativeVolumes)
+         {
+             wxFSVolumeBase volume(url.fileSystemRepresentation);
++#endif
+             int flags = volume.GetFlags();
+             if ((flags & flagsSet) == flagsSet && !(flags & flagsUnset))
+                 volumePaths.push_back(volume.GetName());
+@@ -87,7 +117,12 @@ bool wxFSVolumeBase::Create(const wxString& name)
+     m_volName = name;
+ 
+     NSURL* url = [NSURL fileURLWithPath:wxCFStringRef(name).AsNSString()];
++#ifdef USE_LEGACY_OBJC
++    NSArray* keys = [NSArray arrayWithObject:NSURLVolumeLocalizedNameKey];
++    NSDictionary* values = [url resourceValuesForKeys:keys error:nil];
++#else
+     auto values = [url resourceValuesForKeys:@[NSURLVolumeLocalizedNameKey] error:nil];
++#endif
+     if (values)
+     {
+         m_isOk = true;
+@@ -105,8 +140,12 @@ bool wxFSVolumeBase::IsOk() const
+ wxFSVolumeKind wxFSVolumeBase::GetKind() const
+ {
+     NSURL* url = [NSURL fileURLWithPath:wxCFStringRef(GetName()).AsNSString()];
++#ifdef USE_LEGACY_OBJC
++    NSArray* keys = [NSArray arrayWithObjects:NSURLVolumeIsLocalKey, NSURLVolumeIsReadOnlyKey, nil];
++    NSDictionary* values = [url resourceValuesForKeys:keys error:nil];
++#else
+     auto values = [url resourceValuesForKeys:@[NSURLVolumeIsLocalKey, NSURLVolumeIsReadOnlyKey] error:nil];
+-
++#endif
+     // Assume disk for local volumes
+     if ([(NSNumber*)[values objectForKey:NSURLVolumeIsLocalKey] boolValue])
+     {
+@@ -122,7 +161,12 @@ wxFSVolumeKind wxFSVolumeBase::GetKind() const
+ int wxFSVolumeBase::GetFlags() const
+ {
+     NSURL* url = [NSURL fileURLWithPath:wxCFStringRef(GetName()).AsNSString()];
++#ifdef USE_LEGACY_OBJC
++    NSArray* keys = [NSArray arrayWithObjects:NSURLVolumeIsRemovableKey, NSURLVolumeIsLocalKey, NSURLVolumeIsReadOnlyKey, nil];
++    NSDictionary* values = [url resourceValuesForKeys:keys error:nil];
++#else
+     auto values = [url resourceValuesForKeys:@[NSURLVolumeIsRemovableKey, NSURLVolumeIsLocalKey, NSURLVolumeIsReadOnlyKey] error:nil];
++#endif
+     if (values)
+     {
+         // mounted status cannot be determined, assume mounted

--- a/graphics/wxgtk-3.2/files/0012-Move-volume.mm-in-place-for-macOS.patch
+++ b/graphics/wxgtk-3.2/files/0012-Move-volume.mm-in-place-for-macOS.patch
@@ -1,0 +1,29 @@
+From f198c3aa382f700133d8552cb1d43d43c1dd8388 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Tue, 3 Jun 2025 01:45:46 +0800
+Subject: [PATCH] Move volume.mm in place for macOS
+
+---
+ build/cmake/files.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/cmake/files.cmake b/build/cmake/files.cmake
+index dbda98df19..0485f673e1 100644
+--- a/build/cmake/files.cmake
++++ b/build/cmake/files.cmake
+@@ -155,7 +155,6 @@
+ set(BASE_AND_GUI_OSX_COCOA_SRC
+     src/osx/cocoa/utils.mm
+     src/osx/cocoa/power.mm
+-    src/osx/volume.mm
+ )
+ 
+ set(BASE_OSX_NOTWXMAC_SRC
+@@ -488,6 +487,7 @@
+     src/common/fs_mem.cpp
+     src/common/msgout.cpp
+     src/common/utilscmn.cpp
++    src/osx/volume.mm
+ )
+ 
+ set(BASE_CMN_HDR

--- a/graphics/wxgtk-3.2/files/0013-unbreak-webrequest.patch
+++ b/graphics/wxgtk-3.2/files/0013-unbreak-webrequest.patch
@@ -1,0 +1,125 @@
+--- a/src/osx/webrequest_urlsession.mm	2026-02-28 20:50:12.000000000 +0800
++++ b/src/osx/webrequest_urlsession.mm	2026-05-18 01:32:53.000000000 +0800
+@@ -12,7 +12,7 @@
+ 
+ #include "wx/webrequest.h"
+ 
+-#if wxUSE_WEBREQUEST && wxUSE_WEBREQUEST_URLSESSION
++#if wxUSE_WEBREQUEST && !wxUSE_WEBREQUEST_CURL
+ 
+ #import <Foundation/Foundation.h>
+ 
+--- a/src/common/webrequest.cpp	2026-02-28 20:50:12.000000000 +0800
++++ b/src/common/webrequest.cpp	2026-05-18 01:39:11.000000000 +0800
+@@ -32,11 +32,10 @@
+ #if wxUSE_WEBREQUEST_WINHTTP
+ #include "wx/msw/private/webrequest_winhttp.h"
+ #endif
+-#if wxUSE_WEBREQUEST_URLSESSION
+-#include "wx/osx/private/webrequest_urlsession.h"
+-#endif
+ #if wxUSE_WEBREQUEST_CURL
+ #include "wx/private/webrequest_curl.h"
++#elif wxUSE_WEBREQUEST_URLSESSION
++#include "wx/osx/private/webrequest_urlsession.h"
+ #endif
+ 
+ extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendWinHTTP[] = "WinHTTP";
+@@ -968,10 +967,10 @@
+         {
+ #if wxUSE_WEBREQUEST_WINHTTP
+             backend = wxWebSessionBackendWinHTTP;
+-#elif wxUSE_WEBREQUEST_URLSESSION
+-            backend = wxWebSessionBackendURLSession;
+ #elif wxUSE_WEBREQUEST_CURL
+             backend = wxWebSessionBackendCURL;
++#elif wxUSE_WEBREQUEST_URLSESSION
++            backend = wxWebSessionBackendURLSession;
+ #endif
+         }
+     }
+@@ -1010,11 +1009,10 @@
+ #if wxUSE_WEBREQUEST_WINHTTP
+     RegisterFactory(wxWebSessionBackendWinHTTP, new wxWebSessionFactoryWinHTTP());
+ #endif
+-#if wxUSE_WEBREQUEST_URLSESSION
+-    RegisterFactory(wxWebSessionBackendURLSession, new wxWebSessionFactoryURLSession());
+-#endif
+ #if wxUSE_WEBREQUEST_CURL
+     RegisterFactory(wxWebSessionBackendCURL, new wxWebSessionFactoryCURL());
++#elif wxUSE_WEBREQUEST_URLSESSION
++    RegisterFactory(wxWebSessionBackendURLSession, new wxWebSessionFactoryURLSession());
+ #endif
+ }
+ 
+--- a/include/wx/osx/setup.h	2026-02-28 20:50:12.000000000 +0800
++++ b/include/wx/osx/setup.h	2026-05-18 01:15:01.000000000 +0800
+@@ -661,11 +661,7 @@
+ //
+ // Recommended setting: 1, can be set to 0 if wxUSE_WEBREQUEST_CURL==1,
+ // otherwise wxWebRequest won't be available at all under Mac.
+-#ifdef __APPLE__
+-#define wxUSE_WEBREQUEST_URLSESSION wxUSE_WEBREQUEST
+-#else
+ #define wxUSE_WEBREQUEST_URLSESSION 0
+-#endif
+ 
+ // wxWebRequest backend based on libcurl, can be used under all platforms.
+ //
+@@ -673,7 +669,7 @@
+ //
+ // Recommended setting: 0 on Windows and macOS, otherwise 1 as it is required
+ // for wxWebRequest to be available at all.
+-#define wxUSE_WEBREQUEST_CURL 0
++#define wxUSE_WEBREQUEST_CURL 1
+ 
+ // wxProtocol and related classes: if you want to use either of wxFTP, wxHTTP
+ // or wxURL you need to set this to 1.
+
+--- a/include/wx/gtk/setup.h	2026-02-28 20:50:12.000000000 +0800
++++ b/include/wx/gtk/setup.h	2026-05-18 01:14:04.000000000 +0800
+@@ -655,11 +655,7 @@
+ //
+ // Recommended setting: 1, can be set to 0 if wxUSE_WEBREQUEST_CURL==1,
+ // otherwise wxWebRequest won't be available at all under Mac.
+-#ifdef __APPLE__
+-#define wxUSE_WEBREQUEST_URLSESSION wxUSE_WEBREQUEST
+-#else
+ #define wxUSE_WEBREQUEST_URLSESSION 0
+-#endif
+ 
+ // wxWebRequest backend based on libcurl, can be used under all platforms.
+ //
+@@ -667,7 +663,7 @@
+ //
+ // Recommended setting: 0 on Windows and macOS, otherwise 1 as it is required
+ // for wxWebRequest to be available at all.
+-#define wxUSE_WEBREQUEST_CURL 0
++#define wxUSE_WEBREQUEST_CURL 1
+ 
+ // wxProtocol and related classes: if you want to use either of wxFTP, wxHTTP
+ // or wxURL you need to set this to 1.
+
+--- a/include/wx/setup_inc.h	2026-02-28 20:50:12.000000000 +0800
++++ b/include/wx/setup_inc.h	2026-05-18 01:32:09.000000000 +0800
+@@ -651,11 +651,7 @@
+ //
+ // Recommended setting: 1, can be set to 0 if wxUSE_WEBREQUEST_CURL==1,
+ // otherwise wxWebRequest won't be available at all under Mac.
+-#ifdef __APPLE__
+-#define wxUSE_WEBREQUEST_URLSESSION wxUSE_WEBREQUEST
+-#else
+ #define wxUSE_WEBREQUEST_URLSESSION 0
+-#endif
+ 
+ // wxWebRequest backend based on libcurl, can be used under all platforms.
+ //
+@@ -663,7 +659,7 @@
+ //
+ // Recommended setting: 0 on Windows and macOS, otherwise 1 as it is required
+ // for wxWebRequest to be available at all.
+-#define wxUSE_WEBREQUEST_CURL 0
++#define wxUSE_WEBREQUEST_CURL 1
+ 
+ // wxProtocol and related classes: if you want to use either of wxFTP, wxHTTP
+ // or wxURL you need to set this to 1.

--- a/graphics/wxgtk-3.2/files/patch-leopard.diff
+++ b/graphics/wxgtk-3.2/files/patch-leopard.diff
@@ -1,0 +1,138 @@
+--- a/src/osx/volume.mm	2025-12-08 06:59:42.000000000 +0800
++++ b/src/osx/volume.mm	2026-01-14 19:28:45.000000000 +0800
+@@ -42,6 +42,10 @@
+ #import <Foundation/NSFileManager.h>
+ #import <Foundation/NSURL.h>
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++#include <sys/mount.h>
++#endif
++
+ // Fallbacks for legacy systems
+ #ifndef NSURLVolumeLocalizedNameKey
+ #define NSURLVolumeLocalizedNameKey @"NSURLVolumeLocalizedNameKey"
+@@ -62,6 +67,9 @@
+ 
+ wxArrayString wxFSVolumeBase::GetVolumes(int flagsSet, int flagsUnset)
+ {
++    wxArrayString volumePaths;
++
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+ #ifdef USE_LEGACY_OBJC
+     NSArray* nativeVolumes = [[NSFileManager defaultManager]
+ #else
+@@ -70,7 +78,6 @@
+                           mountedVolumeURLsIncludingResourceValuesForKeys:nil
+                           options:NSVolumeEnumerationSkipHiddenVolumes];
+ 
+-    wxArrayString volumePaths;
+     if ( nativeVolumes == nil )
+     {
+         wxFSVolumeBase volume("/");
+@@ -96,6 +103,29 @@
+                 volumePaths.push_back(volume.GetName());
+         }
+     }
++#else
++    int count = getfsstat(NULL, 0, MNT_NOWAIT);
++    if (count > 0)
++    {
++        std::vector<struct statfs> mounts(count);
++        count = getfsstat(mounts.data(), count * sizeof(struct statfs), MNT_NOWAIT);
++
++        for (int i = 0; i < count; i++)
++        {
++            wxFSVolumeBase volume(mounts[i].f_mntonname);
++            int flags = volume.GetFlags();
++            if ((flags & flagsSet) == flagsSet && !(flags & flagsUnset))
++                volumePaths.push_back(volume.GetName());
++        }
++    }
++    else
++    {
++        wxFSVolumeBase volume("/");
++        int flags = volume.GetFlags();
++        if ((flags & flagsSet) == flagsSet && !(flags & flagsUnset))
++            volumePaths.push_back(volume.GetName());
++    }
++#endif
+     return volumePaths;
+ }
+ 
+--- a/src/osx/cocoa/stdpaths.mm	2025-12-08 06:59:42.000000000 +0800
++++ b/src/osx/cocoa/stdpaths.mm	2026-01-14 19:29:05.000000000 +0800
+@@ -113,6 +113,7 @@
+         case Dir_Downloads:
+             dirType = NSDownloadsDirectory;
+             break;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+         case Dir_Music:
+             dirType = NSMusicDirectory;
+             break;
+@@ -122,6 +123,7 @@
+         case Dir_Videos:
+             dirType = NSMoviesDirectory;
+             break;
++#endif
+         default:
+             dirType = NSDocumentDirectory;
+             break;
+
+--- a/src/osx/cocoa/utils_base.mm	2025-12-08 06:59:42.000000000 +0800
++++ b/src/osx/cocoa/utils_base.mm	2026-01-14 19:28:55.000000000 +0800
+@@ -213,6 +213,8 @@
+ 
+     // Path to bundle
+     wxString path = *argv++;
++
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+     NSError *error = nil;
+     NSURL *url = [NSURL fileURLWithPath:wxCFStringRef(path).AsNSString() isDirectory:YES];
+ 
+@@ -275,7 +277,6 @@
+ 
+     NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+ 
+-
+     NSRunningApplication *app = nil;
+ 
+     if ( [params count] > 0 )
+@@ -316,6 +317,10 @@
+ #endif
+         return false;
+     }
++#else
++    // Ugly hack for < 10.6
++    return false;
++#endif
+     return true;
+ }
+ 
+@@ -325,5 +330,12 @@
+ {
+     // The values of NSOrdered{Ascending,Same,Descending} are the same as
+     // expected return values of wxCmpNatural(), so we don't need to convert.
+-    return [wxCFStringRef(s1).AsNSString() localizedStandardCompare: wxCFStringRef(s2).AsNSString()];
++    NSString* ns1 = wxCFStringRef(s1).AsNSString();
++    NSString* ns2 = wxCFStringRef(s2).AsNSString();
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++    NSComparisonResult result = [ns1 localizedStandardCompare: ns2];
++#else
++    NSComparisonResult result = [ns1 localizedCompare: ns2];
++#endif
++    return static_cast<int>(result);
+ }
+
+--- a/src/osx/core/secretstore.cpp	2025-12-08 06:59:42.000000000 +0800
++++ b/src/osx/core/secretstore.cpp	2026-01-14 19:25:42.000000000 +0800
+@@ -31,6 +31,10 @@
+ 
+ #include <Security/Security.h>
+ 
++#ifndef errSecSuccess
++#define errSecSuccess 0
++#endif
++
+ namespace
+ {
+ 


### PR DESCRIPTION
#### Description

More & more ports get broken by unconditional forcing of wxWidgets-3.2 (which itself is broken on a lot of systems).
Add wxgtk-3.2 that can be used on 10.5+.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15
macOS 10.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
