### PR TITLE
expat: update to 2.8.4

### DIFF
--- a/textproc/expat/Portfile
+++ b/textproc/expat/Portfile
@@ -6,11 +6,11 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                expat
-version             2.8.3
+version             2.8.4
 revision            0
-checksums           rmd160  cc320cb65f982cd2388b7b94fab9d292ba225387 \
-                    sha256  b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670 \
-                    size    663048
+checksums           rmd160  e90e6523b6b69a3969502b1276635e16a376c48d \
+                    sha256  963250a823c16a498582b4ad82ad0f88926be0769675d3b6956be4d769a1cd8f \
+                    size    666106
 
 categories          textproc devel
 platforms           darwin freebsd


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `55a25a1fc3e0`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
