### PR TITLE
lerc: update to 4.2.0

### DIFF
--- a/gis/lerc/Portfile
+++ b/gis/lerc/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cmake   1.1
 
-github.setup        Esri lerc 4.1.0 v
+github.setup        Esri lerc 4.2.0 v
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  9c8e9ebcf17cea2fd66c3347550bad9a766d5b64 \
-                    sha256  f05b24d2368becab9144873878655bb718910631550d4f786262378c16ab94a7 \
-                    size    4056763
+checksums           rmd160  64cb25542b28bbb809a3a796ce080818744fc909 \
+                    sha256  a1fb593ed1fcb5b38800caf3c4454f872745202e961d00d745e53d81447e17c9 \
+                    size    4059752
 
 categories          gis
 maintainers         {vince @Veence} openmaintainer


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `6bf368524b4b`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
