### PR TITLE
rio: update to 0.5.27

### DIFF
--- a/aqua/rio/Portfile
+++ b/aqua/rio/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        raphamorim rio 0.5.25 v
+github.setup        raphamorim rio 0.5.27 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  469a4cb159f62bf49a838431f712e7d6ac22075b \
-                    sha256  4e6c3c412e8db1e8d7db3bb043a39afc2fd78091ab30ce4c6d264f96c25a5d60 \
-                    size    10894553
+                    rmd160  144a8b7b9c4fb30e15708e6bd84780b3b26c8c64 \
+                    sha256  860cb019a4f6a87bffb786ac2408f51f7c7f09551be234355fb3fd4feeac5331 \
+                    size    10928347
 
 set appname         Rio
 
@@ -58,7 +58,7 @@ cargo.crates \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     alsa                             0.9.1  ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43 \
     alsa-sys                         0.3.1  db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527 \
-    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    android_system_properties        0.1.6  ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
     anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
     anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
@@ -82,11 +82,11 @@ cargo.crates \
     async-recursion                  1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
     async-signal                    0.2.14  52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485 \
     async-task                       4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
-    async-trait                     0.1.91  ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
+    async-trait                     0.1.92  82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     baremetal                       0.33.0  c9cac49f90014f62132579bce49ad56aeaba4ae582174dade1420e24ee01279b \
-    base64                          0.23.0  b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9 \
+    base64                          0.23.1  ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5 \
     bincode                          2.0.1  36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740 \
     bincode_derive                   2.0.1  bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09 \
     bindgen                         0.70.1  f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f \
@@ -97,17 +97,17 @@ cargo.crates \
     bit-vec                          0.9.1  b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                        2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
-    blake3                           1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
+    blake3                           1.8.7  6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-rs                         0.2.0  be18a19ad1a48c5619f06160be5885df75586ecf17b61410bcfe94532fd8b53a \
     block2                           0.5.1  2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
-    blocking                         1.6.2  e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21 \
+    blocking                         1.7.0  a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa \
     borsh                            1.8.0  a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f \
     bumpalo                         3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     bytecount                        0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     bytemuck                        1.25.2  95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797 \
-    bytemuck_derive                 1.11.0  f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5 \
+    bytemuck_derive                 1.12.0  fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                           1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
@@ -116,7 +116,7 @@ cargo.crates \
     calloop-wayland-source           0.3.0  95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20 \
     calloop-wayland-source           0.4.1  138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                               1.4.0  5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9 \
+    cc                               1.4.4  0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273 \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cexpr                            0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
@@ -126,8 +126,8 @@ cargo.crates \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
     clang-sys                        1.9.1  157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a \
-    clap                             4.6.5  301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf \
-    clap_builder                     4.6.5  94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078 \
+    clap                             4.6.6  473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca \
+    clap_builder                     4.6.6  7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889 \
     clap_derive                      4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
     clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     clipboard-win                    5.4.1  bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4 \
@@ -156,7 +156,7 @@ cargo.crates \
     cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
     crc                              3.4.0  5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
     crc-catalog                      2.5.0  217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
-    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    crc32fast                        1.5.1  8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550 \
     criterion                        0.6.0  3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679 \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
     crossbeam-channel               0.5.16  d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
@@ -191,21 +191,21 @@ cargo.crates \
     dtor                             0.8.1  edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dwrote                          0.11.5  9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02 \
-    either                          1.17.0  9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d \
+    either                          1.18.0  252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     endi                             1.1.1  66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099 \
     enumflags2                      0.7.12  1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef \
     enumflags2_derive               0.7.12  67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
-    error-code                       3.3.2  dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59 \
+    error-code                       3.4.0  0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7 \
     euclid                         0.22.14  f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06 \
     event-listener                   5.4.2  5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2 \
     event-listener-strategy          0.5.4  8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
     fastrand                         2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
     fax                              0.2.7  caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a \
     fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
-    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    find-msvc-tools                 0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
     fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
     flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
     float-ord                        0.3.2  8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d \
@@ -213,7 +213,7 @@ cargo.crates \
     foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     font-kit                        0.14.3  2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3 \
     font-types                      0.10.1  39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5 \
-    font-types                      0.12.2  0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100 \
+    font-types                      0.12.4  e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23 \
     fontconfig-parser                0.5.8  bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646 \
     foreign-types                    0.5.0  d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965 \
     foreign-types-macros             0.2.4  ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225 \
@@ -222,16 +222,16 @@ cargo.crates \
     freetype-sys                    0.20.1  0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134 \
     fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
     fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
-    futures                         0.3.33  a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218 \
-    futures-channel                 0.3.33  262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae \
-    futures-core                    0.3.33  2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7 \
-    futures-executor                0.3.33  6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458 \
-    futures-io                      0.3.33  4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a \
+    futures                         0.3.34  9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3 \
+    futures-channel                 0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
+    futures-core                    0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
+    futures-executor                0.3.34  031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432 \
+    futures-io                      0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
     futures-lite                     2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
-    futures-macro                   0.3.33  2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b \
-    futures-sink                    0.3.33  e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307 \
-    futures-task                    0.3.33  b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109 \
-    futures-util                    0.3.33  a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa \
+    futures-macro                   0.3.34  9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44 \
+    futures-sink                    0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                    0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-util                    0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     gethostname                      1.1.0  1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8 \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
@@ -258,19 +258,19 @@ cargo.crates \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    icu_collections                  2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
-    icu_locale_core                  2.2.0  92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29 \
-    icu_normalizer                   2.2.0  c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4 \
-    icu_normalizer_data              2.2.0  da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38 \
-    icu_properties                   2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
-    icu_properties_data              2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
-    icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
+    icu_collections                  2.3.0  fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513 \
+    icu_locale_core                  2.3.0  d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb \
+    icu_normalizer                   2.3.0  12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f \
+    icu_normalizer_data              2.3.0  1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0 \
+    icu_properties                   2.3.0  7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148 \
+    icu_properties_data              2.3.0  e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa \
+    icu_provider                     2.3.1  d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
     image                          0.25.10  85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104 \
     image-webp                       0.2.4  525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3 \
     indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
-    inotify                         0.11.4  153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8 \
+    inotify                         0.11.5  4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592 \
     inotify-sys                      0.1.8  c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d \
     is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
@@ -281,11 +281,11 @@ cargo.crates \
     jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                       0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
-    js-sys                         0.3.103  53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
+    js-sys                         0.3.104  0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a \
     keyboard-types                   0.7.0  b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a \
     khronos-egl                      6.0.0  6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76 \
     khronos_api                      3.1.0  e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc \
-    kqueue                           1.2.0  273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5 \
+    kqueue                           1.2.1  8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea \
     kqueue-sys                       1.1.2  07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libc                           0.2.189  3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
@@ -300,15 +300,15 @@ cargo.crates \
     librashader-reflect             0.12.0  923a7ea3724e2fca281a08598217fe2daa5b6a245a278448251c851f19c0b290 \
     librashader-runtime             0.12.0  b10ef2d1a3f80068ca08f7e64bf4bd9f72ccf08555bf811622928b881dc48f9a \
     librashader-runtime-wgpu        0.12.0  947af07d04b41d5d9cd7e985b5920646663aa23e0025d8d0f213b6636a0ba0a4 \
-    libredox                        0.1.19  2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa \
+    libredox                        0.1.20  28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
-    litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
+    litemap                          0.8.3  47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae \
     litrs                            1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                             0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
+    log                             0.4.34  f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6 \
     lru                             0.16.4  7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39 \
     mach2                            0.4.3  d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
@@ -317,15 +317,15 @@ cargo.crates \
     memchr                           2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     memmap2                         0.9.11  d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0 \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
-    minicov                          0.3.8  4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d \
+    minicov                          0.3.9  c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
     miow                             0.5.0  52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123 \
     miow                             0.6.1  536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08 \
     moxcms                           0.8.1  bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b \
-    naga                            30.0.0  23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033 \
-    naga-types                      30.0.0  658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11 \
+    naga                            30.0.1  a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130 \
+    naga-types                      30.0.1  590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49 \
     ndk                              0.8.0  2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7 \
     ndk                              0.9.0  c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4 \
     ndk-context                      0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
@@ -374,7 +374,7 @@ cargo.crates \
     oorandom                        11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     orbclient                       0.3.55  5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747 \
-    ordered-float                    5.3.0  b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e \
+    ordered-float                    5.5.0  8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0 \
     ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
     owned_ttf_parser                0.25.1  36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
@@ -392,7 +392,7 @@ cargo.crates \
     pin-project-internal            1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
     pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     piper                            0.2.5  c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1 \
-    pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
+    pkg-config                      0.3.34  f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548 \
     plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
     platform-dirs                    0.3.0  e188d043c1a692985f78b5464853a263f1a27e5bd6322bad3a4078ee3c998a38 \
     plotters                         0.3.7  5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747 \
@@ -401,9 +401,9 @@ cargo.crates \
     png                            0.17.16  82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526 \
     png                             0.18.1  60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61 \
     polling                         3.11.0  5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218 \
-    portable-atomic                 1.14.0  3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3 \
+    portable-atomic                 1.15.0  05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85 \
     portable-atomic-util             0.2.7  c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618 \
-    potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
+    potential_utf                    0.1.6  d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     presser                          0.3.1  e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
@@ -432,11 +432,11 @@ cargo.crates \
     read-fonts                      0.41.0  046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709 \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
     redox_syscall                   0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
-    redox_syscall                    0.9.1  07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e \
+    redox_syscall                    0.9.3  d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     regex                           1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
-    regex-automata                  0.4.16  8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad \
+    regex-automata                  0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     renderdoc-sys                    1.1.0  19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832 \
     roxmltree                       0.20.0  6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97 \
@@ -447,7 +447,7 @@ cargo.crates \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustversion                     1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
-    safe_arch                        1.1.0  3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59 \
+    safe_arch                        1.2.0  42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
@@ -497,9 +497,9 @@ cargo.crates \
     tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.19  09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
+    thiserror                       2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.19  43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
+    thiserror-impl                  2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
     thread_local                    1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
     tiff                            0.11.3  b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52 \
     tiny-skia                       0.11.4  83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab \
@@ -507,7 +507,7 @@ cargo.crates \
     tiny-skia-path                  0.11.4  9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93 \
     tiny-skia-path                  0.12.0  edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9 \
     tiny-xlib                        0.2.5  a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4 \
-    tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
+    tinystr                          0.8.4  b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643 \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                         1.12.0  bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
@@ -545,15 +545,15 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                        1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
-    wasm-bindgen                   0.2.126  4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4 \
-    wasm-bindgen-futures            0.4.76  c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d \
-    wasm-bindgen-macro             0.2.126  167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1 \
-    wasm-bindgen-macro-support     0.2.126  f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e \
-    wasm-bindgen-shared            0.2.126  dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24 \
-    wasm-bindgen-test               0.3.76  2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4 \
-    wasm-bindgen-test-macro         0.3.76  94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120 \
-    wasm-bindgen-test-shared       0.2.126  c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920 \
-    wayland-backend                 0.3.16  016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8 \
+    wasm-bindgen                   0.2.127  1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70 \
+    wasm-bindgen-futures            0.4.77  6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950 \
+    wasm-bindgen-macro             0.2.127  77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1 \
+    wasm-bindgen-macro-support     0.2.127  e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284 \
+    wasm-bindgen-shared            0.2.127  7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf \
+    wasm-bindgen-test               0.3.77  895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1 \
+    wasm-bindgen-test-macro         0.3.77  4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759 \
+    wasm-bindgen-test-shared       0.2.127  33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987 \
+    wayland-backend                 0.3.17  38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078 \
     wayland-client                 0.31.15  e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073 \
     wayland-csd-frame                0.3.0  625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e \
     wayland-cursor                 0.31.14  4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d \
@@ -564,18 +564,18 @@ cargo.crates \
     wayland-protocols-wlr           0.3.12  eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234 \
     wayland-scanner                0.31.11  338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0 \
     wayland-sys                    0.31.11  d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be \
-    web-sys                        0.3.103  8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
+    web-sys                        0.3.104  c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     weezl                           0.1.12  a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88 \
-    wgpu                            30.0.0  6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114 \
-    wgpu-core                       30.0.0  08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2 \
-    wgpu-core-deps-apple            30.0.0  3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225 \
-    wgpu-core-deps-emscripten       30.0.0  85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad \
-    wgpu-core-deps-windows-linux-android    30.0.0  f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43 \
-    wgpu-hal                        30.0.0  cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101 \
-    wgpu-naga-bridge                30.0.0  c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5 \
-    wgpu-types                      30.0.0  1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565 \
-    wide                             1.6.0  be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1 \
+    wgpu                            30.0.1  527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e \
+    wgpu-core                       30.0.1  14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14 \
+    wgpu-core-deps-apple            30.0.1  061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68 \
+    wgpu-core-deps-emscripten       30.0.1  d98b86cf4abf524a902dd35f18ca6a3f08fc2ae9847c8f10b48e30491b1f0b86 \
+    wgpu-core-deps-windows-linux-android    30.0.1  7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f \
+    wgpu-hal                        30.0.1  b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58 \
+    wgpu-naga-bridge                30.0.1  d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081 \
+    wgpu-types                      30.0.1  99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286 \
+    wide                             1.6.1  de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
@@ -631,7 +631,7 @@ cargo.crates \
     winres                          0.1.12  b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c \
     wio                              0.2.2  5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5 \
     wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    writeable                        0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
+    writeable                        0.6.4  3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc \
     wyhash                           0.5.0  baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295 \
     x11-clipboard                    0.9.3  662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3 \
     x11-dl                          2.21.0  38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f \
@@ -641,7 +641,7 @@ cargo.crates \
     xdg-home                         1.3.0  ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6 \
     xkbcommon-dl                     0.4.2  d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5 \
     xkeysym                          0.2.1  b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56 \
-    xml-rs                          0.8.28  3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f \
+    xml-rs                          0.8.29  e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yazi                             0.2.1  e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5 \
     yeslogic-fontconfig-sys          6.0.1  1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76 \
@@ -651,16 +651,16 @@ cargo.crates \
     zbus_macros                      4.4.0  267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e \
     zbus_names                       3.0.0  4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c \
     zeno                             0.3.3  6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524 \
-    zerocopy                        0.8.55  b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb \
-    zerocopy-derive                 0.8.55  0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb \
+    zerocopy                        0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
+    zerocopy-derive                 0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
     zerofrom                         0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
-    zerotrie                         0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
-    zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
-    zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
+    zerotrie                         0.2.5  4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f \
+    zerovec                         0.11.8  bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8 \
+    zerovec-derive                  0.11.6  34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da \
     zigzag                           0.1.0  70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf \
     zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
-    zune-core                        0.5.1  cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9 \
+    zune-core                        0.5.3  d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b \
     zune-jpeg                       0.5.15  27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296 \
     zvariant                         4.2.0  2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe \
     zvariant_derive                  4.2.0  73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449 \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `b2a4b18968bb`
  — Tahoe: linted with 616 warnings, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
