### PR TITLE
ouch: update to 0.8.2

### DIFF
--- a/sysutils/ouch/Portfile
+++ b/sysutils/ouch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        ouch-org ouch 0.8.1
+github.setup        ouch-org ouch 0.8.2
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 platforms           darwin
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b4f6cf41bc86980c878368aee5aad72cf882de34 \
-                    sha256  920f73d4b162bd1814b67c57906b7322345f198d763f28d04722a406f8352246 \
-                    size    102381
+                    rmd160  9520d3f370d56301a2f14d37198fe1d3a0a1db69 \
+                    sha256  803dd9d0bcdb0b4f94336bc1e9fbb5c878bf2867e03f58f266adc679c224698d \
+                    size    113833
 
 depends_lib-append  port:libiconv   \
                     port:lzma       \
@@ -45,120 +45,119 @@ destroot {
 
 cargo.crates \
     adler2                              2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
-    aes                                 0.9.0  66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8 \
-    aho-corasick                        1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    aes                                 0.9.2  f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58 \
+    aho-corasick                        1.1.5  c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba \
     alloc-no-stdlib                     2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
-    alloc-stdlib                        0.2.2  94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece \
+    alloc-stdlib                        0.2.4  0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195 \
     anstream                            1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
     anstyle                            1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
     anstyle-parse                       1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                       1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                     3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
-    anyhow                            1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    anyhow                            1.0.104  330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
     assert_cmd                          2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
-    autocfg                             1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    autocfg                             1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     bindgen                            0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     bit-set                             0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                             0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
-    bitflags                           2.11.1  c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
-    block-buffer                       0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
+    bitflags                           2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
+    block-buffer                       0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     block-padding                       0.4.2  710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b \
     brotli                              8.0.4  5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3 \
-    brotli-decompressor                 5.0.0  874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03 \
-    bstr                               1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
-    bumpalo                            3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    brotli-decompressor                 5.0.3  3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583 \
+    bstr                               1.13.1  6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f \
+    bumpalo                            3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     byteorder                           1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                              1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
-    bytesize                            2.3.1  6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3 \
+    bytes                              1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
+    bytesize                            2.7.0  7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b \
     bzip2                               0.6.1  f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c \
     bzip3                              0.12.0  b9090f9972d76f35fc3cef4650614d1877ab970bc125c45fe3cad2e0213fb6e3 \
-    cbc                                 0.2.0  98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225 \
-    cc                                 1.2.62  a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98 \
+    cbc                                 0.2.1  ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896 \
+    cc                                  1.4.4  0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273 \
     cexpr                               0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
-    cfb                                 0.7.3  d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f \
+    cfb                                0.14.0  a347dcabdae9c31b0825fd6a8bed285ec9c2acb89c47827126d52fa4f59cece3 \
     cfg-if                              1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
-    cipher                              0.5.1  e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea \
-    clang-sys                           1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                                4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
-    clap_builder                        4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_complete                       4.6.5  e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772 \
-    clap_complete_nushell               4.6.0  fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897 \
-    clap_derive                         4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
+    cipher                              0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
+    clang-sys                           1.9.1  157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a \
+    clap                                4.6.6  473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca \
+    clap_builder                        4.6.6  7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889 \
+    clap_complete                       4.6.9  3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19 \
+    clap_complete_nushell               4.6.2  ffb66bc82eb9c92b1727310ae2c5868df22ae7cf46185bc5c544a4fa71955e49 \
+    clap_derive                         4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
     clap_lex                            1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
-    clap_mangen                         0.3.0  d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07 \
-    cmov                                0.5.3  3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746 \
+    clap_mangen                         0.3.3  211d617eaa4b735c96c9e0228fcbdb5120ef623f2b8cb67ffb84c3e02dbc28a4 \
+    cmov                                0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     colorchoice                         1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
-    console                            0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
+    console                            0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     const-oid                          0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     constant_time_eq                    0.4.2  3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b \
     core_affinity                       0.8.3  a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342 \
     cpubits                             0.1.1  15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae \
     cpufeatures                         0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
-    crc32fast                           1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
-    crossbeam-deque                     0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
-    crossbeam-epoch                    0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                    0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
-    crypto-common                       0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
+    crc32fast                           1.5.1  8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550 \
+    crossbeam-deque                     0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
+    crossbeam-epoch                    0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
+    crossbeam-utils                    0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
+    crypto-common                       0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
     ctutils                             0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     deranged                            0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     derive-ex                           0.1.8  bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407 \
     diff                               0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     difflib                             0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                             0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
-    either                             1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    either                             1.18.0  252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34 \
     encode_unicode                      1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
+    enumflags2                         0.7.12  1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef \
+    enumflags2_derive                  0.7.12  67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827 \
     equivalent                          1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                              0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
-    fastrand                            2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
+    fastrand                            2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
     file_type_enum                      3.0.1  9269884314a3a7945446567bef55eecdf809d464feb5f3dc2b5a5469fcbecf8a \
     filetime                           0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     filetime_creation                   0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
-    find-msvc-tools                     0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    find-msvc-tools                    0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
     flate2                              1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
     flume                              0.11.1  da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095 \
     fnv                                 1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                            0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
-    fs-err                              3.3.0  73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0 \
-    futures-core                       0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
-    futures-sink                       0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
-    futures-task                       0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
-    futures-util                       0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    fs-err                              3.3.1  b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a \
+    futures-core                       0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
+    futures-sink                       0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                       0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-util                       0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
     getrandom                          0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                           0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
-    getrandom                           0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
-    glob                                0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
-    globset                            0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
-    gzp                                 2.0.2  7abe9930717197e0ea50d8c8a1106a38b5bee0536ed4cbf4b93ba1a953f97d04 \
-    hashbrown                          0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
+    getrandom                           0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
+    glob                                0.3.4  e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
+    globset                            0.4.20  07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988 \
+    gzp                                 2.0.4  661d8307941355219635daa5ce1b110a247a17e6e49a2d8be2058d51b7d5f317 \
     hashbrown                          0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
     heck                                0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                          0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hmac                               0.13.0  6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
-    hybrid-array                       0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
-    id-arena                            2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
-    ignore                             0.4.26  b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d \
+    hybrid-array                       0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
+    ignore                             0.4.33  00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f \
     indexmap                           2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
-    infer                              0.19.0  a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7 \
+    infer                              0.22.0  f4200d433cbd5178df7797c9c2e75b348b728e39631cf14520d1e2fc424201f4 \
     inout                               0.2.2  4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7 \
     insta                              1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
     is_executable                       1.0.6  82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd \
     is_terminal_polyfill               1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                          0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
-    itertools                          0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
-    itoa                               1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jobserver                          0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                             0.3.98  67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08 \
-    leb128fmt                           0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
+    itertools                          0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
+    jobserver                          0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
+    js-sys                            0.3.104  0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a \
+    landlock                            0.4.7  4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1 \
     libbz2-rs-sys                       0.2.5  34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c \
     libbzip3-sys                  0.5.1+1.5.3  d2a00fe0cfbd644674a56106ec593014b3f95e94c185fd5d4a75c397cd3b0805 \
-    libc                              0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
+    libc                              0.2.189  3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
     libloading                          0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     linux-raw-sys                      0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     lock_api                           0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                                0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
-    lz4_flex                           0.13.1  7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e \
-    lzma-rust2                         0.16.4  ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02 \
-    memchr                              2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
+    log                                0.4.34  f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6 \
+    lz4_flex                           0.14.0  ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226 \
+    lzma-rust2                         0.18.1  243cb2271683c2855cad62142cbf38199db439b1b1e1ccdd5a011342894dd7cc \
+    lzma-rust2                         0.19.0  5c1bf3331fb5cf60f2ef15b63361f6cc39492a5d94c096053c395515e17d147f \
+    memchr                              2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     minimal-lexical                     0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                         0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     nanorand                            0.7.0  6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3 \
@@ -172,7 +171,7 @@ cargo.crates \
     parse-display-derive               0.11.0  8e95a50d1084dab562913062c4c34bb204b68fc6ec38a1395909ff5aaaf4f10a \
     pbkdf2                             0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
     pin-project-lite                   0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
-    pkg-config                         0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
+    pkg-config                         0.3.34  f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548 \
     powerfmt                            0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppmd-rust                           1.4.0  efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24 \
     ppv-lite86                         0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
@@ -181,80 +180,75 @@ cargo.crates \
     predicates-tree                    1.0.13  d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
     pretty_assertions                   1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     prettyplease                       0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
-    proc-macro2                       1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    proc-macro2                       1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     proptest                           1.11.0  4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744 \
     quick-error                         1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
-    quote                              1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    quote                              1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                               5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                               6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
-    rand                                0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
+    rand                                0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
     rand_chacha                         0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                           0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_xorshift                       0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
     rayon                              1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                         1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
-    regex                              1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
-    regex-automata                     0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex                              1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                     0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-syntax                       0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     roff                                1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
-    rustc-hash                          2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
+    rustc-hash                          2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustix                              1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustversion                        1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    rustversion                        1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     rusty-fork                          0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     same-file                           1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                          1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    semver                             1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
-    serde                             1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde_core                        1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                      1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                        1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
-    sevenz-rust2                       0.21.0  dbbd24232798280d6bc896e3429a3469174de008ec8b1b591a96618b46664195 \
+    serde_core                        1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                      1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    sevenz-rust2                       0.21.6  b7e6633e9d494e3b8e69b6e806cd76fb19e5d60b7aedcf35ac051e78c4f0c27c \
     sha1                               0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha2                               0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     shlex                               1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
-    simd-adler32                        0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
+    shlex                               2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
+    simd-adler32                       0.3.10  3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea \
     similar                             2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     slab                               0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
-    snap                                1.1.1  1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b \
-    spin                                0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    snap                                1.1.2  199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886 \
+    spin                                0.9.9  3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e \
     strip-ansi-escapes                  0.2.1  2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025 \
     strsim                             0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     structmeta                          0.3.0  2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329 \
     structmeta-derive                   0.3.0  152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc \
     strum                              0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                       0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
-    syn                               2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    syn                               2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
+    syn                                 3.0.4  e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f \
     tar                                0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                           3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termtree                            0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     test-strategy                       0.4.5  8f7fd1eb9efb36942b85a290c4201d317980fe09bc88d34dd48aaaae03075c6a \
-    thiserror                          2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
-    thiserror-impl                     2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
-    time                               0.3.49  711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469 \
+    thiserror                          2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
+    thiserror-impl                     2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
+    time                               0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
     time-core                           0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
-    twox-hash                           2.1.2  9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c \
+    twox-hash                           2.1.3  8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9 \
     typed-path                         0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
-    typenum                            1.20.0  40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
+    typenum                            1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
     unarray                             0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
     unicode-ident                      1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
-    unicode-xid                         0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
-    unrar-ng                            0.7.6  7881a7cefee603cdd23e6acd424ee62c64e088d39688f60d20649d978de55f41 \
-    unrar-ng-sys                        0.7.6  afa06861a15d69012d3c1035510e9ca416031ae37b6d27bb7e3ab1a2984e1230 \
+    unrar-ng                            0.7.7  9ff7a01700c732826b5a3414f911cb72015642ebdf16566f2e88b36d5dc49aec \
+    unrar-ng-sys                        0.7.7  72678d22d4d6aa9f0b905f5d6d5cd3e462c55631b526297d06fb1663532daa76 \
     utf8parse                           0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                               1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
+    uuid                               1.25.0  f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc \
     vte                                0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     wait-timeout                        0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
     walkdir                             2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi        0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasip2                   1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
-    wasip3     0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                      0.2.121  49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790 \
-    wasm-bindgen-macro                0.2.121  8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578 \
-    wasm-bindgen-macro-support        0.2.121  d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2 \
-    wasm-bindgen-shared               0.2.121  c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441 \
-    wasm-encoder                      0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
-    wasm-metadata                     0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
-    wasmparser                        0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
+    wasip2                  1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
+    wasm-bindgen                      0.2.127  1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70 \
+    wasm-bindgen-macro                0.2.127  77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1 \
+    wasm-bindgen-macro-support        0.2.127  e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284 \
+    wasm-bindgen-shared               0.2.127  7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf \
+    web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     widestring                          1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                              0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu          0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -272,21 +266,14 @@ cargo.crates \
     windows_x86_64_gnu                 0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnullvm             0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc                0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    wit-bindgen                        0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
     wit-bindgen                        0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    wit-bindgen-core                   0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
-    wit-bindgen-rust                   0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
-    wit-bindgen-rust-macro             0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
-    wit-component                     0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
-    wit-parser                        0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
     xattr                               1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     yansi                               1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
-    zerocopy                           0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
-    zerocopy-derive                    0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
-    zeroize                             1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
+    zerocopy                           0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
+    zerocopy-derive                    0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
+    zeroize                             1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
     zip                                 8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
-    zlib-rs                             0.6.3  3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513 \
-    zmij                               1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
+    zlib-rs                             0.6.7  34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12 \
     zstd                               0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
     zstd-safe                           7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \
     zstd-sys                2.0.16+zstd.1.5.7  91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `7a9be0551dd7`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
