### PR TITLE
qemu: update to 11.1.1

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,8 +8,8 @@ PortGroup               legacysupport   1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
-version                 11.1.0
-revision                2
+version                 11.1.1
+revision                0
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -26,9 +26,9 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_xz                  yes
 
-checksums               rmd160  22e2026b2e6ba04daeb1c89039c4f5e350106c00 \
-                        sha256  6ee1d1a61f68212476b27108c26da5f449dc09b626d42f8279ba0dc2e08fa858 \
-                        size    141831772
+checksums               rmd160  c188ed69963b06f3b1129124348846d818ababe3 \
+                        sha256  079ffbff8a7111bbc89022107cbabf3bbfd614d5fc9d7cc675991196aca12482 \
+                        size    141888716
 
 set py_branch           3.14
 set py_version          [string replace ${py_branch} 1 1]


### PR DESCRIPTION
#### Description

Updates `qemu` to 11.1.1, a point release on the 11.1 series.

All nineteen patchfiles the port carries apply to 11.1.1 unchanged, with no
fuzz or ignored hunks. `revision` resets to 0 for the new upstream version.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? — built through `destroot`
- [ ] tested basic functionality of all binary files?
