### PR TITLE
xercesj: update to 2.12.2

### DIFF
--- a/java/xercesj/Portfile
+++ b/java/xercesj/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                xercesj
-version             2.11.0
+version             2.12.2
 categories          java textproc
 license             Apache-2 W3C
 maintainers         nomaintainer
@@ -23,21 +23,26 @@ distname            Xerces-J-src.${version}
 distfiles           ${distname}${extract.suffix} \
                     Xerces-J-tools.${version}${extract.suffix}
 
-master_sites        apache:xerces/j/
+master_sites        apache:xerces/j/source/
 checksums           ${distname}${extract.suffix} \
-                        rmd160 5ae4b52c2907e560aed36cdb146140fd4db05875 \
-                        sha256 f59a5ef7b51bd883f2e9bda37a9360692e6c5e439b98d9b6ac1953e1f98b0680 \
+                        rmd160  2a7227d1babca9acd62fa2dac8896f6650069f2f \
+                        sha256  6dd1ebd4c88e935c182375346cd7365514bd8dd2ad2f30f0d0b05257bab34ee8 \
+                        size    1812583 \
                     Xerces-J-tools.${version}${extract.suffix} \
-                        rmd160 a9469fb48b7ca23cced0bb68d0f424ad8209aed5 \
-                        sha256 ff9a5e3a12b4bdad5a9238db03ed5a4709831d3e2c13fe53601163c374ad2051
+                        rmd160  60cce241c67b34eb678c9e0232551e3677017054 \
+                        sha256  66b88ccbbba507f9f9cffb285a94258cd9fb6a842dfbeb8499866b156021a574 \
+                        size    7074111
 
 depends_build       bin:ant:apache-ant
-depends_lib         bin:java:kaffe
+
+# See bump-jdk-version.diff
+java.version        1.8+
+java.fallback       openjdk11
 
 worksrcdir          xerces-[string map ". _" $version]
-set tools           tools
 
 patchfiles          build.xml.patch \
+                    bump-jdk-version.diff \
                     patch-src_org_apache_html_dom_HTMLElementImpl.java-add-getContentDocument-DOM2-method.diff
                     # See #37217 and https://issues.apache.org/jira/browse/XERCESJ-983?page=all
                     # This patch might not be the best way to fix this issue, though.
@@ -45,21 +50,31 @@ patchfiles          build.xml.patch \
 use_configure       no
 
 build.cmd           ant
-build.target        jars docs javadocs
-build.env-append    CLASSPATH=${tools}/xml-apis.jar:${tools}/xercesImpl.jar:${tools}/bin/xjavac.jar
+build.target        jars jars-schema11
 
 post-extract {
-    file rename ${workpath}/tools ${worksrcpath}/
+    move ${workpath}/tools ${worksrcpath}/
 }
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
+
+    xinstall -d ${destjavadir}
     xinstall -m 644 \
         ${worksrcpath}/build/xml-apis.jar \
         ${worksrcpath}/build/xercesImpl.jar \
-        ${destroot}${prefix}/share/java/
-    file copy ${worksrcpath}/build/docs ${destroot}${prefix}/share/doc/${name}
+        ${worksrcpath}/build/schema11-xercesImpl.jar \
+        ${destjavadir}
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/NOTICE \
+        ${worksrcpath}/README \
+        ${destdocdir}
 }
 
-livecheck.name      Xerces2
+livecheck.type      regex
+livecheck.url       https://downloads.apache.org/xerces/j/source/
+livecheck.regex     Xerces-J-src\\.(\[0-9.]+)\\.tar\\.gz

--- a/java/xercesj/Portfile
+++ b/java/xercesj/Portfile
@@ -1,63 +1,65 @@
-PortSystem 1.0
-PortGroup  java 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name				xercesj
-version				2.11.0
-categories			java textproc
-license				Apache-2 W3C
-maintainers			nomaintainer
-platforms			any
-supported_archs			noarch
+PortSystem          1.0
+PortGroup           java 1.0
 
-description			Apache Xerces 2 Java XML Parser
-long_description	The Xerces 2 Java Parser supports XML 1.0 Third Edition\; \
-					XML 1.1\; XML 1.1 Namespaces\; DOM Level 2 \
-					Core, Events, Traversal and Range\; \
-					SAX 2.0.1 Core and Extensions\; JAXP 1.2\; \
-					Schema 1.0 Structure and Datatypes.
-homepage			https://xerces.apache.org/xerces2-j/
+name                xercesj
+version             2.11.0
+categories          java textproc
+license             Apache-2 W3C
+maintainers         nomaintainer
+platforms           any
+supported_archs     noarch
 
-distname			Xerces-J-src.${version}
-distfiles			${distname}${extract.suffix} \
-					Xerces-J-tools.${version}${extract.suffix}
+description         Apache Xerces 2 Java XML Parser
+long_description    The Xerces 2 Java Parser supports XML 1.0 Third Edition\; \
+                    XML 1.1\; XML 1.1 Namespaces\; DOM Level 2 \
+                    Core, Events, Traversal and Range\; \
+                    SAX 2.0.1 Core and Extensions\; JAXP 1.2\; \
+                    Schema 1.0 Structure and Datatypes.
+homepage            https://xerces.apache.org/xerces2-j/
 
-master_sites		apache:xerces/j/
-checksums			${distname}${extract.suffix} \
-						rmd160 5ae4b52c2907e560aed36cdb146140fd4db05875 \
-						sha256 f59a5ef7b51bd883f2e9bda37a9360692e6c5e439b98d9b6ac1953e1f98b0680 \
-					Xerces-J-tools.${version}${extract.suffix} \
-						rmd160 a9469fb48b7ca23cced0bb68d0f424ad8209aed5 \
-						sha256 ff9a5e3a12b4bdad5a9238db03ed5a4709831d3e2c13fe53601163c374ad2051
+distname            Xerces-J-src.${version}
+distfiles           ${distname}${extract.suffix} \
+                    Xerces-J-tools.${version}${extract.suffix}
 
-depends_build		bin:ant:apache-ant
-depends_lib			bin:java:kaffe
+master_sites        apache:xerces/j/
+checksums           ${distname}${extract.suffix} \
+                        rmd160 5ae4b52c2907e560aed36cdb146140fd4db05875 \
+                        sha256 f59a5ef7b51bd883f2e9bda37a9360692e6c5e439b98d9b6ac1953e1f98b0680 \
+                    Xerces-J-tools.${version}${extract.suffix} \
+                        rmd160 a9469fb48b7ca23cced0bb68d0f424ad8209aed5 \
+                        sha256 ff9a5e3a12b4bdad5a9238db03ed5a4709831d3e2c13fe53601163c374ad2051
 
-worksrcdir			xerces-[string map ". _" $version]
-set tools			tools
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
+
+worksrcdir          xerces-[string map ". _" $version]
+set tools           tools
 
 patchfiles          build.xml.patch \
                     patch-src_org_apache_html_dom_HTMLElementImpl.java-add-getContentDocument-DOM2-method.diff
                     # See #37217 and https://issues.apache.org/jira/browse/XERCESJ-983?page=all
                     # This patch might not be the best way to fix this issue, though.
 
-use_configure		no
+use_configure       no
 
-build.cmd			ant
-build.target		jars docs javadocs
-build.env-append		CLASSPATH=${tools}/xml-apis.jar:${tools}/xercesImpl.jar:${tools}/bin/xjavac.jar
+build.cmd           ant
+build.target        jars docs javadocs
+build.env-append    CLASSPATH=${tools}/xml-apis.jar:${tools}/xercesImpl.jar:${tools}/bin/xjavac.jar
 
 post-extract {
-	file rename ${workpath}/tools ${worksrcpath}/
+    file rename ${workpath}/tools ${worksrcpath}/
 }
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 \
-		${worksrcpath}/build/xml-apis.jar \
-		${worksrcpath}/build/xercesImpl.jar \
-		${destroot}${prefix}/share/java/
-	file copy ${worksrcpath}/build/docs ${destroot}${prefix}/share/doc/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 \
+        ${worksrcpath}/build/xml-apis.jar \
+        ${worksrcpath}/build/xercesImpl.jar \
+        ${destroot}${prefix}/share/java/
+    file copy ${worksrcpath}/build/docs ${destroot}${prefix}/share/doc/${name}
 }
 
 livecheck.name      Xerces2

--- a/java/xercesj/files/build.xml.patch
+++ b/java/xercesj/files/build.xml.patch
@@ -1,6 +1,6 @@
 --- build.xml.orig	2010-11-27 07:42:11.000000000 +1100
 +++ build.xml	2011-12-01 05:56:14.000000000 +1100
-@@ -430,6 +430,7 @@
+@@ -434,6 +434,7 @@
        <arg value="targetDirectory=${build.docs}"/>
        <arg value="${build.dir}/xdocs/docs-book.xml"/>
        <arg value="${build.dir}/xdocs/style"/>

--- a/java/xercesj/files/bump-jdk-version.diff
+++ b/java/xercesj/files/bump-jdk-version.diff
@@ -1,0 +1,13 @@
+--- build.xml.orig	2022-01-21 10:21:02
++++ build.xml	2026-08-28 23:39:42
+@@ -90,8 +90,8 @@
+     <!--<property name="javac.source" value="${ant.java.version}"/>
+     <property name="javac.target" value="${ant.java.version}"/>-->
+     
+-    <property name="javac.source" value="1.7"/>
+-    <property name="javac.target" value="1.7"/>
++    <property name="javac.source" value="1.8"/>
++    <property name="javac.target" value="1.8"/>
+ 
+     <property name="docs.book" value="${docs.dir}/docs-book.xml"/>
+ 


### PR DESCRIPTION
#### Description

Update the `xercesj` port to version 2.12.2, fix some build failures, and polish the Portfile's formatting.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?