### PR TITLE
go: update versions

### DIFF
--- a/_resources/port1.0/group/go_toolchain-1.0.tcl
+++ b/_resources/port1.0/group/go_toolchain-1.0.tcl
@@ -200,9 +200,10 @@ set go_toolchain.min_darwin(1.27)   21  ;# 12    Monterey     (see below)
 # provides. Reread at 1.27.0: the directives and the shipped binaries' undefined
 # symbols are unchanged from the prerelease, and from 1.26.
 #
-# This entry decides where go-devel is offered, setup deriving its platforms
-# from it. It is never returned as a ceiling, being the newest series here, and
-# `go` never selects an unpackaged series, so nothing else depends on it.
+# This entry sets the platforms of go-1.27 and go-devel, setup deriving them
+# from it, and decides what `go` provides: 1.27 is the newest packaged series,
+# so `go` wraps it on darwin 21 and later. It is never returned as a ceiling,
+# being the newest series here.
 
 # The series MacPorts packages as go-1.NN ports.
 #
@@ -216,9 +217,9 @@ set go_toolchain.min_darwin(1.27)   21  ;# 12    Monterey     (see below)
 # series a system is offered, so a series is only ever chosen where no newer
 # packaged series is offered as well -- which means one sharing a floor with a
 # newer series is never what `go` provides. Today that is 1.20, 1.22, 1.23,
-# 1.25 and 1.26; they are packaged so that a build can pin them, not because anything
-# reaches them by default. This recomputes from the tables and is worth
-# rechecking whenever a floor moves.
+# 1.25 and 1.26; they are packaged so that a build can pin them, not because
+# anything reaches them by default. This recomputes from the tables and is
+# worth rechecking whenever a floor moves.
 set go_toolchain.packaged {1.17 1.20 1.22 1.23 1.24 1.25 1.26 1.27}
 
 # The newest series MacPorts packages.

--- a/lang/go-1.26/Portfile
+++ b/lang/go-1.26/Portfile
@@ -3,19 +3,19 @@
 PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
-go_toolchain.setup  1.26.7
+go_toolchain.setup  1.26.8
 revision            0
 
 checksums           \
-                    go1.26.7.src.tar.gz \
-                    rmd160  653e52e8c39e7f57508a41e162594f770dd5a127 \
-                    sha256  0ed24eac755105085b89fe9cabc2742b91a0ad7b94b59d3ad364918ebc8956ad \
-                    size    34150794 \
-                    go1.26.7.darwin-arm64.tar.gz \
-                    rmd160  d06cb04ef7527429702dfc6ce243f9224b9e9235 \
-                    sha256  020a1e8224811be75163e920bc77e0926a1390a6aeea19bdcf23f74b9d749f6d \
-                    size    64772572 \
-                    go1.26.7.darwin-amd64.tar.gz \
-                    rmd160  385d8410e958b27301b9e328be57f719ada835cc \
-                    sha256  92e8b34bff3c89ab16404c595669ac8cb004cc2f676dcbd1f5b87a6b8def3b47 \
-                    size    67852067
+                    go1.26.8.src.tar.gz \
+                    rmd160  28c3b017bf610a3dd409a0bb55b68fc483724317 \
+                    sha256  4e39b98e42f946fa05ac8bc5b71877df97dbdb7cbb1a777b541667ad7117fd2e \
+                    size    34150120 \
+                    go1.26.8.darwin-arm64.tar.gz \
+                    rmd160  c68bd9092d7a953b4ca2dd7ec95b1cb16623d1b7 \
+                    sha256  a012b25b571bd0138a03dcd25375ceba866fe5ca822f426d2c66a4de56fd3f4b \
+                    size    64626620 \
+                    go1.26.8.darwin-amd64.tar.gz \
+                    rmd160  0519b8d854bfdf794ea5e4da14b5973635a2208a \
+                    sha256  186be014105aa6542b767d2c6ed5cca10a0214bdff809ef1724022a8c7894150 \
+                    size    67759394

--- a/lang/go-1.27/Portfile
+++ b/lang/go-1.27/Portfile
@@ -3,19 +3,19 @@
 PortSystem          1.0
 PortGroup           go_toolchain 1.0
 
-go_toolchain.setup  1.27.0
+go_toolchain.setup  1.27.1
 revision            0
 
 checksums           \
-                    go1.27.0.src.tar.gz \
-                    rmd160  7c5ab0a2a88bfb9f6dd92e3a4fce256ac434eaf7 \
-                    sha256  7002403d7cc44529ef6d26f69a44818263395ead7c16c05a5808ae047ebeb0e5 \
-                    size    35080395 \
-                    go1.27.0.darwin-arm64.tar.gz \
-                    rmd160  aee482edf12da03fe2bba0fa3cebafaf48be289d \
-                    sha256  90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e \
-                    size    68303667 \
-                    go1.27.0.darwin-amd64.tar.gz \
-                    rmd160  15d80b7278157c3cec55df1778d2619bc6715e42 \
-                    sha256  d3314e25496e4381d71a5c51d2907e7af655d199f6780b549f015bd85fef4986 \
-                    size    71684980
+                    go1.27.1.src.tar.gz \
+                    rmd160  5b0174f2eedd084f8a5f568bf7af298785b9f6e8 \
+                    sha256  4e408abae126d916b6164627193f2c54f0e3ca1312d693b86db45f862ab238b1 \
+                    size    35109201 \
+                    go1.27.1.darwin-arm64.tar.gz \
+                    rmd160  a03cfa6c3a1e328f4e843f2ed320fdcd772c518e \
+                    sha256  ee215d57e0ec269c60cc9ceca68e6bda321ba9ee5afe24f4b0988703c2d87d12 \
+                    size    68100347 \
+                    go1.27.1.darwin-amd64.tar.gz \
+                    rmd160  8d118fb0dd90b3b370a331bad851d709a83d1917 \
+                    sha256  8f8f52c6649542cf027bbc9b9c68d1ec042f9f34808a40413f0b8b3f66f3caa4 \
+                    size    71621873


### PR DESCRIPTION
- `go-1.26`: 1.26.7 → 1.26.8
- `go-1.27`: 1.27.0 → 1.27.1

Also corrects a note in the `go_toolchain` PortGroup that packaging 1.27 left stale: `go` wraps 1.27 now, where the note still said it never selects that series. Comments only.