### PR TITLE
whisper-cli 0.211.0: new port

### DIFF
--- a/net/whisper-cli/Portfile
+++ b/net/whisper-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/whisper-sec/whisper-cli 0.210.1 v
+go.setup            github.com/whisper-sec/whisper-cli 0.211.0 v
 go.toolchain_min    1.25
 categories          net security
 maintainers         {kaveh.org:kaveh @kakooch} \
@@ -35,9 +35,9 @@ is called 'whisper'.
 "
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  8d8c7e00556c60af01ae6518090e1aa718f34014 \
-                        sha256  5c40e8a1c15cd61e94bf1975e5059adeff8701323ec41adc814206463ead9e5c \
-                        size    954217
+                        rmd160  ebb3c9cf2e38ce142707dc5f0c19b89432735f36 \
+                        sha256  77abdb9a2ea222b5060249f59fd951179ac53defb24ce2c014ba91097dc0abd4 \
+                        size    1352893
 
 go.vendors          gvisor.dev/gvisor \
                         repo    github.com/google/gvisor \

--- a/net/whisper-cli/Portfile
+++ b/net/whisper-cli/Portfile
@@ -1,0 +1,277 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/whisper-sec/whisper-cli 0.210.1 v
+go.toolchain_min    1.25
+categories          net security
+maintainers         {kaveh.org:kaveh @kakooch} \
+                    openmaintainer
+license             MIT
+
+description         Give an AI agent a routable IPv6 identity and safe egress
+
+long_description    The Whisper CLI gives an AI agent a real, routable IPv6 /128 \
+                    address out of AS219419 as its identity: reverse DNS, RDAP and \
+                    a DANE-published key make it verifiable from the outside by \
+                    anyone, with no account. It also brings up egress that leaves \
+                    from that same address, so what an agent does is attributable \
+                    to the address it did it from. Register, connect and verify are \
+                    one command each, and the verification half needs no API key.
+
+homepage            https://whisper.online
+
+# The MacPorts port that owns ${prefix}/bin/whisper is audio/whisper, which is
+# whisper.cpp, the speech recogniser. Unrelated software, same obvious name. So
+# this port installs its binary as whisper-cli rather than take a name another
+# port already installs, and says so in notes: everywhere else the command is
+# whisper.
+notes               "
+The command this port installs is 'whisper-cli'. The name 'whisper' is already
+taken in MacPorts by the unrelated audio/whisper port (whisper.cpp), so this
+port does not install a file under that name. Everywhere else the Whisper CLI
+is called 'whisper'.
+"
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  8d8c7e00556c60af01ae6518090e1aa718f34014 \
+                        sha256  5c40e8a1c15cd61e94bf1975e5059adeff8701323ec41adc814206463ead9e5c \
+                        size    954217
+
+go.vendors          gvisor.dev/gvisor \
+                        repo    github.com/google/gvisor \
+                        lock    39ed1f5ac29c \
+                        rmd160  9946d9a7a733c444c5b967f5b42b726b47b944c4 \
+                        sha256  68fc402aefd6aa0a575707d1e4adc86bd08b653e94c574da8a2693bce4da85e1 \
+                        size    3441915 \
+                    golang.zx2c4.com/wireguard \
+                        repo    github.com/WireGuard/wireguard-go \
+                        lock    ecfc5a8d5446 \
+                        rmd160  d52606d201d996a1a7a3db893214a1c52a8bb51a \
+                        sha256  ae1a6fa832fb12fae14e53352234293cd19421fee172c526e7cd118d78506739 \
+                        size    116597 \
+                    golang.org/x/tools \
+                        lock    v0.47.0 \
+                        rmd160  80cd1d75559acc4ae15befd07f6db5d2e822a6a2 \
+                        sha256  723f8d6c365335085375622961b77bb87fb546fb7010414bbdc49e5aa74cf782 \
+                        size    8538575 \
+                    golang.org/x/time \
+                        lock    v0.7.0 \
+                        rmd160  1885aebb7c781f6333bfed2447ab9ae9c47bf13b \
+                        sha256  3e73eda4d6e1cd90fe9927871e6db02f0e1d56522e2cbc90e6017555ef9a5ecf \
+                        size    12358 \
+                    golang.org/x/text \
+                        lock    v0.40.0 \
+                        rmd160  75205b5abd0d36bd9508c4cf056b035a02e39739 \
+                        sha256  35fdb039fb974052bc42cd655ee47c141298f1a1962279828e921c6f7130a0d8 \
+                        size    6772390 \
+                    golang.org/x/sys \
+                        lock    v0.47.0 \
+                        rmd160  1be59a8208fd6f7f4319b306138e77f215293e1a \
+                        sha256  2bed220513067f721fc7c19314bab58860c28397f5e48093a8fe35a27a915b06 \
+                        size    1551474 \
+                    golang.org/x/sync \
+                        lock    v0.22.0 \
+                        rmd160  20621d3bf14d184401e9078618e77033788ab04a \
+                        sha256  e074c1cec8b65ba20ce0aa41d3a3a569b6f2e9022d9556869d0f1ef65a0e1777 \
+                        size    18247 \
+                    golang.org/x/net \
+                        lock    v0.57.0 \
+                        rmd160  32c1b1c4903de772168076e5747a60c0b27f245e \
+                        sha256  1f5e7fae3267c8d518156b2b6e24c7f92175c82e6e2a7e8383b41cf50805c600 \
+                        size    1443429 \
+                    golang.org/x/mod \
+                        lock    v0.37.0 \
+                        rmd160  71bdd60a665fc88675fae5cdf4d6ee38c955a5c9 \
+                        sha256  ed635c68e03084780a3756ec1b5f7245f69c4675f551b29156999287c4ea5515 \
+                        size    128406 \
+                    golang.org/x/crypto \
+                        lock    v0.54.0 \
+                        rmd160  a146f82dd107e0a114fbf2b03c5fb2e7fb5b212c \
+                        sha256  97ea67bc6e37dc3db07526c4ee90099da469b3b8c118b28cf25b4cdcddb4278e \
+                        size    2158822 \
+                    github.com/xo/terminfo \
+                        lock    abceb7e1c41e \
+                        rmd160  03f45e9801b38da949e34fec0c1881c96d6fa37d \
+                        sha256  c8f968af54b9283119a9132ff6748f081afdd6b52deef111f6ac680c00a01f19 \
+                        size    35179 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cobra \
+                        lock    v1.8.1 \
+                        rmd160  a735ec73fa26b66076a971e066513fff3eb7e367 \
+                        sha256  49ca05093e0452e1b56be8a0765e23fd74be819228f0e1870c759b2e2e8178da \
+                        size    192387 \
+                    github.com/smallstep/pkcs7 \
+                        lock    v0.2.3 \
+                        rmd160  138552f50d69d8371206a5dfcca07abb54a923ec \
+                        sha256  81772880eeef6842b31c91a56e539188da6045cf87a4dcec1b4f06ddef0d77e9 \
+                        size    112666 \
+                    github.com/rivo/uniseg \
+                        lock    v0.4.7 \
+                        rmd160  a9056dc9a2a80aa9c46d0ff9e54f9e2e5a498c41 \
+                        sha256  abc6a2f17b64b34b8a0c56eb9d0b53886ebbe0c88d467755c09c7fa696a16677 \
+                        size    458166 \
+                    github.com/muesli/termenv \
+                        lock    v0.16.0 \
+                        rmd160  463214c9628bd837b8372a1fc4e97741390c6c39 \
+                        sha256  d7c5257a53385dfc5a362aa1e28ae1667c18610f61db203a482784b1ea4b3f74 \
+                        size    422997 \
+                    github.com/muesli/cancelreader \
+                        lock    v0.2.2 \
+                        rmd160  cbc757f0d680959cea46000a5dd74e63ddbb8a15 \
+                        sha256  33f793cd6fbf7733ed7cba381920606b4917ba472148f85a5fd0965477146fc8 \
+                        size    9431 \
+                    github.com/muesli/ansi \
+                        lock    276c6243b2f6 \
+                        rmd160  bbc37c92ce2b54f538eb0d5f32edefd7074d540a \
+                        sha256  0b4beac5757eb25d0c45f9f931e2b241168e16c2bd58d21e5aafce7e33c669ee \
+                        size    5249 \
+                    github.com/mitchellh/hashstructure/v2 \
+                        lock    v2.0.2 \
+                        rmd160  9044adcba30a6c7cf7c97ae8a20329a73bac24ce \
+                        sha256  855ba6ee0a14f0bc88af9d82fb6ab564cc4456f296058270ce7b55800fe3f09e \
+                        size    9005 \
+                    github.com/miekg/dns \
+                        lock    v1.1.72 \
+                        rmd160  71a272dc063db92ac59e7dd173129b07104bb58b \
+                        sha256  f1d87d4ad424d2c083493cb00e6f830d09451cf0fa4d1503fc9e82a194ea27c1 \
+                        size    223347 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.19 \
+                        rmd160  b0f62e2f1c2086189f2ed14ad635733c4e5ced56 \
+                        sha256  6f5a00cdfbf4d88d05406a07bb95c34dc0abc2f65f15e9c5ca35814f4008b82f \
+                        size    20550 \
+                    github.com/mattn/go-localereader \
+                        lock    v0.0.1 \
+                        rmd160  7afdbbc0f4978c6f54c25df0d86ff3c66db19ce2 \
+                        sha256  75a68e82a83b37aee40ad81dfcfce54d2f999945282bb198add16a49b8ec7f46 \
+                        size    1738 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.3.0 \
+                        rmd160  f32cca200fcf4db4d0e51cc457baf68f212d8965 \
+                        sha256  4168f7454b19120873f75a67d1eeb7be312ea852542e21db1a96b65e514e56c2 \
+                        size    982361 \
+                    github.com/kardianos/service \
+                        lock    v1.3.0 \
+                        rmd160  c45927fd8038469d44fb467675bf00b140e0fb0b \
+                        sha256  66385e6a08350164688f67af01054de3157b47a72ef4c038a034070aaed69049 \
+                        size    38066 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
+                    github.com/google/btree \
+                        lock    v1.1.2 \
+                        rmd160  eb1f3f67b53dab641253929ea27331535abc1169 \
+                        sha256  313d9beb63d42ce7dd524c0d06f5be81d6ded1a0a667fb3e868129f4b9657ca0 \
+                        size    19785 \
+                    github.com/erikgeiser/coninput \
+                        lock    1c3628e74d0f \
+                        rmd160  77744cb442933c6c38c33aa830419834ba8e0ed6 \
+                        sha256  39ca6afc6b66e6c6a1772b497fdd0bb97471fac341c966fcae14ff6019629638 \
+                        size    8951 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.1 \
+                        rmd160  3c799a1cbda2e82f3d35ec20e539581fd9c24b9d \
+                        sha256  aa5a5059ebd8fffc9e9b9e3c888d85cdb1f4c8f7b73944a6c027647039a83df7 \
+                        size    17709 \
+                    github.com/cloudflare/circl \
+                        lock    v1.6.4 \
+                        rmd160  1d38e04d3801edefda143299d73e48fda980f067 \
+                        sha256  eb1c3a988235d1751179bdf9ae24ed993f352084ccab50a2ccd21528c0393de7 \
+                        size    48339832 \
+                    github.com/clipperhouse/uax29/v2 \
+                        lock    v2.5.0 \
+                        rmd160  125722e2638157946407f0be25e3e46f69a777b7 \
+                        sha256  64652c06538cf011435bdc7be18693b4f646607c329f16f243bf5d11d5ab4eb9 \
+                        size    315597 \
+                    github.com/clipperhouse/stringish \
+                        lock    v0.1.1 \
+                        rmd160  83e859a426d4041c5fc3d756c082786bd4d8132c \
+                        sha256  8ff258affd8bbada149f5ef799bf99391494faa86a9fa88f04c26c51db63db12 \
+                        size    2316908 \
+                    github.com/clipperhouse/displaywidth \
+                        lock    v0.9.0 \
+                        rmd160  ea7f861726b614a324b33ed63b7ac10d52535587 \
+                        sha256  b2f16b702173d452dde0130b4b59a5f3bc0a20d65043ac5961d06a79ffb9a4cc \
+                        size    242214 \
+                    github.com/charmbracelet/x/term \
+                        lock    term/v0.2.2 \
+                        rmd160  bf64de8c6de1ada687ddb996fa0372feb50550f4 \
+                        sha256  7361d37cbc6fd64ea39a10c50a611f58715928bf01fbbb5cb4ecd1a93e6bdeb6 \
+                        size    395863 \
+                    github.com/charmbracelet/x/exp/strings \
+                        lock    212f7b056ed0 \
+                        rmd160  4e453c10c95dbb16fdf59ed5eae838cc3d4e64b8 \
+                        sha256  b381432b967adccd6a522c0d51078e5f504e8d6cc3480e35ac5eb6e04d1f0fea \
+                        size    222066 \
+                    github.com/charmbracelet/x/cellbuf \
+                        lock    cellbuf/v0.0.15 \
+                        rmd160  e5050f0a8c51c6e33d359af222bda64d6551bf05 \
+                        sha256  874860088d8811780b27ce7771df340a27f5f0680cc585b2cb4301e3725a799d \
+                        size    518191 \
+                    github.com/charmbracelet/x/ansi \
+                        lock    ansi/v0.11.6 \
+                        rmd160  00a4a0fd678c64f7e0fc0d70de62594737aed28e \
+                        sha256  920fd5e616a1749dbb80b483360db378ee9db96ed120900814ae963a4a259b05 \
+                        size    518326 \
+                    github.com/charmbracelet/lipgloss \
+                        lock    v1.1.0 \
+                        rmd160  c754345ebdcdfef38263a8ca9a4dcf76b758a77f \
+                        sha256  ef19e44ed60b132285a119fbdede4443d270fe570f998187f021596af7a16c02 \
+                        size    97409 \
+                    github.com/charmbracelet/huh \
+                        lock    v1.0.0 \
+                        rmd160  6ff3996e894d8766429a4e4beedfe7f24c220d5a \
+                        sha256  760578c9fa4fbdecd013d5199b56ad534e256d69464e3b606c6a81b6c4a73a54 \
+                        size    88320 \
+                    github.com/charmbracelet/colorprofile \
+                        lock    v0.4.1 \
+                        rmd160  8064418d3ae93cf94d1f55e0051bd80a9da58ef7 \
+                        sha256  09b38eca6b39f8df8c0ee2f6ce535ee152e405ebd2d7c6cc9f85a1ec4ad2c44a \
+                        size    15488 \
+                    github.com/charmbracelet/bubbletea \
+                        lock    v1.3.10 \
+                        rmd160  55c64f7a82cbce8d642b1d83a8e454a16a82bcff \
+                        sha256  d156fcd744922409200bbde4430e2fb93753a5c64665cfd173e982f442664236 \
+                        size    2191651 \
+                    github.com/charmbracelet/bubbles \
+                        lock    v1.0.0 \
+                        rmd160  c437089cdf3fd5f960d12a7b2eb3520c4dd59af1 \
+                        sha256  0a22c0c6dec928719aae2dcebc4e865431f132dc37549432a8aec4954fb6efd1 \
+                        size    82758 \
+                    github.com/catppuccin/go \
+                        lock    v0.3.0 \
+                        rmd160  0738e507a9574bde4e4636072341b8511c610314 \
+                        sha256  53594ed6d7e23c767e05d69b6625c1733006cd5ac83b548c82d54aa076618f94 \
+                        size    225968 \
+                    github.com/aymanbagabas/go-osc52/v2 \
+                        lock    v2.0.1 \
+                        rmd160  8669f2bdcf2704bbc8df6af7e5fd396215737b9b \
+                        sha256  0904dc990e2f1e5bbe290e02f418940def4168b63e36914e3bf76ff2ac1fb2a5 \
+                        size    5889 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023
+
+build.args-append   -trimpath \
+                    -ldflags "-s -w -X ${go.package}/internal/cli.Version=${version}" \
+                    -o ${worksrcpath}/${name} \
+                    ./cmd/whisper
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port: `net/whisper-cli`, the CLI for the Whisper agent identity network. It gives an AI agent a real, routable IPv6 /128 out of AS219419 as its identity (reverse DNS, RDAP and a DANE-published key make it verifiable by anyone, no account needed), and brings up egress that leaves from that same address. MIT, upstream <https://github.com/whisper-sec/whisper-cli>.

**Name.** The port installs `${prefix}/bin/whisper-cli`, not `whisper`. `${prefix}/bin/whisper` is already installed by `audio/whisper` (whisper.cpp, the speech recogniser), which is unrelated software that happened on the same obvious name, so this port takes neither the port name nor the file. A `notes` block tells the user what the command is called and why.

**Portfile.** Generated with `go2port` and then corrected by hand:

- `golang.zx2c4.com/wireguard` needed `repo github.com/WireGuard/wireguard-go`. go2port guessed a GitLab-shaped URL under `git.zx2c4.com`, which 404s, and `go.vendors` cannot fetch from that host in any case.
- `golang.zx2c4.com/wintun` is dropped. It has no mirror on a host `go.vendors` supports, and it is Windows-only: `GOOS=darwin go list -deps ./cmd/whisper` pulls `golang.zx2c4.com/wireguard/...` and `gvisor.dev/gvisor/...` but never wintun.
- `go.toolchain_min 1.25`. The build is offline/GOPATH mode, so go.mod is not consulted, but the source really does need a recent toolchain: on Go 1.23 it fails with ``cannot find package "crypto/hkdf"`` (reached through `golang.org/x/crypto/hkdf`), which is stdlib only from Go 1.24. Upstream's go.mod declares `go 1.25.13`, so that is the floor declared here. MacPorts ships Go 1.26.

**Testing.** I do not have a macOS machine, so this has not been through `port lint` or a real `port install`; I am relying on the PR builders for that and will fix whatever they report. What I could check off-Mac:

- the exact build MacPorts would run, reproduced on Linux with the same environment the portgroup sets (`GOPATH` populated from the `go.vendors` set, `GO111MODULE=off GOPROXY=off GOTOOLCHAIN=local`, `GOOS=darwin GOARCH=arm64`), builds `./cmd/whisper` cleanly and produces a Mach-O arm64 binary. So the vendor set is complete for a darwin build;
- every `go.vendors` checksum was verified against the `codeload.github.com/.../legacy.tar.gz/<lock>` URL the portgroup actually fetches, and the distfile checksum against the `github.com/.../archive/v0.210.1.tar.gz` that `github.tarball_from archive` fetches;
- the Portfile parses as Tcl.

Happy to adjust anything, including the binary name if you would rather see a different resolution of the `whisper` collision.
