### PR TITLE
checkstyle: fix and update port

### DIFF
--- a/java/checkstyle/Portfile
+++ b/java/checkstyle/Portfile
@@ -1,50 +1,52 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			checkstyle
-version			4.3
-categories		java lang
-platforms		darwin
-maintainers		nomaintainer
-description		CheckStyle is a Java source code analyzer
-long_description	Checkstyle is a Java source code analyzer. \
-			It automates the process of checking Java code, \
-			and can be made to support almost any coding \
-			standard.  It can also find class design problems, \
-			duplicate code, or bug patterns like \
-			double checked locking.
+PortSystem          1.0
 
-homepage		http://checkstyle.sourceforge.net/
-master_sites	sourceforge
-distname		${name}-src-${version}
-checksums		md5 b1e6288526e9258947b9eeef69d08e6b
-use_zip			yes
+name                checkstyle
+version             4.3
+categories          java lang
+platforms           darwin
+maintainers         nomaintainer
+description         CheckStyle is a Java source code analyzer
+long_description    Checkstyle is a Java source code analyzer. \
+                    It automates the process of checking Java code, \
+                    and can be made to support almost any coding \
+                    standard.  It can also find class design problems, \
+                    duplicate code, or bug patterns like \
+                    double checked locking.
 
-depends_build	bin:ant:apache-ant
-depends_lib		bin:java:kaffe
-depends_run		port:junit
+homepage            http://checkstyle.sourceforge.net/
+master_sites        sourceforge
+distname            ${name}-src-${version}
+checksums           md5 b1e6288526e9258947b9eeef69d08e6b
+use_zip             yes
 
-worksrcdir		${name}-src-${version}
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
+depends_run         port:junit
 
-use_configure	no
+worksrcdir          ${name}-src-${version}
 
-build.cmd		ant
-build.target	build.bindist
-build.dir		${worksrcpath}
-build.env		CLASSPATH=${prefix}/share/java/junit.jar
+use_configure       no
 
-destroot	{
-	xinstall -m 755 ${filespath}/${name} ${destroot}${prefix}/bin
-	reinplace "s|_PREFIX_|${prefix}|g" ${destroot}${prefix}/bin/${name}
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/target/dist/${name}-${version}/${name}-all-${version}.jar \
-		${destroot}${prefix}/share/java/${name}.jar
-	xinstall -m 644 ${worksrcpath}/target/dist/${name}-${version}/${name}-optional-${version}.jar \
-		${destroot}${prefix}/share/java/${name}-optional.jar
-	file copy ${worksrcpath}/target/docs \
-		${destroot}${prefix}/share/doc/${name}
-	file mkdir ${destroot}${prefix}/share/${name}/
-	foreach xsl [glob -nocomplain ${worksrcpath}/contrib/*.xsl] {
-	  file copy ${xsl} ${destroot}${prefix}/share/${name}/
-	}
+build.cmd           ant
+build.target        build.bindist
+build.dir           ${worksrcpath}
+build.env           CLASSPATH=${prefix}/share/java/junit.jar
+
+destroot {
+    xinstall -m 755 ${filespath}/${name} ${destroot}${prefix}/bin
+    reinplace "s|_PREFIX_|${prefix}|g" ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/target/dist/${name}-${version}/${name}-all-${version}.jar \
+        ${destroot}${prefix}/share/java/${name}.jar
+    xinstall -m 644 ${worksrcpath}/target/dist/${name}-${version}/${name}-optional-${version}.jar \
+        ${destroot}${prefix}/share/java/${name}-optional.jar
+    file copy ${worksrcpath}/target/docs \
+        ${destroot}${prefix}/share/doc/${name}
+    file mkdir ${destroot}${prefix}/share/${name}/
+    foreach xsl [glob -nocomplain ${worksrcpath}/contrib/*.xsl] {
+      file copy ${xsl} ${destroot}${prefix}/share/${name}/
+    }
 }

--- a/java/checkstyle/Portfile
+++ b/java/checkstyle/Portfile
@@ -1,12 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           maven 1.0
 
 name                checkstyle
-version             4.3
+github.setup        ${name} ${name} 14.0.0 ${name}-
+github.tarball_from archive
+
 categories          java lang
-platforms           darwin
+platforms           any
+supported_archs     noarch
+license             LGPL-2.1
 maintainers         nomaintainer
+
 description         CheckStyle is a Java source code analyzer
 long_description    Checkstyle is a Java source code analyzer. \
                     It automates the process of checking Java code, \
@@ -15,38 +22,47 @@ long_description    Checkstyle is a Java source code analyzer. \
                     duplicate code, or bug patterns like \
                     double checked locking.
 
-homepage            http://checkstyle.sourceforge.net/
-master_sites        sourceforge
-distname            ${name}-src-${version}
-checksums           md5 b1e6288526e9258947b9eeef69d08e6b
-use_zip             yes
+homepage            https://checkstyle.org
+checksums           rmd160  dc16a1bc5060c39063ac17903ab4eb78ef20a034 \
+                    sha256  6dd2580872bc83071a02fb569c7a314916025e8c88b8878ee720840ba6994002 \
+                    size    8481680
 
-depends_build       bin:ant:apache-ant
-depends_lib         bin:java:kaffe
-depends_run         port:junit
+java.version        21+
+java.fallback       openjdk21
 
-worksrcdir          ${name}-src-${version}
-
-use_configure       no
-
-build.cmd           ant
-build.target        build.bindist
-build.dir           ${worksrcpath}
-build.env           CLASSPATH=${prefix}/share/java/junit.jar
+build.args-append   --activate-profiles assembly \
+                    --activate-profiles no-validations
 
 destroot {
-    xinstall -m 755 ${filespath}/${name} ${destroot}${prefix}/bin
-    reinplace "s|_PREFIX_|${prefix}|g" ${destroot}${prefix}/bin/${name}
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/target/dist/${name}-${version}/${name}-all-${version}.jar \
-        ${destroot}${prefix}/share/java/${name}.jar
-    xinstall -m 644 ${worksrcpath}/target/dist/${name}-${version}/${name}-optional-${version}.jar \
-        ${destroot}${prefix}/share/java/${name}-optional.jar
-    file copy ${worksrcpath}/target/docs \
-        ${destroot}${prefix}/share/doc/${name}
-    file mkdir ${destroot}${prefix}/share/${name}/
-    foreach xsl [glob -nocomplain ${worksrcpath}/contrib/*.xsl] {
-      file copy ${xsl} ${destroot}${prefix}/share/${name}/
+    set destbindir  ${destroot}${prefix}/bin
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+    set destxmldir  ${destroot}${prefix}/share/${name}
+
+    xinstall -d \
+        ${destbindir} \
+        ${destdocdir} \
+        ${destjavadir} \
+        ${destxmldir}
+
+    xinstall -m 755 ${filespath}/${name} ${destbindir}
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${destbindir}/${name}
+
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/SECURITY.md \
+        {*}[glob -directory ${worksrcpath}/docs/ *] \
+        ${destdocdir}
+
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}-all.jar \
+        ${destjavadir}/${name}-all.jar
+
+    foreach config [glob -directory ${worksrcpath}/src/main/resources/ *.xml] {
+        xinstall -m 644 ${config} ${destxmldir}
     }
 }

--- a/java/checkstyle/files/checkstyle
+++ b/java/checkstyle/files/checkstyle
@@ -1,3 +1,2 @@
 #!/bin/sh
-PREFIX=_PREFIX_
-java -classpath ${PREFIX}/share/java/checkstyle.jar:${PREFIX}/share/java/checkstyle-optional.jar com.puppycrawl.tools/checkstyle.Main "$@"
+exec java -jar '@@PREFIX@@/share/java/checkstyle-all.jar' "$@"


### PR DESCRIPTION
#### Description

Update the `checkstyle` port to version 14.0.0 and fix issues that arose from the port being outdated.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?