### PR TITLE
Rev bumps [a-i] for ImageMagick soname

### DIFF
--- a/R/R-magick/Portfile
+++ b/R/R-magick/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # GitHub version lags behind.
 R.setup             cran ropensci magick 2.8.5
-revision            0
+revision            1
 categories-append   graphics
 maintainers         nomaintainer
 license             MIT

--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -11,7 +11,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     PortGroup qt4 1.0
 
     version         2.3.8
-    revision        1
+    revision        2
 
     checksums       rmd160  80b2c53d12b04dd64a6326b4b1ea505dcb352120 \
                     sha256  7e8f56d148cb459eb00abbe9c6371744e4ff077b842c0024153a3f094b10d4ad \

--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -33,7 +33,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     PortGroup qt5 1.0
 
     version         2.3.8
-    revision        1
+    revision        2
 
     checksums       rmd160  80b2c53d12b04dd64a6326b4b1ea505dcb352120 \
                     sha256  7e8f56d148cb459eb00abbe9c6371744e4ff077b842c0024153a3f094b10d4ad \
@@ -53,7 +53,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     PortGroup qt5 1.0
 
     version         2.4.4
-    revision        0
+    revision        1
 
     checksums       rmd160  3b2f66cad93def5e3f61c985281affa16b7a71fd \
                     sha256  ffacd37480f320f3f3f8f30445fe40897e9df44c94ee87ba0413e364086f4b90 \

--- a/aqua/LyX1/Portfile
+++ b/aqua/LyX1/Portfile
@@ -5,7 +5,7 @@ PortGroup           qt4 1.0
 
 name                LyX1
 version             1.6.10
-revision            3
+revision            4
 categories          aqua
 platforms           darwin
 license             GPL-2+

--- a/graphics/ale/Portfile
+++ b/graphics/ale/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ale
 version             0.8.11.2
-revision            0
+revision            1
 checksums           rmd160  f0aaec53befb5e9650fbd9fd2b77828d57b68833 \
                     sha256  bedea6f0d14b149b0b2419626182b7840a66f8bfa715ffddfd72dd57b125eefa \
                     size    1373375

--- a/graphics/autotrace/Portfile
+++ b/graphics/autotrace/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 epoch                   1
 github.setup            autotrace autotrace 0.31.10
-revision                1
+revision                2
 checksums               rmd160  f617e82d09dcb080a37e732b4debea082296ed20 \
                         sha256  14627f93bb02fe14eeda0163434a7cb9b1f316c0f1727f0bdf6323a831ffe80d \
                         size    924682

--- a/graphics/chafa/Portfile
+++ b/graphics/chafa/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        hpjansson chafa 1.18.2
 github.tarball_from releases
-revision            1
+revision            2
 
 homepage            https://hpjansson.org/chafa
 

--- a/graphics/converseen/Portfile
+++ b/graphics/converseen/Portfile
@@ -12,7 +12,7 @@ if {(${os.platform} eq "darwin" && ${os.major} > 13) \
 
     github.setup    Faster3ck converseen 0.15.2.7 v
     github.tarball_from archive
-    revision        0
+    revision        1
 
     checksums       rmd160  a722b60e276957fd912c16f1f83dba66d9bd9275 \
                     sha256  1e2be90695f802e038c385346c19fd438185aac4eda83124af71fbc2854871f2 \
@@ -35,7 +35,7 @@ if {(${os.platform} eq "darwin" && ${os.major} > 13) \
     # Version for legacy systems using Qt4.
     github.setup    Faster3ck converseen 0.9.2 v
     github.tarball_from tarball
-    revision        0
+    revision        1
 
     checksums       rmd160  8fb30774f2105641c864fd5d828dc51bb218eb7c \
                     sha256  4ad8a612ff8dc693159743031b6bf14af966b163a155296ce809d1dc3789faee \

--- a/graphics/converseen/Portfile
+++ b/graphics/converseen/Portfile
@@ -35,7 +35,7 @@ if {(${os.platform} eq "darwin" && ${os.major} > 13) \
     # Version for legacy systems using Qt4.
     github.setup    Faster3ck converseen 0.9.2 v
     github.tarball_from tarball
-    revision        1
+    revision        0
 
     checksums       rmd160  8fb30774f2105641c864fd5d828dc51bb218eb7c \
                     sha256  4ad8a612ff8dc693159743031b6bf14af966b163a155296ce809d1dc3789faee \

--- a/graphics/converseen/Portfile
+++ b/graphics/converseen/Portfile
@@ -12,7 +12,7 @@ if {(${os.platform} eq "darwin" && ${os.major} > 13) \
 
     github.setup    Faster3ck converseen 0.15.2.7 v
     github.tarball_from archive
-    revision        1
+    revision        0
 
     checksums       rmd160  a722b60e276957fd912c16f1f83dba66d9bd9275 \
                     sha256  1e2be90695f802e038c385346c19fd438185aac4eda83124af71fbc2854871f2 \

--- a/graphics/cyan/Portfile
+++ b/graphics/cyan/Portfile
@@ -20,7 +20,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # TODO: see if we can fix a newer version.
     # For QtMimeTypes use qt4-mimetypes port.
     github.setup    olear cyan 1.0.0 {} .RC2
-    revision        0
+    revision        1
     checksums       rmd160  0325d3d86d269fd7ccec5f77ac55e0d9478f1941 \
                     sha256  77ce3b37ffa32d0057544b59c1e8b231e533ab351236f70926333881456ec3ea \
                     size    475138
@@ -28,7 +28,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     PortGroup       qmake5 1.0
 
     github.setup    rodlie cyan 1.2.4
-    revision        0
+    revision        1
     checksums       rmd160  21bc30bd4cc1daa4050038db62aea21cd82629ff \
                     sha256  4edfb4414820934c6898ccfa9ef1c2bfe3745effe8736f0c14f3523e8c926ab0 \
                     size    9413972

--- a/graphics/dmtx-utils/Portfile
+++ b/graphics/dmtx-utils/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        dmtx dmtx-utils 0.7.6 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            2
+revision            3
 categories          graphics
 maintainers         nomaintainer
 license             LGPL-2.1

--- a/graphics/gscan2pdf/Portfile
+++ b/graphics/gscan2pdf/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                gscan2pdf
 version             2.13.2
-revision            1
+revision            2
 
 categories          graphics
 maintainers         nomaintainer

--- a/graphics/imageindex/Portfile
+++ b/graphics/imageindex/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                imageindex
 
 version             1.1
-revision            8
+revision            9
 platforms           any
 supported_archs     noarch
 categories          graphics

--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -13,7 +13,7 @@ set ver_date        2023-11-25
 set ver_hash        091e20ef0f
 set ver_gal_item    44615
 version             ${ver_num}
-revision            2
+revision            3
 epoch               2
 
 categories          graphics gnome

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -14,7 +14,7 @@ set ver_hash        0d15f75042
 set ver_gal_item    58914
 version             ${ver_num}
 epoch               1
-revision            2
+revision            3
 
 categories          graphics gnome
 license             GPL-3+

--- a/multimedia/dvdauthor/Portfile
+++ b/multimedia/dvdauthor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dvdauthor
 version             0.7.2
-revision            5
+revision            6
 categories          multimedia
 maintainers         {perry.ch:maurice @robbyn}
 license             GPL-2+

--- a/multimedia/dvdrip/Portfile
+++ b/multimedia/dvdrip/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                dvdrip
 perl5.branches      5.34
 perl5.setup         ${name} 0.98.11
-revision            8
+revision            9
 categories          multimedia
 maintainers         nomaintainer
 license             {Artistic-1 GPL}

--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -5,7 +5,7 @@ PortGroup           texlive 1.0
 
 name                LaTeXML
 version             0.8.8
-revision            0
+revision            1
 checksums           rmd160  4f6aee98474e58905fe89327b55be42e3d5138f0 \
                     sha256  7d2bbe2ce252baf86ba3f388cd0dec3aa4838f49d612b9ec7cc4ff88105badcc \
                     size    15310900

--- a/textproc/cuneiform/Portfile
+++ b/textproc/cuneiform/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    cuneiform
 version                 1.1.0
-revision                8
+revision                9
 set branch              [join [lrange [split ${version} .] 0 1] .]
 maintainers             nomaintainer
 categories              textproc graphics

--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -6,7 +6,7 @@ PortGroup           texlive 1.0
 
 name                dblatex
 version             0.3.12
-revision            2
+revision            3
 categories          textproc tex
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2+


### PR DESCRIPTION
#### Description

* Part 1, ports [a-i]
* Rev bump ImageMagick dependents for unexpected soname reversion 8.0 --> 7.1.
* See: https://trac.macports.org/ticket/74369

###### Tested on

Not tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?