### PR TITLE
algol68g: Update to 3.13.3

### DIFF
--- a/lang/algol68g/Portfile
+++ b/lang/algol68g/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                algol68g
-version             3.12.3
+version             3.13.3
 revision            0
 categories          lang algol devel
 license             GPL-3
@@ -17,9 +17,9 @@ long_description    Algol68G is an implementation of Algol 68 as defined by the 
 homepage            https://algol68genie.nl/en/algol-68-genie/
 master_sites        https://algol68genie.nl
 
-checksums           rmd160  73232151ae7026869c6b54306ac64c34afb6bd63 \
-                    sha256  4d2e66f81ca2fb98f88e23ae41b475e7d40445f349b1088636782da320bd22b1 \
-                    size    681167
+checksums           rmd160  0a811dcb49e0ebb87bbade17446216104cc27677 \
+                    sha256  78dc53f4a712a9c8ee159b1eb7045fe4ea060c4eb2a49efb9634f83c2cb13995 \
+                    size    694386
 
 extract.rename      yes
 

--- a/lang/algol68g/files/0004-configure.ac-clear-up-a-mess.patch
+++ b/lang/algol68g/files/0004-configure.ac-clear-up-a-mess.patch
@@ -1,15 +1,15 @@
---- configure.ac.orig	2025-08-08 14:55:07
-+++ configure.ac	2025-08-09 23:20:14
-@@ -175,7 +175,7 @@
- #
+--- configure.ac.orig	2026-08-13 00:42:58
++++ configure.ac	2026-08-26 08:08:21
+@@ -179,7 +179,7 @@
  
  AM_INIT_AUTOMAKE([subdir-objects serial-tests])
+ AC_USE_SYSTEM_EXTENSIONS
 -AC_PREFIX_DEFAULT(/usr/local)
 +AC_PREFIX_DEFAULT(/opt/local)
  AC_CONFIG_SRCDIR([src/include/a68g.h])
  AC_CONFIG_HEADERS([a68g-config.h])
  AC_PROG_INSTALL
-@@ -199,12 +199,12 @@
+@@ -203,12 +203,12 @@
  else
  # On rhel8 "rpmbuild" sneaks in -pie and -fPIE, so a68g also needs to pass through.
  # On Suse15 the header files for pgsql and R have their own directories.
@@ -25,7 +25,7 @@
    A68G_AC_PROG_CC_CFLAGS([-Wall])
    A68G_AC_PROG_CC_CFLAGS([-Wshadow])
    A68G_AC_PROG_CC_CFLAGS([-Wunused-variable])
-@@ -438,101 +438,20 @@
+@@ -494,101 +494,20 @@
  else
    AC_MSG_NOTICE([... $prefix/include])
    EXTRA_INCLUDES="-I$prefix/include"

--- a/lang/algol68g/files/0006-Fix-endianness-includes-and-macros.patch
+++ b/lang/algol68g/files/0006-Fix-endianness-includes-and-macros.patch
@@ -1,16 +1,19 @@
+UPDATED *****************
+
 From 9ffa1d1f29fc1ac92f28e809aa5bf97897338d1d Mon Sep 17 00:00:00 2001
 From: barracuda156 <vital.had@gmail.com>
 Date: Sat, 20 Jan 2024 16:48:45 +0800
 Subject: [PATCH 6/6] Fix endianness includes and macros
 
 2025 Sept 17: Updated 2 of 4 patches for algol68g version 3.9.5.
+2026 Aug. 26: Updated 1          patch for algol68g version 3.13.3.
+2026 Aug. 26: Removed 1 obsolete patch for algol68g version 3.13.3.
 
 ---
  a68g-config.h               | 8 +++++++-
  configure.ac                | 2 +-
- src/a68g/rts-sounds.c       | 9 ++++-----
  src/include/a68g-includes.h | 4 ++++
- 4 files changed, 16 insertions(+), 7 deletions(-)
+ 3 files changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a68g-config.h a68g-config.h
 index d3a0e0e..3c87975 100644
@@ -32,39 +35,18 @@ index d3a0e0e..3c87975 100644
  /* Define to 1 if you have the <errno.h> header file. */
  #define HAVE_ERRNO_H 1
 
---- configure.ac.orig	2025-09-15 08:48:43
-+++ configure.ac	2025-09-17 18:10:37
-@@ -567,7 +567,7 @@
+--- configure.ac.orig	2026-08-13 00:42:58
++++ configure.ac	2026-08-26 10:46:32
+@@ -691,7 +691,7 @@
  AC_HEADER_SYS_WAIT
  AC_HEADER_TIOCGWINSZ
  
--AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h malloc.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h sys/time.h termios.h time.h unistd.h])
-+AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h machine/endian.h sys/endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h malloc.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h sys/time.h termios.h time.h unistd.h])
+-AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h malloc.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h termios.h sys/time.h unistd.h])
++AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h machine/endian.h sys/endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h malloc.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h termios.h sys/time.h unistd.h])
  
  #
  # Functions we expect.
 
-diff -u src/a68g/rts-sounds.c.orig src/a68g/rts-sounds.c
---- src/a68g/rts-sounds.c.orig	2025-08-08 14:52:48
-+++ src/a68g/rts-sounds.c	2025-08-09 23:33:53
-@@ -31,14 +31,13 @@
- 
- #define MAX_BYTES 4
- 
--#if (__BYTE_ORDER == __LITTLE_ENDIAN)
--  #define A68G_LITTLE_ENDIAN A68G_TRUE
--  #define A68G_BIG_ENDIAN A68G_FALSE
--#elif (__BYTE_ORDER == __BIG_ENDIAN)
-+#if (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \
-+  (defined(BYTE_ORDER) && (BYTE_ORDER == BIG_ENDIAN))
-   #define A68G_LITTLE_ENDIAN A68G_FALSE
-   #define A68G_BIG_ENDIAN A68G_TRUE
- #else
--  #error "undefined endianness"
-+  #define A68G_LITTLE_ENDIAN A68G_TRUE
-+  #define A68G_BIG_ENDIAN A68G_FALSE
- #endif
- 
  // From public Microsoft RIFF documentation.
 
 --- src/include/a68g-includes.h.orig	2025-09-15 08:46:38


### PR DESCRIPTION
#### Description

* Update algol68g 3.12.3 --> 3.13.3.
* Update two patch files.

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?