### PR TITLE
java/apktool: fix install when openjdk25 installed

### DIFF
--- a/java/apktool/Portfile
+++ b/java/apktool/Portfile
@@ -26,7 +26,7 @@ checksums               rmd160  b769d238a2170826d42e57e053d1b9a49db22259 \
                         sha256  22b577d080ca53381c61cbeade7d80ff7a5f365faeb469ec80b2bce6bdd1f763 \
                         size    29566900
 
-java.version            1.8+
+java.version            21
 java.fallback           openjdk11
 
 use_configure           no


### PR DESCRIPTION
The apktool port uses java/gradle8 to build which does not work when java/openjdk25 is installed.  The 'java.version` mechanism in the java-1.0 portgroup (directly dependent on the behaviour of /usr/libexec/java_home) does not allow a maximum Java version to be specified.  As a workaround, we specify the latest LTS openjdk explicitly to fix installation.

