### PR TITLE
tart-softnet: new port, version 0.23.0

### DIFF
--- a/sysutils/tart-softnet/Portfile
+++ b/sysutils/tart-softnet/Portfile
@@ -1,0 +1,438 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        openai softnet 0.23.0
+github.tarball_from archive
+revision            0
+
+name                tart-softnet
+
+# Tart resolves the helper from PATH under its upstream name
+set binname         softnet
+
+categories          sysutils net
+# Functional Source License 1.1, converting to Apache-2 two years after release
+license             Restrictive/Distributable
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Software networking with isolation for Tart
+long_description    Softnet provides software networking with isolation for \
+                    Tart virtual machines, built on Apple's vmnet framework. \
+                    It isolates virtual machines from each other and from the \
+                    host network, and alleviates DHCP address shortage when \
+                    running many VMs.
+
+checksums           ${distfiles} \
+                    rmd160  3eab7ac9383017ebf77d4b3da60daad20475d204 \
+                    sha256  1eec9735be064201d701144f34d0f510df8db6372567adcbed33e037121b126d \
+                    size    64652
+
+# The version number for macosx is the darwin version number (os.major)
+platforms           {macosx >= 24}
+
+if {${os.platform} eq "darwin" && ${os.major} < 24} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} requires macOS 15 or later."
+        return -code error "incompatible macOS version"
+    }
+}
+
+# dhcproto 0.16.0 is unreleased and vendored from git, so cargo fetches it during build
+build.pre_args-delete \
+                    --offline --frozen
+
+build.env-append    SOFTNET_VERSION=${version}
+
+destroot {
+    # setuid root: softnet needs privileges to create vmnet interfaces, then drops them
+    xinstall -m 4755 ${worksrcpath}/target/[option triplet.${muniversal.build_arch}]/release/${binname} \
+        ${destroot}${prefix}/bin/
+}
+
+notes "
+    ${binname} is installed setuid root. It needs root privileges to create\
+    vmnet interfaces and to apply DHCP-related system settings, and drops them\
+    to the calling user once initialisation is complete.
+"
+
+cargo.crates \
+    actix-codec                      0.5.2  5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a \
+    actix-http                      3.12.1  93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662 \
+    actix-router                     0.5.3  13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8 \
+    actix-rt                        2.10.0  24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208 \
+    actix-server                     2.6.0  a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502 \
+    actix-service                    2.0.3  9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f \
+    actix-utils                      3.0.1  88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8 \
+    actix-web                       4.10.2  f2e3b15b3dc6c6ed996e4032389e9849d4ab002b1e92fbfe85b5f307d1479b4d \
+    addr2line                       0.24.1  f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375 \
+    adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
+    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
+    anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
+    anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
+    anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
+    anyhow                         1.0.104  330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
+    array-const-fn-init              0.1.1  8bcb85e548c05d407fa6faff46b750ba287714ef32afc0f5e15b4641ffd6affb \
+    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
+    backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
+    base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    base64ct                         1.8.0  55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.9.4  2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394 \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    block-buffer                    0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
+    bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bytes                           1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
+    bytestring                       1.4.0  e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f \
+    cc                              1.2.57  7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    chacha20                        0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
+    clap                             4.6.6  473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca \
+    clap_builder                     4.6.6  7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889 \
+    clap_derive                      4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
+    clap_lex                         1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
+    coarsetime                      0.1.37  e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2 \
+    colorchoice                      1.0.2  d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0 \
+    combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
+    concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
+    const-oid                       0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
+    core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
+    core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
+    critical-section                 1.2.0  790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b \
+    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    crypto-common                    0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
+    darling                         0.14.4  7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850 \
+    darling_core                    0.14.4  109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0 \
+    darling_macro                   0.14.4  a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    data-encoding                    2.6.0  e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2 \
+    debugid                          0.8.0  bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d \
+    defmt                            0.3.8  a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0 \
+    defmt-macros                     0.3.9  e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb \
+    defmt-parser                     0.3.4  ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f \
+    der                             0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
+    deranged                         0.5.5  ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587 \
+    derive_more                      2.0.1  093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678 \
+    derive_more-impl                 2.0.1  bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3 \
+    digest                          0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
+    displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
+    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
+    enum-iterator                    1.5.0  9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94 \
+    enum-iterator-derive             1.4.0  a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                           0.3.12  cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18 \
+    fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
+    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    findshlibs                      0.10.2  40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
+    getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
+    getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
+    getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
+    gimli                           0.31.0  32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64 \
+    hash32                           0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
+    hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
+    hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
+    heapless                         0.9.2  2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
+    hermit-abi                       0.5.1  f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08 \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    hexdump                          0.1.2  cf31ab66ed8145a1c7427bd8e9b42a6131bd74ccf444f69b9e620c2e73ded832 \
+    hickory-proto                   0.26.1  0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643 \
+    hostname                         0.4.0  f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba \
+    http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
+    http                             1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
+    http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
+    http-body-util                   0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
+    httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
+    httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    hybrid-array                    0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
+    hyper                            1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
+    hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
+    hyper-util                      0.1.17  3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8 \
+    icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
+    icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
+    icu_locid_transform              1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
+    icu_locid_transform_data         1.5.0  fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e \
+    icu_normalizer                   1.5.0  19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f \
+    icu_normalizer_data              1.5.0  f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516 \
+    icu_properties                   1.5.1  93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5 \
+    icu_properties_data              1.5.0  67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569 \
+    icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
+    icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
+    idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
+    impl-more                        0.1.9  e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2 \
+    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    ip_network                       0.4.1  aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1 \
+    ipnet                           2.12.1  6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78 \
+    iri-string                      0.7.10  c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a \
+    is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
+    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    jni                             0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
+    jni-macros                      0.22.4  a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
+    jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
+    jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
+    js-sys                          0.3.83  464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8 \
+    jsonrpsee-types                 0.26.0  bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5 \
+    language-tags                    0.3.2  d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388 \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
+    libc                           0.2.189  3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
+    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
+    litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
+    local-channel                    0.1.5  b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8 \
+    local-waker                      0.1.4  4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487 \
+    lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
+    log                             0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
+    mac_address                      1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
+    managed                          0.8.0  0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d \
+    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
+    mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
+    native-tls                      0.2.12  a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466 \
+    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
+    nix                             0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
+    nix                             0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
+    num-conv                         0.2.0  cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    num_enum                        0.5.11  1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9 \
+    num_enum                         0.7.6  5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26 \
+    num_enum_derive                 0.5.11  dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799 \
+    num_enum_derive                  0.7.6  680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8 \
+    object                          0.36.4  084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a \
+    once_cell                       1.20.1  82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1 \
+    once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
+    openssl                        0.10.79  bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
+    openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
+    openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
+    openssl-sys                    0.9.115  158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781 \
+    os_info                          3.8.2  ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092 \
+    oslog                            0.2.0  80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969 \
+    parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
+    parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
+    pem-rfc7468                      0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
+    polling                         3.11.0  5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218 \
+    portable-atomic                  1.9.0  cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2 \
+    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
+    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
+    prefix-trie                      0.9.2  fbeb97a96d43f215f842f6ab81e8c7b5f6e9b912495c3178127f54f9dce28e32 \
+    prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
+    privdrop                         0.5.6  70722a5a3728c9603c8d9469b64b8d1ee54dae6d74e24146da7f501b4c76540f \
+    proc-macro-crate                 1.3.1  7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919 \
+    proc-macro-crate                 3.2.0  8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    r-efi                            5.2.0  74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5 \
+    r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
+    rand                             0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
+    rand                            0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
+    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
+    rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
+    rand_core                       0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
+    regex                           1.11.0  38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8 \
+    regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
+    regex-lite                       0.1.6  53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a \
+    regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    reqwest                         0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
+    rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
+    rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
+    rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
+    rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
+    rustls-pki-types                1.12.0  229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79 \
+    rustversion                     1.0.21  8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
+    ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schannel                        0.1.24  e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
+    security-framework-sys          2.12.0  ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6 \
+    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
+    sentry                          0.49.1  63207365db50cb817402f0ec8097d6dad3d644ef3fffd6ba30c75b3077e514da \
+    sentry-actix                    0.49.1  4a0eb1ed18478fb48db007aeaa672a3de176055357feb768eee0c3471802d0ce \
+    sentry-anyhow                   0.49.1  6265521f1b724f709bc07747ecb01c5289b974cb70b348026df01780280fc136 \
+    sentry-backtrace                0.49.1  e3bcc2497c2327998146207b7600599ef7592233920f4d4e1d41ddeeba0e4210 \
+    sentry-contexts                 0.49.1  1cb04cba225b38f59d08f9e3c29ab7259d9cc94fbb2c46d613a51cb0a4a7ee05 \
+    sentry-core                     0.49.1  48759bc392fb5e3b36b4efcb485f51074c0ba8479711cd5c8cf79e86f9f75d41 \
+    sentry-debug-images             0.49.1  0a5bd325059b70b21ca6e42b0f2409821272dddc1cf37923de37269af55389b5 \
+    sentry-log                      0.49.1  f9553a2f0f75bc8550137ebc753e8d2161af63ff780ca59983935f8df8f01655 \
+    sentry-panic                    0.49.1  a685d22f672b1562ebeff3f2affceb5960595648cc936dae73da3e1d6a55fbd1 \
+    sentry-tracing                  0.49.1  8aa7d8e0db4cccddbac01ddabd5344ad03b7c2f954b3ff850cecb1d9cf5d4758 \
+    sentry-types                    0.49.1  fab146d15a30ab4897a95fd15d6a038b8d7fbf2661c5f8b13738ce8df7a095b7 \
+    serde                          1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde_core                     1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                   1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                     1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    serial_test                      4.0.1  a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11 \
+    serial_test_derive               4.0.1  a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae \
+    sha1                            0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    signal-hook-registry             1.4.5  9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410 \
+    simd_cesu8                       1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
+    simdutf8                         0.1.5  e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    smoltcp                         0.13.1  5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e \
+    socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
+    socket2                          0.6.1  17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881 \
+    stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    syn                              3.0.2  a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3 \
+    sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
+    synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
+    system-configuration             0.8.0  501336eb7ba9e417300a6a0fa985721065467aa83a6dcf0422a8e43e4c0328fa \
+    system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
+    tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
+    thiserror                       1.0.64  d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84 \
+    thiserror                       2.0.19  09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
+    thiserror-impl                  1.0.64  08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3 \
+    thiserror-impl                  2.0.19  43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
+    time                            0.3.47  743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c \
+    time-core                        0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
+    time-macros                     0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
+    tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
+    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
+    tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+    tokio                           1.44.2  e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48 \
+    tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
+    tokio-util                      0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
+    toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
+    toml_edit                      0.19.15  1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421 \
+    toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
+    tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-http                       0.6.8  d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
+    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
+    tracing-core                    0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
+    tracing-subscriber              0.3.20  2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5 \
+    try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    typenum                         1.20.0  40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
+    uname                            0.1.1  b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8 \
+    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
+    unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
+    ureq                            3.0.12  9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39 \
+    ureq-proto                       0.4.2  59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7 \
+    url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
+    utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
+    utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
+    utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
+    uuid                            1.10.0  81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314 \
+    uzers                           0.12.2  0b8275fb1afee25b4111d2dc8b5c505dbbc4afd0b990cb96deb2d88bff8be18d \
+    valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
+    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    vmnet                            0.5.1  03f0531c358eba83803f9a46c165b8d1e9747758bf45c41df1499c1017d43f8c \
+    vmnet-derive                     0.5.1  ee8cbf3c6928db44bb3757ac38ed65d25460205be9f6e50f61840c1d350c0e9c \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
+    want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
+    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasi                          0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
+    wasip2                        1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
+    wasip3                        0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
+    wasix                           0.13.1  1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332 \
+    wasm-bindgen                   0.2.106  0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd \
+    wasm-bindgen-futures            0.4.43  61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed \
+    wasm-bindgen-macro             0.2.106  48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3 \
+    wasm-bindgen-macro-support     0.2.106  cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40 \
+    wasm-bindgen-shared            0.2.106  cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4 \
+    wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
+    wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
+    wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
+    web-sys                         0.3.70  26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0 \
+    webpki-root-certs              0.26.11  75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e \
+    webpki-root-certs                1.0.1  86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
+    windows-sys                     0.61.0  e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa \
+    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                 0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
+    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm         0.53.1  a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
+    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc            0.53.1  b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
+    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                0.53.1  960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
+    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm            0.53.1  fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
+    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc               0.53.1  1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
+    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu              0.53.1  9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
+    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm          0.53.1  0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
+    winnow                          0.5.40  f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876 \
+    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
+    wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
+    wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
+    wit-bindgen-core                0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
+    wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
+    wit-bindgen-rust                0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
+    wit-bindgen-rust-macro          0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
+    wit-component                  0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
+    wit-parser                     0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
+    write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
+    writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
+    yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
+    yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
+    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
+    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zerofrom                         0.1.5  cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e \
+    zerofrom-derive                  0.1.5  595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808 \
+    zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
+    zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
+    zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
+    zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b

--- a/sysutils/tart/Portfile
+++ b/sysutils/tart/Portfile
@@ -91,10 +91,13 @@ destroot {
 }
 
 notes "
+    Install the tart-softnet port to enable softnet networking (--net-softnet),\
+    which isolates virtual machines from each other and from the host network.
+
     Bridged networking (--net-bridged) is unavailable in this build. It requires the\
-    com.apple.vm.networking entitlement, which Apple grants only to binaries signed\
-    with an approved Developer ID. Softnet networking (--net-softnet) needs the\
-    softnet helper, which is not packaged. NAT networking is unaffected.
+    com.apple.vm.networking entitlement, which Apple grants only through a\
+    provisioning profile issued to an approved developer account. NAT networking is\
+    unaffected.
 
     To avoid DHCP address shortage when running many VMs per day, consider reducing\
     the default lease time from 86400 to 600 seconds:


### PR DESCRIPTION
https://github.com/openai/softnet

#### Description

New port: `tart-softnet`, the Softnet helper for Tart. It provides software networking with isolation for Tart virtual machines on Apple's vmnet framework, isolating VMs from each other and from the host network, and alleviating DHCP address shortage when running many VMs at once.

The port is named `tart-softnet` rather than upstream's `softnet`, which is too generic for the global port namespace — the same reasoning as `devel/tldr-pages` (upstream `tldr`) and `devel/volta-node` (upstream `volta`). The installed binary keeps the upstream name `softnet`, since that is what Tart resolves from `PATH`.

It is installed setuid root: Softnet needs privileges to create vmnet interfaces and apply DHCP-related system settings, and drops them to the calling user once initialisation completes.

A second commit updates `sysutils/tart`'s notes to point at this port for `--net-softnet`, and corrects the description of how Apple grants the `com.apple.vm.networking` entitlement (via a provisioning profile, not the signing certificate).

##### Verified behaviour

Builds and installs from source on macOS 26.6 / arm64. The setuid bit survives destroot, archiving and activation — the activated binary is `-rwsr-xr-x` owned by root — and it runs as an unprivileged user, reporting the version stamped in via `SOFTNET_VERSION`.

##### Known limitations

* `dhcproto` 0.16.0 is unreleased — crates.io has only 0.15.0 — so it is vendored from git. `cargo.crates_github` cannot express it: `dhcproto` and `dhcproto-macros` are two workspace packages in one repository, and the port group emits one `[source."…"]` table per entry, so two entries would duplicate the table. `--offline --frozen` is therefore dropped so cargo fetches that single repository during build, as `sysutils/mcfly` does. The remaining 376 crates come from MacPorts distfiles as usual.
* Upstream pins `channel = "nightly"` in `rust-toolchain.toml`, but there are no `#![feature(...)]` gates in the sources and it builds with MacPorts' stable rust.
* Softnet provides NAT and host networking only (`--vm-net-type nat|host`); it is not a substitute for bridged networking, which still requires the `com.apple.vm.networking` entitlement.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install from source, and confirmed the installed binary runs?
- [x] tested basic functionality of all binary files?

Two caveats on the above, rather than leave them implied:

* Trace mode is not usable on the test host, so `sudo port -vst install` could not be run — `darwintrace.dylib` ships `x86_64 arm64` while `/usr/bin/tar` and `/usr/bin/gzip` are `arm64e`, so the `DYLD_INSERT_LIBRARIES` shim aborts during extract. The install was done without `-t`.
* End-to-end `tart run --net-softnet` against a real VM has not been exercised; verification covers the build, the installed mode and ownership, and running the binary.

`sudo port test` and variants are not applicable: the port defines no test phase and no variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
