### PR TITLE
libdeflate: update to 1.26

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -5,13 +5,13 @@ PortGroup           cmake           1.1
 PortGroup           github          1.0
 PortGroup           legacysupport   1.1
 
-github.setup        ebiggers libdeflate 1.25 v
+github.setup        ebiggers libdeflate 1.26 v
 github.tarball_from releases
 revision            0
 
-checksums           rmd160  58584517791330b7eed1f8ae8d3475b1dec37794 \
-                    sha256  fed5cd22f00f30cc4c2e5329f94e2b8a901df9fa45ee255cb70e2b0b42344477 \
-                    size    186474
+checksums           rmd160  a23852b8c9dcb3ca5b6dcbbe572a95edc13fed8a \
+                    sha256  125856d4656e0feab660f94842f835923410c9281fedbcee64598c918da42b5a \
+                    size    187565
 
 description         Heavily optimized library for DEFLATE/zlib/gzip \
                     compression and decompression


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `0294f4b828a2`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
