### PR TITLE
aws-vault: update to 7.13.6

### DIFF
--- a/security/aws-vault/Portfile
+++ b/security/aws-vault/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ByteNess/aws-vault 7.13.5 v
+go.setup            github.com/ByteNess/aws-vault 7.13.6 v
 go.offline_build    no
 go.toolchain_min    1.26
 go.package          github.com/ByteNess/aws-vault
@@ -21,9 +21,9 @@ long_description    \
     designed to be complementary to the AWS CLI tools, and is aware of your \
     profiles and configuration in ~/.aws/config.
 
-checksums           rmd160  990df890dc2f2057a58e577a89d0a1c828c1d121 \
-                    sha256  8276092b6526f6244b3bf8a515ad78ad1ddb5a7ab56eeaad1ac1b7ee01d4678e \
-                    size    380270
+checksums           rmd160  5a3c0a1fc49e89f6fe5098d87ca0e01f3eda8f4d \
+                    sha256  84d282802cd867ea37dde7824ec2628cbe19f599b3acd55e73cd3d6f6cf244de \
+                    size    380259
 
 categories          security
 installs_libs       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `38c4fdaa69ed`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
