### PR TITLE
gopass-hibp: update to 1.17.0

### DIFF
--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.16.1 v
-go.toolchain_min    1.24.1
+go.setup            github.com/gopasspw/gopass-hibp 1.17.0 v
+go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
 categories          security
@@ -17,9 +17,9 @@ description         Gopass haveibeenpwnd.com integration
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
-checksums           rmd160  3d718176173e9813d1f3010b49ce40bd0597cc09 \
-                    sha256  c1f2d990126257031d0e1397de87bf1879597d643aa5a00c011332479a576788 \
-                    size    22883
+checksums           rmd160  0c20604f7d787e07bfc254903f9a6da38d0dfa28 \
+                    sha256  db4ece704ea3ec62735da34967347206215674668ab8992567654dd4751940c0 \
+                    size    22303
 
 build.cmd           ${go.bin} mod tidy \&\& ${go.bin} build
 build.args          -ldflags '-X main.version=${version}'


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `64eefb8c62e7`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
