### PR TITLE
rockxy: new port, version 0.36.0-53

### DIFF
--- a/devel/rockxy/Portfile
+++ b/devel/rockxy/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                rockxy
+version             0.36.0-53
+revision            0
+
+categories          devel aqua
+platforms           {darwin any >= 23}
+supported_archs     arm64 x86_64
+universal_variant   no
+license             Restrictive Nomirror
+maintainers         {gmail.com:bystephenx @LocNguyenHuu} openmaintainer
+
+description         Native macOS HTTP/S and WebSocket debugging proxy
+long_description    Rockxy is a native macOS proxy and traffic inspection tool for \
+                    capturing, inspecting, and debugging HTTP/S and WebSocket traffic.
+homepage            https://rockxy.io/
+
+set release_version [join [lrange [split ${version} -] 0 end-1] -]
+master_sites        https://github.com/RockxyApp/Rockxy/releases/download/v${release_version}/
+distname            Rockxy-${version}
+
+checksums           rmd160  f623ad54c3c36e728cf191ecf0a8a23244dd685b \
+                    sha256  7b7efb226efdc287e4ff36979885278d3f6dd4aa2f83365dca973a459e053685 \
+                    size    35551815
+
+use_dmg             yes
+use_configure       no
+
+build {}
+
+destroot {
+    xinstall -d ${destroot}${applications_dir}
+    copy ${worksrcpath}/Rockxy.app ${destroot}${applications_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://raw.githubusercontent.com/RockxyApp/Rockxy/main/releases/latest.json
+livecheck.regex     {Rockxy-(\d+(?:\.\d+)+-\d+)\.dmg}


### PR DESCRIPTION
#### Description

Adds Rockxy 0.36.0-53, a native macOS HTTP/S and WebSocket debugging proxy.

The port fetches the notarized upstream DMG directly. `Restrictive Nomirror` prevents MacPorts mirrors from redistributing it. The checksum phase and a manual no-install destroot reproduction passed; a privileged full install was intentionally left to CI so an existing Rockxy installation would not be replaced.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.1 25G76 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there are not other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? (0 errors, 0 warnings)
- [ ] tried existing tests with `sudo port test`? (no test phase)
- [ ] tried a full install with `sudo port -vst install`? (deferred to CI to avoid replacing an existing app)
- [ ] tested basic functionality of all binary files? (artifact signature, notarization, app metadata, universal architectures, and no-install destroot copy were verified; the app was not launched)
- [x] checked that the Portfile most important [variants](https://trac.macports.org/wiki/Variants) have not been broken? (no variants)
