### PR TITLE
micronaut: update to 5.1.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.1.1 v
+github.setup    micronaut-projects micronaut-starter 5.1.2 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  b05391ab25d1075a7d7815bca583687c690f7a56 \
-                 sha256  2342c3616a231b0158cf0723521b5527225819bfb1d9eb6b0a31011cc7840076 \
-                 size    34122622
+    checksums    rmd160  5bee8a6422c684964c39695d259011fb933e65e9 \
+                 sha256  0b745df059c470514a6d7afc46021ace7ba8a2bdbd9ede6a8643e2f9d99cd64b \
+                 size    34144750
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  13264f88819b36870ab47de9b9f99915af8f45f7 \
-                 sha256  2d48f1274910164b44246659c8c2e86d18390067227b6f478e7363be7c4d873f \
-                 size    39157596
+    checksums    rmd160  5f4d4ffa4a9ef33a681f0480ed318f70554b459d \
+                 sha256  dc6f3248f2e9d3519f4f8cdfdacd1ccf11b08a4c584efea389b707147677bf38 \
+                 size    39177628
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.1.2.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?