### PR TITLE
spymemcached: update to 2.12.3

### DIFF
--- a/java/spymemcached/Portfile
+++ b/java/spymemcached/Portfile
@@ -1,7 +1,12 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- vim:fenc=utf-8:ft=tcl:et:sw=8:ts=8:sts=8
 
-name                    spymemcached
-version                 2.8.4
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               maven 1.0
+
+github.setup            couchbase spymemcached 2.12.3
+github.tarball_from     archive
+
 categories              java
 license                 MIT
 platforms               any
@@ -16,36 +21,26 @@ long_description        Memcached is a high-performance, distributed \
                         Port provides a native Java client written by \
                         Dustin Sallings.
 
-homepage                https://code.google.com/p/spymemcached/
+checksums               rmd160  95d02a59bf9a7fe70f89a4e2a0e37199d4dce5c6 \
+                        sha256  31f1e804e6cfc58ee71b666684e2521f1cf71ba325652500417db1decb9d7cdc \
+                        size    452986
 
-master_sites            googlecode
-distfiles               spymemcached-${version}.jar \
-                        spymemcached-${version}-javadocs.jar
-extract.only
-
-checksums               spymemcached-${version}.jar \
-                                sha1   e12eeaa3c62d27210e1ab7e4165569ba825b350f \
-                                rmd160 fcd145f7295c308b7aee25cf8e2c7a555ad6885d \
-                                sha256 4933c18d5a4b053a23904df7d13035bf33eb9d6f1fc28a7993a9a089689769f8 \
-                        spymemcached-${version}-javadocs.jar \
-                                sha1   af085be34e576264ce6a763a034d651317acf351 \
-                                rmd160 8cb3ff6334f0bd600537ca67f26356200239e7dd \
-                                sha256 391b27ee156e3d61cb9565dc5dc44d9814c33fe9a1ba9d280c11606d52f64d52
-
-depends_lib             bin:java:kaffe
-
-use_configure           no
-
-build { }
+java.version            1.6+
+java.fallback           openjdk11
 
 destroot {
         set javadir ${destroot}${prefix}/share/java
         set docdir ${destroot}${prefix}/share/doc/${name}
 
         xinstall -d -m 755 ${javadir}
-        xinstall -d -m 755 ${docdir}/api
+        xinstall -d -m 755 ${docdir}
 
-        file copy ${distpath}/spymemcached-${version}.jar \
-                ${javadir}/spymemcached.jar
-        system "unzip -q ${distpath}/spymemcached-${version}-javadocs.jar -d ${docdir}/api"
+        xinstall -m 644 \
+                [glob -directory ${worksrcpath}/target/ ${name}-*.jar] \
+                ${javadir}/${name}.jar
+
+        xinstall -m 644 \
+                ${worksrcpath}/LICENSE.txt \
+                ${worksrcpath}/README.markdown \
+                ${docdir}
 }


### PR DESCRIPTION
#### Description

Update the `spymemcached` port to version 2.12.3.  And while at it, migrate away from Google Code and `kaffe`, and towards the `github` and `maven` PortGroups.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?