### PR TITLE
babl-devel: Fix builds on macOS 11 and earlier by using nm

### DIFF
--- a/graphics/babl-devel/Portfile
+++ b/graphics/babl-devel/Portfile
@@ -8,7 +8,7 @@ name                babl-devel
 conflicts           babl
 set my_name         babl
 version             0.1.128
-revision            0
+revision            1
 license             LGPL-3+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          graphics
@@ -42,6 +42,8 @@ depends_lib-append  port:lcms2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection
 
 license_noconflict  vala
+
+patchfiles-append   0001-tools-Add-support-to-macOS-11-and-earlier-SDKs-on-de.patch
 
 # require C11 (typedef redefinition)
 # babl-icc.c:1031:25: error: redefinition of typedef 'UTF8' is invalid in C

--- a/graphics/babl-devel/files/0001-tools-Add-support-to-macOS-11-and-earlier-SDKs-on-de.patch
+++ b/graphics/babl-devel/files/0001-tools-Add-support-to-macOS-11-and-earlier-SDKs-on-de.patch
@@ -1,0 +1,51 @@
+From b12c5e85a69f05637dcda84acfbd43bc832801e3 Mon Sep 17 00:00:00 2001
+From: Bruno Lopes <brunvonlope@outlook.com>
+Date: Mon, 31 Aug 2026 15:13:22 -0300
+Subject: [PATCH] tools: Add support to macOS 11 and earlier SDKs on defcheck
+
+dyld_info was introduced on macOS 12 only
+---
+ tools/defcheck.py | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git tools/defcheck.py tools/defcheck.py
+index 59758f8..d0c6e52 100644
+--- tools/defcheck.py
++++ tools/defcheck.py
+@@ -73,7 +73,9 @@ if sys.platform in ['win32', 'cygwin']:
+    platform_macos = False
+ elif sys.platform == 'darwin':
+    libextension   = ".dylib"
+-   command        = "dyld_info -exports "
++   command        = getenv("NM", default="nm") + " -gU "
++   if shutil.which("dyld_info"):
++     command      = "dyld_info -exports "
+    platform_linux = False
+    platform_win32 = False
+    platform_macos = True
+@@ -166,7 +168,21 @@ for df in def_files:
+             if len(parts) >= 4:
+                nmsymbols += " 0 0 " + parts[3] # Keep the [2::3] logic happy
+ 
+-   elif platform_macos:
++   elif platform_macos and not shutil.which("dyld_info"): # macOS 11 and earlier
++      lines = nm.split(sep='\n')
++      for line in lines:
++         parts = line.split()
++         if len(parts) == 3 and parts[1].upper() in "TDBRS":
++            symbol = parts[2]
++         elif len(parts) == 2 and parts[0].upper() in "TDBRS":
++            symbol = parts[1]
++         else:
++            continue
++         if symbol.startswith('_'):
++            symbol = symbol[1:]
++         nmsymbols += " 0 0 " + symbol # Keep the [2::3] logic happy
++
++   elif platform_macos: # macOS 12 and up
+       lines = nm.split(sep='\n')
+       for line in lines:
+          parts = line.split()
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
#### Description

Patch from upstream

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
