### PR TITLE
golangci-lint: update to 2.13.2

### DIFF
--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golangci/golangci-lint 2.13.1 v
+go.setup            github.com/golangci/golangci-lint 2.13.2 v
 revision            0
 
 homepage            https://golangci-lint.run
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {@steenzout} \
                     openmaintainer
 
-checksums           rmd160  c4961cf195d0976b1b26f6da68dfddab60573eac \
-                    sha256  1e132dc546c90611af81eede4c213018a542ff33e4c10eadab5d964854e0d9ae \
-                    size    5488112
+checksums           rmd160  93037a2fd782fcb2678a7719265674a77989aa55 \
+                    sha256  a79a7a1faad9c1538e3f7f8b32843a53bbeedfa9ead45d9e8ca3bb210d55ece0 \
+                    size    5489610
 
 # date is the release commit's date; refresh it on every update.
 build.args          -trimpath \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `e457a6f9592c`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
