### PR TITLE
lyra: update to 1.8.0

### DIFF
--- a/devel/lyra/Portfile
+++ b/devel/lyra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake   1.1
 PortGroup           github  1.0
 
-github.setup        bfgroup lyra 1.7.0
+github.setup        bfgroup lyra 1.8.0
 github.tarball_from archive
 revision            0
 
@@ -18,6 +18,6 @@ license             Boost-1
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  238478c4a3ae0231212763ef666f86deda699a20 \
-                    sha256  d26b9e9dc1e08f88feaebc68965a6e5b25c7cd88617ce910d47cc83efb1e07d9 \
-                    size    565368
+checksums           rmd160  8687bb8c4d5ac2238569e6700a77e3efcb0e29eb \
+                    sha256  cd657146167cd2f80c27e4414ecd1a6639537f5a6d527e608bcd0c633d8beca9 \
+                    size    569006


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `6be63221004e`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
