### PR TITLE
openjdk11-openj9: update to 11.0.32.10

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -20,33 +20,32 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.32
-set build    9
+version      ${feature}.0.32.10
 revision     0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6b9e6b11e9858403c730d0a5467cd07396a0e5c3 \
-                 sha256  3f24cebbfaf947d24bbb0fe194d001876a5c3ea75a9d08d06a34bf61ae51185f \
-                 size    213252378
+    checksums    rmd160  fddf47670ba8c25a07bea6a1a7ae15bc86a3448a \
+                 sha256  85ee80438dff6104f3beef50ee34d7273765af4d165badc7d16d88a8c76cbbad \
+                 size    213260659
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  78bbe08eed340a65f30f7368f6d8c530ef74b5b7 \
-                 sha256  5dcc5e5fee9ad2399100db51b5a84182e91e27cabd2ea441061a61f83f0e852a \
-                 size    207618648
+    checksums    rmd160  c1dc08c76be37dcfa1d62a0cd10a232d0121dfc4 \
+                 sha256  e2a00bd177449bd9eda4a49d7c282e70111c4c05fc6710be7328f1d87de06809 \
+                 size    207626165
 } else {
     set arch_classifier unsupported_arch
 }
 
-distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}.${revision}
+distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}
 
-worksrcdir   jdk-${version}+${build}
+worksrcdir   jdk-${version}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.32.10.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?