### PR TITLE
tokei: update to 14.0.0

### DIFF
--- a/devel/tokei/Portfile
+++ b/devel/tokei/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        XAMPPRocky tokei 13.0.0 v
+github.setup        XAMPPRocky tokei 14.0.0 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6477fb699cdaa49ecef9511276e734710a23bff8 \
-                    sha256  b426ab03b8eedf4fe3ea70ca8379a2355981b0e9ca1d0083a66e623858e7e481 \
-                    size    164105
+                    rmd160  139cc106d25c31d88d36e2ada17b1c80967b33c3 \
+                    sha256  4e561dbb83ef1b46359714fc623fd45eddfb14821ece63a219470500fdd1cd26 \
+                    size    164314
 
 destroot {
     xinstall -m 0755 \
@@ -40,7 +40,7 @@ cargo.crates \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anstream                        0.6.15  64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526 \
-    anstyle                          1.0.8  1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1 \
+    anstyle                         1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
     anstyle-parse                    0.2.5  eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb \
     anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
     anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
@@ -59,11 +59,11 @@ cargo.crates \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     chrono-tz                        0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
-    clap                            4.5.16  ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019 \
-    clap-cargo                      0.13.0  38ae55615695e768a76899c8411b4ebacfbe525e964f94fd24f0007b10b45cd3 \
-    clap_builder                    4.5.15  216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6 \
-    clap_derive                     4.5.13  501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0 \
-    clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
+    clap                            4.5.53  c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8 \
+    clap-cargo                      0.18.3  936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006 \
+    clap_builder                    4.5.53  d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00 \
+    clap_derive                     4.5.49  2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671 \
+    clap_lex                         0.7.6  a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d \
     colorchoice                      1.0.2  d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0 \
     colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
@@ -179,7 +179,7 @@ cargo.crates \
     tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
-    terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
+    terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
     thiserror                       1.0.63  c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724 \
     thiserror-impl                  1.0.63  a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261 \
     tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `c15e8778b3ea`
  — Tahoe: linted with 204 warnings, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
