### PR TITLE
Rev bumps [l-p] for ImageMagick soname

### DIFF
--- a/databases/psiconv/Portfile
+++ b/databases/psiconv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                psiconv
 version             0.9.9
-revision            5
+revision            6
 categories          databases
 license             GPL-2+
 maintainers         nomaintainer

--- a/devel/libpst/Portfile
+++ b/devel/libpst/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libpst
 version             0.6.76
-revision            0
+revision            1
 checksums           rmd160  856fc7770e5d4d83dcbe0b283229b40ad04a3caa \
                     sha256  3d291beebbdb48d2b934608bc06195b641da63d2a8f5e0d386f2e9d6d05a0b42 \
                     size    12886768

--- a/devel/libtuxcap/Portfile
+++ b/devel/libtuxcap/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                libtuxcap
 version             1.4.0
-revision            8
+revision            9
 checksums           rmd160  43d236b65fd6bb28b3ceaa6ba3193ecbcc5e6675 \
                     sha256  dae27bad276bffce6eba8114cd0e3edc0db710306f627b984464c4f0ec1fab2f \
                     size    4622159

--- a/graphics/oofcanvas/Portfile
+++ b/graphics/oofcanvas/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                oofcanvas
 version             1.1.2
-revision            0
+revision            1
 
 license             public-domain
 categories          graphics

--- a/graphics/photoqt/Portfile
+++ b/graphics/photoqt/Portfile
@@ -9,7 +9,7 @@ name                photoqt
 # https://trac.macports.org/ticket/69366
 # https://github.com/luspi/photoqt/issues/22
 github.setup        luspi photoqt 3.4 v
-revision            3
+revision            4
 categories          graphics
 license             GPL-2
 maintainers         nomaintainer
@@ -78,7 +78,7 @@ subport photoqt-qt4 {
     # This is the last version to support Qt4.
     # TODO: restore Qt4 support into 1.x.
     github.setup    luspi photoqt-legacy 1.0 v
-    revision        2
+    revision        3
     conflicts       photoqt
     platforms       {darwin < 11}
     checksums       rmd160  e43351a7d1c1bc5fa96c1b4e759134d594c68c4f \

--- a/graphics/pstoedit/Portfile
+++ b/graphics/pstoedit/Portfile
@@ -8,7 +8,7 @@ legacysupport.redirect_bins pstoedit
 
 name                pstoedit
 version             4.02
-revision            1
+revision            2
 checksums           rmd160  69e4bdf539c5b5be2085e5206450e9eab78ca4c1 \
                     sha256  5588b432d2c6b2ad9828b44915ea5813ff9a3a3312a41fa0de4c38ddac9df72f \
                     size    1369790

--- a/multimedia/libopenshot/Portfile
+++ b/multimedia/libopenshot/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        OpenShot libopenshot 0.7.0 v
-revision            1
+revision            2
 github.tarball_from archive
 checksums           rmd160  cc5b77e10f8483a49e990774a2f03c326e2394e9 \
                     sha256  a7954c6af479fbd2e83059d4b6cbb13228de183f9a4eefcbcc8b3fd8de630dd2 \

--- a/multimedia/libsstv/Portfile
+++ b/multimedia/libsstv/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            rimio libsstv 0.9.0 v
-revision                0
+revision                1
 categories              multimedia
 maintainers             nomaintainer
 license                 MIT

--- a/perl/p5-gd-securityimage/Portfile
+++ b/perl/p5-gd-securityimage/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         GD-SecurityImage 1.75
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Security image (captcha) generator.

--- a/perl/p5-gtk3-imageview/Portfile
+++ b/perl/p5-gtk3-imageview/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Gtk3-ImageView 12 ../../authors/id/A/AS/ASOKOLOV
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Gtk3::ImageView - Image viewer widget for Gtk3

--- a/perl/p5-image-sane/Portfile
+++ b/perl/p5-image-sane/Portfile
@@ -14,7 +14,7 @@ checksums           rmd160  f313d74d543823d613938306067ae4670f6bbdd9 \
                     sha256  229aa0e9f049efa760f3c2f6e61d9d539af43d8f764b50a6e03064b4729a35ff \
                     size    47781
 
-revision            2
+revision            3
 
 if {${perl5.major} != ""} {
     depends_lib-append \

--- a/perl/p5-pdf-builder/Portfile
+++ b/perl/p5-pdf-builder/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         PDF-Builder 3.028 ../../authors/id/P/PM/PMPERRY
-revision            0
+revision            1
 license             LGPL-2.1
 maintainers         nomaintainer
 description         PDF::Builder - Facilitates the creation and modification of PDF files

--- a/php/php-magickwand/Portfile
+++ b/php/php-magickwand/Portfile
@@ -5,7 +5,7 @@ PortGroup           php 1.1
 
 name                php-magickwand
 version             1.0.9-2
-revision            6
+revision            7
 categories-append   graphics
 maintainers         {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 license             ImageMagick

--- a/python/py-wand/Portfile
+++ b/python/py-wand/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-wand
 python.rootname     Wand
 version             0.7.0
-revision            0
+revision            1
 categories-append   graphics
 license             MIT
 supported_archs     noarch

--- a/science/opendx/Portfile
+++ b/science/opendx/Portfile
@@ -5,7 +5,7 @@ PortGroup               deprecated 1.0
 
 name                    opendx
 version                 4.4.4
-revision                14
+revision                15
 categories              science
 license                 Permissive
 # "IBM PUBLIC LICENSE", http://opendx.org/dlSource.html


### PR DESCRIPTION
#### Description

* Part 2, ports [l-p]
* Rev bump ImageMagick dependents for unexpected soname reversion 8.0 --> 7.1.
* See: https://trac.macports.org/ticket/74369

###### Tested on

Not tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?