### PR TITLE
libproxy: Update to 0.5.12

### DIFF
--- a/net/libproxy/Portfile
+++ b/net/libproxy/Portfile
@@ -5,9 +5,8 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 
 epoch               1
-github.setup        libproxy libproxy 0.5.11
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        libproxy libproxy 0.5.12
+github.tarball_from archive
 revision            0
 
 categories          net
@@ -20,9 +19,9 @@ long_description    Libproxy exists to answer the question: Given \
                     the details, enabling you to get back to programming.
 homepage            https://libproxy.github.io/libproxy
 
-checksums           rmd160  bc877169946ca143d4c585120b46015cf3ccfa59 \
-                    sha256  9238ed0766e388142cf5b4228baa3b26704e2f9f48cbc10721b8881394766efd \
-                    size    60512
+checksums           rmd160  00dde825e11dffd35e61e031f4cc3020dda1d2a6 \
+                    sha256  a1fa55991998b80a567450a9e84382421a7176a84446c95caaa8b72cf09fa86f \
+                    size    60529
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
@@ -66,7 +65,7 @@ subport ${name}-vapi {
     depends_lib-prepend \
                     port:${name}
 
-    depends_lib-append \
+    depends_build-append \
                     path:bin/vala:vala
 
     configure.args-replace \


### PR DESCRIPTION
#### Description

Update libproxy to 0.5.12. [Change vala to `depends_build` instead.](https://trac.macports.org/ticket/71697
) No revbumps needed. Highlighted as outdated by [#34418](https://github.com/macports/macports-ports/pull/34418).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
