### PR TITLE
libheif: Update to 1.23.3

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -8,7 +8,9 @@ PortGroup                   legacysupport 1.1
 name                        libheif
 categories                  multimedia
 license                     LGPL-3+
-maintainers                 {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} openmaintainer
+maintainers                 {mascguy @mascguy} \
+                            {@Dave-Allured noaa.gov:dave.allured} \
+                            openmaintainer
 description                 a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
 long_description            ${name} is {*}${description}.
 
@@ -29,12 +31,12 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
 }
 
 if {${which_version} eq "latest"} {
-    github.setup            strukturag libheif 1.23.2 v
+    github.setup            strukturag libheif 1.23.3 v
     revision                0
 
-    checksums               rmd160  35e1395413b418dca4f786bde7aa0f8d0ebb305a \
-                            sha256  8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405 \
-                            size    2111195
+    checksums               rmd160  87158d772ce478fab759270539630ce0da94ec47 \
+                            sha256  11c1179e0e4bec33624b87f22ec42c1e993a40d946d44d26f9c431cf1456a863 \
+                            size    2178756
 
     compiler.cxx_standard   2020
 } else {


### PR DESCRIPTION
#### Description

* Update 1.23.2 --> 1.23.3.
* Release notes: https://github.com/strukturag/libheif/releases/tag/v1.23.3
* Add self as co-maintainer.
* Remove inactive maintainer.

###### Type(s)

- [x] security fix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?