### PR TITLE
claude-code: update to 2.1.247

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.246
+version             2.1.247
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  217522193e135f0eac3dd7e56be18bfd30970eb1 \
-                 sha256  336625850986371487de7ece776d583f36cc3b3bc7178fcfbde3656d010289fb \
-                 size    239710512
+    checksums    rmd160  7167ed45b570172bd60aafdbbdb1d1a44bfd8f1d \
+                 sha256  162e65d7bf8735dbcdc75b0122dbb126d5704a00e682bbdfc413749188a20cfd \
+                 size    241972656
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  f0923b6a9b3ac8993319ca64cdbd516b41eb931a \
-                 sha256  7b09f01cb76a38e0e3a7c47c5d698d382162a5ff26538fc778683770caf9218b \
-                 size    230824016
+    checksums    rmd160  eedb0c0f7ffc71f35f02c3d7c2b3958abce3ce31 \
+                 sha256  5086b9b64d8bb842e1f599cdd3767ab08c6b2266e462fcc5686ae4b019cca8f7 \
+                 size    233073008
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.247.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?