### PR TITLE
tree-sitter: update to 0.27.0

### DIFF
--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        tree-sitter tree-sitter 0.26.12 v
+github.setup        tree-sitter tree-sitter 0.27.0 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 dist_subdir         ${name}/${version}_${revision}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  be1e6698749bf1555ff242542adbac2252fe8f61 \
-                    sha256  428e2b182fe38eddc100d8bd851e47c96921a69281b66abafc25ba4b0aaeeeab \
-                    size    923279
+                    rmd160  a1d7be21987aedb3ca17dedab07ea7c0d636cfe9 \
+                    sha256  d35c96e68736bd9569d2757c3cc71052485f33082c3825f1aed9d0e86013a159 \
+                    size    1020259
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `b045c653b644`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
