### PR TITLE
fontconfig: update to 2.18.3

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -5,11 +5,11 @@ PortGroup                   muniversal 1.0
 PortGroup                   gitlab 1.0
 
 gitlab.instance             https://gitlab.freedesktop.org
-gitlab.setup                fontconfig fontconfig 2.18.2
+gitlab.setup                fontconfig fontconfig 2.18.3
 revision                    0
-checksums                   rmd160  ffab1a88d47ae05beeb75b0baa43879e905717f6 \
-                            sha256  cf8e6576ef0484c15079bdaf77cd9c51c464df5365814ada4d3ee7331ea31eb5 \
-                            size    1347988
+checksums                   rmd160  5a05f7ffd0d4794831e720f37cefc3ad11bebbfd \
+                            sha256  4f7b554a38cdf78c033f666c8871f3749e14a094f65a07f630c91ed0b43d35e3 \
+                            size    1172016
 
 categories                  graphics
 maintainers                 {ryandesign @ryandesign}


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `4b41307002c0`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
