### PR TITLE
cloudflared: Update to 2026.8.2

### DIFF
--- a/net/cloudflared/Portfile
+++ b/net/cloudflared/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/cloudflare/cloudflared 2026.8.1
+go.setup            github.com/cloudflare/cloudflared 2026.8.2
+go.toolchain_min    1.26
 revision            0
 categories          net security
 maintainers         {i0ntempest @i0ntempest} @cicku openmaintainer
@@ -15,20 +16,28 @@ long_description    Contains the command-line client for Cloudflare Tunnel, a tu
 
 homepage            https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
 
-checksums           rmd160  ec3e72bdceec7c074e6368bfa974e99de260a6a4 \
-                    sha256  59d7dd479c121c03c49597f158a15582a6881c310b57f73e05b76f4b28566735 \
-                    size    6327213
+checksums           rmd160  0ab3effd2fe6a1b4b02c70b84d85e47fffe66ff6 \
+                    sha256  acdf125b7e872be6e1d13116e8054d27b2c4755760b0cdc3b4ee3910edd37b93 \
+                    size    6326795
 
 go.offline_build    no
 
-set time [clock format [clock seconds] -format "%Y-%m-%d-%H%M %Z"]
-build.args-append   -ldflags=\"-X 'main.Version=${version}' -X 'main.BuildTime=${time}'\" -o ./${name} ./cmd/${name}
+set build_time      [clock format ${source_date_epoch} -format "%Y-%m-%dT%H:%M:%SZ"]
+build.args-append   -ldflags \"-B gobuildid \
+                               -X main.Version=${version} \
+                               -X main.BuildTime=${build_time} \
+                               -X ${go.package}/config.DefaultUnixConfigLocation=${prefix}/etc/${name} \
+                               -X ${go.package}/config.DefaultUnixLogLocation=${prefix}/var/log \
+                               -X ${go.package}/cmd/${name}/updater.BuiltForPackageManager=MacPorts\"
 
-post-patch {
-    reinplace "s|\"/etc/cloudflared\", DefaultUnixConfigLocation|\"/etc/cloudflared\", \"${prefix}/etc/cloudflared\", DefaultUnixConfigLocation|" \
-              ${gopath}/src/github.com/cloudflare/cloudflared/config/configuration.go
-}
+build.post_args-append \
+                    ./cmd/${name}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
+
+startupitem.create      yes
+startupitem.executable  ${prefix}/bin/${name}
+startupitem.logfile     ${prefix}/var/log/${name}.log
+startupitem.pidfile     manual ${prefix}/var/run/${name}.pid


### PR DESCRIPTION
#### Description

Update cloudflared to 2026.8.2. Close related [Trac ticket](https://trac.macports.org/ticket/71600
) since it is no longer supported by upstream due to its restriction to go 1.26.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
