### PR TITLE
rabbitmq-c: update to 0.17.0

### DIFF
--- a/net/rabbitmq-c/Portfile
+++ b/net/rabbitmq-c/Portfile
@@ -5,12 +5,12 @@ PortGroup           cmake 1.1
 PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
-github.setup        alanxz rabbitmq-c 0.15.0 v
+github.setup        alanxz rabbitmq-c 0.17.0 v
 github.tarball_from archive
 revision            0
-checksums           rmd160  11d83d8e88ce42b08bd3d6d1817d69e5f982d146 \
-                    sha256  7b652df52c0de4d19ca36c798ed81378cba7a03a0f0c5d498881ae2d79b241c2 \
-                    size    131818
+checksums           rmd160  03b19a6d11400d3eb0b67b3c07e76b9a81068942 \
+                    sha256  66c36901178c872565f732468e91688f6280c18810fe8b21a199d46347ba3a0c \
+                    size    137489
 
 categories          net devel
 maintainers         {ryandesign @ryandesign} openmaintainer


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `5a2d2366e0db`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
