### PR TITLE
xmlenc: update to 0.53

### DIFF
--- a/java/xmlenc/Portfile
+++ b/java/xmlenc/Portfile
@@ -1,9 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               maven 1.0
 
 name                    xmlenc
-version                 0.52
+github.setup            znerd ${name} 0.53 ${name}-
+github.tarball_from     archive
+
 categories              java textproc
-license                 BSD
+license                 BSD-2-Clause
 platforms               any
 maintainers             nomaintainer
 supported_archs         noarch
@@ -13,27 +19,30 @@ long_description        The xmlenc library is a fast stream-based XML output \
                         library for Java. Main design goals are performance, \
                         simplicitity and pureness.
 
-homepage                http://xmlenc.sourceforge.net/
-master_sites            ${homepage}
+homepage                https://xmlenc.sourceforge.net/
 
-checksums               rmd160  98aa383152c8b1f30c285b47d3872c4ee270bdd4 \
-                        sha256  b9440fe46d4a4e53cfbef15f9702b3cff955728a210d3246faf50a24a7b3aa53
+checksums               rmd160  313462d82c9934a64c041af96d10853b0d0c9e28 \
+                        sha256  e7eb006ed8355c299e13bfa075144aebad12c5b0783727a0be3fe8ae3bb70183 \
+                        size    42232
 
-extract.suffix          .tgz
+java.version            1.8+
+java.fallback           openjdk11
 
-depends_build           bin:ant:apache-ant
-depends_lib             bin:java:kaffe
-
-use_configure           no
-
-build.cmd               ant
-build.target            jar javadoc-public
+patchfiles              bump-jdk-version.diff
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java/ \
-        ${destroot}${prefix}/share/doc/
-    xinstall -m 644 ${worksrcpath}/build/xmlenc.jar \
-        ${destroot}${prefix}/share/java/
-    file copy ${worksrcpath}/build/javadoc \
-        ${destroot}${prefix}/share/doc/${name}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/CHANGES.txt \
+        ${worksrcpath}/COPYRIGHT.txt \
+        ${worksrcpath}/README.txt \
+        ${destdocdir}
+
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
 }

--- a/java/xmlenc/files/bump-jdk-version.diff
+++ b/java/xmlenc/files/bump-jdk-version.diff
@@ -1,0 +1,16 @@
+Building with JDK 1.6 is no longer supported.  Bump up the version to
+JDK 1.8 to prevent a build failure.
+
+--- pom.xml.orig	2026-08-28 19:57:10
++++ pom.xml	2026-08-28 20:30:21
+@@ -70,8 +70,8 @@
+         <artifactId>maven-compiler-plugin</artifactId>
+         <version>2.3.2</version>
+         <configuration>
+-          <source>1.6</source>
+-          <target>1.6</target>
++          <source>1.8</source>
++          <target>1.8</target>
+         </configuration>
+       </plugin>
+       <plugin>


### PR DESCRIPTION
#### Description

The xmlenc project appears to have migrated from [SourceForge](https://sourceforge.net/projects/xmlenc) to [GitHub](https://github.com/znerd/xmlenc), with the latter repository containing an additional release (version 0.53).  Modify the `xmlenc` port to fetch from the GitHub repo and install the updated version.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?