### PR TITLE
task: update to 3.5.0

### DIFF
--- a/office/task/Portfile
+++ b/office/task/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cmake   1.1
 
-github.setup        GothenburgBitFactory taskwarrior 3.4.2 v
+github.setup        GothenburgBitFactory taskwarrior 3.5.0 v
 github.tarball_from releases
 revision            0
 name                task
@@ -24,9 +24,9 @@ homepage            https://taskwarrior.org/
 
 distname            task-${github.version}
 
-checksums           rmd160  d489d26685dfdbe5bd71e2dd69d046af82e96178 \
-                    sha256  d302761fcd1268e4a5a545613a2b68c61abd50c0bcaade3b3e68d728dd02e716 \
-                    size    959873
+checksums           rmd160  9bd09746694b764030e439e2c096cc44f066e9fb \
+                    sha256  9ea64b411f8314414f440ec765dfdf5a86c9f6159df47e2f60cff3db6b31157a \
+                    size    970271
 
 depends_build-append \
                     port:cargo


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `f7e8877815a8`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
