### PR TITLE
wasm3: update to 0.9.0

### DIFF
--- a/lang/wasm3/Portfile
+++ b/lang/wasm3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cmake   1.1
 
-github.setup        wasm3 wasm3 0.5.0 v
+github.setup        wasm3 wasm3 0.9.0 v
 github.tarball_from archive
 revision            0
 
@@ -13,9 +13,9 @@ description         \
 
 long_description    {*}${description}
 
-checksums           rmd160  b21b0de54d74c928f2424ebf1985069d034e0d9a \
-                    sha256  b778dd72ee2251f4fe9e2666ee3fe1c26f06f517c3ffce572416db067546536c \
-                    size    2582080
+checksums           rmd160  c98e003e03f92eaa8cf8996a0afc96e8ad33b949 \
+                    sha256  cab79ce74bcac25bbf80b5ebe14af9795b9bac30b05ee8f620a3bc8002f3b8e6 \
+                    size    2656936
 
 categories          lang devel
 installs_libs       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `4bf75d9ec172`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
