### PR TITLE
okf: new port, version 0.4.0

### DIFF
--- a/textproc/okf/Portfile
+++ b/textproc/okf/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/okfcli/okf 0.4.0 v
+go.toolchain_min    1.27
+revision            0
+
+description         Vendor-neutral CLI for the Open Knowledge Format
+
+long_description    {*}${description}. ${name} creates, validates, lints, \
+                    indexes, searches and graphs OKF bundles, which record \
+                    machine-readable knowledge as Markdown with YAML \
+                    frontmatter.
+
+categories          textproc
+installs_libs       no
+license             Apache-2
+maintainers         @jrjsmrtn openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  aa8e89b28b4eddaa504bb28bb09910ef0a4623a8 \
+                    sha256  8bc65074db3e195e8627032e2df9244b798d162d300e2472bfb815dd84894eb0 \
+                    size    59184
+
+# The main package lives in cmd/, not at the repository root. The version is
+# injected the way upstream's Makefile does; commit and date are left at their
+# in-source defaults, since a tarball carries no git metadata and a build
+# timestamp would make the result unreproducible.
+build.args          -trimpath \
+                    -ldflags \"-s -w -X main.version=${version}\" \
+                    ./cmd/${name}
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port: `okf`, a vendor-neutral command-line tool for the Open Knowledge Format
(<https://github.com/okfcli/okf>). OKF records machine-readable knowledge as Markdown
files with YAML frontmatter; `okf` creates, validates, lints, indexes, searches and
graphs those bundles, reporting results as JSON.

Packaging notes:

- The main package is in `cmd/okf`, not at the repository root, so `build.args` sets the
  target explicitly. The PortGroup's default `go build` would find no main package.
- `go.mod` requires Go 1.27.0, so `go.toolchain_min 1.27` is declared.
- The version is injected through `-ldflags` the way upstream's `Makefile` does.
  `main.commit` and `main.date` are deliberately left at their in-source defaults
  (`none` and `unknown`): a release tarball carries no git metadata, and injecting a
  build timestamp would make the package unreproducible.
- One dependency, `gopkg.in/yaml.v3`, so `go.vendors` has a single entry.
  `go2port get github.com/okfcli/okf v0.4.0` generated the skeleton and checksums.
- Pure Go — upstream builds with `CGO_ENABLED=0`, and the resulting binary links only
  `libSystem.B.dylib` and `libresolv.9.dylib`.

Upstream's `LICENSE` is the Apache License 2.0. GitHub's licence detector does not
classify it and reports "None", so `license Apache-2` comes from reading the file.

Three verification boxes are left unticked deliberately, rather than by oversight:

- **`sudo port -vst install`** — trace mode cannot run on this machine, as
  `darwintrace.dylib` has no arm64e slice. I ran `sudo port -vs install`, which built,
  staged, installed and activated the port. I can run the `-vst` form on an Intel host
  if you would like that before merging.
- **`sudo port test`** — the Portfile declares no test phase, so there is nothing for
  `port test` to run. Upstream does have a Go test suite (`go test ./...`); I am happy to
  wire it up if you would prefer a port that exercises it.
- **Trac ticket reference** — no existing ticket. `okfcli` returns "No matches", and the
  ten hits for the bare string `okf` are all substring matches inside unrelated crash
  dumps and symbol names.

`port lint --nitpick` reports 0 errors and 0 warnings.

Functionality tested after install: `okf --version` reports `0.4.0`, and `validate`,
`lint` and `list` all return correct JSON against a real OKF bundle. The port has no
variants and installs one binary.

Portfile drafted with AI assistance; built, `port lint`-clean, and tested on the versions
below. I can explain and defend every line.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
