### PR TITLE
toot: update to 0.52.1

### DIFF
--- a/net/toot/Portfile
+++ b/net/toot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                toot
-version             0.51.0
+version             0.52.1
 revision            0
 
 description         A CLI and TUI tool for interacting with Mastodon instances
@@ -19,9 +19,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  1858f8edadc932563cd56e1d4df9db019cf76bcc \
-                    sha256  48e2c422c92aebca20c1913238b6dbff969a048ee4eaa70d62921a1e58415797 \
-                    size    1316620
+checksums           rmd160  a804e55daf29e0ef8d5165b8324415fb1d09e4d3 \
+                    sha256  b737173be5587522077c18c4024eb1741a4a30e59d3165e72fd6ce4519d2fecb \
+                    size    1318274
 
 python.default_version 313
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `a674a6aaebe1`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
