### PR TITLE
krep: update to 3.0.1

### DIFF
--- a/textproc/krep/Portfile
+++ b/textproc/krep/Portfile
@@ -8,7 +8,7 @@ PortGroup           makefile        1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        davidesantangelo krep 3.0.0 v
+github.setup        davidesantangelo krep 3.0.1 v
 github.tarball_from archive
 revision            0
 
@@ -20,9 +20,9 @@ long_description    \
     search algorithms and leverages modern hardware capabilities to deliver \
     maximum throughput.
 
-checksums           rmd160  7f3cc6bdfc1f0e7eea06b2252626dff27ffaba78 \
-                    sha256  78ed8e36051145d523c9a7be878f7af82bd26405ff28d1ebdcae07efe4c52fdf \
-                    size    89770
+checksums           rmd160  5875d81f5fadb1746c80096dd8808aa844dc41af \
+                    sha256  2d0f254dfcbf49b69ab39d7874a290b4de3c869c0ae7818494bba5adc835581a \
+                    size    90470
 
 categories          textproc
 installs_libs       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `737582030e72`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
