### PR TITLE
tilemaker: update to 3.2.0

### DIFF
--- a/gis/tilemaker/Portfile
+++ b/gis/tilemaker/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
-github.setup        systemed tilemaker 3.1.0 v
+github.setup        systemed tilemaker 3.2.0 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ long_description    {*}${description}
 
 installs_libs       no
 
-checksums           rmd160  129d5b4efb6bd2e9f7e4150cf0cc4eda884c2e9d \
-                    sha256  3b0b26aed96e12e9ebf50ea13878c4115aec6c0b4b5798eda41384449cb6c5d7 \
-                    size    43826872
+checksums           rmd160  7381efd8539506e0765ef7e01c50433b9209f9ec \
+                    sha256  7f8a49412e6e0fbe8d9230ccf8ec8a9be442c9d765d4bd6a63465ca82c087f75 \
+                    size    43860516
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
https://github.com/systemed/tilemaker/releases/tag/v3.2.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
