### PR TITLE
groovy: update to 5.1.1

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         5.1.0
+version         5.1.1
 revision        0
 
 categories      lang java
@@ -30,9 +30,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  c62a605150730f24ff10e1dcea0da9f9c842fc0b \
-                sha256  c0d709a36d95a5576e06c5d2163d86f747d0006b12b499d7c198943288102f40 \
-                size    34573514
+checksums       rmd160  5c94acf2266a09c3b9b7624a533143fcea8a4b5b \
+                sha256  51a5a86c638abc618273f9f318ad2d906fcd4fecbdc1b9fa3c9f47c8c3cd753b \
+                size    34798626
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 5.1.1.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?