### PR TITLE
mq: new port, version 0.8.4

### DIFF
--- a/textproc/mq/Portfile
+++ b/textproc/mq/Portfile
@@ -1,0 +1,666 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        harehare mq 0.8.4 v
+github.tarball_from archive
+revision            0
+
+description         A jq-like Markdown query language for command-line processing
+
+long_description    {*}${description}. ${name} parses Markdown into a syntax \
+                    tree and exposes a small functional query language over \
+                    it, so documents can be filtered, transformed and \
+                    reformatted from the command line the way jq handles \
+                    JSON. It also provides a REPL and can convert HTML to \
+                    Markdown.
+
+categories          textproc
+installs_libs       no
+license             MIT
+maintainers         @jrjsmrtn openmaintainer
+homepage            https://mqlang.org
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  ed2043eef78219f6bf72597ffaa37e03eab0613c \
+                    sha256  df0033bffa4886f927640d93f0aae7b175bb45b5de43b60cfa69924eb83a32bc \
+                    size    7564691
+
+# The upstream workspace also holds a WASM build, a web API, a language server
+# and a Zed extension. Only the CLI crate is built; its mq-dbg binary needs the
+# non-default "debugger" feature and is therefore not produced.
+build.args-append   -p mq-run
+
+post-build {
+    # mq writes a completion script to stdout for each supported shell.
+    set mq_bin ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
+    foreach shell {bash zsh fish} {
+        system -W ${worksrcpath} "${mq_bin} completion ${shell} > ${name}.${shell}"
+    }
+}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.zsh ${zsh_comp_path}/_${name}
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}/${name}.fish
+
+    set docdir ${destroot}${prefix}/share/doc/${name}
+    xinstall -d ${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE README.md ${docdir}
+}
+
+# Tests are deliberately not wired up. The upstream suite is not parallel-safe
+# and test_watch_reruns_on_file_change leaves an "mq --watch" process behind
+# that never exits, which blocks the test phase rather than failing it.
+
+cargo.crates \
+    addr2line                       0.25.1  1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b \
+    adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    aho-corasick                     1.1.5  c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba \
+    ammonia                          4.1.4  dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d \
+    android_system_properties        0.1.6  ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc \
+    ansi-str                         0.9.0  060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d \
+    ansitok                          0.3.0  c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee \
+    anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
+    anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
+    anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
+    anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
+    anyhow                         1.0.104  330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
+    approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
+    arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
+    arboard                          3.6.1  0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf \
+    arraydeque                       0.5.1  7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236 \
+    arrayvec                         0.7.8  d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56 \
+    assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
+    assert_cmd                       2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
+    async-compression               0.4.43  3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8 \
+    async-lock                       3.4.2  290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311 \
+    async-object-pool                0.2.0  e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f \
+    async-trait                     0.1.92  82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667 \
+    async-tungstenite               0.32.1  8acc405d38be14342132609f06f02acaf825ddccfe76c4824a69281e0458ebd4 \
+    atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
+    auditable-serde                  0.8.0  5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5 \
+    autocfg                          1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
+    aws-lc-rs                       1.18.0  ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e \
+    aws-lc-sys                      0.44.0  f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483 \
+    axum                             0.8.9  31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90 \
+    axum-core                        0.5.6  08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1 \
+    backtrace                       0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
+    backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
+    base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    base64                          0.23.1  ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5 \
+    bimap                            0.6.3  230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7 \
+    bit-set                          0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
+    bit-vec                          0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
+    bitflags                        2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    block-buffer                    0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
+    borrow-or-share                  0.2.4  dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c \
+    borsh                            1.8.0  a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f \
+    bstr                            1.13.1  6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f \
+    bumpalo                         3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
+    bytecount                        0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
+    bytes                           1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
+    cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cbindgen                        0.29.4  2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20 \
+    cc                               1.4.3  509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d \
+    cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
+    cfg_aliases                      0.2.2  f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
+    chacha20                        0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
+    chromiumoxide                    0.9.1  26ed067eb6c1f660bdb87c05efb964421d2ca262bae0296cdfe38cf0cd949a3e \
+    chromiumoxide_cdp                0.9.1  68a6a03a7ebac4ea85308f285d6959a3e6b2ce32a0c9465dc7a7b1db0144eec7 \
+    chromiumoxide_pdl                0.9.1  c602dea92337bc4d824668d78c5b79c3b4ddb29b40dd7218282bbe8fd3fc2091 \
+    chromiumoxide_types              0.9.1  678d5146e74f16fc4a41978b275af572cd913de1f10270d2b93b6c276bc57d80 \
+    chrono                          0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
+    ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
+    ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
+    ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
+    clap                             4.6.6  473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca \
+    clap_builder                     4.6.6  7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889 \
+    clap_complete                    4.6.9  3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19 \
+    clap_complete_nushell            4.6.2  ffb66bc82eb9c92b1727310ae2c5868df22ae7cf46185bc5c544a4fa71955e49 \
+    clap_derive                      4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
+    clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    clipboard-win                    5.4.1  bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4 \
+    cmake                           0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
+    codspeed                         4.7.0  57af92d1db7f6871b7e82c79cd87f2501db66f36b0eab924be6ea83dd6b2f3f3 \
+    codspeed-divan-compat            4.7.0  c4ea79fd0b1f2128cfac6308369013dba92df47baf4a4f66b57d8158224a361d \
+    codspeed-divan-compat-macros     4.7.0  f70e4ddd6beedefeb48f59d5f85fc21365a66e7976408c3d39f6cbbc4f03e08c \
+    codspeed-divan-compat-walltime     4.7.0  490c04f6076be6eacfafb496b8b237f3efbbed93838f2689115cc6f35fcf81c9 \
+    colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
+    colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
+    colored                          3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
+    combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
+    compression-codecs              0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
+    compression-core                0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
+    condtype                         1.3.0  baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af \
+    const-oid                       0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
+    cookie                          0.16.2  e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb \
+    cookie                          0.18.2  1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87 \
+    core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
+    core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    core_maths                       0.1.1  77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30 \
+    cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
+    cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
+    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    crossbeam                        0.8.4  1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
+    crossbeam-channel               0.5.16  d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
+    crossbeam-deque                  0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
+    crossbeam-epoch                 0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
+    crossbeam-queue                 0.3.13  803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26 \
+    crossbeam-utils                 0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
+    crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
+    crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
+    crypto-common                    0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
+    cssparser                       0.37.0  8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98 \
+    cssparser-macros                 0.7.0  10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf \
+    csv                              1.4.0  52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938 \
+    csv-core                        0.1.13  704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782 \
+    dap                           0.4.1-alpha1  35c7fc89d334ab745ba679f94c7314c9b17ecdcd923c111df6206e9fd7729fa9 \
+    dashmap                          6.2.1  e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c \
+    data-encoding                   2.11.1  4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06 \
+    deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
+    derive_arbitrary                 1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
+    derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
+    derive_more-impl                 2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
+    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    digest                          0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
+    dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
+    dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
+    dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
+    dispatch2                        0.3.1  1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38 \
+    displaydoc                       0.2.7  c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8 \
+    divan-macros                    0.1.17  8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c \
+    dtoa                            1.0.11  4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590 \
+    dtoa-short                       0.3.5  cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87 \
+    dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
+    ego-tree                        0.11.0  b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3 \
+    either                          1.17.0  9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d \
+    encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
+    endian-type                      0.2.0  869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2 \
+    equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
+    errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
+    error-code                       3.4.0  0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7 \
+    event-listener                   5.4.2  5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2 \
+    event-listener-strategy          0.5.4  8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
+    fancy-regex                     0.17.0  72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8 \
+    fantoccini                      0.22.1  7737298823a6f9ca743e372e8cb03658d55354fbab843424f575706ba9563046 \
+    fastrand                         2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
+    find-msvc-tools                 0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
+    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    fluent-uri                       0.4.1  bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
+    form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
+    fs_extra                         1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
+    fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
+    futures                         0.3.34  9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3 \
+    futures-channel                 0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
+    futures-core                    0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
+    futures-executor                0.3.34  031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432 \
+    futures-io                      0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
+    futures-macro                   0.3.34  9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44 \
+    futures-sink                    0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                    0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-timer                    3.0.4  af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968 \
+    futures-util                    0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    gethostname                      1.1.0  1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8 \
+    getopts                         0.2.24  cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df \
+    getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
+    getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
+    getrandom                        0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
+    gimli                           0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
+    glob                             0.3.4  e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
+    globset                         0.4.20  07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988 \
+    h2                              0.4.16  a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27 \
+    half                             2.7.1  6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b \
+    hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
+    hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
+    hashlink                        0.12.1  32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248 \
+    headers                          0.4.1  b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb \
+    headers-core                     0.3.0  54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4 \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    html-escape                     0.2.15  c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5 \
+    html5ever                       0.39.0  46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8 \
+    http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
+    http                             1.5.0  918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0 \
+    http-body                        1.1.0  ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
+    http-body-util                   0.1.5  23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c \
+    httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
+    httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    httpmock                         0.8.3  bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e \
+    hybrid-array                    0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
+    hyper                           1.11.0  d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72 \
+    hyper-rustls                    0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
+    hyper-timeout                    0.5.2  2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0 \
+    hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
+    iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
+    icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
+    icu_collections                  2.3.0  fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513 \
+    icu_locale_core                  2.3.0  d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb \
+    icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
+    icu_normalizer                   2.3.0  12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f \
+    icu_normalizer_data              2.3.0  1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0 \
+    icu_properties                   2.3.0  7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148 \
+    icu_properties_data              2.3.0  e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa \
+    icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
+    icu_provider                     2.3.0  92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428 \
+    icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    icu_segmenter                    1.5.0  a717725612346ffc2d7b42c94b820db6908048f39434504cb130e8b46256b0de \
+    icu_segmenter_data               1.5.1  a1e52775179941363cc594e49ce99284d13d6948928d8e72c755f55e98caa1eb \
+    id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
+    idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
+    idna_adapter                     1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
+    ignore                          0.4.33  00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f \
+    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    inotify                         0.11.5  4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592 \
+    inotify-sys                      0.1.8  c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d \
+    ipnet                           2.12.1  6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78 \
+    is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
+    is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
+    itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itertools                       0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+    jni                             0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
+    jni-macros                      0.22.4  a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
+    jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
+    jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
+    jobserver                       0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
+    js-sys                         0.3.104  0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a \
+    kqueue                           1.2.1  8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea \
+    kqueue-sys                       1.1.2  07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087 \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
+    libc                           0.2.189  3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
+    libfuzzer-sys                   0.4.13  a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2 \
+    libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
+    libmimalloc-sys                 0.1.44  667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870 \
+    libredox                        0.1.20  28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a \
+    linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
+    litemap                          0.7.5  23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856 \
+    litemap                          0.8.3  47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae \
+    lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
+    log                             0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
+    lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
+    ls-types                         0.0.6  896e16b8e17d8732b9efe4d5b66cb0cc162b3023a2d8122f2aea6f7f185e0a67 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    markdown                         1.0.0  a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb \
+    markup5ever                     0.39.0  7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de \
+    matchers                         0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
+    matchit                          0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
+    md5                              0.8.1  7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c \
+    memchr                           2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
+    miette                           7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
+    miette-derive                    7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
+    mimalloc                        0.1.48  e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8 \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
+    minicov                          0.3.9  c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0 \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
+    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    mio                              1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
+    new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
+    nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
+    nix                             0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
+    nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    nom                              8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
+    nom_locate                       5.0.0  0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d \
+    notify                           8.2.0  4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3 \
+    notify-types                     2.1.0  42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a \
+    nu-ansi-term                    0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
+    num-conv                         0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    objc2                            0.6.4  3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f \
+    objc2-app-kit                    0.3.2  d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c \
+    objc2-core-foundation            0.3.2  2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536 \
+    objc2-core-graphics              0.3.2  e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807 \
+    objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
+    objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
+    objc2-io-surface                 0.3.2  180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d \
+    object                          0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
+    once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
+    oorandom                        11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
+    openssl-probe                    0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
+    opentelemetry                   0.32.0  b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682 \
+    opentelemetry-http              0.32.0  5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331 \
+    opentelemetry-otlp              0.32.0  9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35 \
+    opentelemetry-proto             0.32.0  56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638 \
+    opentelemetry_sdk               0.32.1  9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9 \
+    opfs                             0.2.0  a81d38c32da5bb367c3e6901de6c6e350bdbff0791f9f8894749bd6c0e00eb0e \
+    option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    owo-colors                       4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
+    papergrid                       0.18.0  d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e \
+    parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
+    parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
+    parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
+    path-tree                        0.8.3  c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136 \
+    percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
+    phf                             0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
+    phf_codegen                     0.13.1  49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1 \
+    phf_generator                   0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
+    phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
+    phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
+    pin-project                     1.1.13  2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924 \
+    pin-project-internal            1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
+    pkg-config                      0.3.34  f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548 \
+    portable-atomic                 1.15.0  05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85 \
+    potential_utf                    0.1.6  d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661 \
+    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
+    ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
+    precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
+    predicates                       3.1.4  ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
+    predicates-core                 1.0.10  cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144 \
+    predicates-tree                 1.0.13  d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
+    prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
+    proc-macro-crate                 3.5.0  e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f \
+    proc-macro2                    1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
+    proptest                        1.11.0  4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744 \
+    prost                           0.14.4  528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1 \
+    prost-derive                    0.14.4  b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf \
+    prost-types                     0.14.4  f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quick-xml                       0.41.0  e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1 \
+    quinn                          0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
+    quinn-proto                    0.11.17  04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83 \
+    quinn-udp                       0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
+    quote                           1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
+    r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
+    r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
+    radix_trie                       0.3.0  3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a \
+    rand                             0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
+    rand                            0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
+    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
+    rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    rand_core                       0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    rand_pcg                        0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
+    rand_xorshift                    0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
+    rayon                           1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
+    rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
+    redox_syscall                   0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
+    redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
+    ref-cast                        1.0.26  216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d \
+    ref-cast-impl                   1.0.26  2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c \
+    regex                           1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                  0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
+    regex-lite                       0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
+    regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
+    relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
+    reqwest                         0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
+    ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
+    robots_txt                       0.7.0  1e8e523889c75c35b3a018da4dbe311d9b248db161786624141b10859800fa0d \
+    ropey                            1.6.1  93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5 \
+    rstest                          0.26.1  f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49 \
+    rstest_macros                   0.26.1  9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0 \
+    rust-embed                      8.12.0  e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9 \
+    rust-embed-impl                 8.12.0  3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097 \
+    rust-embed-utils                8.12.0  42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0 \
+    rustc-demangle                  0.1.28  b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb \
+    rustc-hash                       2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
+    rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
+    rustls                         0.23.43  0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06 \
+    rustls-native-certs              0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
+    rustls-pki-types                1.15.1  2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
+    rustls-platform-verifier         0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
+    rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
+    rustls-webpki                 0.103.14  0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a \
+    rustversion                     1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
+    rusty-fork                       0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
+    rustyline                       18.0.1  53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684 \
+    ryu                             1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schannel                        0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    scraper                         0.27.0  bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2 \
+    security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
+    security-framework-sys          2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
+    selectors                       0.38.0  8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d \
+    semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
+    serde                          1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
+    serde_core                     1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                   1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                     1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
+    serde_path_to_error             0.1.20  10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
+    serde_regex                      1.2.0  bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012 \
+    serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    servo_arc                        0.4.3  170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930 \
+    sha1                            0.10.7  a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8 \
+    sha2                            0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
+    sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
+    shlex                            2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
+    signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
+    simd-adler32                    0.3.10  3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea \
+    simd_cesu8                       1.2.0  11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520 \
+    simdutf8                         0.1.5  e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
+    similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
+    similar                          3.2.0  4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987 \
+    siphasher                        1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
+    slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
+    slotmap                          1.1.1  bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038 \
+    smallvec                        1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
+    smol_str                         0.3.6  4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523 \
+    socket2                          0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
+    spdx                            0.10.9  c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3 \
+    stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
+    statrs                          0.18.0  2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e \
+    str_indices                      0.4.4  d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6 \
+    string-interner                 0.20.0  ad3df9b59e2eded8d825c7c4363ad339a20fb6bc0b9a4778560f518f59910b15 \
+    string_cache                     0.9.0  a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901 \
+    string_cache_codegen             0.6.1  585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69 \
+    stringmetrics                    2.2.2  7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765 \
+    strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    strum                           0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
+    strum_macros                    0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
+    subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
+    supports-color                   3.0.2  c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6 \
+    supports-hyperlinks              3.2.0  e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91 \
+    supports-unicode                 3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
+    syn                            2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
+    syn                              3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
+    sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
+    synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
+    system-configuration             0.7.0  a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
+    system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
+    tabled                          0.21.0  b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff \
+    tabwriter                        1.4.1  fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432 \
+    tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
+    tendril                          0.5.1  5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08 \
+    terminal_size                    0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
+    termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
+    testing_table                    0.3.0  0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc \
+    textwrap                        0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
+    thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
+    thiserror                       2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
+    thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
+    thiserror-impl                  2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
+    thread_local                    1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
+    tiktoken-rs                     0.12.0  027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2 \
+    time                            0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
+    time-core                        0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
+    time-macros                     0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
+    tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
+    tinystr                          0.8.4  b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643 \
+    tinyvec                         1.12.0  bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
+    tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+    tokio                           1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
+    tokio-macros                     2.7.2  78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e \
+    tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
+    tokio-stream                    0.1.19  a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b \
+    tokio-util                      0.7.19  494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52 \
+    toml                          0.9.12+spec-1.1.0  cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863 \
+    toml                          1.1.4+spec-1.1.0  3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5 \
+    toml_datetime                 0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
+    toml_datetime                 1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
+    toml_edit                     0.25.13+spec-1.1.0  6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b \
+    toml_parser                   1.1.3+spec-1.1.0  1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56 \
+    toml_writer                   1.1.2+spec-1.1.0  7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2 \
+    tonic                           0.14.6  ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef \
+    tonic-prost                     0.14.6  50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0 \
+    tonic-types                     0.14.6  73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8 \
+    toon-format                      0.5.0  8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e \
+    topological-sort                 0.2.2  ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d \
+    tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
+    tower-http                      0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
+    tower-http                       0.7.0  b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233 \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-lsp-server                0.23.0  2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72 \
+    tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
+    tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
+    tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
+    tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
+    tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
+    tracing-opentelemetry           0.33.0  adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26 \
+    tracing-serde                    0.2.0  704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1 \
+    tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
+    try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    tungstenite                     0.28.0  8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442 \
+    typenum                         1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
+    unarray                          0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
+    unicase                          2.9.0  dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142 \
+    unicode-id                       0.3.6  70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580 \
+    unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
+    unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
+    unicode-segmentation            1.13.3  c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8 \
+    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
+    unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
+    unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
+    untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
+    ureq                             3.4.0  972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d \
+    ureq-proto                       0.6.1  da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613 \
+    url                              2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
+    utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    utf8-zero                        0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
+    utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
+    utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
+    utoipa                           5.5.0  8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160 \
+    utoipa-gen                       5.5.0  6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8 \
+    utoipa-swagger-ui                9.0.2  d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55 \
+    utoipa-swagger-ui-vendored       0.1.2  e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d \
+    uuid                            1.24.1  2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9 \
+    valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
+    wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
+    want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
+    wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
+    wasip2                        1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
+    wasm-bindgen                   0.2.127  1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70 \
+    wasm-bindgen-futures            0.4.77  6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950 \
+    wasm-bindgen-macro             0.2.127  77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1 \
+    wasm-bindgen-macro-support     0.2.127  e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284 \
+    wasm-bindgen-shared            0.2.127  7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf \
+    wasm-bindgen-test               0.3.77  895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1 \
+    wasm-bindgen-test-macro         0.3.77  4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759 \
+    wasm-bindgen-test-shared       0.2.127  33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987 \
+    wasm-encoder                   0.227.1  80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822 \
+    wasm-metadata                  0.227.1  ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d \
+    wasmparser                     0.227.1  0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2 \
+    web-sys                        0.3.104  c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30 \
+    web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
+    web_atoms                        0.2.6  ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3 \
+    webdriver                       0.53.0  91d53921e1bef27512fa358179c9a22428d55778d2c2ae3c5c37a52b82ce6e92 \
+    webpki-root-certs                1.0.9  b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b \
+    webpki-roots                     1.0.9  7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
+    which                            8.0.5  8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c \
+    winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
+    windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
+    windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \
+    windows-interface               0.59.3  3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358 \
+    windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-registry                 0.6.1  02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
+    windows-result                   0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
+    windows-strings                  0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
+    windows-sys                     0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                 0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm         0.53.1  a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc            0.53.1  b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                0.53.1  960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
+    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm            0.53.1  fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc               0.53.1  1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu              0.53.1  9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm          0.53.1  0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
+    winnow                          0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
+    winnow                           1.0.4  23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81 \
+    wit-bindgen                     0.41.0  10fb6648689b3929d56bbc7eb1acf70c9a42a29eb5358c67c10f54dbd5d695de \
+    wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
+    wit-bindgen-core                0.41.0  92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b \
+    wit-bindgen-rt                  0.41.0  c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621 \
+    wit-bindgen-rust                0.41.0  9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce \
+    wit-bindgen-rust-macro          0.41.0  ad19eec017904e04c60719592a803ee5da76cb51c81e3f6fbf9457f59db49799 \
+    wit-component                  0.227.1  635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676 \
+    wit-parser                     0.227.1  ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11 \
+    writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
+    writeable                        0.6.4  3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc \
+    x11rb                           0.13.2  9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414 \
+    x11rb-protocol                  0.13.2  ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd \
+    yaml-rust2                      0.12.0  c6edb26322e610d4f04b7cd34478317685d24d0999437e551fb97c5441151041 \
+    yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
+    yoke                             0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
+    yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
+    yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
+    zed_extension_api                0.7.0  0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0 \
+    zerocopy                        0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
+    zerocopy-derive                 0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
+    zerofrom                         0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
+    zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
+    zeroize                          1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
+    zerotrie                         0.2.5  4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f \
+    zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
+    zerovec                         0.11.7  94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8 \
+    zerovec-derive                  0.10.4  3e3c6377872d72510393f688a555d7097b0f741995c7a00f0407f786dd486b2d \
+    zerovec-derive                  0.11.5  9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9 \
+    zip                              3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \
+    zlib-rs                          0.6.7  34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12 \
+    zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
+    zopfli                           0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249


### PR DESCRIPTION
#### Description

New port: `mq`, a jq-like query language for Markdown (<https://mqlang.org>). It
parses Markdown into a syntax tree and exposes a small functional query language
over it, so documents can be filtered, transformed and reformatted from the
command line the way jq handles JSON. It also provides a REPL and can convert
HTML to Markdown.

Packaging notes:

- The upstream workspace also holds a WASM build, a web API, a language server, a
  debug adapter and a Zed extension. Only the CLI crate (`mq-run`) is built; the
  rest are neither built nor shipped.
- `mq-dbg` needs the non-default `debugger` feature and is not produced.
- Shell completions for bash, zsh and fish are generated at build time from
  `mq completion <shell>` and installed.

Three verification boxes are left unticked deliberately, rather than by oversight:

- **`sudo port test`** — the suite is deliberately not wired up. I ran it during
  packaging: 13 test binaries and 6450 tests pass, but three tests are unreliable.
  `mq-help`'s `catalog::tests::test_doc_examples_are_correct` and `mq-run`'s
  `test_repl_without_allow_read_is_blocked` both pass in isolation and fail under
  parallel execution. More seriously, `mq-run`'s `test_watch_reruns_on_file_change`
  failed 2 of 8 runs even single-threaded, and each failure leaves an `mq --watch`
  process alive that never exits. One of those held the test phase's pipe open, so
  `port test` hung rather than failing. Enabling `test.run` would risk tying up a
  buildbot worker instead of reporting an error, so the Portfile records the reason
  in a comment and leaves tests off. I will report these upstream.
- **`sudo port -vst install`** — trace mode cannot run on this machine, as
  `darwintrace.dylib` has no arm64e slice. I ran `sudo port -vs install`, which
  built, staged, installed and activated the port. I can run the `-vst` form on an
  Intel host if you would like that before merging.
- **Trac ticket reference** — no existing ticket. Searches for `mq`, `mqlang` and
  `harehare` all return "No matches", and there is no other open pull request for
  this port.

Functionality tested after install: `mq --version`; the `.h`, `.code` and `.[]`
queries against a sample document; a transform
(`.h | upcase(to_text(self))`); HTML input via `--input-format html`; and
`mq completion` for all three shells. The port installs one binary, three
completion files, `LICENSE` and `README.md`.

Portfile drafted with AI assistance; built, `port lint`-clean, and tested on the
versions below. I can explain and defend every line.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
