### PR TITLE
fastfetch: 2.68.1, peg 2.67.1 before 10.13

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -46,10 +46,11 @@ configure.args-append \
                     -DENABLE_OPENCL=OFF \
                     -DENABLE_LUA=OFF
 
-compiler.c_standard     2011
-compiler.cxx_standard   2017
+compiler.cxx_standard \
+                    2017
 
-patch.pre_args-replace  -p0 -p1
+patch.pre_args-replace \
+                    -p0 -p1
 
 # https://trac.macports.org/ticket/70616
 if {${os.platform} eq "darwin" \
@@ -80,6 +81,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     checksums       rmd160  e6549efbe91eed77641468535bf3d5bbb86dc60d \
                     sha256  c3fcccf9502e41c76c30e89530820bf1c7719257e5624bfa5fa77e6627ecb602 \
                     size    1136647
+
+    compiler.c_standard \
+                    2011
 
     # https://github.com/fastfetch-cli/fastfetch/issues/942
     # https://github.com/fastfetch-cli/fastfetch/issues/943
@@ -117,4 +121,21 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # https://trac.macports.org/ticket/59917
     configure.cflags-append \
                     -F/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks
+} elseif {${os.platform} eq "darwin" && ${os.major} < 17} {
+    # Fastfetch 2.68.1 uses macOS APIs which are unavailable before 10.13.
+    github.setup    fastfetch-cli fastfetch 2.67.1
+    revision        0
+    checksums       rmd160  d77078e99f86c8dc6133955dc0a726d9fc0bff44 \
+                    sha256  52489550d1fdeac8bde8b3442064e3bc78d28fda752a171dc46a6cd97454f237 \
+                    size    1573878
+
+    compiler.c_standard \
+                    2023
+    compiler.blacklist-append \
+                    {clang < 1600}
+} elseif {${os.platform} eq "darwin"} {
+    compiler.c_standard \
+                    2023
+    compiler.blacklist-append \
+                    {clang < 1600}
 }

--- a/sysutils/fastfetch/files/1001-CMakeLists-disable-bluetooth-modules.patch
+++ b/sysutils/fastfetch/files/1001-CMakeLists-disable-bluetooth-modules.patch
@@ -8,17 +8,17 @@ Subject: [PATCH] CMakeLists: disable bluetooth modules
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 35469bfd..6b2a2bcf 100644
+index 687e89b5e..f677c85b9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -634,8 +634,8 @@ elseif(APPLE)
-         src/common/sysctl.c
+@@ -1014,8 +1014,8 @@ elseif(APPLE)
+         src/common/apple/smc_temps.c
+         src/common/apple/version.m
          src/detection/battery/battery_apple.c
-         src/detection/bios/bios_apple.c
 -        src/detection/bluetooth/bluetooth_apple.m
 -        src/detection/bluetoothradio/bluetoothradio_apple.m
 +        src/detection/bluetooth/bluetooth_nosupport.c
 +        src/detection/bluetoothradio/bluetoothradio_nosupport.c
-         src/detection/board/board_apple.c
          src/detection/bootmgr/bootmgr_apple.c
-         src/detection/brightness/brightness_nosupport.c
+         src/detection/brightness/brightness_apple.c
+         src/detection/btrfs/btrfs_nosupport.c


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
