### PR TITLE
openexr: Update to 3.14.5

### DIFF
--- a/graphics/openexr/Portfile
+++ b/graphics/openexr/Portfile
@@ -5,17 +5,19 @@ PortGroup                       cmake           1.1
 PortGroup                       github          1.0
 PortGroup                       legacysupport   1.1
 
-github.setup                    AcademySoftwareFoundation openexr 3.4.14 v
+github.setup                    AcademySoftwareFoundation openexr 3.4.15 v
 github.tarball_from             releases
 revision                        0
 
-checksums                       rmd160  263dfda6a85a2581e0fc59f017d0de7e632636c8 \
-                                sha256  174d0d711d963c46eaa7cd2669d6cb1ea52579f43aa2726892f0b9554339ba6b \
-                                size    25838337
+checksums                       rmd160  f5f692aebdefaf65837ada45b4bcdc88250db09b \
+                                sha256  ab893d8003773ccd9a5556b2caf38da591ae37e20b06ee9d589a08984c5191f2 \
+                                size    25840011
 
 categories                      graphics
 license                         BSD
-maintainers                     {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} openmaintainer
+maintainers                     {mascguy @mascguy} \
+                                {@Dave-Allured noaa.gov:dave.allured} \
+                                openmaintainer
 
 description                     OpenEXR Graphics Library
 long_description                OpenEXR is the professional-grade high dynamic range image \


### PR DESCRIPTION
#### Description

* Update openexr 3.14.4 --> 3.14.5.
* Add self as co-maintainer.
* Remove inactive maintainer.

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?