### PR TITLE
apache-ant*: obsolete apache-ant-1.9

### DIFF
--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -1,69 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup               java 1.0
+PortGroup               obsolete 1.0
 
 name                    apache-ant-1.9
 version                 1.9.16
-set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              devel java
 license                 Apache-2 W3C
-maintainers             nomaintainer
-supported_archs         noarch
 
-description             Java opensource build system
-long_description        Ant is a Java based build tool.  In theory it is \
-                        kind of like make without make's wrinkles.  Ant \
-                        uses XML build files that define a set of targets.  \
-                        Each target has dependencies (other targets) and \
-                        contains a set of tasks to perform.
 homepage                https://ant.apache.org/
 
 platforms               any
 
-distname                apache-ant-${version}-bin
-master_sites            apache:ant/
-master_sites.mirror_subdir  binaries
-
-checksums               rmd160  3b8fb74f30e76c35c7320902e861146b5d141c53 \
-                        sha256  57ceb0b249708cb28d081a72045657ab067fc4bc4a0d1e4af252496be44c2e66 \
-                        size    4495811
-
-worksrcdir              apache-ant-${version}
-set workTarget          ""
-
-use_bzip2               yes
-use_configure           no
-
-conflicts               apache-ant
-
-build {}
-
-pre-destroot {
-    delete \
-        ${worksrcpath}${workTarget}/bin/ant.bat \
-        ${worksrcpath}${workTarget}/bin/ant.cmd \
-        ${worksrcpath}${workTarget}/bin/antRun.bat \
-        ${worksrcpath}${workTarget}/bin/antenv.cmd \
-        ${worksrcpath}${workTarget}/bin/envset.cmd \
-        ${worksrcpath}${workTarget}/bin/lcp.bat \
-        ${worksrcpath}${workTarget}/bin/runrc.cmd
-}
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java
-    file copy ${worksrcpath}${workTarget} \
-        ${destroot}${prefix}/share/java/apache-ant
-
-    xinstall -m 755 -d ${destroot}${prefix}/share/doc/apache-ant
-    foreach f { INSTALL KEYS LICENSE NOTICE README WHATSNEW manual } {
-        file rename ${destroot}${prefix}/share/java/apache-ant/${f} \
-            ${destroot}${prefix}/share/doc/apache-ant/${f}
-    }
-
-    ln -s ../share/java/apache-ant/bin/ant ${destroot}${prefix}/bin/ant
-}
-
-livecheck.type          regex
-livecheck.url           https://www.apache.org/dist/ant/binaries/
-livecheck.regex         apache-ant-([quotemeta ${branch}](?:\\.\\d+)*)-bin\\.tar\\.bz2
+# Obsoleted 2026-08-30; may be removed after a year.
+replaced_by             apache-ant
+obsolete.note           The Apache Ant 1.9.x series is EOL.

--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -34,8 +34,6 @@ set workTarget          ""
 use_xz                  yes
 use_configure           no
 
-conflicts               apache-ant-1.9
-
 java.version            1.8+
 
 build {}


### PR DESCRIPTION
#### Description

There are currently two ports for [Apache Ant](https://ant.apache.org): `apache-ant-1.9` and `apache-ant`, which follow the 1.9.x and 1.10.x release series, respectively.

On 2024-06-19 (about two years ago), the 1.9.x series was officially EOL'd (see the [announcement](https://lists.apache.org/thread/f6jw4v3gjwhqt5fz25og0my2o6xwvvm1)).  While the 1.10.x series is still maintained, with the latest release being on 2026-04-10 (see the [download page](https://ant.apache.org/bindownload.cgi)).

So given that `apache-ant-1.9` currently has no dependents, this pull request obsoletes `apache-ant-1.9` in favour of `apache-ant`.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?