### PR TITLE
lego: update to 5.4.1

### DIFF
--- a/security/lego/Portfile
+++ b/security/lego/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-acme/lego 5.4.0 v
+go.setup            github.com/go-acme/lego 5.4.1 v
 go.offline_build    no
 go.toolchain_min    1.25.0
 revision            0
@@ -29,9 +29,9 @@ build.cmd           make
 build.pre_args      VERSION=v${version}
 build.args          build
 
-checksums           rmd160  a4a711ddd5f2f334f03a2cdb876eb9ff9d849a89 \
-                    sha256  af297c5fffa4270b647405967500ba4c6531f611932e3a66e018e84ac2c33b40 \
-                    size    1284273
+checksums           rmd160  5297ac670864999672314a9f39463811d4506087 \
+                    sha256  71eb5342f42d3b65002a5ef4c0a2f65889eddaf23bc270814b10f22578139e73 \
+                    size    1283566
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `5fb7c3fc44ad`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
