### PR TITLE
google-cloud-sdk: update to 582.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             581.0.0
+version             582.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  b966cb72b71058f888f202272e750e35f08968cc \
-                    sha256  1ea341bda45b8b63ae51886d1b0b79198bde296b96306394f0d5f5ff6c7ac83f \
-                    size    60562945
+    checksums       rmd160  efa00508d347ce8a25bdfaa3b01674827a5b043f \
+                    sha256  378b5a4cfda519fa81a71373e6cfb1c89d1dfbcac8453b12dc3e431ed5552e3e \
+                    size    50690547
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  8d8c8508aecb911c638131c2ca44fb83c3478500 \
-                    sha256  0a1d266f4785977dba578a6cd2e3dce551d82dedf14b1ce1cb8d3728d5e0ee94 \
-                    size    62222458
+    checksums       rmd160  7c6135bb12c073286e8c7d718a6b389c77db03e8 \
+                    sha256  44c3c0e429a764b9634f203478b436feeb5b1c84c513950ca961c436c1432598 \
+                    size    52349186
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  40aae42285803e9daaa29fbeba19675915263d49 \
-                    sha256  5d5b79fc28c302ebbdffb83cddb50a138b3d364edccd70dfafee8969d3c44bdd \
-                    size    62128574
+    checksums       rmd160  489ef5111da3ecd5b967b9feb328bfa17310dd67 \
+                    sha256  7ed2c24d1a5f288e0079339634b340085622ea229dfbdbb6c436b12a36a9c650 \
+                    size    52255332
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 582.0.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?