### PR TITLE
openjdk26-temurin: update to 26.0.2.1

### DIFF
--- a/java/openjdk26-temurin/Portfile
+++ b/java/openjdk26-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=25&os=mac&arch=any&mode=filter
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.2
-set build    10
+version      ${feature}.0.2.1
+set build    1
 revision     0
 
 # End of availability: https://adoptium.net/support
@@ -33,14 +33,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  f88b559b847ee865bbb7644f81591caacd4245ff \
-                 sha256  def6874a01072031c2c850b03b4d29d4e97772af7cc2f564f6fae03f98eb6ea9 \
-                 size    123136383
+    checksums    rmd160  345b2a0b075e538c0886cacbe65ba450b316eb4d \
+                 sha256  e1b58af4ef2089f6de66bdadd5c77a661adfad8340d5b8e19771a76ab5f02188 \
+                 size    123143867
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f8cc1847317b3edcd87730b42e05e6eb06e8859d \
-                 sha256  4c9255ed5a9fa84ad6e25675bac6ba6a4906fc7878169d7369a1424157b50256 \
-                 size    139613305
+    checksums    rmd160  12c3dca335f55229c9b27c3c924bec02cc056dad \
+                 sha256  8c77a069a150c5b1c80280269ba062463053ebb7619ddef38dcfe3921fc60bdd \
+                 size    139615274
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 26.0.2.1.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?