### PR TITLE
minizinc: update to 2.10.1

### DIFF
--- a/devel/minizinc/Portfile
+++ b/devel/minizinc/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        MiniZinc libminizinc 2.10.0
+github.setup        MiniZinc libminizinc 2.10.1
 github.tarball_from archive
 name                minizinc
 revision            0
@@ -35,9 +35,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 platforms           darwin linux
 
-checksums           rmd160  deab398ea8964785f46d01d2a26a62e2c61baba9 \
-                    sha256  a71d1359dda1bd68e9946e5c49a95b44c4aefd6dc4654cae769097c28698be0e \
-                    size    8205349
+checksums           rmd160  b90c6cddc2bb81583502130a3cb3bd82692c64b7 \
+                    sha256  089ea94698cea94ed8396be77559b82d828437a808f5e37d10bccc9f1d39dd33 \
+                    size    8571096
 
 depends_build-append \
                     port:bison


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `61c836a5e2bc`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
