### PR TITLE
py-uharfbuzz: update to 0.56.0

### DIFF
--- a/python/py-uharfbuzz/Portfile
+++ b/python/py-uharfbuzz/Portfile
@@ -4,18 +4,18 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-uharfbuzz
-version             0.53.7
+version             0.56.0
 revision            0
 categories          python graphics
 license             Apache-2
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 description         Streamlined Cython bindings for the HarfBuzz shaping engine.
 long_description    {*}${description}
-homepage            https://github.com/trufont/uharfbuzz
+homepage            https://github.com/harfbuzz/uharfbuzz
 
-checksums           rmd160  50b76ec7270d4540637bb2090f1dd0a4b61a18dc \
-                    sha256  c13cfe32accd4dc5b7e5d1c3c7bd5f04ba77be186ffd249ab1ba82a0b25b70bc \
-                    size    1869099
+checksums           rmd160  f5584aca43ab1b7cc5ba24d8598c235b7758afd8 \
+                    sha256  77f4ad1c9f32f44cc6f0c0c4f98fab54587719c96c810a043d01669f704d3e0c \
+                    size    38643044
 
 python.versions     310 311 312 313 314
 


### PR DESCRIPTION
#### Description

py-uharfbuzz: update to 0.56.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
