### PR TITLE
mbusd: update to 0.5.3

### DIFF
--- a/net/mbusd/Portfile
+++ b/net/mbusd/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        3cky mbusd 0.5.2 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        3cky mbusd 0.5.3 v
+github.tarball_from archive
 revision            0
 categories          net
 license             BSD
@@ -14,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Modbus TCP to Modbus RTU (RS-232/485) gateway
 long_description    {*}${description}
 
-checksums           rmd160  5a26ff400c9e7ceac5510ef284192c887a5a2097 \
-                    sha256  885e8150de852a43990e7f76d1fffb291b047141f3b7d2bca4571c210b43ae8a \
-                    size    45752
+checksums           rmd160  c7609cd903ba79aefa97571f42180fe2c8de2169 \
+                    sha256  9bca31bb86aa4db50826ee53e967e6736abd42554941aab7fb389938287454bb \
+                    size    46730
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
https://github.com/3cky/mbusd/releases/tag/v0.5.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
