### PR TITLE
jxrlib: update to 1.4.2

### DIFF
--- a/graphics/jxrlib/Portfile
+++ b/graphics/jxrlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mircomir jxrlib 1.4.1
+github.setup        mircomir jxrlib 1.4.2
 revision            0
 categories          graphics
 license             BSD
@@ -17,9 +17,9 @@ long_description    {*}${description}
 
 patchfiles          0001-Add-ability-to-build-using-cmake.patch
 
-checksums           rmd160  0b7a422f315d5ee075c837179a6ce554baab9271 \
-                    sha256  bb46ce30d5719cfffba8da0df314b7bca9aa68dfbf156ecb5670d1c325ad021e \
-                    size    352075
+checksums           rmd160  29f1e7a969ee119c897eb5870a044ce3ac1336f2 \
+                    sha256  1ccc2b6e3afd758c8b33cabc1f05ff56c9babb8b91a99b8281136a1a329b8adb \
+                    size    352141
 
 patch.pre_args-replace \
                     -p0 \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `0fff1e6fcd8d`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
