### PR TITLE
bashunit: update to 0.50.1

### DIFF
--- a/devel/bashunit/Portfile
+++ b/devel/bashunit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        TypedDevs bashunit 0.50.0
+github.setup        TypedDevs bashunit 0.50.1
 github.tarball_from releases
 revision            0
 
@@ -28,9 +28,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 supported_archs     noarch
 
-checksums           rmd160  c7917a4ae0e42874d70a16f8efdda0bc03c946d6 \
-                    sha256  1df4d6358292fa972e3870cc6ad5946c06b3fdf162aa796fa108dc1641465b14 \
-                    size    604768
+checksums           rmd160  bc48ba81c02b1ac8069f487d43558da37807cf03 \
+                    sha256  18d83d590c5304f1853dd4fe4fec4ec6effbd9fe5a21831fe9f66f70afe17d93 \
+                    size    607877
 
 depends_lib-append  port:bash
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `f4b196589fd9`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
