### PR TITLE
jtidy: update to 1.0.5

### DIFF
--- a/java/jtidy/Portfile
+++ b/java/jtidy/Portfile
@@ -1,9 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           maven 1.0
 
 name                jtidy
-version             04aug2000r7
+github.setup        ${name} ${name} 1.0.5 ${name}-
+github.tarball_from archive
+
 categories          java devel textproc
 # Looks equivalent to zlib license but uses different wording
 license             Permissive
@@ -19,25 +23,31 @@ long_description    jtidy is a Java port of HTML Tidy, a HTML syntax \
                     which effectively makes you able to use jtidy as a DOM \
                     parser for real-world HTML.
 
-homepage            http://jtidy.sourceforge.net/
-master_sites        sourceforge
-distname            ${distname}-dev
-checksums           md5 8fa91a760f7eea722e57f8b8da4a7d5f
-use_zip             yes
+homepage            https://jtidy.sourceforge.net/
+checksums           rmd160  d650722022af74f79ef60b1129d61f290ca190de \
+                    sha256  6a7447f1f91fe5e27bc3e1cbd2c86fb06d6a4762202e43275bd74292de865edb \
+                    size    685248
 
-depends_build       bin:ant:apache-ant
-depends_lib         bin:java:kaffe
-
-use_configure       no
-
-build.cmd           ant
-build.args          -Dant.build.javac.source=1.4
-build.target        jar javadoc
+java.version        1.8+
+java.fallback       openjdk11
 
 destroot {
-    xinstall -d -m 755 ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc/
-    xinstall -m 644 ${worksrcpath}/build/Tidy.jar \
-        ${destroot}${prefix}/share/java/jtidy.jar
-    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
+    set destbindir  ${destroot}${prefix}/bin
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/README.md \
+        ${destdocdir}
+
+    xinstall -d ${destbindir}
+    xinstall ${filespath}/${name} ${destbindir}
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${destbindir}/${name}
 }

--- a/java/jtidy/Portfile
+++ b/java/jtidy/Portfile
@@ -1,41 +1,43 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name		jtidy
-version		04aug2000r7
-categories	java devel textproc
+PortSystem          1.0
+
+name                jtidy
+version             04aug2000r7
+categories          java devel textproc
 # Looks equivalent to zlib license but uses different wording
-license		Permissive
-platforms	any
-supported_archs	noarch
-maintainers	nomaintainer
-description	Java library for syntax checking and pretty printing HTML
-long_description	jtidy is a Java port of HTML Tidy, a HTML syntax \
-			checker and pretty printer. Like its non-Java cousin, \
-			jtidy can be used as a tool for cleaning up malformed \
-			and faulty HTML. In addition, jtidy provides a DOM \
-			interface to the document that is being processed, \
-			which effectively makes you able to use jtidy as a DOM \
-			parser for real-world HTML.
+license             Permissive
+platforms           any
+supported_archs     noarch
+maintainers         nomaintainer
+description         Java library for syntax checking and pretty printing HTML
+long_description    jtidy is a Java port of HTML Tidy, a HTML syntax \
+                    checker and pretty printer. Like its non-Java cousin, \
+                    jtidy can be used as a tool for cleaning up malformed \
+                    and faulty HTML. In addition, jtidy provides a DOM \
+                    interface to the document that is being processed, \
+                    which effectively makes you able to use jtidy as a DOM \
+                    parser for real-world HTML.
 
-homepage	http://jtidy.sourceforge.net/
-master_sites	sourceforge
-distname	${distname}-dev
-checksums	md5 8fa91a760f7eea722e57f8b8da4a7d5f
-use_zip		yes
+homepage            http://jtidy.sourceforge.net/
+master_sites        sourceforge
+distname            ${distname}-dev
+checksums           md5 8fa91a760f7eea722e57f8b8da4a7d5f
+use_zip             yes
 
-depends_build	bin:ant:apache-ant
-depends_lib	bin:java:kaffe
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
 
-use_configure	no
+use_configure       no
 
-build.cmd	ant
-build.args  -Dant.build.javac.source=1.4
-build.target	jar javadoc
+build.cmd           ant
+build.args          -Dant.build.javac.source=1.4
+build.target        jar javadoc
 
-destroot	{
-	xinstall -d -m 755 ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc/
-	xinstall -m 644 ${worksrcpath}/build/Tidy.jar \
-		${destroot}${prefix}/share/java/jtidy.jar
-	file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
+destroot {
+    xinstall -d -m 755 ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc/
+    xinstall -m 644 ${worksrcpath}/build/Tidy.jar \
+        ${destroot}${prefix}/share/java/jtidy.jar
+    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
 }

--- a/java/jtidy/files/jtidy
+++ b/java/jtidy/files/jtidy
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec java -jar '@@PREFIX@@/share/java/jtidy.jar' "$@"


### PR DESCRIPTION
#### Description

Migrate the `jtidy` port to a (relatively) more maintained [community fork](https://github.com/jtidy/jtidy) and update it to the latest release (version 1.0.5).  Also add a helper script for running the CLI and tidy up the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?