### PR TITLE
dtool: update to 0.17.0

### DIFF
--- a/devel/dtool/Portfile
+++ b/devel/dtool/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        guoxbin dtool 0.12.0 v
+github.setup        guoxbin dtool 0.17.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d0cda30d12e9aa711d215357cfae4aebe7bb11f8 \
-                    sha256  e1a1f531f9d01dbe67416cf7ee9a8237326030e8baa311484b7d1a9ff35bd9ff \
-                    size    59700
+                    rmd160  6e54b2b5d63a7c899b07dfa491b35a62f95ae915 \
+                    sha256  956e1554446e0263739cda07bcb12e2007f31ed92d76c9edce82a9f76117aa07 \
+                    size    78759
 
 destroot {
     xinstall -m 0755 \
@@ -30,165 +30,343 @@ destroot {
 }
 
 cargo.crates \
-    aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
-    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    aes                              0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
+    aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    aligned                          0.4.2  377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923 \
+    aligned-vec                      0.6.4  dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b \
+    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                         1.0.100  a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61 \
+    arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
+    arg_enum_proc_macro              0.3.4  0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea \
+    arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
-    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
+    as-slice                         0.2.1  516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516 \
+    async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    atomic                           0.6.1  a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340 \
+    atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
-    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
-    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
-    bitcoin_hashes                   0.9.7  7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1 \
-    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    av-scenechange                  0.14.1  0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394 \
+    av1-grain                        0.2.5  8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8 \
+    avif-serialize                   0.8.6  47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f \
+    axum                             0.7.9  edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f \
+    axum-core                        0.4.5  09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199 \
+    base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
+    base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    bit_field                       0.10.3  1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6 \
+    bitcoin-private                  0.1.0  73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57 \
+    bitcoin_hashes                  0.12.0  5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                        2.10.0  812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3 \
+    bitstream-io                     4.9.0  60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757 \
+    blake2b_simd                     1.0.3  06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99 \
+    blake3                           1.8.2  3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0 \
     block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
-    bs58                             0.3.0  b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae \
-    bstr                             0.2.9  3ede750122d9d1f87919570cb2cccee38c84fbc8c5599b25c289af40625b7030 \
-    build_const                      0.2.1  39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39 \
-    bumpalo                          3.2.0  1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742 \
+    block-padding                    0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
+    bs58                             0.3.1  476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb \
+    build_const                      0.2.2  b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7 \
+    built                            0.8.0  f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64 \
+    bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
     byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
-    byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
-    cc                              1.0.70  d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0 \
-    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.10  31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01 \
-    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    bytemuck                        1.24.0  1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4 \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
+    bytes                           1.11.0  b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3 \
+    cbc                              0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
+    cc                              1.2.47  cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07 \
+    cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
+    chrono                          0.4.42  145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2 \
+    cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
+    clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    const-oid                        0.6.0  44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22 \
-    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
-    cpufeatures                      0.2.1  95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469 \
+    color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
+    const-oid                        0.6.2  9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b \
+    constant_time_eq                 0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    core2                            0.4.0  b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505 \
+    cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     crc                              1.8.1  d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb \
-    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
-    crypto-bigint                    0.2.6  e49339137316df1914fdb54a5eae75a73f45068fd0d2178fe235b11d93238a6e \
+    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
+    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
+    crypto-bigint                   0.2.11  f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03 \
+    crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-mac                      0.11.1  b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714 \
-    csv                              1.1.2  11f8cbd084b9a431d52dfac0b8428a26b68f1061138a7bea18aa56b9cdf55266 \
-    csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
-    curve25519-dalek-ng              4.0.1  574d8b2cd0bae5434fd50d53280f8299d95557a978686555880aaf5b8f4f81e9 \
-    der                              0.4.1  31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412 \
+    csv                              1.4.0  52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938 \
+    csv-core                        0.1.13  704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782 \
+    ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
+    curve25519-dalek-ng              4.1.1  1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8 \
+    data-encoding                    2.9.0  2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476 \
+    der                              0.4.5  79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4 \
+    deranged                         0.5.5  ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587 \
     digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
-    dirs                             1.0.5  3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901 \
-    dtoa                             0.4.4  ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e \
+    dirs-next                        2.0.0  b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1 \
+    dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
+    dtoa                             0.4.8  56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0 \
+    ecb                              0.1.2  1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7 \
     ecdsa                           0.12.4  43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372 \
+    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     elliptic-curve                  0.10.6  beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b \
-    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     entities                         1.0.1  b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca \
-    escaper                          0.1.0  39da344028c2227132b2dfa7c186e2104ecc153467583d00ed9c398f9ff693b0 \
+    equator                          0.4.2  4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc \
+    equator-macro                    0.4.2  44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3 \
+    escaper                          0.1.1  a53eb97b7349ba1bdb31839eceafe9aaae8f1d8d944dc589b67fb0b26e1c1666 \
+    exr                             1.74.0  4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be \
     fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fax                              0.2.6  f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab \
+    fax_derive                       0.2.0  a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d \
+    fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
     ff                              0.10.1  d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f \
+    find-msvc-tools                  0.1.5  3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844 \
+    flate2                           1.1.5  bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    gcc                             0.3.55  8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2 \
-    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
-    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
-    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
-    getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
+    futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
+    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
+    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
+    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
+    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
+    getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
+    gif                             0.14.0  f954a9e9159ec994f73a30a12b96a702dde78f5547bcb561174597924f7d4162 \
     group                           0.10.0  1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912 \
-    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
-    hermit-abi                       0.1.6  eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772 \
-    hex                              0.4.0  023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e \
+    half                             2.7.1  6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hmac                            0.11.0  2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b \
-    indexmap                         1.3.1  0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc \
-    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
-    js-sys                          0.3.53  e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d \
-    keccak                           0.1.0  67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7 \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.101  3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21 \
-    linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
-    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
+    http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
+    http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
+    http-range-header                0.4.2  9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c \
+    httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
+    httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    hyper                            1.8.1  2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11 \
+    hyper-util                      0.1.18  52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56 \
+    iana-time-zone                  0.1.64  33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
+    image                           0.25.9  e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a \
+    image-webp                       0.2.4  525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3 \
+    imgref                          1.12.0  e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8 \
+    indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
+    interpolate_name                 0.2.4  c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60 \
+    is-terminal                     0.4.17  3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46 \
+    itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
+    jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
+    js-sys                          0.3.82  b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65 \
+    jsonwebtoken                     9.3.1  5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde \
+    keccak                           0.1.5  ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654 \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    lebe                             0.5.3  7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8 \
+    libc                           0.2.177  2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976 \
+    libfuzzer-sys                   0.4.10  5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404 \
+    libredox                        0.1.10  416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb \
+    linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
+    lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
+    log                             0.4.28  34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432 \
+    loop9                            0.1.5  0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062 \
     madato                           0.5.3  c36112680b23ee7a5d2a10e56b59a74e4028963e9080b8abec4e69d0d773dc06 \
+    matchit                          0.7.3  0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94 \
+    maybe-rayon                      0.1.1  8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519 \
     md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
-    memchr                           2.3.0  3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223 \
+    memchr                           2.7.6  f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273 \
     merlin                           3.0.0  58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
+    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    mio                              1.1.0  69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873 \
+    moxcms                           0.7.9  0fbdd3d7436f8b5e892b8b7ea114271ff0fa00bc5acae845d53b07d498616ef6 \
+    new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
-    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
-    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
-    once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
+    nom                              8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
+    noop_proc_macro                  0.3.0  0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8 \
+    num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
+    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
+    num-derive                       0.4.2  ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202 \
+    num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-rational                     0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
-    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     p256                             0.9.0  d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186 \
     p384                             0.8.0  f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157 \
     parity-codec                     3.5.4  2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9 \
-    pkcs8                            0.7.5  fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a \
-    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
-    prettytable-rs                   0.8.0  0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e \
-    proc-macro2                     1.0.29  b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d \
-    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
-    rand                            0.3.23  64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
-    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
+    parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
+    paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
+    pastey                           0.1.1  35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec \
+    pem                              3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
+    percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
+    pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkcs8                            0.7.6  ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447 \
+    png                             0.18.0  97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0 \
+    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
+    ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
+    prettytable-rs                  0.10.0  eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a \
+    proc-macro2                    1.0.103  5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8 \
+    profiling                       1.0.17  3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773 \
+    profiling-procmacros            1.0.17  52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b \
+    pxfm                            0.1.25  a3cbdf373972bf78df4d3b518d07003938e2c7d1fb5891e55f9cb6df57009d84 \
+    qoi                              0.4.1  7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001 \
+    qrcode                          0.14.1  d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec \
+    quick-error                      2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
+    quote                           1.0.42  a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f \
+    r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     rand                             0.5.6  c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9 \
-    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
-    rand                             0.8.4  2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8 \
-    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
     rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
-    rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
-    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
-    rand_hc                          0.3.1  d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7 \
-    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
-    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
-    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
-    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
-    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
-    redox_users                      0.3.3  1dc1887cbcd764cc066e2c08681a5615433ac3de9752838a9ec114613b118575 \
-    regex                            1.3.3  b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87 \
-    regex-automata                   0.1.8  92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9 \
-    regex-syntax                    0.6.13  e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
+    rav1e                            0.8.1  43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b \
+    ravif                           0.12.0  ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285 \
+    rayon                           1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
+    rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
+    redox_syscall                   0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
+    regex                           1.12.2  843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4 \
+    regex-automata                  0.4.13  5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c \
+    regex-syntax                     0.8.8  7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58 \
+    rgb                             0.8.52  0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce \
     ring                           0.16.20  3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
+    ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     ripemd160                        0.8.0  ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a \
-    rust-argon2                      0.6.1  416f5109bdd413cec4f04c029297838e7604c993f8d1483b1d438f23bdc3eb35 \
-    rust-crypto                     0.2.36  f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a \
-    rustc-serialize                 0.3.24  dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda \
-    ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
-    schnorrkel                      0.10.1  f7bd2b0ecf15c5651c66e7f3484642780022d3fa6205512b709c75a93e11cd92 \
-    secp256k1                       0.20.3  97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a \
-    secp256k1-sys                    0.4.1  827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b \
-    serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
-    serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
-    serde_test                     1.0.104  33f96dff8c3744387b53404ea33e834073b0791dcc1ea9c85b805745f9324704 \
+    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
+    schnorrkel                      0.10.2  844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    secp256k1                       0.27.0  25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f \
+    secp256k1-sys                    0.8.2  4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99 \
+    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_bytes                    0.11.19  a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8 \
+    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                     1.0.145  402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c \
+    serde_path_to_error             0.1.20  10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_yaml                       0.7.5  ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051 \
-    sha2                             0.8.1  27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0 \
-    sha2                             0.9.6  9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3 \
+    sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
+    sha2                             0.8.2  a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69 \
+    sha2                             0.9.9  4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800 \
     sha3                             0.8.2  dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf \
-    signature                        1.3.1  c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    signal-hook-registry             1.4.6  b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b \
+    signature                        1.3.2  f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4 \
+    simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
+    simd_helpers                     0.1.0  95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6 \
+    simple_asn1                      0.6.3  297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb \
+    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    socket2                          0.6.1  17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881 \
     spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
-    spki                             0.4.0  987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521 \
+    spki                             0.4.1  5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32 \
+    stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     subtle                           2.4.1  6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601 \
-    subtle-ng                        2.4.1  8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f \
-    syn                             1.0.76  c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84 \
-    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
-    term                             0.5.2  edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42 \
+    subtle-ng                        2.5.0  734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142 \
+    syn                            2.0.110  a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea \
+    sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
+    term                             0.7.0  c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
-    time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
-    twox-hash                        1.6.1  1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e \
-    typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
-    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
-    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
-    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
+    thiserror                       2.0.17  f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8 \
+    thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
+    thiserror-impl                  2.0.17  3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913 \
+    tiff                            0.10.3  af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f \
+    time                            0.3.44  91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d \
+    time-core                        0.1.6  40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b \
+    time-macros                     0.2.24  30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3 \
+    tokio                           1.48.0  ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408 \
+    tokio-macros                     2.6.0  af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5 \
+    tokio-util                      0.7.17  2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594 \
+    tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-http                       0.5.2  1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5 \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
+    tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
+    tracing-core                    0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
+    twox-hash                        1.6.3  97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675 \
+    typenum                         1.19.0  562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb \
+    unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
+    unicode-ident                   1.0.22  9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5 \
+    unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
+    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
-    urlencoding                      1.0.0  3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed \
-    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
-    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
-    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
-    wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
-    wasm-bindgen                    0.2.76  8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0 \
-    wasm-bindgen-backend            0.2.76  cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041 \
-    wasm-bindgen-macro              0.2.76  44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef \
-    wasm-bindgen-macro-support      0.2.76  0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad \
-    wasm-bindgen-shared             0.2.76  acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29 \
-    web-sys                         0.3.53  224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c \
-    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
+    urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
+    uuid                            1.18.1  2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2 \
+    v_frame                          0.3.9  666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
+    wasip2                1.0.1+wasi-0.2.4  0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7 \
+    wasm-bindgen                   0.2.105  da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60 \
+    wasm-bindgen-macro             0.2.105  04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2 \
+    wasm-bindgen-macro-support     0.2.105  420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc \
+    wasm-bindgen-shared            0.2.105  76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76 \
+    web-sys                         0.3.82  3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1 \
+    weezl                           0.1.12  a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d \
+    windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
+    windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \
+    windows-interface               0.59.3  3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358 \
+    windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-result                   0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
+    windows-strings                  0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
+    windows-sys                     0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
+    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                 0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
+    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm         0.53.1  a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
+    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc            0.53.1  b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
+    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                0.53.1  960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
+    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm            0.53.1  fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
+    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc               0.53.1  1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
+    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu              0.53.1  9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
+    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm          0.53.1  0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
+    wit-bindgen                     0.46.0  f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59 \
+    y4m                              0.8.0  7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448 \
+    yaml-rust                        0.4.5  56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
     yogcrypt                         0.0.0  b8709dbece7eccde97e3def21330cf24d5c5f9cdac35d8ba5af7f960e88d8999 \
-    zeroize                          1.4.1  377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd \
-    zeroize_derive                   1.0.0  de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2
+    zerocopy                        0.8.28  43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90 \
+    zerocopy-derive                 0.8.28  c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26 \
+    zeroize                          1.4.3  d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619 \
+    zeroize_derive                   1.4.2  ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69 \
+    zune-core                       0.4.12  3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a \
+    zune-core                        0.5.0  111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773 \
+    zune-inflate                    0.2.54  73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02 \
+    zune-jpeg                       0.4.21  29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713 \
+    zune-jpeg                        0.5.5  dc6fb7703e32e9a07fb3f757360338b3a567a5054f21b5f52a666752e333d58e


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `5ee249397740`
  — Tahoe: linted with 340 warnings, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
