### PR TITLE
trufflehog: update to 3.97.1

### DIFF
--- a/security/trufflehog/Portfile
+++ b/security/trufflehog/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/trufflesecurity/trufflehog 3.97.0 v
+go.setup            github.com/trufflesecurity/trufflehog 3.97.1 v
 go.package          github.com/trufflesecurity/trufflehog/v3
 go.offline_build    no
 go.toolchain_min    1.25.0
@@ -25,9 +25,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 build.args-append \
     -ldflags \" -X ${go.package}/pkg/version.BuildVersion=${version} \"
 
-checksums           rmd160  2ec1cdc740d3b5f952de084706ac2c4fbbc5917f \
-                    sha256  719397b158e4fc9bfe3a777c68fca4b64bb89363caa3ce3013dc28a9e70251de \
-                    size    6180553
+checksums           rmd160  7de9c03d041ceb8e80f11b39628dc56b379b79a4 \
+                    sha256  d54e4d055c59b9bf50d1cf2177f638cdfa0672b2d58fd4fc49c87219c54c38e8 \
+                    size    6193000
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `a3c014c0487d`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
