### PR TITLE
pcre2: update to 10.48

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -10,7 +10,7 @@ if {${subport} eq ${name}} {
 subport pcre2 {
     PortGroup       github 1.0
 
-    github.setup    PCRE2Project pcre2 10.47 pcre2-
+    github.setup    PCRE2Project pcre2 10.48 pcre2-
     github.tarball_from releases
     revision        0
 
@@ -48,9 +48,9 @@ use_bzip2           yes
 set rmd160(pcre)    9792fbed380a39be36674e74839b9a2a6a4ce65a
 set sha256(pcre)    4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
 set size(pcre)      1578809
-set rmd160(pcre2)   5a1ef68e1844961bebca667ae008f3b44eb0c434
-set sha256(pcre2)   47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7
-set size(pcre2)     2145789
+set rmd160(pcre2)   172ed8daccc6a0563a6e72bd569bb4cd5395d0d9
+set sha256(pcre2)   b6c68fdf6f3ac31388b50aa89ff0fc49c00c987c16e7b5146491d12003f2c8ed
+set size(pcre2)     2213024
 checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport}) \
                     size    $size(${subport})


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `94ab5313c4d6`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
