### PR TITLE
rtorrent: fix build on macOS <11

### DIFF
--- a/net/libtorrent/Portfile
+++ b/net/libtorrent/Portfile
@@ -34,6 +34,8 @@ depends_build-append \
 depends_lib-append  port:curl \
                     path:lib/libssl.dylib:openssl
 
+patchfiles-append   include-vector.diff
+
 # malformed object (unknown load command 2)
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     depends_build-append port:cctools

--- a/net/libtorrent/files/include-vector.diff
+++ b/net/libtorrent/files/include-vector.diff
@@ -1,0 +1,10 @@
+--- src/torrent/system/scheduler.h
++++ src/torrent/system/scheduler.h
+@@ -3,6 +3,7 @@
+ 
+ #include <functional>
+ #include <thread>
++#include <vector>
+ #include <torrent/system/common.h>
+ 
+ namespace torrent::system {

--- a/net/rtorrent/Portfile
+++ b/net/rtorrent/Portfile
@@ -5,8 +5,9 @@ PortGroup           active_variants 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-# strnlen
-legacysupport.newest_darwin_requires_legacy 10
+# strnlen, std::atomic::wait
+legacysupport.newest_darwin_requires_legacy 19
+legacysupport.use_mp_libcxx yes
 
 github.setup        rakshasa rtorrent 0.16.21 v
 github.tarball_from releases
@@ -37,6 +38,8 @@ depends_lib-append  port:libtorrent \
                     path:lib/libssl.dylib:openssl \
                     port:zlib
 
+patchfiles-append   include-vector.diff
+
 # control.cc:34:15: error: aligned allocation function of type 'void
 # *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
 if {${os.platform} eq "darwin" && ${os.major} < 17} {
@@ -44,6 +47,18 @@ if {${os.platform} eq "darwin" && ${os.major} < 17} {
         configure.cxxflags-append \
                     -fno-aligned-allocation
     }
+}
+
+# waitpid_queue.cc:29:27: error: 'wait'
+# is unavailable: introduced in macOS 11.0
+# std::atomic<T>::wait is missing from the libc++ system
+# library, and Clang reports this error even with
+# macports-libcxx, so pass this flag.
+if {${os.platform} eq "darwin" && ${os.major} < 20 && ${configure.cxx_stdlib} eq "libc++"} {
+     if {[string match *clang* ${configure.compiler}]} {
+          configure.cxxflags-append \
+                    -D_LIBCPP_DISABLE_AVAILABILITY
+     }
 }
 
 # Starting with version 0.16.13, a compiler that supports C++20 is mandatory

--- a/net/rtorrent/files/include-vector.diff
+++ b/net/rtorrent/files/include-vector.diff
@@ -1,0 +1,10 @@
+--- src/utils/gzip.h
++++ src/utils/gzip.h
+@@ -2,6 +2,7 @@
+ #define RTORRENT_UTILS_GZIP_H
+ 
+ #include <functional>
++#include <vector>
+ 
+ namespace utils {
+ 


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?