### PR TITLE
jansson: update to 2.15.1

### DIFF
--- a/devel/jansson/Portfile
+++ b/devel/jansson/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github  1.0
 
-github.setup        akheron jansson 2.15.0 v
+github.setup        akheron jansson 2.15.1 v
 github.tarball_from releases
 revision            0
 
@@ -17,9 +17,9 @@ long_description    {*}${description}
 homepage            https://www.digip.org/jansson/
 
 use_bzip2           yes
-checksums           rmd160  9b3181f93a974306b1980829f1875e68791d3340 \
-                    sha256  a7eac7765000373165f9373eb748be039c10b2efc00be9af3467ec92357d8954 \
-                    size    486348
+checksums           rmd160  249aded2ae8649169a9f257f49cf0140007502fd \
+                    sha256  f9aa4b3ec8496fee69db94f06f3d76fd4a26b012ee9bf1e917078c2cd2841881 \
+                    size    488779
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `d3d7ac0fd482`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
