### PR TITLE
Rev bumps [r-z] for ImageMagick soname

### DIFF
--- a/devel/virtuoso-5/Portfile
+++ b/devel/virtuoso-5/Portfile
@@ -9,7 +9,7 @@ openssl.branch      1.0
 name                virtuoso-5
 set myname          virtuoso
 version             5.0.15
-revision            2
+revision            3
 categories          devel
 maintainers         nomaintainer
 license             GPL

--- a/devel/virtuoso-6/Portfile
+++ b/devel/virtuoso-6/Portfile
@@ -9,7 +9,7 @@ openssl.branch      1.0
 name                virtuoso-6
 set myname          virtuoso
 version             6.1.8
-revision            10
+revision            11
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL

--- a/devel/virtuoso-7/Portfile
+++ b/devel/virtuoso-7/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 name                virtuoso-7
 set myname          virtuoso
 version             7.2.10
-revision            2
+revision            3
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             {GPL-2 OpenSSLException}

--- a/graphics/synfig/Portfile
+++ b/graphics/synfig/Portfile
@@ -34,7 +34,7 @@ if {${subport} in [list ${name} ${name}studio]} {
 if {${subport} eq ${name}} {
     PortGroup           ffmpeg 1.0
 
-    revision            2
+    revision            3
     checksums           rmd160  d8bc8a38524e657fcdc24edf5d7c7b4278920ab9 \
                         sha256  51a395f7dceb2ec51721043eb9b9f7149477a3399d92d624eef266f155521bc1 \
                         size    5219077
@@ -94,7 +94,7 @@ if {${subport} eq ${name}} {
 }
 
 subport ETL {
-    revision            0
+    revision            1
     checksums           rmd160  5c8e64aa6a2d520ddcc56a2fc1b751d37ecded41 \
                         sha256  fbd0328296bfe12f52d53389740c0f3fea5005152b9da43f52ac1f5ab6e22c73 \
                         size    277975
@@ -134,7 +134,7 @@ subport ETL {
 }
 
 subport synfigstudio {
-    revision            0
+    revision            1
     checksums           rmd160  ca2b9366cf25e2e17391145336208b4b3c25b767 \
                         sha256  82a2d8a6d03f72443f8ddeb9d7ea38214313c1ac56f4ddba3e872464e8f91568 \
                         size    6870810

--- a/graphics/t-rec/Portfile
+++ b/graphics/t-rec/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 github.setup        sassman t-rec-rs 0.8.2 v
 github.tarball_from archive
 name                t-rec
-revision            0
+revision            1
 
 homepage            https://crates.io/crates/t-rec
 

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 PortGroup           meson 1.0
 
 github.setup        libvips libvips 8.16.0 v
-revision            4
+revision            5
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/graphics/zbar/Portfile
+++ b/graphics/zbar/Portfile
@@ -6,7 +6,7 @@ PortGroup               active_variants 1.1
 
 github.setup            mchehab zbar 0.23.93
 github.tarball_from     archive
-revision                1
+revision                2
 
 checksums               rmd160  2e83289a940f1192fda8c55ce244d65d754bd3ea \
                         sha256  212dfab527894b8bcbcc7cd1d43d63f5604a07473d31a5f02889e372614ebe28 \

--- a/multimedia/transcode/Portfile
+++ b/multimedia/transcode/Portfile
@@ -6,7 +6,7 @@ PortGroup   ffmpeg 1.0
 
 name        transcode
 version     1.1.7
-revision    36
+revision    37
 epoch       1
 license     GPL-2+
 categories  multimedia

--- a/multimedia/vapoursynth/Portfile
+++ b/multimedia/vapoursynth/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            vapoursynth vapoursynth 73 R
 github.tarball_from     archive
-revision                3
+revision                2
 
 description             A video processing framework with simplicity in mind
 

--- a/multimedia/vapoursynth/Portfile
+++ b/multimedia/vapoursynth/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            vapoursynth vapoursynth 73 R
 github.tarball_from     archive
-revision                2
+revision                3
 
 description             A video processing framework with simplicity in mind
 

--- a/multimedia/xine-lib/Portfile
+++ b/multimedia/xine-lib/Portfile
@@ -5,7 +5,7 @@ PortGroup           ffmpeg 1.0
 
 name                xine-lib
 version             1.2.13
-revision            8
+revision            9
 checksums           rmd160  2b1045e3dfe475c92a442f3506ee8b570b73da32 \
                     sha256  5f10d6d718a4a51c17ed1b32b031d4f9b80b061e8276535b2be31e5ac4b75e6f \
                     size    5004196

--- a/ruby/rb-rmagick/Portfile
+++ b/ruby/rb-rmagick/Portfile
@@ -5,7 +5,7 @@ PortGroup               ruby 1.0
 
 ruby.branches           3.2 3.1 3.0 2.7 2.6 2.5 2.4 2.3
 ruby.setup              rmagick 5.0.0 gem
-revision                1
+revision                2
 categories-append       graphics
 maintainers             nomaintainer
 license                 MIT

--- a/science/xastir/Portfile
+++ b/science/xastir/Portfile
@@ -17,7 +17,7 @@ github.tarball_from archive
 checksums           rmd160  3db74760bfc66accd4bf9302c3c222020f9d9f2e \
                     sha256  e80d1640ef2b8071984a633d45beae878c120d6012cb371405b160a06b328542 \
                     size    2246995
-revision            2
+revision            3
 
 use_autoconf        yes
 autoconf.cmd        ./bootstrap.sh


### PR DESCRIPTION
#### Description

* Part 3, ports [r-z]
* Rev bump ImageMagick dependents for unexpected soname reversion 8.0 --> 7.1.
* See: https://trac.macports.org/ticket/74369

###### Tested on

Not tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?