### PR TITLE
opencode: update to 1.18.22

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.18.21
+version             1.18.22
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  50b1b0fd4a1af67c0d9e8e6b7fbb6ce7931b5ef0 \
-                    sha256  62eae64938cfc9ae1ee74222c6967ab081a2b5037bce947b0a3ba0b35694cd38 \
-                    size    3048
+checksums           rmd160  0ae18611c64ecd71f2a272d4c6e3cb1ff5d58b4e \
+                    sha256  920ce17f8d9f24865d161e26d7e3e5121aa386b5a221374109cc118d52cce4e7 \
+                    size    3045


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.22.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?