### PR TITLE
jmock1: build from source

### DIFF
--- a/java/jmock1/Portfile
+++ b/java/jmock1/Portfile
@@ -1,9 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           java 1.0
 
 name                jmock1
-version             1.2.0
+github.setup        jmock-developers jmock-library 1.2.0
+github.tarball_from archive
+livecheck.type      none
+revision            1
+
 categories          java
 platforms           any
 supported_archs     noarch
@@ -15,40 +21,48 @@ long_description    jMock is a library that supports test-driven \
                     development of Java code with mock objects.  Mock \
                     objects help you design and test the interactions \
                     between the objects in your programs.
-homepage            http://www.jmock.org/
+homepage            https://www.jmock.org/
 
-master_sites        ${homepage}dist
-distfiles           jmock-${version}-jars.zip \
-                    jmock-${version}-javadoc.zip
-checksums           jmock-${version}-jars.zip \
-                        md5 551c531f7fe36ac2fb0f4e9354be1a82 \
-                        sha1 b1fa7cb1fe4acaacc67b8d37bb2bcc563bc63ea7 \
-                        rmd160 0cc4683285615875e39fc654222b133b2fb1bf82 \
-                    jmock-${version}-javadoc.zip \
-                        md5 1ee41636ec18fa68dc8881dbec9b3879 \
-                        sha1 0944d4850b12375811dd9b4974fb70f6ac877c22 \
-                        rmd160 7895cd7895ef1721f7f32948d540dc10637b7a8e
-use_zip             yes
+set stealth_count   1
+dist_subdir         ${name}/${version}_${stealth_count}
 
-worksrcdir          .
+checksums           rmd160  ca3e50d645efeb6da987997417e60528751470e4 \
+                    sha256  80a73edb96df0b73fbe5b8ee3d483089ec3a0c493320b1d76cf46b0730a4b976 \
+                    size    481816
 
-depends_lib         bin:java:kaffe
+depends_build-append \
+                    bin:ant:apache-ant
+
+java.version        1.8+
+java.fallback       openjdk11
+
+patchfiles          bump-jdk-version.diff \
+                    correct-version.diff
+
+post-patch {
+    reinplace "s|@@VERSION@@|${version}|g" ${worksrcpath}/build.xml
+}
 
 use_configure       no
 
-build {}
+build.cmd           ant
+build.target        jars
 
 destroot {
-    set javadir ${destroot}${prefix}/share/java
-    set docdir ${destroot}${prefix}/share/doc/${name}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
 
-    xinstall -d -m 755 ${javadir}
-    xinstall -d -m 755 ${docdir}
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/build/jmock-cglib-${version}.jar \
+        ${destjavadir}/jmock-cglib.jar
+    xinstall -m 644 \
+        ${worksrcpath}/build/jmock-core-${version}.jar \
+        ${destjavadir}/jmock-core.jar
 
-    file copy ${workpath}/jmock-core-${version}.jar \
-        ${javadir}/jmock1-core.jar
-    file copy ${workpath}/jmock-cglib-${version}.jar \
-        ${javadir}/jmock1-cglib.jar
-    file copy ${workpath}/javadoc-${version} \
-        ${docdir}/api
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/overview.html \
+        ${destdocdir}
 }

--- a/java/jmock1/Portfile
+++ b/java/jmock1/Portfile
@@ -1,52 +1,54 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			jmock1
-version			1.2.0
-categories		java
-platforms		any
-supported_archs	noarch
-license			BSD
-maintainers		nomaintainer
+PortSystem          1.0
 
-description		Library for testing Java code using mock objects
-long_description	jMock is a library that supports test-driven \
-			development of Java code with mock objects.  Mock \
-			objects help you design and test the interactions \
-			between the objects in your programs.
-homepage		http://www.jmock.org/
+name                jmock1
+version             1.2.0
+categories          java
+platforms           any
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
 
-master_sites		${homepage}dist
-distfiles		jmock-${version}-jars.zip \
-			jmock-${version}-javadoc.zip
-checksums		jmock-${version}-jars.zip \
-				md5 551c531f7fe36ac2fb0f4e9354be1a82 \
-				sha1 b1fa7cb1fe4acaacc67b8d37bb2bcc563bc63ea7 \
-				rmd160 0cc4683285615875e39fc654222b133b2fb1bf82 \
-			jmock-${version}-javadoc.zip \
-				md5 1ee41636ec18fa68dc8881dbec9b3879 \
-				sha1 0944d4850b12375811dd9b4974fb70f6ac877c22 \
-				rmd160 7895cd7895ef1721f7f32948d540dc10637b7a8e
-use_zip			yes
+description         Library for testing Java code using mock objects
+long_description    jMock is a library that supports test-driven \
+                    development of Java code with mock objects.  Mock \
+                    objects help you design and test the interactions \
+                    between the objects in your programs.
+homepage            http://www.jmock.org/
 
-worksrcdir		.
+master_sites        ${homepage}dist
+distfiles           jmock-${version}-jars.zip \
+                    jmock-${version}-javadoc.zip
+checksums           jmock-${version}-jars.zip \
+                        md5 551c531f7fe36ac2fb0f4e9354be1a82 \
+                        sha1 b1fa7cb1fe4acaacc67b8d37bb2bcc563bc63ea7 \
+                        rmd160 0cc4683285615875e39fc654222b133b2fb1bf82 \
+                    jmock-${version}-javadoc.zip \
+                        md5 1ee41636ec18fa68dc8881dbec9b3879 \
+                        sha1 0944d4850b12375811dd9b4974fb70f6ac877c22 \
+                        rmd160 7895cd7895ef1721f7f32948d540dc10637b7a8e
+use_zip             yes
 
-depends_lib		bin:java:kaffe
+worksrcdir          .
 
-use_configure		no
+depends_lib         bin:java:kaffe
+
+use_configure       no
 
 build {}
 
 destroot {
-	set javadir ${destroot}${prefix}/share/java
-	set docdir ${destroot}${prefix}/share/doc/${name}
+    set javadir ${destroot}${prefix}/share/java
+    set docdir ${destroot}${prefix}/share/doc/${name}
 
-	xinstall -d -m 755 ${javadir}
-	xinstall -d -m 755 ${docdir}
+    xinstall -d -m 755 ${javadir}
+    xinstall -d -m 755 ${docdir}
 
-	file copy ${workpath}/jmock-core-${version}.jar \
-		${javadir}/jmock1-core.jar
-	file copy ${workpath}/jmock-cglib-${version}.jar \
-		${javadir}/jmock1-cglib.jar
-	file copy ${workpath}/javadoc-${version} \
-		${docdir}/api
+    file copy ${workpath}/jmock-core-${version}.jar \
+        ${javadir}/jmock1-core.jar
+    file copy ${workpath}/jmock-cglib-${version}.jar \
+        ${javadir}/jmock1-cglib.jar
+    file copy ${workpath}/javadoc-${version} \
+        ${docdir}/api
 }

--- a/java/jmock1/files/bump-jdk-version.diff
+++ b/java/jmock1/files/bump-jdk-version.diff
@@ -1,0 +1,22 @@
+--- build.xml.orig	2007-06-03 08:23:18
++++ build.xml	2026-08-31 21:12:03
+@@ -12,7 +12,7 @@
+ 		 <javac srcdir="src"
+ 		 	    destdir="build/classes" 
+ 		 		debug="true"
+-		    	source="1.3" target="1.3">
++		    	source="1.8" target="1.8">
+             <classpath>
+                 <fileset dir="lib" includes="*.jar"/>
+             </classpath>
+@@ -98,8 +98,8 @@
+ 		       srcdir="testdata"
+ 			   debug="yes"
+ 			   failonerror="yes"
+-		       source="1.5" 
+-		       target="1.5"/>
++		       source="1.8" 
++		       target="1.8"/>
+ 		
+ 		<jar destfile="build/testdata/signed.jar" compress="false">
+ 			<fileset dir="build/testdata/classes/" includes="*"/>

--- a/java/jmock1/files/correct-version.diff
+++ b/java/jmock1/files/correct-version.diff
@@ -1,0 +1,9 @@
+--- build.xml.orig	2007-06-03 08:23:18
++++ build.xml	2026-08-31 21:18:24
+@@ -1,5 +1,5 @@
+ <project name="jMock 1" default="build">
+-	<property name="version" value="DEVELOPER-BUILD"/>
++	<property name="version" value="@@VERSION@@"/>
+ 	
+ 	<target name="build" depends="clean, package"/>
+ 	


### PR DESCRIPTION
#### Description

Reformat the Portfile of `jmock1` and modify it to build from source rather than just fetching the precompiled `.jar` files.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?