### PR TITLE
jaxen: update to 2.0.6

### DIFF
--- a/java/jaxen/Portfile
+++ b/java/jaxen/Portfile
@@ -1,7 +1,13 @@
-PortSystem      1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            jaxen
-version         1.1.2
+PortSystem      1.0
+PortGroup       github 1.0
+PortGroup       maven 1.0
+
+github.setup    jaxen-xpath jaxen 2.0.6 v
+github.tarball_from \
+                archive
+
 categories      java devel textproc
 license         BSD
 platforms       any
@@ -13,24 +19,33 @@ description     Java XPath engine
 long_description \
     The jaxen project is a Java XPath Engine. jaxen is a universal object \
     model walker, capable of evaluating XPath expressions across multiple \
-    models. Currently supported are dom4j and JDOM.
+    models. Currently supported are DOM, XOM, dom4j, and JDOM.
 
-homepage        http://www.jaxen.org/
-master_sites    http://dist.codehaus.org/jaxen/jars/
+homepage        https://jaxen-xpath.github.io/jaxen/
 
-extract.suffix  .jar
-extract.only
+checksums       rmd160  8fd669f7fbe426e270021a4491e9cba1d4edb12a \
+                sha256  442c2b23c78d634cd3ae6578c53d938f0260b7429cabbf8b1a1189a59f854fea \
+                size    315037
 
-checksums       md5     6e84c110959c35faaff3ceb953b7191e \
-                sha1    87a23a2136305e807e811677a9231235d216b4b5 \
-                rmd160  b1b1b3e548eaa3822fd3020268539a2b596fcb61
+java.version    1.8+
+java.fallback   openjdk11
 
-use_configure   no
-
-build           {}
+patchfiles      bump-jdk-version.diff \
+                remove-bad-javadoc-links.diff
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java
-    xinstall -m 644 ${distpath}/${distfiles} \
-        ${destroot}${prefix}/share/java/${name}.jar
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/core/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/SECURITY.md \
+        ${destdocdir}
 }

--- a/java/jaxen/files/bump-jdk-version.diff
+++ b/java/jaxen/files/bump-jdk-version.diff
@@ -1,0 +1,33 @@
+--- pom.xml.orig	2026-06-06 02:26:38
++++ pom.xml	2026-08-29 18:17:53
+@@ -28,8 +28,8 @@
+     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+     <project.build.outputTimestamp>2026-06-05T16:25:36Z</project.build.outputTimestamp>
+     <project.javadoc.version>3.12.0</project.javadoc.version>
+-    <maven.compiler.source>1.5</maven.compiler.source>
+-    <maven.compiler.target>1.5</maven.compiler.target>
++    <maven.compiler.source>1.8</maven.compiler.source>
++    <maven.compiler.target>1.8</maven.compiler.target>
+   </properties>
+ 
+   <modules>
+@@ -208,8 +208,8 @@
+         <configuration>
+           <debug>true</debug>
+           <showDeprecation>true</showDeprecation>
+-          <source>1.5</source>
+-          <target>1.5</target>
++          <source>1.8</source>
++          <target>1.8</target>
+           <compilerArgs>
+             <arg>-Xlint:-options</arg>
+           </compilerArgs>
+@@ -428,7 +428,7 @@
+         <version>3.28.0</version>
+         <configuration>
+           <sourceEncoding>utf-8</sourceEncoding>
+-          <targetJdk>1.5</targetJdk>
++          <targetJdk>1.8</targetJdk>
+         </configuration>
+       </plugin> 
+       <plugin>

--- a/java/jaxen/files/remove-bad-javadoc-links.diff
+++ b/java/jaxen/files/remove-bad-javadoc-links.diff
@@ -1,0 +1,22 @@
+--- pom.xml.orig	2026-06-06 02:26:38
++++ pom.xml	2026-08-29 18:44:44
+@@ -276,9 +276,6 @@
+           <quiet>true</quiet>
+           <bottom>Copyright {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>
+           <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers,org.jaxen.pattern,org.jaxen.jdom,org.jaxen.xom,org.jaxen.dom4j</excludePackageNames>
+-          <links>
+-            <link>https://docs.oracle.com/javase/1.5.0/docs/api/</link>
+-          </links>
+           <docencoding>UTF-8</docencoding>
+           <tags>
+             <tag>
+@@ -403,9 +400,6 @@
+           <quiet>true</quiet>
+           <bottom>Copyright {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>
+           <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers,org.jaxen.pattern,org.jaxen.jdom,org.jaxen.xom,org.jaxen.dom4j</excludePackageNames>
+-          <links>
+-            <link>https://docs.oracle.com/javase/1.5.0/docs/api/</link>
+-          </links>
+           <docencoding>UTF-8</docencoding>
+           <tags>
+             <tag>


### PR DESCRIPTION
#### Description

Alter the `jaxen` port to fetch from its current GitHub repo and install the latest release (version 2.0.6).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?