### PR TITLE
commons-io: specify required java version

### DIFF
--- a/java/commons-io/Portfile
+++ b/java/commons-io/Portfile
@@ -1,30 +1,32 @@
-PortSystem 1.0
-PortGroup			maven 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name				commons-io
-version				2.22.0
+PortSystem          1.0
+PortGroup           maven 1.0
 
-categories			java
-license				Apache-2
-maintainers			nomaintainer
+name                commons-io
+version             2.22.0
 
-description			Jakarta Commons-IO
-long_description	Commons IO is a library of utilities to assist with developing IO functionality \
-					from Java.
-homepage			https://commons.apache.org/io/
+categories          java
+license             Apache-2
+maintainers         nomaintainer
 
-distname			${name}-${version}-src
-master_sites		apache:commons/io/source/
+description         Jakarta Commons-IO
+long_description    Commons IO is a library of utilities to assist \
+                    with developing IO functionality from Java.
+homepage            https://commons.apache.org/io/
+
+distname            ${name}-${version}-src
+master_sites        apache:commons/io/source/
 checksums           rmd160  7f6465f494a3913baa674f79f068c2517c866fe5 \
                     sha256  9a8e6d731e06edb10a35e2221aeea7f539b3ff4d5b90538bf119726e72644ff4 \
                     size    838797
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java
-	xinstall -m 644 ${worksrcpath}/target/${name}-${version}.jar \
-		${destroot}${prefix}/share/java/
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java
+    xinstall -m 644 ${worksrcpath}/target/${name}-${version}.jar \
+        ${destroot}${prefix}/share/java/
 }
 
-livecheck.type  regex
-livecheck.url   https://commons.apache.org/proper/commons-io/download_io.cgi
-livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.type      regex
+livecheck.url       https://commons.apache.org/proper/commons-io/download_io.cgi
+livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"

--- a/java/commons-io/Portfile
+++ b/java/commons-io/Portfile
@@ -5,10 +5,13 @@ PortGroup           maven 1.0
 
 name                commons-io
 version             2.22.0
+revision            1
 
 categories          java
 license             Apache-2
 maintainers         nomaintainer
+platforms           any
+supported_archs     noarch
 
 description         Jakarta Commons-IO
 long_description    Commons IO is a library of utilities to assist \
@@ -21,10 +24,17 @@ checksums           rmd160  7f6465f494a3913baa674f79f068c2517c866fe5 \
                     sha256  9a8e6d731e06edb10a35e2221aeea7f539b3ff4d5b90538bf119726e72644ff4 \
                     size    838797
 
+java.version        1.8+
+java.fallback       openjdk11
+
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java
-    xinstall -m 644 ${worksrcpath}/target/${name}-${version}.jar \
-        ${destroot}${prefix}/share/java/
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
+
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
 }
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

Set `java.version` as expected by the `java` PortGroup.  This should hopefully remove the port's dependency on `kaffe`.  Also add a modeline to polish up the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?