### PR TITLE
gopass: update to 1.17.0

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.16.1 v
-go.toolchain_min    1.24.1
+go.setup            github.com/gopasspw/gopass 1.17.0 v
+go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
 categories          security
@@ -20,9 +20,9 @@ homepage            https://www.gopass.pw
 
 depends_lib-append  port:gnupg2
 
-checksums           rmd160  f59e48c21d83ab78502d9c3cc66b8dceafd75681 \
-                    sha256  33451a782b66266c59560a5ec7f4e34c104c501a36b445fc574fad71e3b3d884 \
-                    size    2932178
+checksums           rmd160  c49e037b8260146a39edb4e811c74be6c3531477 \
+                    sha256  ce004c82b65ffac44de2991020843828b38bb510909506f2fa0f40bec05b7c75 \
+                    size    3153916
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -tags=netgo


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `0ffd0d948663`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
