### PR TITLE
openjdk25-openj9: update to 25.0.4.10

### DIFF
--- a/java/openjdk25-openj9/Portfile
+++ b/java/openjdk25-openj9/Portfile
@@ -20,33 +20,32 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.4
-set build    7
+version      ${feature}.0.4.10
 revision     0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5fe0b89092b15b9c4ccf2e9426a2fb96a6a9545a \
-                 sha256  6a0be956cf61f73cdb2f016c04a9b5d8118d9ebf3b2e58a22703d1fd341e1e42 \
-                 size    240245232
+    checksums    rmd160  1888f6ce73021c187b6b9c75d3fc2dbaae505406 \
+                 sha256  811b5d33ca14a73c5268ad346932464abcff133dab655760b473fe2b123f2b39 \
+                 size    240255005
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f885790f66d37c79d799fe1af353e6cbb61341c1 \
-                 sha256  872eef131370704bd498b8f7961917758f980b86b98903d482c48c145f8c1a32 \
-                 size    234146940
+    checksums    rmd160  855af0ac2f4424a3ddf4ed17549e356a8313894a \
+                 sha256  7a5f6606454c2f347d1157babdcf5773886dfa04afe4eb4993c09a0e89edfcd7 \
+                 size    234176559
 } else {
     set arch_classifier unsupported_arch
 }
 
-distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}.${revision}
+distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}
 
-worksrcdir   jdk-${version}+${build}
+worksrcdir   jdk-${version}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 25.0.4.10.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?