### PR TITLE
commons-lang3: use maven PortGroup

### DIFF
--- a/java/commons-lang3/Portfile
+++ b/java/commons-lang3/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           java 1.0
+PortGroup           maven 1.0
 
 name                commons-lang3
 version             3.20.0
+revision            1
 
 checksums           rmd160  c60d8376b3e29b50927041e62f9e7f2cdf94015d \
                     sha256  ca736b78a140fdc83a8d23572ad0521a30d0239c5f8c7ddcb7cbf8c0abfb6215 \
@@ -26,39 +27,33 @@ long_description    The Lang Component provides a host of helper utilities for \
                     a series of utlities dedicated to help with building methods, \
                     such as hashCode, toString and equals.
 homepage            https://commons.apache.org/lang/
-                
+
 distname            ${name}-${version}-src
 master_sites        apache:commons/lang/source/
 
 java.version        11+
 # Use latest LTS Java as fallback
-java.fallback       openjdk11
-
-depends_build       bin:mvn3:maven3
-                
-use_configure       no
-
-set maven_local_repository ${worksrcpath}/.m2/repository
-pre-build {
-    file mkdir ${maven_local_repository}
-}
-
-build.cmd           mvn3
-build.target        site
-build.pre_args      -Dmaven.repo.local=${maven_local_repository} \
-                    -Drat.ignoreErrors=true \
-                    -DskipTests
+java.fallback       openjdk25
 
 destroot {
-    # Ensure needed directories
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-        
-    # Install jar
-    xinstall -m 644 ${worksrcpath}/target/${name}-${version}.jar \
-        ${destroot}${prefix}/share/java/${name}.jar
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/CONTRIBUTING.md \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/NOTICE.txt \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/RELEASE-NOTES.txt \
+        ${destdocdir}
 }
 
-livecheck.type  regex
-livecheck.url   https://commons.apache.org/proper/commons-lang/download_lang.cgi
-livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.type      regex
+livecheck.url       https://commons.apache.org/proper/commons-lang/download_lang.cgi
+livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"


### PR DESCRIPTION
#### Description

Use the `maven` PortGroup to simplify the Portfile.  Also include some documentation in the installation.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?