### PR TITLE
gitlab-runner: update to 19.3.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 19.3.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 19.3.1 v
 revision            0
 
 homepage            https://docs.gitlab.com/runner/
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  4b7d63e6d5c1ddaa5c0d9b13babd5ae26899c87a \
-                    sha256  93ddf6a712cfea1e431c74a41e17a93c0f03275d88fb51d83661e531dc9cdf98 \
-                    size    2962749
+checksums           rmd160  bad848792ea0012676646bcbd47adb292fead65c \
+                    sha256  4e09488084ed3259fe2b16104c712aca2bd38568daed8c737584a68f9ebffe2f \
+                    size    2962522
 
 # Allow Go to fetch deps at build time
 go.offline_build no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `408c8ed5aa32`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
