### PR TITLE
vault: pin Go version 1.26

### DIFF
--- a/security/vault/Portfile
+++ b/security/vault/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/hashicorp/vault 2.0.4 v
 go.offline_build    no
 go.toolchain_min    1.26.4
-revision            0
+revision            1
 
 homepage            https://www.vaultproject.io
 
@@ -32,6 +32,12 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 # Vault's build process requires the git repository.
 fetch.type          git
 
+# The enumer package causes a build failure when compiling when Go 1.27.
+# Upstream recently changed to using a forked version of the enumer package
+# that includes fixes to build with Go 1.27. For 2.0.4, the version of enumer
+# pinned in the tools.sh script still requires Go 1.26, so we build with that.
+depends_build       port:go-1.26
+
 # The "dev" build target must be used to build just the binary for this
 # platform, instead of for ALL platforms
 # - https://www.vaultproject.io/docs/install/index.html#compiling-from-source
@@ -48,8 +54,11 @@ use_parallel_build  no
 # official Go module proxy.
 #
 # - https://github.com/hashicorp/vault/issues/8696
+#
+# vault's build uses make, which calls go from PATH, rather that go directly,
+# so we have to append the go-1.26 bin to the PATH.
 build.env-append    "GOPRIVATE=github.com/hashicorp/vault-plugin*" \
-                    PATH=$env(PATH):${gopath}/bin
+                    PATH=${prefix}/lib/go-1.26/bin:$env(PATH):${gopath}/bin
 
 destroot {
     xinstall -m 0755 ${gopath}/bin/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
The enumer package needs Go 1.26 to compile (it fails with Go 1.27). Pin the version of Go to 1.26 to compile vault.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
