### PR TITLE
fastfetch: update to 2.68.1

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -5,7 +5,7 @@ PortGroup           github  1.0
 PortGroup           cmake   1.1
 PortGroup           legacysupport 1.1
 
-github.setup        fastfetch-cli fastfetch 2.67.1
+github.setup        fastfetch-cli fastfetch 2.68.1
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  d77078e99f86c8dc6133955dc0a726d9fc0bff44 \
-                    sha256  52489550d1fdeac8bde8b3442064e3bc78d28fda752a171dc46a6cd97454f237 \
-                    size    1573878
+checksums           rmd160  098dd2a6f8c3e4c71a0c3ee65f4dcf05db983c4d \
+                    sha256  c268cfcd230cc7ed5447fb34ed21bf4977315c7104356a39388b6ba784ad11b0 \
+                    size    1635873
 
 set py_branch       3.14
 set py_version      [string map {. ""} ${py_branch}]


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `c116bbddf3c4`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
