### PR TITLE
claude-code: update to 2.1.245

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.241
+version             2.1.245
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  622cad6e9e1ab31b68483855a524649fb22b7d11 \
-                 sha256  cf01b8cace66485ef5b476f14d96f69af61194a38c3df8412a80eb8f1316c10d \
-                 size    333784816
+    checksums    rmd160  ed318d93c48958dc86020ec0ae7eb143bd454d07 \
+                 sha256  de044bb543e826352f31587a74356e1b2dae94dc1b9c960a362d9f07df96c2a7 \
+                 size    385137136
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  eef513fcabaa327ff36c81cbe8388bf68adf3efd \
-                 sha256  1495eb7c42d3b4451f5f1cd38b6d498d22a4a38c802bc2be5c1cf1795e64820d \
-                 size    325055632
+    checksums    rmd160  1da18af7195071393eb96b043cc8878e75179f3d \
+                 sha256  9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1 \
+                 size    376109392
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.245.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?