### PR TITLE
openjdk26-openj9: update to 26.0.2.10

### DIFF
--- a/java/openjdk26-openj9/Portfile
+++ b/java/openjdk26-openj9/Portfile
@@ -20,33 +20,32 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.2
-set build    10
+version      ${feature}.0.2.10
 revision     0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until September 2026)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5960d8c4f02a0451b0c1a3c9159703c84d602749 \
-                 sha256  171ede5edcafb7616d57353c17a9d37f4d668e29e8500e5b4421ff59d2d34430 \
-                 size    244734343
+    checksums    rmd160  b9aa587b68098000c3f6bd7487fa4357ffcdb269 \
+                 sha256  e13fb0aa11eec03d9dd7d6aaf5cde07b46a7bea45ea803c1c18fd33c38a4703b \
+                 size    244743800
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  ffcf184fa94b421c3ce81b78afa79bd96cb5666d \
-                 sha256  5c00a6ae25519cb33c106d38dd70987a0d0923f958679d72d2fd674bd400d9d0 \
-                 size    238615556
+    checksums    rmd160  70c6868ef06f8756ec858cfe75f093f6a997343b \
+                 sha256  4d3df73a0f79c3e2db4dc36c93ebfbb9c1f9de72ec635a07d8d20451aba8098e \
+                 size    238618653
 } else {
     set arch_classifier unsupported_arch
 }
 
-distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}.${revision}
+distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}
 
-worksrcdir   jdk-${version}+${build}
+worksrcdir   jdk-${version}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 26.0.2.10.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?