### PR TITLE
scw: update to 2.62.0

### DIFF
--- a/net/scw/Portfile
+++ b/net/scw/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/scaleway/scaleway-cli 2.61.0 v
+go.setup            github.com/scaleway/scaleway-cli 2.62.0 v
 go.offline_build    no
 go.toolchain_min    1.26.3
 revision            0
@@ -23,9 +23,9 @@ description         Command Line Interface for Scaleway
 long_description    Scaleway CLI is a tool to help you pilot your Scaleway \
                     infrastructure directly from your terminal.
 
-checksums           rmd160  056d54a9653d3b25b3b7a26784f0d2be6d718273 \
-                    sha256  dda6a781182a93ed067fd2e73e6a5a183c355cba21f1bc958c4297e50765874d \
-                    size    4071275
+checksums           rmd160  9fe66c296f42800d2472ae5178d84c1cbc09624d \
+                    sha256  055c5c99ac022fdb1d7c235928bd9a331ec04926ba00241b93cbb4c9ff8a5583 \
+                    size    4105220
 
 build.pre_args-append \
     -ldflags \" -X main.Version=${github.tag_prefix}${version} \"


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `a08bbd5bb3d3`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
