### PR TITLE
openjdk17-openj9: update to 17.0.20.10

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -20,33 +20,32 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.20
-set build    8
+version      ${feature}.0.20.10
 revision     0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  b7e4e2dd1a243dcce1729b6fd31f82e16b243b1b \
-                 sha256  04d711f51e00021e4c24d8917cd3a8a79c7564f50c7f57679a962aaeb0f7e911 \
-                 size    219964337
+    checksums    rmd160  7efd27de58c3e86a7c62c94b72040f00caa4761a \
+                 sha256  bfdd67b1111d9ece1ec53079322b1a488f81d212790db0a6d7982a60fc5e9c29 \
+                 size    219974018
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  94fdb464cff1851f90c2e17eaf2f48504d008ad5 \
-                 sha256  811db6bc798cef68fd723e1729584bc05836f15fca739f0fa725d55f2744f13f \
-                 size    213957294
+    checksums    rmd160  02fc359414812ae6db83434c95dcd1219b14f9f0 \
+                 sha256  1a2a4e83099bb801441158c6cfeb09690bbe0f1fb2fffbc4ee9cc63c6f2e7f17 \
+                 size    213990140
 } else {
     set arch_classifier unsupported_arch
 }
 
-distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}.${revision}
+distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}
 
-worksrcdir   jdk-${version}+${build}
+worksrcdir   jdk-${version}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.20.10.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?