### PR TITLE
jdom: update to 2.0.6.1

### DIFF
--- a/java/jdom/Portfile
+++ b/java/jdom/Portfile
@@ -1,44 +1,51 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           java 1.0
 
-name                jdom
-version             1.1.1
+github.setup        hunterhacker jdom 2.0.6.1 JDOM-
+github.tarball_from archive
+
 categories          java devel textproc
-license             Apache-1.1
+license             Permissive
 platforms           any
 supported_archs     noarch
 maintainers         nomaintainer
 description         JDOM is a Java API for manipulating XML the Java way.
 long_description    {*}${description}
 
-homepage            http://www.jdom.org/
-master_sites        ${homepage}dist/source/ \
-                    ${homepage}dist/source/archive/
+homepage            https://www.jdom.org/
 
-checksums           md5     0ad116194e3101fb08fab8f6f00cc58f \
-                    sha1    affa11961f93aefef5f9df3173260c269df247c9 \
-                    rmd160  f677cdfaf6510d9117288edda75f28a86bff7d36
+checksums           rmd160  b3e2488cb5a7f93108837a2c98f341a8cb16955e \
+                    sha256  18639399104d5c57b92fd6791823a74393651e80499b67ae3067294d62df083e \
+                    size    8368301
 
 depends_build       bin:ant:apache-ant
-depends_lib         bin:java:kaffe
+
+java.version        1.8+
+java.fallback       openjdk11
+
+patchfiles          bump-jdk-version.diff
 
 use_configure       no
 
-worksrcdir          ${name}
-
 build.cmd           ant
-build.target        package javadoc
+build.target
 
 destroot {
-    xinstall -d ${destroot}${prefix}/share/java/ \
-        ${destroot}${prefix}/share/doc/
-    xinstall -m 644 ${worksrcpath}/build/jdom.jar \
-        ${destroot}${prefix}/share/java/jdom.jar
-    file copy ${worksrcpath}/build/apidocs \
-        ${destroot}${prefix}/share/doc/${name}
-}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
 
-livecheck.type      regex
-livecheck.url       http://www.jdom.org/dist/source/archive/
-livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        [glob -directory ${worksrcpath}/build/package/ ${name}-2.x-????.??.??.??.??.jar] \
+        ${destjavadir}/${name}.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/COMMITTERS.txt \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/README.md \
+        ${destdocdir}
+}

--- a/java/jdom/Portfile
+++ b/java/jdom/Portfile
@@ -1,42 +1,44 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			jdom
-version			1.1.1
-categories		java devel textproc
-license			Apache-1.1
-platforms		any
-supported_archs	noarch
-maintainers		nomaintainer
-description		JDOM is a Java API for manipulating XML the Java way.
-long_description	{*}${description}
+PortSystem          1.0
 
-homepage		http://www.jdom.org/
-master_sites	${homepage}dist/source/ \
-				${homepage}dist/source/archive/
+name                jdom
+version             1.1.1
+categories          java devel textproc
+license             Apache-1.1
+platforms           any
+supported_archs     noarch
+maintainers         nomaintainer
+description         JDOM is a Java API for manipulating XML the Java way.
+long_description    {*}${description}
 
-checksums       md5     0ad116194e3101fb08fab8f6f00cc58f \
-                sha1    affa11961f93aefef5f9df3173260c269df247c9 \
-                rmd160  f677cdfaf6510d9117288edda75f28a86bff7d36
+homepage            http://www.jdom.org/
+master_sites        ${homepage}dist/source/ \
+                    ${homepage}dist/source/archive/
 
-depends_build	bin:ant:apache-ant
-depends_lib		bin:java:kaffe
+checksums           md5     0ad116194e3101fb08fab8f6f00cc58f \
+                    sha1    affa11961f93aefef5f9df3173260c269df247c9 \
+                    rmd160  f677cdfaf6510d9117288edda75f28a86bff7d36
 
-use_configure	no
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
 
-worksrcdir      ${name}
+use_configure       no
 
-build.cmd		ant
-build.target	package javadoc
+worksrcdir          ${name}
 
-destroot	{
-	xinstall -d ${destroot}${prefix}/share/java/ \
-		${destroot}${prefix}/share/doc/
-	xinstall -m 644 ${worksrcpath}/build/jdom.jar \
-		${destroot}${prefix}/share/java/jdom.jar
-	file copy ${worksrcpath}/build/apidocs \
-		${destroot}${prefix}/share/doc/${name}
+build.cmd           ant
+build.target        package javadoc
+
+destroot {
+    xinstall -d ${destroot}${prefix}/share/java/ \
+        ${destroot}${prefix}/share/doc/
+    xinstall -m 644 ${worksrcpath}/build/jdom.jar \
+        ${destroot}${prefix}/share/java/jdom.jar
+    file copy ${worksrcpath}/build/apidocs \
+        ${destroot}${prefix}/share/doc/${name}
 }
 
-livecheck.type  regex
-livecheck.url   http://www.jdom.org/dist/source/archive/
-livecheck.regex ${name}-(\\d+(?:\\.\\d+)*)
+livecheck.type      regex
+livecheck.url       http://www.jdom.org/dist/source/archive/
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/java/jdom/files/bump-jdk-version.diff
+++ b/java/jdom/files/bump-jdk-version.diff
@@ -1,0 +1,13 @@
+--- build.xml.orig	2021-10-21 07:50:34
++++ build.xml	2026-08-29 22:48:54
+@@ -47,8 +47,8 @@
+ 
+ 	<property name="compile.debug"       value="true" />
+ 	<property name="compile.optimize"    value="true" />
+-	<property name="compile.target"      value="1.5" />
+-	<property name="compile.source"      value="1.5" />
++	<property name="compile.target"      value="1.8" />
++	<property name="compile.source"      value="1.8" />
+ 	<property name="compile.deprecation" value="true" />
+ 
+ 	<property name="build" value="./build"/>


### PR DESCRIPTION
#### Description

Update the `jdom` port to version 2.0.6.1 and fix up the Portfile's formatting.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?