### PR TITLE
siege: Update to 4.2.0

### DIFF
--- a/www/siege/Portfile
+++ b/www/siege/Portfile
@@ -1,12 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           openssl 1.0
+PortGroup           legacysupport 1.1
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
 
 name                siege
-version             4.1.1
-revision            1
+version             4.2.0
+revision            0
 categories          www benchmarks
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-3
 
@@ -19,24 +23,25 @@ long_description    Siege is an HTTP/HTTPS regression testing and benchmarking \
                     web server with a configurable number of concurrent \
                     simulated users.
 
-homepage            https://www.joedog.org/siege-home/
-master_sites        http://download.joedog.org/siege/
+homepage            https://www.joedog.org/siege
+master_sites        https://download.joedog.org/${name}/
 
-checksums           rmd160  3ccf8d6ba69f1aeb6d83ec5971a2bf8264a5e0e8 \
-                    sha256  143c25727b9bb2c439486c35121602f4d963385305aab4ed1ff9851581bfe4a8 \
-                    size    543378
+checksums           rmd160  0924be325284fdf42084cb9d89f2fd08dcc65fbd \
+                    sha256  78af482fc655f1cf7270fdbc3171581ed4cb3163009f7f4f056fc2b7e2d24453 \
+                    size    543450
 
-depends_lib         path:lib/libssl.dylib:openssl
+depends_lib-append  port:zlib
 
 patchfiles          patch-doc-Makefile.in.diff
+patchfiles-append   uuid.diff
 
-configure.args      --mandir=${prefix}/share/man \
-                    --with-ssl=${prefix}
+configure.args      --with-ssl=[openssl::install_area] \
+                    --with-zlib=${prefix}
 
 set docdir ${prefix}/share/doc/${name}
 
 post-destroot {
-    # copy an example siegerc to ${prefix}share/doc so an updater can see
+    # copy an example siegerc to ${prefix}/share/doc so an updater can see
     # possible changes to siegerc:
     xinstall -d ${destroot}${docdir}
     xinstall -m 644 ${worksrcpath}/doc/siegerc ${destroot}${docdir}

--- a/www/siege/files/uuid.diff
+++ b/www/siege/files/uuid.diff
@@ -1,0 +1,23 @@
+Don't "link" with uuid library on Mac OS X.
+
+There's no strict uuid library requiring linking flags on
+Mac OS X.
+=========================================================
+--- configure.orig	2026-08-18 15:17:05.000000000 -0400
++++ configure	2026-09-01 16:00:22.601498445 -0400
+@@ -13462,7 +13462,6 @@
+          UUID_CFLAGS=""
+          UUID_LDFLAGS="-L$dir/lib"
+          UUID_INCLUDE="-I$MYUUID/include/uuid -I$MYUUID/include"
+-         UUID_LIBS="-luuid"
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for UUIDLIB version" >&5
+ $as_echo_n "checking for UUIDLIB version... " >&6; }
+          CPPFLAGS="$U_INCLUDE $CPPFLAGS"
+@@ -13481,7 +13480,6 @@
+     UUID_CFLAGS=""
+     UUID_LDFLAGS="-L$MYUUID/lib"
+     UUID_INCLUDE="-I$MYUUID/include/uuid/uuid.h -I$MYUUID/include"
+-    UUID_LIBS="-luuid"
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for UUID version" >&5
+ $as_echo_n "checking for UUID version... " >&6; }
+     CPPFLAGS="$U_INCLUDE $CPPFLAGS"


### PR DESCRIPTION
#### Description

Update siege to 4.2.0.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
