### PR TITLE
git-credential-gopass: update to 1.17.0

### DIFF
--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.16.1 v
-go.toolchain_min    1.24.1
+go.setup            github.com/gopasspw/git-credential-gopass 1.17.0 v
+go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
 
@@ -19,9 +19,9 @@ description         Gopass git-credentials helper
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
-checksums           rmd160  1d63b8d791dc40451991b3dcd742e5627f3ee32b \
-                    sha256  8382b98e56b4547232cc5ea8967eb2a7497a9821a50499d215dafc2f530ba32e \
-                    size    23540
+checksums           rmd160  e116eb0c4ffd13b272f1bf935e4f4beb2bc39705 \
+                    sha256  2efe7cc34ad18f4e12368d24528c5b589c9d0796a606ede8154ad6a412b05ad0 \
+                    size    24889
 
 build.cmd           ${go.bin} mod tidy \&\& ${go.bin} build
 build.args          -ldflags '-X main.version=${version}'


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `97b6f0200540`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
