### PR TITLE
libheif: Update to 1.23.2

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -29,12 +29,12 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
 }
 
 if {${which_version} eq "latest"} {
-    github.setup            strukturag libheif 1.23.1 v
-    revision                1
+    github.setup            strukturag libheif 1.23.2 v
+    revision                0
 
-    checksums               rmd160  52f1ade573cd8c3137d06e09a0019462d4481193 \
-                            sha256  0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a \
-                            size    2071186
+    checksums               rmd160  35e1395413b418dca4f786bde7aa0f8d0ebb305a \
+                            sha256  8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405 \
+                            size    2111195
 
     compiler.cxx_standard   2020
 } else {


### PR DESCRIPTION
#### Description

* Upstream security fixes.
* Release notes: https://github.com/strukturag/libheif/releases#release-v1.23.0

###### Type(s)

- [x] security fix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?