### PR TITLE
riscv32-none-elf-gcc: update to gcc 16.2.0

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -146,6 +146,11 @@ array set crossgcc.versions_info {
         sha256  50efb4d94c3397aff3b0d61a5abd748b4dd31d9d3f2ab7be05b171d36a510f79 \
         size    102456900
     }}
+    16.2.0 {xz {
+        rmd160  405146366b7c601dccb1da19ed1a337f836a46f9 \
+        sha256  e6738e29597f733270731aa90600f37ffdc045079dfc27ec7e8192cc81085c3e \
+        size    107200820
+    }}
 }
 
 array set newlib.versions_info {

--- a/cross/riscv32-none-elf-gcc/Portfile
+++ b/cross/riscv32-none-elf-gcc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossgcc 1.0
 
-set gccversion      16.1.0
+set gccversion      16.2.0
 set newlibversion   4.6.0.20260123
 crossgcc.setup      riscv32-none-elf ${gccversion}
 crossgcc.setup_libc newlib ${newlibversion}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
