### PR TITLE
gdcm: Update to 3.2.11

### DIFF
--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -8,13 +8,14 @@ PortGroup               legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup            malaterre GDCM 3.2.8 v
+github.setup            malaterre GDCM 3.2.11 v
 revision                0
 
 name                    gdcm
 categories              science graphics
 license                 BSD
-maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+maintainers             {@Dave-Allured noaa.gov:dave.allured} \
+                        openmaintainer
 description             a C++ library for DICOM medical files
 long_description        Grassroots DiCoM is a C++ library for DICOM medical files.
 
@@ -22,9 +23,9 @@ long_description        Grassroots DiCoM is a C++ library for DICOM medical file
 homepage                https://sourceforge.net/projects/gdcm/
 
 github.tarball_from     archive
-checksums               rmd160  35be4e0d6afed61bf7ed82f58abcccc7c20ddc76 \
-                        sha256  bf9f75af2607adb8a4ee0e30dd3d61f61e8dc4e5229c748bdcc72c1c546fd232 \
-                        size    4111429
+checksums               rmd160  ce52686a788d762a3f348ce874147e8adc02d985 \
+                        sha256  3969bd514674bcfeb8f09df58de86dbc8a5eb1bd8ad5d0b1061567da8ce10f78 \
+                        size    4112404
 
 compiler.cxx_standard   2014
 


### PR DESCRIPTION
#### Description

* Update gdcm 3.2.8 --> 3.2.11.
* Take maintainership.  Port seemed to be abandoned.

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?