### PR TITLE
lefthook: update to 2.1.12

### DIFF
--- a/devel/lefthook/Portfile
+++ b/devel/lefthook/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/evilmartians/lefthook 2.1.11 v
+go.setup            github.com/evilmartians/lefthook 2.1.12 v
 go.offline_build    no
 go.toolchain_min    1.26.6
 revision            0
@@ -25,9 +25,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  6aecab5665607705facf85f56603d14d3f37011c \
-                    sha256  c09f388e2f062a71165a9fc2f006cbc68d65a0d5ea5e75e8a069edb560c6cc2c \
-                    size    226403
+checksums           rmd160  0502a3baf7ffb6542a86c34813228d41cf588fdd \
+                    sha256  c2e79ff53d31aaeb5a5765d118552a7b6f6e2667647347200386615ee4e88acf \
+                    size    227213
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `222fd88b6ebf`
  — Tahoe: built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
