### PR TITLE
scala-migrations: migrate to java PortGroup

### DIFF
--- a/java/scala-migrations/Portfile
+++ b/java/scala-migrations/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               java 1.0
 
 name                    scala-migrations
 version                 1.0.1
 categories              java
-platforms               darwin
+platforms               any
+supported_archs         noarch
+license                 BSD
 maintainers             {blair @blair} openmaintainer
 description             Database migrations written in Scala
 
@@ -39,7 +42,8 @@ checksums               md5 313dd712d8d8f9929f611bcd54e7d42e \
                         rmd160 f017c7bc92d29b7e46dfd699ea1a685d5858d4d0
 extract.only
 
-depends_lib             bin:java:kaffe
+java.version            1.6+
+java.fallback           openjdk11
 
 use_configure           no
 

--- a/java/scala-migrations/Portfile
+++ b/java/scala-migrations/Portfile
@@ -1,4 +1,6 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
 
 name                    scala-migrations
 version                 1.0.1
@@ -44,8 +46,8 @@ use_configure           no
 build { }
 
 destroot {
-        set javadir ${destroot}${prefix}/share/java
+    set javadir ${destroot}${prefix}/share/java
 
-        xinstall -d -m 755 ${javadir}
-        file copy ${distpath}/${name}-${version}-2.7.7-jdbc4.jar ${javadir}/${name}.jar
+    xinstall -d -m 755 ${javadir}
+    file copy ${distpath}/${name}-${version}-2.7.7-jdbc4.jar ${javadir}/${name}.jar
 }


### PR DESCRIPTION
#### Description

Polish up the `scala-migrations` Portfile and use the `java` PortGroup to replace its dependency on `kaffe`.  Also add a `license` value.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
