### PR TITLE
xmlpull: migrate to java PortGroup

### DIFF
--- a/java/xmlpull/Portfile
+++ b/java/xmlpull/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       java 1.0
 
 name            xmlpull
 version         1.1.3.4c
 set version_us  [string map {. _} $version]
+revision        1
 categories      java textproc
 license         public-domain
 platforms       any
@@ -20,16 +22,21 @@ long_description    XmlPull v1 API is a simple to use XML pull parsing API \
                 can be interrupted at any given moment and resumed when \
                 application is ready to consume more input.
 
-homepage        http://www.xmlpull.org/
+homepage        https://www.xmlpull.org/
 master_sites    ${homepage}v1/download/
 distfiles       ${name}_${version_us}_src.tgz
-checksums       md5 34c8a093e5678dd633411dfea88f8558 \
-                sha1 cc20f5952d85a2c138e702650c29c79c6b556c6c
+checksums       rmd160  795d95822b27ef5af099cfb78f2e89b63011bd6e \
+                sha256  e17aa1a26119966258a3656a262bbba0f0b036eecb6d9bf192cf4b497686f4c3 \
+                size    145459
 
 worksrcdir      ${name}_${version_us}
 
 depends_build   bin:ant:apache-ant
-depends_lib     bin:java:kaffe
+
+java.version    1.8+
+java.fallback   openjdk11
+
+patchfiles      bump-java-version.diff
 
 use_configure   no
 

--- a/java/xmlpull/Portfile
+++ b/java/xmlpull/Portfile
@@ -1,41 +1,43 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			xmlpull
-version			1.1.3.4c
+PortSystem      1.0
+
+name            xmlpull
+version         1.1.3.4c
 set version_us  [string map {. _} $version]
-categories		java textproc
-license			public-domain
-platforms		any
-supported_archs	noarch
-maintainers		nomaintainer
-description		XML pullparser API
-long_description	XmlPull v1 API is a simple to use XML pull parsing API \
-				that was designed for simplicity and very good performance \
-				both in constrained environment such as defined by J2ME and on \
-				server side when used in J2EE application servers. XML pull \
-				parsing allows incremental (sometimes called streaming) \
-				parsing of XML where application is in control - the parsing \
-				can be interrupted at any given moment and resumed when \
-				application is ready to consume more input.
+categories      java textproc
+license         public-domain
+platforms       any
+supported_archs noarch
+maintainers     nomaintainer
+description     XML pullparser API
+long_description    XmlPull v1 API is a simple to use XML pull parsing API \
+                that was designed for simplicity and very good performance \
+                both in constrained environment such as defined by J2ME and on \
+                server side when used in J2EE application servers. XML pull \
+                parsing allows incremental (sometimes called streaming) \
+                parsing of XML where application is in control - the parsing \
+                can be interrupted at any given moment and resumed when \
+                application is ready to consume more input.
 
-homepage		http://www.xmlpull.org/
-master_sites	${homepage}v1/download/
-distfiles		${name}_${version_us}_src.tgz
-checksums		md5 34c8a093e5678dd633411dfea88f8558 \
+homepage        http://www.xmlpull.org/
+master_sites    ${homepage}v1/download/
+distfiles       ${name}_${version_us}_src.tgz
+checksums       md5 34c8a093e5678dd633411dfea88f8558 \
                 sha1 cc20f5952d85a2c138e702650c29c79c6b556c6c
 
-worksrcdir		${name}_${version_us}
+worksrcdir      ${name}_${version_us}
 
-depends_build	bin:ant:apache-ant
-depends_lib		bin:java:kaffe
+depends_build   bin:ant:apache-ant
+depends_lib     bin:java:kaffe
 
-use_configure	no
+use_configure   no
 
-build.cmd		ant
-build.target	jar
+build.cmd       ant
+build.target    jar
 
 destroot {
-	xinstall -m 755 -d ${destroot}${prefix}/share/java
-	xinstall -m 644 ${worksrcpath}/build/lib/${name}_${version_us}.jar \
-		${destroot}${prefix}/share/java/${name}.jar
+    xinstall -m 755 -d ${destroot}${prefix}/share/java
+    xinstall -m 644 ${worksrcpath}/build/lib/${name}_${version_us}.jar \
+        ${destroot}${prefix}/share/java/${name}.jar
 }

--- a/java/xmlpull/files/bump-java-version.diff
+++ b/java/xmlpull/files/bump-java-version.diff
@@ -1,0 +1,82 @@
+--- build.xml.orig	2006-10-23 15:20:43
++++ build.xml	2026-08-28 17:04:24
+@@ -142,7 +142,7 @@
+   <!-- =================================================================== -->
+ 
+   <target name="api" depends="prepare">
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_api}" destdir="${build_classes}" classpath="${build_classes}"/>
+   </target>
+ 
+@@ -157,7 +157,7 @@
+ 
+   <target name="samples" depends="xmlpull">
+     <mkdir dir="${build_samples}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+       srcdir="${src_samples}" destdir="${build_samples}"
+       classpath="${build_classes}"/>
+   </target>
+@@ -174,7 +174,7 @@
+ 
+   <target name="dom2_builder" depends="api">
+     <mkdir dir="${build_dom2_builder}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_dom2_builder}" destdir="${build_dom2_builder}" 
+        classpath="${build_classes}"/>
+     <jar jarfile="${jar_dom2_builder}">
+@@ -184,7 +184,7 @@
+ 
+   <target name="parser_pool" depends="api">
+     <mkdir dir="${build_parser_pool}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_parser_pool}" destdir="${build_parser_pool}" 
+        classpath="${build_classes}"/>
+     <jar jarfile="${jar_parser_pool}">
+@@ -194,7 +194,7 @@
+ 
+   <target name="sax2" depends="api">
+     <mkdir dir="${build_sax2}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_sax2}" destdir="${build_sax2}">
+        <classpath>
+         <pathelement location="${build_classes}" />
+@@ -210,7 +210,7 @@
+ 
+   <target name="util" depends="api">
+     <mkdir dir="${build_util}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_util}" destdir="${build_util}" classpath="${build_classes}"/>
+     <jar jarfile="${jar_util}">
+       <fileset dir="${build_util}"/>
+@@ -219,7 +219,7 @@
+ 
+   <target name="wrapper" depends="require_junit,util">
+     <mkdir dir="${build_wrapper}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_wrapper}" destdir="${build_wrapper}" classpath="${build_classes}:${build_util}"/>
+     <jar jarfile="${jar_wrapper}">
+       <fileset dir="${build_wrapper}"/>
+@@ -228,14 +228,14 @@
+ 
+   <target name="wrapper_tests" depends="require_junit,wrapper">
+     <mkdir dir="${build_addons_tests}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_wrapper_tests}" destdir="${build_wrapper}" 
+        classpath="${build_classes}:${build_util}:${build_wrapper}"/>
+   </target>
+ 
+   <target name="xmlrpc" depends="api">
+     <mkdir dir="${build_xmlrpc}"/>
+-    <javac debug="${debug}" deprecation="${deprecation}" source="1.2" target="1.1"
++    <javac debug="${debug}" deprecation="${deprecation}" source="1.8" target="1.8"
+        srcdir="${src_xmlrpc}" destdir="${build_xmlrpc}" classpath="${build_classes}"/>
+     <jar jarfile="${jar_xmlrpc}">
+       <fileset dir="${build_xmlrpc}"/>


### PR DESCRIPTION
#### Description

Fix up `xmlpull`'s Portfile's formatting and replace its dependency on `kaffe` with the `java` PortGroup.

While at it, fix the build by bumping up the required JDK version to 1.8+ with a patch.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?