### PR TITLE
deff: update to 0.4.2

### DIFF
--- a/textproc/deff/Portfile
+++ b/textproc/deff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        flamestro deff 0.2.4 v
+github.setup        flamestro deff 0.4.2 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fb977c39a41f95822298a039f81c5a105b3f1def \
-                    sha256  05fb8296cd63800f8045a7b25f3bd403ae3ac0adf005e68d25c9eb86ac8f420f \
-                    size    981309
+                    rmd160  65aebccc88c36c62d06ead79945d708e1ab247d9 \
+                    sha256  bc85896b93ecec2afe9fbe3cddb8d9f8e520b07fededa80b437dca58caec6f3b \
+                    size    985950
 
 destroot {
     xinstall -m 0755 \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `b67eef722c25`
  — Tahoe: linted with 123 warnings, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
