### PR TITLE
imath: update to 3.2.3

### DIFF
--- a/graphics/imath/Portfile
+++ b/graphics/imath/Portfile
@@ -5,14 +5,14 @@ PortGroup                       cmake 1.1
 PortGroup                       github 1.0
 PortGroup                       legacysupport 1.1
 
-github.setup                    AcademySoftwareFoundation Imath 3.2.2 v
+github.setup                    AcademySoftwareFoundation Imath 3.2.3 v
 name                            imath
 github.tarball_from             releases
 revision                        0
 
-checksums                       rmd160  fcee7626db78df0372496349608e614cb5f6e742 \
-                                sha256  0f5a783b424f374e6f27ec8b0c73130e89b08814ac8fa2e84fd7fe0b05862c53 \
-                                size    680358
+checksums                       rmd160  44ee430fbed4e825912752ed66580c13b5e0dc35 \
+                                sha256  72f498e7073890a2a1b870e453908a07c9725f9d1384527043a38578bfb4ef31 \
+                                size    684604
 
 categories                      graphics
 license                         BSD


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `4eb02992f3e9`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
