### PR TITLE
chrony: fix build on macOS <10.12

### DIFF
--- a/sysutils/chrony/Portfile
+++ b/sysutils/chrony/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           legacysupport 1.1
 
-# strnlen
-legacysupport.newest_darwin_requires_legacy 10
+# strnlen, clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 name                chrony
 version             4.9


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?