### PR TITLE
openjdk25-graalvm: update to 25.3.4.1

### DIFF
--- a/java/openjdk25-graalvm/Portfile
+++ b/java/openjdk25-graalvm/Portfile
@@ -20,12 +20,12 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  arm64
 
-set innovation   2
-version          ${feature}.${innovation}.4
-set build        7
+set innovation   3
+version          ${feature}.${innovation}.4.1
+set build        1
 revision         0
 
-set jdk_version  ${feature}.0.4
+set jdk_version  ${feature}.0.4.1
 
 description GraalVM Community Edition based on OpenJDK ${feature} (Long Term Support)
 long_description {*}${description} \
@@ -33,9 +33,9 @@ long_description {*}${description} \
 
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${version}/
 
-checksums    rmd160  c64d3a6ca9d0f2b6a13f748d8f66b17aaacdb274 \
-             sha256  507330fff8907de51b8621c95a21a491fa9b0d8c240de184594f40f83add3bfa \
-             size    331502567
+checksums    rmd160  ed72deae8cee544fae1e5d47e7fa415cef1b075d \
+             sha256  ebfab1d74420f355a459076162012d6835fa6068bd9d2f230f1fcaf7ee0dd923 \
+             size    339188208
 
 distname     graalvm-community-jdk-${feature}i${innovation}-${jdk_version}_macos-aarch64_bin
 


### PR DESCRIPTION
#### Description

Update to GraalVM Community 25.3.4.1.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?