### PR TITLE
mp3rgain: update to 3.4.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.3.0 v
+github.setup        M-Igashi mp3rgain 3.4.0 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3f24ec0f105afd78658d5e73e8f3264f2d227f60 \
-                    sha256  b438621bbc83ba3fe3b4bea0f6e206268b0e9a6d73277366dc1c0f51131b541a \
-                    size    560376
+                    rmd160  387980048d5144f4d3eb143a31764ac11a2ea815 \
+                    sha256  3ef5e9a7b059059e525f63188e0b5acab232c9b42a7530cfea3d2228cbf0cbe1 \
+                    size    564720
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
audio/mp3rgain: update to upstream 3.4.0.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.4.0

- Bumped github.setup to 3.4.0, reset checksums (rmd160/sha256/size) for the new source tarball. revision stays 0.
- cargo.crates regenerated from the release Cargo.lock; the dependency set is unchanged from 3.3.0, so the block is identical.

Notable upstream changes: a new `-s R` mode that applies gain from stored ReplayGain tags without rescanning, and a panic hook in the GUI (not packaged here).