### PR TITLE
gosec: update to 2.29.0

### DIFF
--- a/security/gosec/Portfile
+++ b/security/gosec/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/securego/gosec 2.28.0 v
+go.setup            github.com/securego/gosec 2.29.0 v
 go.package          github.com/securego/gosec/v2
 go.offline_build    no
 go.toolchain_min    1.25.8
@@ -22,9 +22,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  a426e009e1351e89f519483bc196a5d1221225e7 \
-                    sha256  ccf7fa75b606c2adfcafadd6a3830966a161c4350a90fdfe4f15d6230da86d8f \
-                    size    389975
+checksums           rmd160  a1407ab33cc736ad1d8ac45310cf99658f588c99 \
+                    sha256  083422c2d64f311062e7fe36ff1bd22c98b029f0a4d69f3e81fd0a4724139092 \
+                    size    393421
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `5d572f4142d1`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
