### PR TITLE
spring-framework*: migrate to java PortGroup

### DIFF
--- a/java/spring-framework25/Portfile
+++ b/java/spring-framework25/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       java 1.0
 
 name            spring-framework25
 version         2.5.6.SEC01
@@ -15,7 +16,7 @@ platforms       any
 description     Spring application framework for Java
 long_description \
     Spring is a layered Java/J2EE application framework.
-homepage        http://www.springframework.org/
+homepage        https://spring.io/projects/spring-framework
 
 distname        spring-framework-${version}-with-dependencies
 master_sites    http://s3.amazonaws.com/dist.springframework.org/release/SPR
@@ -25,7 +26,8 @@ checksums       rmd160  8200e5ccb17249201ebf60e01d18ae3fa7cba9b7 \
 
 use_zip         yes
 
-depends_lib     bin:java:kaffe
+java.version    1.4+
+java.fallback   openjdk11
 
 use_configure   no
 
@@ -66,4 +68,5 @@ variant with_libs description {Install libraries used for sample applications} {
 
 livecheck.type          sourceforge
 livecheck.name          springframework
-livecheck.distname      springframework-2
+livecheck.distname      spring-framework
+livecheck.version       2.5.6

--- a/java/spring-framework30/Portfile
+++ b/java/spring-framework30/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       java 1.0
 
 name            spring-framework30
 version         3.0.7
@@ -16,18 +17,21 @@ platforms       any
 description     Spring application framework for Java
 long_description \
     Spring is a layered Java/J2EE application framework.
-homepage        http://www.springsource.org/about
+homepage        https://spring.io/projects/spring-framework
 
 distname        spring-framework-${full_version}-with-docs
 master_sites    http://s3.amazonaws.com/dist.springframework.org/release/SPR
 checksums       rmd160  b35c1c60b8c1b90fc459b5a6daacf920ad54ee5b \
                 sha256  cbb482ab52d95506fa72273d9b09173a5afd1765f4279bf36d0151f973aea8d7 \
                 size    49158669
+livecheck.type  none
 
 use_zip         yes
 
 conflicts       spring-framework31
-depends_lib     bin:java:kaffe
+
+java.version    1.6+
+java.fallback   openjdk11
 
 use_configure   no
 

--- a/java/spring-framework31/Portfile
+++ b/java/spring-framework31/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       java 1.0
 
 name            spring-framework31
 version         3.1.2
@@ -16,18 +17,21 @@ platforms       any
 description     Spring application framework for Java
 long_description \
     Spring is a layered Java/J2EE application framework.
-homepage        http://www.springsource.org/about
+homepage        https://spring.io/projects/spring-framework
 
 distname        spring-framework-${full_version}-with-docs
 master_sites    http://s3.amazonaws.com/dist.springframework.org/release/SPR
 checksums       rmd160  fed31138af34415522a52241232f2813cb875957 \
                 sha256  2677b52ec066ca94b7fcf77729ad01dd7c1f1ec8f9f50026587449c4b4ef93ee \
                 size    54379925
+livecheck.type  none
 
 use_zip         yes
 
 conflicts       spring-framework30
-depends_lib     bin:java:kaffe
+
+java.version    1.6+
+java.fallback   openjdk11
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Migrate the `spring-framework25`, `spring-framework30`, and `spring-framework31` ports to the `java` PortGroup.  Also fix up their livechecks where possible.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?