### PR TITLE
ast-grep: update to 0.45.3

### DIFF
--- a/devel/ast-grep/Portfile
+++ b/devel/ast-grep/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        ast-grep ast-grep 0.45.2
+github.setup        ast-grep ast-grep 0.45.3
 github.tarball_from archive
 revision            0
 
@@ -27,9 +27,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d501245674baf3422a23d59f0bd8fd46804a2343 \
-                    sha256  b372fdc542b050336c5491c5d7cc91e0648c107bba90c3ad8e02913e5cf2f4ab \
-                    size    586869
+                    rmd160  e246d8d5e5eec7de71b066fdc62137b4b71d6047 \
+                    sha256  0ad252ce2535493e105bd4b2dd6db2829439732d15599825aecb0b02fc9e606f \
+                    size    589614
 
 destroot {
     xinstall -m 0755 \
@@ -243,7 +243,7 @@ cargo.crates \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
-    tree-sitter                    0.26.13  17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29 \
+    tree-sitter                     0.27.0  2038684e0058edba0d17302619f62eabce4a8e11c6ac59506996a8d79848851d \
     tree-sitter-bash                0.25.1  9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062 \
     tree-sitter-c                   0.24.2  a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728 \
     tree-sitter-c-sharp             0.23.5  c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c \
@@ -259,7 +259,7 @@ cargo.crates \
     tree-sitter-javascript          0.25.0  68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5 \
     tree-sitter-json                0.24.8  4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471 \
     tree-sitter-kotlin-sg            0.4.1  c06ec43ae3c12165d4ac08afe4e1f5fc6757ffe274fa7bd5af9007ef11ba4319 \
-    tree-sitter-language             0.1.7  009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782 \
+    tree-sitter-language             0.1.8  ca0d1bf6fdd806e43ae5198f82f527056d359def39e54e67a0f478ac09dac081 \
     tree-sitter-lua                  0.5.0  8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c \
     tree-sitter-md                   0.5.3  2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882 \
     tree-sitter-nix                  0.3.0  4952a9733f3a98f6683a0ccd1035d84ab7a52f7e84eeed58548d86765ad92de3 \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `e8da74708549`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
