### PR TITLE
corsixth: update to 0.70.1

### DIFF
--- a/games/corsixth/Portfile
+++ b/games/corsixth/Portfile
@@ -5,10 +5,10 @@ PortGroup           cmake         1.1
 PortGroup           github        1.0
 PortGroup           legacysupport 1.1
 
-github.setup        CorsixTH CorsixTH 0.70.0 v
+github.setup        CorsixTH CorsixTH 0.70.1 v
 github.tarball_from archive
 name                corsixth
-revision            1
+revision            0
 
 description         Open source clone of Theme Hospital
 
@@ -23,9 +23,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9bd30205d998c7c82b3692ca872c749a1ed42b18 \
-                    sha256  e8f9803f6f64d23f057506202fbf275fe136c3245bab4bc19ff4c63691459cb7 \
-                    size    4414049
+checksums           rmd160  523a7aa0f9f3b5ff25f6a0274d2f749a1bc5a889 \
+                    sha256  b3a37b09f168f30600d305314f5a823d3af10bf407074e9a837e0e85acfe9ba3 \
+                    size    4416633
 
 legacysupport.use_mp_libcxx \
                     yes


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `e30e06661a90`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
