### PR TITLE
gh: update to 2.99.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             2.98.0
+version             2.99.0
 revision            0
 
 # Github CLI is failing to build on 10.12 and below.
@@ -55,9 +55,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  9f60ff862cd972a9c73f4a54fffbbc3e39396830 \
-                        sha256  abada9e8b550547ac93f99250f3ad4d90ad623fa245cb54cb058f78030a6a5f6 \
-                        size    14955890
+    checksums           rmd160  88a057128e6554b345047aaba87c5313bdb0c823 \
+                        sha256  65fff9aa7eb4410689c4c4c6756d2ef58492b1a6ce985e97dfd1b61588aa52f9 \
+                        size    15023512
 
     dist_subdir         ${name}
 
@@ -75,9 +75,9 @@ if ${source_build} {
 
     distname        gh_${version}_macOS_amd64
 
-    checksums       rmd160  9226871685e9f4ba01b77efcfdf9bcd69b3d63b3 \
-                    sha256  734c7bbd0bc56a3974500ee9aea74d60f0e5b89be09e92b9d9148939a3a1e0e6 \
-                    size    15521035
+    checksums       rmd160  96c0be5f82c7ef79ef8d8ac806198859c1531418 \
+                    sha256  70c05750c75df9465bc73b994e8bc379243bb494271f1b51f54ead2e19e45471 \
+                    size    15586528
 
     use_configure   no
     use_zip         yes


### PR DESCRIPTION
#### Description

Not locally verified: no verification environment on the submitting machine.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
