### PR TITLE
window-layouts: new port, version 1.3.0

### DIFF
--- a/aqua/window-layouts/Portfile
+++ b/aqua/window-layouts/Portfile
@@ -1,9 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+PortGroup           xcodeversion 1.0
 
+github.setup        baddison2005 window-layouts-macos 1.3.0 v
+github.tarball_from archive
 name                window-layouts
-version             1.3.0
 revision            0
 categories          aqua
 platforms           {darwin >= 23}
@@ -16,23 +20,28 @@ long_description    Window Layouts is a native macOS utility for arranging appli
                     windows with fixed and custom layouts, keyboard shortcuts, drag \
                     targets, monitor movement, and layout groups.
 
-homepage            https://github.com/baddison2005/window-layouts-macos
-master_sites        ${homepage}/releases/download/v${version}/
-distname            Window-Layouts-${version}-macOS
-use_dmg             yes
+checksums           rmd160  1f5fdd6465b82f1bea6d346c190117755cb7efa2 \
+                    sha256  320dc862bcd805ec97858a775ab46f21ba80da34b652b0419d6d8562aa155f48 \
+                    size    145492
 
-checksums           rmd160  17902d95922a2bb386f4d1eb6601584c128132b8 \
-                    sha256  2587a9a7f0de7265ef4b0d44af2b68bf786923045b86262fc73dcc11038601be \
-                    size    938119
+minimum_xcodeversions \
+                    {23 16.0 24 16.0 25 26.0}
 
-use_configure       no
-build               {}
+xcode.project       WindowLayouts.xcodeproj
+xcode.scheme        WindowLayouts
+xcode.configuration Release
+xcode.build.settings-append \
+                    CODE_SIGN_IDENTITY= \
+                    CODE_SIGNING_ALLOWED=NO \
+                    CODE_SIGNING_REQUIRED=NO
 
 destroot {
     xinstall -d ${destroot}${applications_dir}
-    copy "${worksrcpath}/Window Layouts.app" ${destroot}${applications_dir}
+    copy "${worksrcpath}/build/${xcode.configuration}/Window Layouts.app" \
+        ${destroot}${applications_dir}
+    system -W ${destroot}${applications_dir} \
+        "/usr/bin/codesign --force --sign - \"Window Layouts.app\""
 }
 
-livecheck.type      regex
-livecheck.url       https://api.github.com/repos/baddison2005/window-layouts-macos/releases/latest
-livecheck.regex     {"tag_name"\s*:\s*"v([0-9.]+)"}
+github.livecheck.regex \
+                    {([0-9.]+)}

--- a/aqua/window-layouts/Portfile
+++ b/aqua/window-layouts/Portfile
@@ -13,7 +13,7 @@ categories          aqua
 platforms           {darwin >= 23}
 supported_archs     x86_64 arm64
 license             GPL-3+
-maintainers         {github:baddison2005 @baddison2005} openmaintainer
+maintainers         {gmail.com:baddison2005 @baddison2005} openmaintainer
 
 description         Create and apply custom layouts to application windows
 long_description    Window Layouts is a native macOS utility for arranging application \

--- a/aqua/window-layouts/Portfile
+++ b/aqua/window-layouts/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+
+PortSystem          1.0
+
+name                window-layouts
+version             1.3.0
+revision            0
+categories          aqua
+platforms           {darwin >= 23}
+supported_archs     x86_64 arm64
+license             GPL-3+
+maintainers         {github:baddison2005 @baddison2005} openmaintainer
+
+description         Create and apply custom layouts to application windows
+long_description    Window Layouts is a native macOS utility for arranging application \
+                    windows with fixed and custom layouts, keyboard shortcuts, drag \
+                    targets, monitor movement, and layout groups.
+
+homepage            https://github.com/baddison2005/window-layouts-macos
+master_sites        ${homepage}/releases/download/v${version}/
+distname            Window-Layouts-${version}-macOS
+use_dmg             yes
+
+checksums           rmd160  17902d95922a2bb386f4d1eb6601584c128132b8 \
+                    sha256  2587a9a7f0de7265ef4b0d44af2b68bf786923045b86262fc73dcc11038601be \
+                    size    938119
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -d ${destroot}${applications_dir}
+    copy "${worksrcpath}/Window Layouts.app" ${destroot}${applications_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://api.github.com/repos/baddison2005/window-layouts-macos/releases/latest
+livecheck.regex     {"tag_name"\s*:\s*"v([0-9.]+)"}


### PR DESCRIPTION
#### Description

Adds Window Layouts, a native macOS utility for arranging application windows with fixed and custom layouts, keyboard shortcuts, drag targets, monitor movement, and layout groups.

The port installs the upstream signed and notarized universal DMG release into the MacPorts applications directory. Window Layouts requires macOS 14 or later and macOS Accessibility permission at runtime.

#### Validation

- `port lint --nitpick`: 0 errors and 0 warnings
- `port livecheck`: current at 1.3.0
- DMG SHA-256, RIPEMD-160, and size independently verified
- DMG mounted and application copy to a temporary destroot verified
- `codesign --verify --deep --strict`: valid
- `spctl --assess --type execute`: accepted, Notarized Developer ID
- notarization staple validated
- executable architectures verified as `arm64 x86_64`