### PR TITLE
s2n-tls: update to 1.7.8

### DIFF
--- a/security/s2n-tls/Portfile
+++ b/security/s2n-tls/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport   1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        aws s2n-tls 1.7.7 v
+github.setup        aws s2n-tls 1.7.8 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    \
     ${name} is a C99 implementation of the TLS/SSL protocols that is designed \
     to be simple, small, fast, and with security as a priority.
 
-checksums           rmd160  7b0a9638159b10901ef035a5f776d48e6eb7cca8 \
-                    sha256  a6f77d2e3343b554bfc2cce27e0407b3c758bb105533c8f0a56e233036b7541d \
-                    size    4912083
+checksums           rmd160  247a66b2bed1c75fcbc923bc0ad59aa9f0b881f7 \
+                    sha256  90ec7934af222b0f58f1143dabe12358489f628956ec25fa1bf752b2a33bfd5a \
+                    size    4920230
 
 categories          security
 license             Apache-2


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `1aa458fea696`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
