### PR TITLE
ruff: update to 0.16.5

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.16.4
+github.setup        astral-sh ruff 0.16.5
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9341d290e7b06a4f924f07e34fa3ef1f6d4b1d31 \
-                    sha256  8e26878a97a0c7f2b364bac11b585b793b8913b14b850c0922d27d4d06de5173 \
-                    size    13126722
+                    rmd160  60258119da04f025b67d06dc18c4e510f1b762ab \
+                    sha256  c447968b1e608450c973d441fa87f949f676064aec2db458b557e8222a4eb252 \
+                    size    13274834
 
 cargo.offline_cmd
 


### PR DESCRIPTION
#### Description

Not locally verified: no verification environment on the submitting machine.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
