### PR TITLE
sif: new port

### DIFF
--- a/security/sif/Portfile
+++ b/security/sif/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/vmfunc/sif 2026.6.10 v
+# This release predates the project's move to github.com/vmfunc, and its go.mod
+# still carries the former module path.
+go.package          github.com/dropalldatabases/sif
+go.offline_build    no
+go.toolchain_min    1.25.7
+revision            0
+
+description         Blazing-fast modular pentesting and recon suite
+
+long_description    sif runs directory and DNS fuzzing, port scanning, web \
+                    crawling, JavaScript secret extraction, CMS and framework \
+                    fingerprinting, Nuclei templates and its own YAML-defined \
+                    modules against a list of targets, concurrently, from a \
+                    single binary.
+
+categories          security net
+installs_libs       no
+license             BSD
+maintainers         {girlboss.ceo:june @x86pup} openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  d83fadf3a52f8ccdec7c175cce2e5f01cce0d57d \
+                        sha256  cf663449f560a0bee3ef38fd5436d9a877ca1326d5c13b775ec8a57dfcdedd32 \
+                        size    1835335
+
+# The bundled modules are searched for next to the executable and in the
+# working directory only, so an installed copy finds none of them. Add the
+# directory they are installed to as a last resort.
+patchfiles          patch-internal-modules-loader.go.diff
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/internal/modules/loader.go
+}
+
+build.pre_args-append \
+    -ldflags \"-X main.version=${version}\"
+build.args-append   ./cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 ${worksrcpath}/man/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/
+
+    xinstall -d ${destroot}${prefix}/share/${name}/modules
+    copy {*}[glob ${worksrcpath}/modules/*] \
+        ${destroot}${prefix}/share/${name}/modules/
+}
+
+notes "
+The modules bundled with ${name} are installed to:
+
+    ${prefix}/share/${name}/modules
+
+Modules of your own go in ~/.config/${name}/modules, and override bundled ones
+of the same name.
+"
+
+github.livecheck.regex  {(\d+(?:\.\d+)+)}

--- a/security/sif/files/patch-internal-modules-loader.go.diff
+++ b/security/sif/files/patch-internal-modules-loader.go.diff
@@ -1,0 +1,15 @@
+--- internal/modules/loader.go.orig
++++ internal/modules/loader.go
+@@ -50,6 +50,12 @@
+ 		builtinDir = "modules"
+ 	}
+ 
++	// Finally, fall back to the directory a packaged install puts the
++	// bundled modules in, since neither of the above applies there.
++	if _, err := os.Stat(builtinDir); os.IsNotExist(err) {
++		builtinDir = "@PREFIX@/share/sif/modules"
++	}
++
+ 	// User modules directory based on OS
+ 	var userDir string
+ 	switch runtime.GOOS {


### PR DESCRIPTION
#### Description

New port: sif, a modular pentesting and recon suite written in Go. It runs
directory and DNS fuzzing, port scanning, web crawling, JavaScript secret
extraction, CMS and framework fingerprinting, Nuclei templates and its own
YAML-defined modules against a list of targets, from a single binary.

Two things in the Portfile that are worth explaining:

* `go.package` is overridden because this release predates upstream's move to
  github.com/vmfunc, and its go.mod still names the former module path.
* The patch adds `${prefix}/share/sif/modules` as a last-resort location for the
  bundled YAML modules. Upstream looks for them next to the executable and in
  the working directory only, so an installed copy loads none of them. Upstream
  has since embedded the modules in the binary, so the patch and the
  `share/sif/modules` install can both be dropped once a release carrying that
  change exists.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? (0 errors, 0 warnings)
- [x] tried a full install with `sudo port -vst install`? (without `-t`, see below)
- [x] tested basic functionality of all binary files? (`sif version`, `sif --list-modules` loads the
  eight bundled modules out of `${prefix}/share/sif/modules`, and the man page renders)

Trace mode could not be part of that. On the test machine `darwintrace.dylib` is built x86_64/arm64
while the macOS 26 system binaries it has to be injected into are arm64e, so dyld refuses to load it
and the extract phase aborts before any of the port's own logic runs. The install above was a source
build from a local repository, with no binary archive available.
