### PR TITLE
lagrange: update to 1.21.0

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-codeberg.setup      skyjake the_Foundation 1.12.2 v
+codeberg.setup      skyjake the_Foundation 1.13.1 v
 revision            0
 categories          devel
 license             BSD
@@ -17,9 +17,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  3342e818e0c9ff9e89af52cc4ea9c0de4e4e236c \
-                    sha256  04b419a9b8f2264a8cf6ba190d4358b3951322ee66b1d67ccdc54dd4f88fcd13 \
-                    size    233451
+checksums           rmd160  d15c96d3fa0a7669b0786f5500118d6e3eed2036 \
+                    sha256  0a8ad34ac9d1559462f3a001a7b96aff25f073b475750ed9d3f9a5724fea5989 \
+                    size    237739
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           codeberg 1.0
 
-codeberg.setup      skyjake lagrange 1.20.9 v
+codeberg.setup      skyjake lagrange 1.21.0 v
 revision            0
 categories          net gemini
 license             BSD
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  468ff5baff2cf19bd2a21647293e5ba5072fbf5b \
-                    sha256  a12fd4d3a5f6cc4aa1d2a0c5012295bbe0b1abaaa5c889a35673b0d63a25bcee \
-                    size    9816056
+checksums           rmd160  4dc60d4bf5bcf1e94dec90ed325306a6ac989711 \
+                    sha256  2d65611537c4ee028e37d069b680053b80fa94c6b8068c39fe3ec2b451b2772a \
+                    size    9837726
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
* https://codeberg.org/skyjake/lagrange/releases/tag/v1.21.0
* https://codeberg.org/skyjake/the_Foundation/releases/tag/v1.13.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
