### PR TITLE
argocd: update to 3.5.2

### DIFF
--- a/devel/argocd/Portfile
+++ b/devel/argocd/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/argoproj/argo-cd 3.5.1 v
+go.setup            github.com/argoproj/argo-cd 3.5.2 v
 go.offline_build    no
 go.toolchain_min    1.26
 name                argocd
@@ -25,9 +25,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e8fc4c1a19f9859edfe9673f3d2c564081b102cd \
-                    sha256  d2a97bfe71bd6135f1643ceaace39c40067ce1ebe1d1f44274516f3618eeff10 \
-                    size    52553949
+checksums           rmd160  dca57cc566d774af33f42520d99e0513cb8bd8ad \
+                    sha256  8236a02fefd9cc349b6bf2ce554713c47a58e3f4ce498ee0208504c8873ef2a8 \
+                    size    52556876
 
 build.cmd               make
 build.pre_args-append   GOPATH=${gopath}


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `ad89f6c96208`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
