### PR TITLE
fortio: update to 1.75.3

### DIFF
--- a/net/fortio/Portfile
+++ b/net/fortio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/fortio/fortio 1.75.2 v
+go.setup            github.com/fortio/fortio 1.75.3 v
 go.package          fortio.org/fortio
 revision            0
 
@@ -29,9 +29,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c63d07ee7a86c24aa1dde7e82354ec7502aea356 \
-                    sha256  b57e4df1fe2fc94c5e074bab0c9350076f7e15c8068d6f82a36e5cb9115cc97b \
-                    size    304496
+checksums           rmd160  c3e7b2a12b7a064eef93f54a9d74e863a30000af \
+                    sha256  2a31c72f2fd559f18706d37e0236d36c0f1551cae60e13908dc4452a5c56d302 \
+                    size    304478
 
 set _ft_share_dir   ${prefix}/share/${name}
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `a12edc2d2b35`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
