### PR TITLE
moor: update to 2.18.0

### DIFF
--- a/textproc/moor/Portfile
+++ b/textproc/moor/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/walles/moor 2.17.0 v
+go.setup            github.com/walles/moor 2.18.0 v
 go.offline_build    no
-go.toolchain_min    1.25.0
+go.toolchain_min    1.27.0
 revision            0
 
 description         Moor is a pager. It's designed to just do the right thing \
@@ -16,9 +16,9 @@ long_description    Moor should work as a drop-in replacement for Less. \
                     support, incremental search and automatic decompression, \
                     among others.
 
-checksums           rmd160  fcd470c3cde55d95e990d65fbfe3366a1257c672 \
-                    sha256  ae901ba6bf680c9ce4c0a223b127f30c38cba83c8a8df4aaf79dbb256b03a30e \
-                    size    5381789
+checksums           rmd160  3e62124c401f033df5ce5faf05729880ff2f29a6 \
+                    sha256  b6b0fddc4d3eb622af3181fa52343705387d017d59114d564cd540a11a0f3f0e \
+                    size    5382471
 
 categories          textproc
 installs_libs       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `a41ae27360c3`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
