### PR TITLE
xalanj: migrate to java PortGroup

### DIFF
--- a/java/xalanj/Portfile
+++ b/java/xalanj/Portfile
@@ -1,50 +1,52 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name				xalanj
-version				2.7.1
+PortSystem          1.0
 
-categories			java textproc
-license				Apache-2 Apache-1.1 W3C MIT
-maintainers			nomaintainer
-platforms			darwin
+name                xalanj
+version             2.7.1
 
-description			Apache Xerces 2 Java XML Parser
-long_description	Xalan-Java is an XSLT processor for transforming XML documents \
-					into HTML, text, or other XML document types. It implements \
-					XSL Transformations (XSLT) Version 1.0 and  XML Path Language \
-					(XPath) Version 1.0. It can be used from the command line, \
-					in an applet or a servlet, or as a module in other program.
-homepage			https://xml.apache.org/xalan-j/
+categories          java textproc
+license             Apache-2 Apache-1.1 W3C MIT
+maintainers         nomaintainer
+platforms           darwin
 
-set ver2			[string map ". _" $version]
-distname			xalan-j_${ver2}-src
-master_sites		apache:xml/xalan-j/source/
+description         Apache Xerces 2 Java XML Parser
+long_description    Xalan-Java is an XSLT processor for transforming XML documents \
+                    into HTML, text, or other XML document types. It implements \
+                    XSL Transformations (XSLT) Version 1.0 and  XML Path Language \
+                    (XPath) Version 1.0. It can be used from the command line, \
+                    in an applet or a servlet, or as a module in other program.
+homepage            https://xml.apache.org/xalan-j/
+
+set ver2            [string map ". _" $version]
+distname            xalan-j_${ver2}-src
+master_sites        apache:xml/xalan-j/source/
 
 checksums           md5     fc805051f0fe505c7a4b1b5c8db9b9e3 \
                     sha1    dfaac3bd3e18a8961c27b3d07b7405bd8a15d64a \
                     rmd160  021c239122b6b3d0bc9781abd9675c7cb5951b13
 
-depends_build		bin:ant:apache-ant
-depends_lib			bin:java:kaffe
-depends_run			port:xercesj
-					
-worksrcdir			xalan-j_${ver2}
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
+depends_run         port:xercesj
+
+worksrcdir          xalan-j_${ver2}
 
 patchfiles          build.xml.diff
 
-use_configure		no
+use_configure       no
 
-build.cmd			ant
-build.target		all docs javadocs
+build.cmd           ant
+build.target        all docs javadocs
 
-destroot	{
-	xinstall -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 \
-		${worksrcpath}/build/xalan.jar \
-		${worksrcpath}/build/serializer.jar \
-		${destroot}${prefix}/share/java/
-	file copy ${worksrcpath}/build/docs ${destroot}${prefix}/share/doc/${name}
+destroot {
+    xinstall -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 \
+        ${worksrcpath}/build/xalan.jar \
+        ${worksrcpath}/build/serializer.jar \
+        ${destroot}${prefix}/share/java/
+    file copy ${worksrcpath}/build/docs ${destroot}${prefix}/share/doc/${name}
 }
 
 livecheck.type      regex

--- a/java/xalanj/Portfile
+++ b/java/xalanj/Portfile
@@ -1,14 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           java 1.0
 
 name                xalanj
 version             2.7.1
 
 categories          java textproc
-license             Apache-2 Apache-1.1 W3C MIT
+license             Apache-2 W3C
 maintainers         nomaintainer
-platforms           darwin
+platforms           any
+supported_archs     noarch
 
 description         Apache Xerces 2 Java XML Parser
 long_description    Xalan-Java is an XSLT processor for transforming XML documents \
@@ -22,31 +24,41 @@ set ver2            [string map ". _" $version]
 distname            xalan-j_${ver2}-src
 master_sites        apache:xml/xalan-j/source/
 
-checksums           md5     fc805051f0fe505c7a4b1b5c8db9b9e3 \
-                    sha1    dfaac3bd3e18a8961c27b3d07b7405bd8a15d64a \
-                    rmd160  021c239122b6b3d0bc9781abd9675c7cb5951b13
+checksums           rmd160  021c239122b6b3d0bc9781abd9675c7cb5951b13 \
+                    sha256  fa52aa629bb882335d45d67401d270c3f21b5131aaea005ac0d4590f2ce8b043 \
+                    size    6284437
 
 depends_build       bin:ant:apache-ant
-depends_lib         bin:java:kaffe
 depends_run         port:xercesj
+
+java.version        1.3.1+
+java.fallback       openjdk11
 
 worksrcdir          xalan-j_${ver2}
 
-patchfiles          build.xml.diff
+patchfiles          remove-bootclasspath.diff \
+                    build.xml.diff
 
 use_configure       no
 
 build.cmd           ant
-build.target        all docs javadocs
+build.target        jar
 
 destroot {
-    xinstall -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
+
+    xinstall -d ${destjavadir}
     xinstall -m 644 \
         ${worksrcpath}/build/xalan.jar \
         ${worksrcpath}/build/serializer.jar \
-        ${destroot}${prefix}/share/java/
-    file copy ${worksrcpath}/build/docs ${destroot}${prefix}/share/doc/${name}
+        ${destjavadir}
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/NOTICE.txt \
+        ${destdocdir}
 }
 
 livecheck.type      regex

--- a/java/xalanj/files/remove-bootclasspath.diff
+++ b/java/xalanj/files/remove-bootclasspath.diff
@@ -1,0 +1,207 @@
+--- build.xml.orig	2007-11-23 07:44:01
++++ build.xml	2026-08-30 21:56:50
+@@ -380,7 +380,7 @@
+       <exclude name="**/IncrementalSAXSource_Xerces.java" 
+         unless="xerces.present"	 />
+       <classpath refid="compile.class.path" />
+-      <bootclasspath refid="xslt.boot.class.path" />
++      <classpath refid="xslt.boot.class.path" />
+     </javac>
+     <!-- Copy needed properties, resource, etc. files to be put into .jar file -->
+     <copy todir="${build.classes}">
+@@ -405,7 +405,7 @@
+       <include name="${xalan.reldir}/**/*.java" />
+       <exclude name="${xsltc.reldir}/**/*.java" />
+       <classpath refid="compile.class.path" />
+-      <bootclasspath refid="xslt.boot.class.path" />
++      <classpath refid="xslt.boot.class.path" />
+       <sourcepath refid="compile.source.path" />
+     </javac>
+     <!-- Copy needed properties, resource, etc. files to be put into .jar file -->
+@@ -447,7 +447,7 @@
+            includes="${xsltc.reldir}/util/**/*.java"
+            debug="${build.debug}">
+       <classpath refid="xsltc.class.path" />
+-      <bootclasspath refid="xslt.boot.class.path" />
++      <classpath refid="xslt.boot.class.path" />
+     </javac>
+     <!-- These tricky uptodate statements hopefully determine if we 
+          actually need to generate the java_cup and jlex files 
+@@ -510,7 +510,7 @@
+            excludes="${serializer.reldir}/**/*.java"
+            debug="${build.debug}"> 
+       <classpath refid="xsltc.class.path" />
+-      <bootclasspath refid="xslt.boot.class.path" />
++      <classpath refid="xslt.boot.class.path" />
+     </javac>
+   </target>
+ 
+@@ -523,7 +523,7 @@
+            includes="${xsltc.reldir}/**/*.java"
+            debug="${build.debug}">
+       <classpath refid="xsltc.class.path" />
+-      <bootclasspath refid="xslt.boot.class.path" />
++      <classpath refid="xslt.boot.class.path" />
+     </javac>
+   </target>
+ 
+@@ -722,77 +722,77 @@
+     <!-- Since the samples are packageless, they must be compiled separately. -->   
+     <javac srcdir="${samples.dir}/SimpleTransform" 
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/UseStylesheetPI"   
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/UseStylesheetParam" 
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/SAX2SAX"  
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/DOM2DOM"  
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/Pipe"  
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/UseXMLFilters"  
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/Trace"   
+            destdir="${build.samples}"  excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/ApplyXPath"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>
+     <javac srcdir="${samples.dir}/ApplyXPathDOM"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>             
+     <javac srcdir="${samples.dir}/trax"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/extensions"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>           
+     <javac srcdir="${samples.dir}/Validate"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac> 
+     <javac srcdir="${samples.dir}/TransformThread"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>
+     <javac srcdir="${samples.dir}/XPathAPI"  
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" >
++           debug="${build.debug}" classpathref="xslt.boot.class.path" >
+       <classpath refid="samples.class.path" />
+     </javac>               
+     <jar jarfile="${build.samples.jar}" basedir="${build.samples}"
+@@ -834,7 +834,7 @@
+      <javac srcdir="${samples.dir}/servlet"
+             destdir="${build.servlet}/WEB-INF/classes"
+             debug="${build.debug}"
+-            bootclasspathref="xslt.boot.class.path" >
++            classpathref="xslt.boot.class.path" >
+        <classpath refid="samples.class.path" />
+      </javac>           
+       <copy todir="${build.servlet}/WEB-INF/classes/servlet">
+@@ -874,10 +874,10 @@
+     <javac srcdir="${samples.dir}/translets"
+            classpath="${java.class.path}:${build.xalan.jar}" 
+            destdir="${build.samples}" excludes="${exclude}" 
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" />
++           debug="${build.debug}" classpathref="xslt.boot.class.path" />
+     <javac srcdir="${samples.dir}/CompiledJAXP"
+            destdir="${build.samples}" excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" />
++           debug="${build.debug}" classpathref="xslt.boot.class.path" />
+   </target>
+ 
+   <!-- =================================================================== -->
+@@ -889,7 +889,7 @@
+     <mkdir dir="${build.samples}/CompiledApplet"/>
+     <javac srcdir="${samples.dir}/CompiledApplet"
+            destdir="${build.samples}/CompiledApplet" excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" />
++           debug="${build.debug}" classpathref="xslt.boot.class.path" />
+     <jar jarfile="${build.xsltc.applet.jar}"
+          basedir="${build.samples}/CompiledApplet"
+          includes="*.class"/>
+@@ -904,7 +904,7 @@
+     <mkdir dir="${build.samples}/CompiledBrazil"/>
+     <javac srcdir="${samples.dir}/CompiledBrazil"
+            destdir="${build.samples}/CompiledBrazil" excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" />
++           debug="${build.debug}" classpathref="xslt.boot.class.path" />
+     <jar jarfile="${build.xsltc.brazil.jar}"
+          basedir="${build.samples}/CompiledBrazil"
+          includes="*.class"/>
+@@ -921,7 +921,7 @@
+     <mkdir dir="${build.samples}/CompiledEJB"/>
+     <javac srcdir="${samples.dir}/CompiledEJB"
+            destdir="${build.samples}/CompiledEJB" excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" />
++           debug="${build.debug}" classpathref="xslt.boot.class.path" />
+     <jar jarfile="${build.xsltc.ejb.jar}"
+          basedir="${build.samples}/CompiledEJB"
+          includes="*.class"/>
+@@ -936,7 +936,7 @@
+     <mkdir dir="${build.samples}/CompiledServlet"/>
+     <javac srcdir="${samples.dir}/CompiledServlet"
+            destdir="${build.samples}/CompiledServlet" excludes="${exclude}"
+-           debug="${build.debug}" bootclasspathref="xslt.boot.class.path" />
++           debug="${build.debug}" classpathref="xslt.boot.class.path" />
+     <jar jarfile="${build.xsltc.servlet.jar}"
+          basedir="${build.samples}/CompiledServlet"
+          includes="*.class"/>
+@@ -1644,7 +1644,7 @@
+            debug="${serializer.build.debug}" >
+       <include name="${serializer.reldir}/**/*.java" />
+       <classpath refid="compile.class.path" />
+-      <bootclasspath refid="xslt.boot.class.path" />
++      <classpath refid="xslt.boot.class.path" />
+     </javac>
+     <!-- Copy needed properties, resource, etc. files to be put into .jar file -->
+     <copy todir="${serializer.build.classes}">


### PR DESCRIPTION
#### Description

Replace the dependency on `kaffe` with the `java` PortGroup, add a patch to fix builds with JDK 9+, and fix up the Portfile's formatting.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?