### PR TITLE
grype: update to 0.118.0

### DIFF
--- a/security/grype/Portfile
+++ b/security/grype/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/anchore/grype 0.117.0 v
+go.setup            github.com/anchore/grype 0.118.0 v
 go.offline_build    no
 go.toolchain_min    1.26.3
 revision            0


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `a7592e3891d6`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
