### PR TITLE
jmock2: update to 2.14.0

### DIFF
--- a/java/jmock2/Portfile
+++ b/java/jmock2/Portfile
@@ -1,15 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           java 1.0
 PortGroup           github 1.0
+PortGroup           maven 1.0
 
 name                jmock2
-github.setup        jmock-developers jmock-library 2.13.1
+github.setup        jmock-developers jmock-library 2.14.0
 github.tarball_from archive
 categories          java
 license             BSD
 maintainers         nomaintainer
+platforms           any
+supported_archs     noarch
 
 description         Library for testing Java code using mock objects
 long_description    jMock is a library that supports test-driven \
@@ -18,50 +20,58 @@ long_description    jMock is a library that supports test-driven \
                     between the objects in your programs.
 homepage            https://www.jmock.org/
 
-checksums           rmd160  e14d85ad2b93e99f73aff9b16c2a6731b29f6f65 \
-                    sha256  cab2485cda6315ed6cc043c4562c0cf4abf7168f18d672d615d52f0477549b60 \
-                    size    275026
+checksums           rmd160  5474af21c1f1baff09bd704698bfa718c737fec3 \
+                    sha256  81eec9509566fd53f5e23ece1e9d4c7df972eabbfb6ae0ff1611b5315bf485e2 \
+                    size    114028
 
-use_zip             yes
+java.version        1.8+
+java.fallback       openjdk11
 
-depends_build       bin:mvn3:maven3
-
-depends_lib         bin:java:kaffe \
-                    port:cglib \
-                    port:hamcrest-core \
-                    port:objenesis
-
-use_configure       no
-
-set maven_local_repository ${worksrcpath}/.m2/repository
-pre-build {
-    file mkdir ${maven_local_repository}
+# Remove on next update if fixed!
+patchfiles          correct-version.diff
+post-patch {
+    reinplace -W ${worksrcpath} \
+        "s|@@VERSION@@|${version}|g" \
+        pom.xml \
+        jmock/pom.xml \
+        jmock-example/pom.xml \
+        jmock-imposters/pom.xml \
+        jmock-imposters-testdata/pom.xml \
+        jmock-imposters-tests/pom.xml \
+        jmock-junit3/pom.xml \
+        jmock-junit4/pom.xml \
+        jmock-junit5/pom.xml \
+        jmock-legacy/pom.xml \
+        testjar/pom.xml
 }
 
-build.cmd           mvn3
-build.target        package
-build.env-append    GRADLE_USER_HOME=${worksrcpath}/${name}
-build.pre_args      install \
-                    -Dmaven.repo.local=${maven_local_repository} \
-                    -DskipTests \
-                    -pl '!jmock-imposters-testdata'
+build.args-append   --projects !jmock-example \
+                    --projects !jmock-imposters-testdata \
+                    --projects !jmock-imposters-tests
 
 destroot {
-    set javadir ${destroot}${prefix}/share/java
-    set docdir  ${destroot}${prefix}/share/doc/${name}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
+    set modules {
+        jmock
+        jmock-imposters
+        jmock-junit3
+        jmock-junit4
+        jmock-junit5
+        jmock-legacy
+    }
 
-    xinstall -d -m 755 ${javadir}
-    xinstall -d -m 755 ${docdir}
+    xinstall -d ${destjavadir}
+    foreach module ${modules} {
+        xinstall -m 644 \
+            ${worksrcpath}/${module}/target/${module}-${version}.jar \
+            ${destjavadir}/${module}.jar
+    }
 
-    file copy ${worksrcpath}/jmock/target/jmock-${version}.jar \
-        ${javadir}/jmock2.jar
-    file copy ${worksrcpath}/jmock-junit3/target/jmock-junit3-${version}.jar \
-        ${javadir}/jmock2-junit3.jar
-    file copy ${worksrcpath}/jmock-junit4/target/jmock-junit4-${version}.jar \
-        ${javadir}/jmock2-junit4.jar
-    file copy ${worksrcpath}/jmock-junit5/target/jmock-junit5-${version}.jar \
-        ${javadir}/jmock2-junit5.jar
-    file copy ${worksrcpath}/jmock-legacy/target/jmock-legacy-${version}.jar \
-        ${javadir}/jmock2-legacy.jar
-    file copy ${worksrcpath}/jmock/target/site/apidocs ${docdir}/api
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/README.DEVELOPMENT \
+        ${worksrcpath}/README.md \
+        ${destdocdir}
 }

--- a/java/jmock2/Portfile
+++ b/java/jmock2/Portfile
@@ -1,65 +1,67 @@
-PortSystem 1.0
-PortGroup		java 1.0
-PortGroup		github 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			jmock2
-github.setup    jmock-developers jmock-library 2.13.1
+PortSystem          1.0
+PortGroup           java 1.0
+PortGroup           github 1.0
+
+name                jmock2
+github.setup        jmock-developers jmock-library 2.13.1
 github.tarball_from archive
-categories		java
-license			BSD
-maintainers		nomaintainer
+categories          java
+license             BSD
+maintainers         nomaintainer
 
-description		Library for testing Java code using mock objects
-long_description	jMock is a library that supports test-driven \
-			development of Java code with mock objects.  Mock \
-			objects help you design and test the interactions \
-			between the objects in your programs.
-homepage		https://www.jmock.org/
+description         Library for testing Java code using mock objects
+long_description    jMock is a library that supports test-driven \
+                    development of Java code with mock objects.  Mock \
+                    objects help you design and test the interactions \
+                    between the objects in your programs.
+homepage            https://www.jmock.org/
 
-checksums		rmd160  e14d85ad2b93e99f73aff9b16c2a6731b29f6f65 \
-            	sha256  cab2485cda6315ed6cc043c4562c0cf4abf7168f18d672d615d52f0477549b60 \
-            	size    275026
+checksums           rmd160  e14d85ad2b93e99f73aff9b16c2a6731b29f6f65 \
+                    sha256  cab2485cda6315ed6cc043c4562c0cf4abf7168f18d672d615d52f0477549b60 \
+                    size    275026
 
-use_zip			yes
+use_zip             yes
 
-depends_build	bin:mvn3:maven3
+depends_build       bin:mvn3:maven3
 
-depends_lib		bin:java:kaffe \
-			port:cglib \
-			port:hamcrest-core \
-			port:objenesis
+depends_lib         bin:java:kaffe \
+                    port:cglib \
+                    port:hamcrest-core \
+                    port:objenesis
 
-use_configure		no
+use_configure       no
 
 set maven_local_repository ${worksrcpath}/.m2/repository
 pre-build {
     file mkdir ${maven_local_repository}
 }
 
-build.cmd		mvn3
-build.target	package
-build.env-append GRADLE_USER_HOME=${worksrcpath}/${name}
-build.pre_args	install \
-                -Dmaven.repo.local=${maven_local_repository} \
-                -DskipTests \
-				-pl '!jmock-imposters-testdata'
+build.cmd           mvn3
+build.target        package
+build.env-append    GRADLE_USER_HOME=${worksrcpath}/${name}
+build.pre_args      install \
+                    -Dmaven.repo.local=${maven_local_repository} \
+                    -DskipTests \
+                    -pl '!jmock-imposters-testdata'
 
 destroot {
-	set javadir ${destroot}${prefix}/share/java
-	set docdir ${destroot}${prefix}/share/doc/${name}
+    set javadir ${destroot}${prefix}/share/java
+    set docdir  ${destroot}${prefix}/share/doc/${name}
 
-	xinstall -d -m 755 ${javadir}
-	xinstall -d -m 755 ${docdir}
+    xinstall -d -m 755 ${javadir}
+    xinstall -d -m 755 ${docdir}
 
-	file copy ${worksrcpath}/jmock/target/jmock-${version}.jar \
-		${javadir}/jmock2.jar
-	file copy ${worksrcpath}/jmock-junit3/target/jmock-junit3-${version}.jar \
-		${javadir}/jmock2-junit3.jar
-	file copy ${worksrcpath}/jmock-junit4/target/jmock-junit4-${version}.jar \
-		${javadir}/jmock2-junit4.jar
-	file copy ${worksrcpath}/jmock-junit5/target/jmock-junit5-${version}.jar \
-		${javadir}/jmock2-junit5.jar
-	file copy ${worksrcpath}/jmock-legacy/target/jmock-legacy-${version}.jar \
-		${javadir}/jmock2-legacy.jar
-	file copy ${worksrcpath}/jmock/target/site/apidocs ${docdir}/api
+    file copy ${worksrcpath}/jmock/target/jmock-${version}.jar \
+        ${javadir}/jmock2.jar
+    file copy ${worksrcpath}/jmock-junit3/target/jmock-junit3-${version}.jar \
+        ${javadir}/jmock2-junit3.jar
+    file copy ${worksrcpath}/jmock-junit4/target/jmock-junit4-${version}.jar \
+        ${javadir}/jmock2-junit4.jar
+    file copy ${worksrcpath}/jmock-junit5/target/jmock-junit5-${version}.jar \
+        ${javadir}/jmock2-junit5.jar
+    file copy ${worksrcpath}/jmock-legacy/target/jmock-legacy-${version}.jar \
+        ${javadir}/jmock2-legacy.jar
+    file copy ${worksrcpath}/jmock/target/site/apidocs ${docdir}/api
 }

--- a/java/jmock2/files/correct-version.diff
+++ b/java/jmock2/files/correct-version.diff
@@ -1,0 +1,146 @@
+It appears upstream forgot to update the project version in the build
+system when tagging the release.  Alter the pom.xml files to allow the
+proper version to be easily substituted in.
+
+--- pom.xml.orig	2025-09-21 09:12:19
++++ pom.xml	2026-08-31 19:18:50
+@@ -7,7 +7,7 @@
+ 
+     <groupId>org.jmock</groupId>
+     <artifactId>jmock-parent</artifactId>
+-    <version>2.13.2-SNAPSHOT</version>
++    <version>@@VERSION@@</version>
+     <packaging>pom</packaging>
+     <name>jMock 2 Parent</name>
+ 
+--- jmock/pom.xml.orig	2025-09-21 09:12:19
++++ jmock/pom.xml	2026-08-31 19:30:07
+@@ -10,7 +10,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+         <relativePath>../pom.xml</relativePath>
+     </parent>
+ 
+--- jmock-example/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-example/pom.xml	2026-08-31 19:30:40
+@@ -12,7 +12,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+         <relativePath>../pom.xml</relativePath>
+     </parent>
+ 
+--- jmock-imposters/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-imposters/pom.xml	2026-08-31 19:32:13
+@@ -6,7 +6,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+     <artifactId>jmock-imposters</artifactId>
+     <description>Class mocks are more numerous than interface mocks, so drop the legacy name</description>
+@@ -36,4 +36,4 @@
+         </plugins>
+     </build>
+ 
+-</project>
+\ No newline at end of file
++</project>
+--- jmock-imposters-testdata/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-imposters-testdata/pom.xml	2026-08-31 19:32:47
+@@ -6,7 +6,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+ 
+     <artifactId>jmock-imposters-testdata</artifactId>
+@@ -40,4 +40,4 @@
+             </plugin>
+         </plugins>
+     </build>
+-</project>
+\ No newline at end of file
++</project>
+--- jmock-imposters-tests/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-imposters-tests/pom.xml	2026-08-31 19:33:15
+@@ -6,7 +6,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+     <artifactId>jmock-imposters-tests</artifactId>
+ 
+@@ -94,4 +94,4 @@
+         </profile>
+     </profiles>
+ 
+-</project>
+\ No newline at end of file
++</project>
+--- jmock-junit3/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-junit3/pom.xml	2026-08-31 19:33:56
+@@ -7,7 +7,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+ 
+     <artifactId>jmock-junit3</artifactId>
+--- jmock-junit4/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-junit4/pom.xml	2026-08-31 19:34:20
+@@ -10,7 +10,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+ 
+     <properties>
+--- jmock-junit5/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-junit5/pom.xml	2026-08-31 19:34:39
+@@ -9,7 +9,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+ 
+     <properties>
+--- jmock-legacy/pom.xml.orig	2025-09-21 09:12:19
++++ jmock-legacy/pom.xml	2026-08-31 19:35:01
+@@ -10,7 +10,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+     </parent>
+ 
+     <properties>
+--- testjar/pom.xml.orig	2025-09-21 09:12:19
++++ testjar/pom.xml	2026-08-31 19:35:39
+@@ -11,7 +11,7 @@
+     <parent>
+         <groupId>org.jmock</groupId>
+         <artifactId>jmock-parent</artifactId>
+-        <version>2.13.2-SNAPSHOT</version>
++        <version>@@VERSION@@</version>
+         <relativePath>../pom.xml</relativePath>
+     </parent>
+ 


### PR DESCRIPTION
#### Description

Update the `jmock2` port to version 2.14.0 and fix up the Portfile by migrating to the `maven` PortGroup, removing unnecessary dependencies, and reformatting the file.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?