### PR TITLE
flyctl: update to 0.4.96

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/superfly/flyctl 0.4.94 v
+go.setup            github.com/superfly/flyctl 0.4.96 v
 go.offline_build    no
 go.toolchain_min    1.26.3
 revision            0
@@ -20,9 +20,9 @@ long_description    ${name} is a command-line interface for fly.io.
 
 homepage            https://fly.io
 
-checksums           rmd160  25d856ffc0803eabad8042a6a450346b9cf18496 \
-                    sha256  a4d4acb20c8650200fa3bddf01a70f4549cf8267329075c8186706133ca30fc7 \
-                    size    2029670
+checksums           rmd160  37d5a0958749fb96c65e7059fbe04299ebac3c04 \
+                    sha256  1909b6a0e1ff585eb8f773281309cae961e79acfcaf6100ea1a2ecdbaa71e90a \
+                    size    2042782
 
 build.cmd           "${go.bin} generate ./... && ${go.bin} build"
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `d653ad3f81a9`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
