### PR TITLE
grpcurl: update to 1.9.4

### DIFF
--- a/devel/grpcurl/Portfile
+++ b/devel/grpcurl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/fullstorydev/grpcurl 1.9.3 v
+go.setup            github.com/fullstorydev/grpcurl 1.9.4 v
 go.toolchain_min    1.21
 go.offline_build    no
 revision            0
@@ -27,9 +27,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  1875b661ae2daf5116ada3dd7537bf0955c06a30 \
-                    sha256  bb555087f279af156159c86d4d3d5dd3f2991129e4cd6b09114e6851a679340d \
-                    size    123945
+checksums           rmd160  ea96a27887b15dfe4e6c16b857c3a637c9807b8f \
+                    sha256  bea899ba2f483a951bf40aa05d41e069dd2f7bfe52d2a229717abfdb5620cb7c \
+                    size    126257
 
 build.pre_args      -ldflags \"-X 'main.version=${github.tag_prefix}${version}'\"
 build.args          ./cmd/${name}


### PR DESCRIPTION
Verified with dockhand at commit `2797fbff0fdf` — Tahoe: built in a pristine VM.
