### PR TITLE
llmfit: update to 1.1.12

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 1.1.11 v
+github.setup            AlexsJones llmfit 1.1.12 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  74231743468c771fa6359781ded4ea6c6c4d5518 \
-                        sha256  918397ac1191b57c2e1dafba8fc0f707326620c6807752aa67a2626cbde5ea32 \
-                        size    8260623
+                        rmd160  05279eb7d4bc92f252fe24e7253098f723da46bb \
+                        sha256  3425decb13d7f614f6aeaecd63698c9f6e681e5f696ccd88691d8c0fd2bf230a \
+                        size    8264471
 
 categories              llm
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
