### PR TITLE
container: update to 1.3.1

### DIFF
--- a/devel/container/Portfile
+++ b/devel/container/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        apple container 1.3.0
+github.setup        apple container 1.3.1
 github.tarball_from archive
 
 revision            0
@@ -19,9 +19,9 @@ long_description    container is a tool that you can use to create and run Linux
                     registry. You can push images that you build to those registries \
                     as well, and run the images in any other OCI-compatible application.
 
-checksums           rmd160  21b7659bbe250c281872b7016ad31151a3802b55 \
-                    sha256  06690c8cde6fef67ec1b40d0ea8f86845b398dd745277aa64f7b5309ce42d9ff \
-                    size    1052911
+checksums           rmd160  d6e46307bdf7f2464e976c392609e3f948afb12c \
+                    sha256  a0c7c33f694f472ebf6d058ff67623f7dfc261092dd6feffaeb377dcd4a2b6af \
+                    size    1059343
 
 # The version number for macosx is the darwin version number (os.major)
 platforms           {macosx >= 25}


### PR DESCRIPTION
#### Description

Update `container` port to the latest security release.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
