### PR TITLE
openjdk8-openj9: update to 8.0.504.0

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -20,9 +20,7 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-set patch    502
-version      ${feature}.0.${patch}.0
-set build    07
+version      ${feature}.0.504.0
 revision     0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
@@ -32,11 +30,11 @@ long_description The IBM Semeru Runtimes are free production-ready open source b
 master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}/
 
 distname     ibm-semeru-open-jdk_x64_mac_${version}
-worksrcdir   jdk${feature}u${patch}-b${build}
+worksrcdir   jdk-${version}
 
-checksums    rmd160  9ee71876b28ab3ba06b913c9fa64d2e71dd11a24 \
-             sha256  62fbb02e49c44c9c447f75108480b4900b3f2583f197e22bb986a731b938e700 \
-             size    129980760
+checksums    rmd160  df7a19c6ffbfd9e49452ae5146937b0b00e5f80c \
+             sha256  7dc3bc504d70feb864c2b278b241dd190270fd76ea33324ea1435c4f0e22899f \
+             size    129987414
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8.0.504.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?