### PR TITLE
mlx: use metal PortGroup

### DIFF
--- a/llm/mlx/Portfile
+++ b/llm/mlx/Portfile
@@ -2,14 +2,12 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           metal 1.0
 
 # This pre-configure block needs to run before those defined in the cmake-1.1
 # PortGroup, or that will have passed an argument based on a wrong value of
 # macosx_sdk_version.
 pre-configure {
-    ui_msg "If the build fails, make sure you have a metal toolchain installed; run `sudo xcodebuild -downloadComponent MetalToolchain` to do so."
-    ui_msg "If you already have the metal toolchain installed but the build still fails, see https://trac.macports.org/wiki/TahoeProblems#MetaltoolchainisnolongerbundledinXcode."
-
     # The CMakeLists.txt will use `xcrun --show-sdk-version` to determine what
     # to enable, if we set a different sysroot, the build may fail because of
     # missing headers.


### PR DESCRIPTION
#### Description

Use the `metal` PortGroup for Metal toolchain checks and actionable advice in case of issues.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?