### PR TITLE
libsvm: update to 3.37

### DIFF
--- a/math/libsvm/Portfile
+++ b/math/libsvm/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                libsvm
 epoch               3
-version             3.36
+version             3.37
 revision            0
 
 categories          math
@@ -22,9 +22,9 @@ long_description    {*}${description} By Chih-Chung Chang and Chih-Jen Lin of   
 
 homepage            https://www.csie.ntu.edu.tw/~cjlin/libsvm/
 master_sites        ${homepage}
-checksums           rmd160  e6141c1a8042cb5d26c2238b9c4ae14ba2a6da61 \
-                    sha256  bc92901fbb928c44bb6d0c38189624c7443bcdbf1dd8350b4914e58e57b93c11 \
-                    size    943316
+checksums           rmd160  9650ec04cc93bad7641d8a3fbd14ef1d7913596a \
+                    sha256  1fa553edc776be3d62fab4607b96ffa505093ea6e3e759a4c7f96294ff75e29a \
+                    size    943582
 
 patchfiles          patch-Makefile.diff
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `cc6f3b9adc3c`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
