### PR TITLE
gopass-jsonapi: update to 1.17.0

### DIFF
--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.16.1 v
-go.toolchain_min    1.24.1
+go.setup            github.com/gopasspw/gopass-jsonapi 1.17.0 v
+go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
 categories          security
@@ -18,9 +18,9 @@ description         Gopass Browser Bindings
 long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
-checksums           rmd160  bdf07f9f4f9c0fc1798d3e829932d7222d106fd2 \
-                    sha256  73449a7c359836a995946e54d91e32afe5a54e1519b5a01f78c9923c13c0894f \
-                    size    34244
+checksums           rmd160  d3f204b1be6162b738a80cfdd0bf22adc76d2d5b \
+                    sha256  eb8f48f23219ef4cbc16944976a42bdcd5f1e74cb892cde3bd8a5aacf451f094 \
+                    size    34190
 
 build.cmd           ${go.bin} mod tidy && ${go.bin} build
 build.args          -ldflags '-X main.version=${version}'


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `4dd8ff682bb1`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
