### PR TITLE
daisydiff: migrate to java PortGroup

### DIFF
--- a/textproc/daisydiff/Portfile
+++ b/textproc/daisydiff/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               java 1.0
 
 name                    daisydiff
 version                 1.2
@@ -25,7 +26,8 @@ checksums               rmd160  feb04a4bfd85a05a801c77753855c2bedaa4ed2e \
                         sha256  4eb8be8c4132560c97629d106194ae99cf191df0055ff5e35954b1b3bde6b432 \
                         size    1447051
 
-depends_run             bin:java:kaffe
+java.version            1.5+
+java.fallback           openjdk11
 
 use_configure           no
 


### PR DESCRIPTION
#### Description

Replace `daisydiff`'s dependency on `kaffe` with the `java` PortGroup.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?