### PR TITLE
symfony-cli: update to 5.20.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.17.1
+version             5.20.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,17 +44,17 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  c77dc9c1a99aba4e32434b37cef8e388f6463fe6 \
-                        sha256  879782e8b8c6d6263e4d2a72f2283879f1c645c5f87db5cdd8a4bd8182e2ee37 \
-                        size    291243
+    checksums           rmd160  e6b4fadbd988adb3cbc08d86d8837aae7a4ff5b0 \
+                        sha256  07e528495409a1ba147a7a3905086f50c629762c60d186547d5483148e7a2cc2 \
+                        size    315015
 } else {
     build {}
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  121b3094df282f922b2693d136c4fc0a9e99bcd7 \
-                        sha256  4e25680428e99f44a4eaf19f33dc51ef9fac27508b08c68a4ff08877213a6f97 \
-                        size    12441360
+    checksums           rmd160  5089b46966572564345f90762e3714188648a4a1 \
+                        sha256  580f1da0e56499848c14db22530c7da690bc74804c2b2468b8484409d60297e4 \
+                        size    13713948
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.20.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
