### PR TITLE
timoni: update to 0.34.0

### DIFF
--- a/sysutils/timoni/Portfile
+++ b/sysutils/timoni/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stefanprodan/timoni 0.33.0 v
+go.setup            github.com/stefanprodan/timoni 0.34.0 v
 go.toolchain_min    1.27.0
 revision            0
 
@@ -27,9 +27,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  a7313b8c14c0d7f2cba37117294d44034479298a \
-                    sha256  d4deea9903b33903a3b30b24047126d639984c95c3e1aec0ec45caace81b1c77 \
-                    size    1264097
+checksums           rmd160  f584c2cf6a8f3d345dd16b4b16057b33ec738ef4 \
+                    sha256  1b7cd6ca484170cfa551015e2d1a00932801d1947e45a415e5d88eb74dac4440 \
+                    size    1318895
 
 go.offline_build no
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `c3e04791261e`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
