### PR TITLE
ladybug: new port, version 0.19.1

### DIFF
--- a/databases/ladybug/Portfile
+++ b/databases/ladybug/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        LadybugDB ladybug 0.20.2 v
+github.tarball_from archive
+revision            0
+
+homepage            https://ladybugdb.com/
+
+categories          databases
+license             MIT
+maintainers         @jrjsmrtn openmaintainer
+
+description         Embedded graph database built for query speed and scalability
+
+long_description    LadybugDB is an embedded property-graph database with a \
+                    Cypher query language, forked from Kuzu after its \
+                    acquisition. It runs inside the application process rather \
+                    than as a server, targets analytical workloads over large \
+                    graphs, and provides full-text search and vector indices. \
+                    It reads and writes Parquet, Arrow and DuckDB. This port \
+                    installs the lbug shell and the C and C++ libraries.
+
+checksums           rmd160  1058544332c43cced047131c808bea05401c19c6 \
+                    sha256  c4dc6844479a799247f0cdf749522bb7597b78a97b90dbde0706601b207c928f \
+                    size    15691963
+
+# std::atomic_ref and std::format need libc++ 17, which arrived with Xcode
+# 16.3; compiler.cxx_standard alone does not express a runtime requirement.
+compiler.cxx_standard 2020
+compiler.blacklist-append \
+                    {clang < 1700}
+
+# scripts/collect-single-file-header.py assembles the installed lbug.hpp. It
+# imports only the standard library, and upstream asks for Python 3.9...4.
+# It runs at build time only: it emits a header, so nothing it produces is
+# architecture-dependent and it never reaches the installed library.
+set python_branch   3.14
+depends_build-append \
+                    port:python[string map {. {}} ${python_branch}]
+
+configure.args-append \
+                    -DPython3_EXECUTABLE=${prefix}/bin/python${python_branch}
+
+# BUILD_TESTS is not enabled: it changes the visibility preset, so the shipped
+# library would differ from a release build. lbug exits 0 on a parser error, so
+# assert on the output.
+test.run            yes
+test {
+    system -W ${build.dir} "printf 'UNWIND \[1,2,3\] AS i RETURN i;\\n' | ./tools/shell/lbug -m csv -s | grep -qx 3"
+}
+
+# cppjieba is a vendored build-time dependency of the full-text search
+# extension; its headers are not part of the LadybugDB API and would collide
+# with a future cppjieba port.
+post-destroot {
+    delete ${destroot}${prefix}/include/cppjieba \
+        ${destroot}${prefix}/share/cppjieba
+}


### PR DESCRIPTION
#### Description

New port: **ladybug** 0.19.1 — LadybugDB, an embedded property-graph database with a
Cypher query language. It is the fork and successor of Kuzu, which was shut down after
its acquisition. MIT licensed, C++20, CMake. Installs the `lbug` shell, `liblbug`
(shared and static) and the `lbug.h` / `lbug.hpp` headers.

**Carries one patch.** `patch-avx2-no-cpu-model.diff` backports upstream commit
`1027dfa82`, which replaces `__builtin_cpu_supports("avx2")` with direct CPUID/XGETBV
detection. Apple's clang lowers that builtin to a reference to `___cpu_model`, which the
Apple toolchain does not provide, so `liblbug.a` fails to link on x86_64:

```
Undefined symbols for architecture x86_64:
  "___cpu_model", referenced from: ... in liblbug.a(base_csv_reader.cpp.o)
```

See https://github.com/LadybugDB/ladybug/issues/848. The fix landed upstream after
0.19.1 was tagged, so it is not in any release yet; the patch can be dropped at the next
one. The one hunk touching `src/function/simd_filter.cpp` was omitted because that file
does not exist in 0.19.1.

**Toolchain floor.** `src/c_api/{database,connection}.cpp` use `std::atomic_ref` and
several files use `std::format`, both of which need libc++ 17 or newer, hence
`compiler.blacklist-append {clang < 1700}` (Xcode 16.3) plus
`legacysupport.use_mp_libcxx yes` so older systems get `macports-libcxx` rather than a
confusing failure. Verified against a real clang-1700.4.4.1 host, which builds with the
system compiler and pulls no `macports-clang`.

**Bundled libraries.** Upstream vendors 27 libraries under `third_party/`, 16 of which
are compiled into `liblbug`; nine duplicate existing ports (brotli, lz4, mbedtls, re2,
snappy, thrift, utf8proc, yyjson, zstd). There is no upstream option to unbuild them —
`third_party/CMakeLists.txt` adds every subdirectory unconditionally, and
`PREFER_SYSTEM_DEPS` governs only cpptrace and googletest. This matches `databases/duckdb`,
which vendors a superset of the same libraries, declares no `depends_lib` for any of them,
and links nothing from `${prefix}`. ladybug at least takes OpenSSL dynamically. I have not
attempted to unbundle; it would need a patch to `third_party/CMakeLists.txt` and every
consumer, carried across releases. Happy to revisit if you would prefer that.

**Why the Command Line Tools python.** The single-file-header generator
(`scripts/collect-single-file-header.py`) is a build-time script importing only the
standard library, and upstream requires `Python3 3.9...4`. Its architecture never reaches
the output, so making it universal buys nothing, while depending on `port:python3xx` pulls
a whole python into `+universal` builds. Pointing cmake at `/usr/bin/python3` drops a build
dependency and keeps the variant independent of that toolchain. Same approach as
`textproc/opencc`.

**Test phase.** `test.run yes` drives a query through the shell that gets installed,
rather than enabling `BUILD_TESTS`. Upstream's suite would fetch googletest over the
network at configure time unless a system copy is found, and `BUILD_TESTS` flips
`CMAKE_CXX_VISIBILITY_PRESET` from hidden to default, so the shipped library would differ
from a release build. The check asserts on output rather than exit status because `lbug`
exits 0 even on a parser error; I confirmed it fails when given an expectation the query
cannot satisfy.

Portfile drafted with AI assistance; built, `port lint`-clean, and `sudo port -vst
install` tested on the versions below. I can explain and defend every line.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

macOS 15.7.9 24G830 x86_64
Command Line Tools 26.1.0.0.1.1761104275

`sudo port -vst install` was run on the x86_64 machine only, where it succeeded and the
build log contains no `___cpu_model` reference. Trace mode cannot run on the Apple
Silicon machine at all: `darwintrace.dylib` ships `x86_64` and `arm64` slices but no
`arm64e`, so dyld refuses the insert and the port dies during extract, before any
compilation. That machine was tested with `sudo port -vs install` instead. Everything
else was run on both machines: `port lint`, `sudo port test`, basic functionality, and
`+universal`, which produced a fat `x86_64 arm64` binary on each (the x86_64 host cross-
building the arm64 slice).

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? *(both)*
- [x] tried existing tests with `sudo port test`? *(both)*
- [x] tried a full install with `sudo port -vst install`? *(on x86_64 — see note below)*
- [x] tested basic functionality of all binary files? *(both)*
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? *(`+universal`, both — the x86_64 host cross-built the arm64 slice)*
