### PR TITLE
jna: update to 5.19.1

### DIFF
--- a/java/jna/Portfile
+++ b/java/jna/Portfile
@@ -1,6 +1,8 @@
-PortSystem 1.0
-PortGroup           java 1.0
-PortGroup           github 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               java 1.0
+PortGroup               github 1.0
 
 github.setup            java-native-access jna 5.18.1
 github.tarball_from     archive
@@ -22,22 +24,21 @@ long_description        Java Native Access provides Java programs easy \
                         some attention is paid to performance, correctness \
                         and ease of use take priority.
 
- checksums              rmd160  7fd81db8efe340781e3877e12595fe54db7fdbed \
+checksums               rmd160  7fd81db8efe340781e3877e12595fe54db7fdbed \
                         sha256  9af4d468a8b94def8c08761780766e919a0806d636b4c2ac55be0afe94cb8bb9 \
                         size    117189568
 
 depends_lib             bin:java:kaffe
-depends_build	        bin:ant:apache-ant
+depends_build           bin:ant:apache-ant
 
 use_configure           no
 
-
 build.cmd               ant
-build.target	        jar
+build.target            jar
 
 destroot {
-        xinstall -m 755 -d ${destroot}${prefix}/share/java
-        
-        xinstall -m 644 ${worksrcpath}/build/jna.jar \
-            ${destroot}${prefix}/share/java/
+    xinstall -m 755 -d ${destroot}${prefix}/share/java
+
+    xinstall -m 644 ${worksrcpath}/build/jna.jar \
+        ${destroot}${prefix}/share/java/
 }

--- a/java/jna/Portfile
+++ b/java/jna/Portfile
@@ -4,12 +4,15 @@ PortSystem              1.0
 PortGroup               java 1.0
 PortGroup               github 1.0
 
-github.setup            java-native-access jna 5.18.1
+github.setup            java-native-access jna 5.19.1
 github.tarball_from     archive
 revision                0
 categories              java
-license                 LGPL AL-2.0
+license                 {LGPL-2.1+ Apache-2}
 maintainers             nomaintainer
+platforms               any
+supported_archs         noarch
+
 description             Access to native shared libraries with pure Java code
 
 long_description        Java Native Access provides Java programs easy \
@@ -24,12 +27,14 @@ long_description        Java Native Access provides Java programs easy \
                         some attention is paid to performance, correctness \
                         and ease of use take priority.
 
-checksums               rmd160  7fd81db8efe340781e3877e12595fe54db7fdbed \
-                        sha256  9af4d468a8b94def8c08761780766e919a0806d636b4c2ac55be0afe94cb8bb9 \
-                        size    117189568
+checksums               rmd160  e85225ca417c619d0e5e91f07bd292cae8628479 \
+                        sha256  33a9e27b5a6eaa024bb117325392d1ccba7ca63f95d201230ad7c33d60f54c23 \
+                        size    121713304
 
-depends_lib             bin:java:kaffe
 depends_build           bin:ant:apache-ant
+
+java.version            9+
+java.fallback           openjdk11
 
 use_configure           no
 
@@ -37,8 +42,22 @@ build.cmd               ant
 build.target            jar
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
 
-    xinstall -m 644 ${worksrcpath}/build/jna.jar \
-        ${destroot}${prefix}/share/java/
+    xinstall -d ${destdocdir} ${destjavadir}
+
+    xinstall -m 644 \
+        ${worksrcpath}/AL2.0 \
+        ${worksrcpath}/CHANGES.md \
+        ${worksrcpath}/LGPL2.1 \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/OTHERS \
+        ${worksrcpath}/README.md \
+        ${destdocdir}
+
+    xinstall -m 644 \
+        ${worksrcpath}/build/${name}.jar \
+        ${worksrcpath}/build/${name}-jpms.jar \
+        ${destjavadir}
 }


### PR DESCRIPTION
#### Description

Update `jna` to version 5.19.1.  Also fix some formatting issues (e.g. mixed tabs and spaces), fix the specified licences (it's LGPL _or_ Apache, not LGPL and Apache), remove the outdated dependency on `kaffe`, and include some docs in the installation.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?