### PR TITLE
py-zmq: remove myself as maintainer

### DIFF
--- a/python/py-zmq/Portfile
+++ b/python/py-zmq/Portfile
@@ -15,7 +15,7 @@ revision            0
 
 python.versions     27 310 311 312 313 314
 
-maintainers         {gmail.com:jrjsmrtn @jrjsmrtn} {michaelld @michaelld} openmaintainer
+maintainers         {michaelld @michaelld} openmaintainer
 
 categories-append   devel net
 license             LGPL


### PR DESCRIPTION
#### Description

Removing myself as a maintainer of `py-zmq`, and I owe an apology for it being overdue.

I have not been carrying my share on this port for a long time. The updates over the past
year — 27.0.2, 27.1.0, the py314 subport, dropping py39 — were done by @reneeotten and
@Schamschula, neither of whom is listed as a maintainer. Being named on the port while
others do the work is worse than not being named at all: it misdirects tickets and makes
the port look better staffed than it is. Sorry for leaving it that way for so long.

```diff
-maintainers         {gmail.com:jrjsmrtn @jrjsmrtn} {michaelld @michaelld} openmaintainer
+maintainers         {michaelld @michaelld} openmaintainer
```

@michaelld remains, so the port keeps a maintainer and nothing falls to `nomaintainer`.

@michaelld — a courtesy heads-up rather than a surprise at merge time: this leaves you as
sole maintainer of `py-zmq` and its six subports (`py27-`, `py310-` … `py314-zmq`). If you
would rather it stayed shared, say so and I will close this instead; I would just rather
the field reflected reality.

`openmaintainer` is unchanged, so others may still commit obvious fixes without asking.

One line changed, no functional effect: `port lint --nitpick` reports 0 errors and 0
warnings, and `port info --maintainers` now resolves to `michaelld@macports.org
michaelld, openmaintainer`.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Build, test, install and binary-functionality items are deleted rather than left unticked:
this changes only the `maintainers` line, so it cannot affect how the port builds or what
it installs.
