### PR TITLE
vacuum: update to 0.30.1

### DIFF
--- a/devel/vacuum/Portfile
+++ b/devel/vacuum/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/daveshanley/vacuum 0.20.4 v
-go.toolchain_min    1.24.7
+go.setup            github.com/daveshanley/vacuum 0.30.1 v
+go.toolchain_min    1.25.7
 go.offline_build    no
 revision            0
 
@@ -26,9 +26,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  05add4cff291c19b2a5368a06a57108c48956e66 \
-                    sha256  3806d35806b5ef0f29dac4ba0ff7b2772448150959b187560c6518e543efa48a \
-                    size    15388250
+checksums           rmd160  cebc37a978b4ed6482bd5fc718286a31014a6b38 \
+                    sha256  183c732d48d8156508a13169185caa7dd1103f71e9cedc479c161cb60e2ea240 \
+                    size    16658423
 
 build.pre_args-append \
     -ldflags \" -X main.version=v${version} \"


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `0444c8073833`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
