### PR TITLE
treefmt: update to 2.6.0

### DIFF
--- a/devel/treefmt/Portfile
+++ b/devel/treefmt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang  1.0
 PortGroup           github  1.0
 
-go.setup            github.com/numtide/treefmt 2.5.0 v
+go.setup            github.com/numtide/treefmt 2.6.0 v
 go.package          github.com/numtide/treefmt/v2
 go.offline_build    no
 go.toolchain_min    1.26.1
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9c721cea5d8f724899b553adee9fb13a7ced4c75 \
-                    sha256  0d30d2d2a0faf642f8c13c00b7e71a58e4e72f0c403a0e478caea4ab596ad8f8 \
-                    size    198241
+checksums           rmd160  e01c844c2546244b8395c0e73044c6a361ab7975 \
+                    sha256  90993f858b376c0a0ca49920b9679dc774107a96fad8ffc3808809c6a82f4ece \
+                    size    201616
 
 build.args-append   \
     -ldflags \"-X ${go.package}/build.Version=v${version}\"


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `417a1cc87d44`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
