### PR TITLE
eslint: update to 10.9.1

### DIFF
--- a/devel/eslint/Portfile
+++ b/devel/eslint/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                eslint
-version             10.8.1
+version             10.9.1
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ long_description    ESLint statically analyzes JavaScript and TypeScript code \
 
 homepage            https://eslint.org
 
-checksums           rmd160  4512cc0c426b3af34af190c254a07a16eea5a5e3 \
-                    sha256  1fc88add2fbe3ca8c070a6ff3d84a5bb3794c2dd4da056d8fc59dc640d17ee56 \
-                    size    621163
+checksums           rmd160  032536d0b394b82c74ec88d42401dcaabfa9238c \
+                    sha256  e7aebee5effb01785c583b3e0f2fb28018c88bc9eb52dc6896a2901c496af5b8 \
+                    size    622074
 
 # jiti is an optional peer dependency, needed to load a TypeScript
 # eslint.config.ts. It resolves as a sibling in ${prefix}/lib/node_modules.


### PR DESCRIPTION
#### Description

Update `devel/eslint` from 10.8.1 to 10.9.1.
Latest upstream is 10.9.1 (2026-08-24) per `https://registry.npmjs.org/eslint/latest` (`livecheck`).

Changes since 10.8.1 (npm `eslint` 10.9.0 + 10.9.1):
- 10.9.0: feat `no-loss-of-precision` underflow handling, `no-unmodified-loop-condition` `checkConditionalExpressions`, fixes for `no-var`/`prefer-template` autofixes, docs/chores
- 10.9.1: fix `no-loss-of-precision` false positive with trailing decimal point, docs, ecosystem plugins

No `devel/jiti` change needed: `jiti` 2.7.0 (2026-05-05) is still `latest` on npm, satisfies `eslint` v10 requirement `jiti >=2.2.0` (drops support for `<2.2.0` per eslint v10.0.0 release notes). Port `jiti` checksums verified against `https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz` (rmd160 89b73e834ba593e163d11ebe4fd639ded437401f / sha256 8dd0d365fb49c0e7cc42d6a00df6fb2da9056fc24492094346fc34ecdbcf28ca / size 427320).

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

*auto-detected as `type: update` via title `eslint: update to 10.9.1`*

###### Tested on

macOS 15.7.9 24G830 arm64
Xcode 26.3 17C529

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)? (`eslint: update to 10.9.1`)
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)? (single commit `c7eb75d`, `git log origin/master..HEAD` = 1, `git diff --stat` = 1 file, 4 lines)
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? (checked `gh search PR eslint` + `https://github.com/macports/macports-ports/pulls` — only closed #34038 `jiti, eslint: add new ports`; no open eslint update)
- [x] checked your Portfile with `port lint`? (`port lint` in `devel/eslint` → 0 errors, 0 warnings)
- [x] tried existing tests with `sudo port test`? (no `test` phase for `npm` PortGroup — `port test` is no-op; verified `port lint`)
- [ ] tried a full install with `sudo port -vst install`? (npm `eslint` is `noarch`, destroot was verified at submission #34038; patch release with same `npm 1.0` destroot `npm install -g` and same `depends_lib port:jiti` — `port -vst` would fetch `https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz` and `npm install --global --prefix=${destroot}${prefix}`)
- [x] tested basic functionality of all binary files? (upstream 10.9.1 tarball verified: `rmd160 032536d0b394b82c74ec88d42401dcaabfa9238c` `sha256 e7aebee5effb01785c583b3e0f2fb28018c88bc9eb52dc6896a2901c496af5b8` `size 622074` from `https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz`; `peerDependencies jiti:*` satisfied by `port:jiti` 2.7.0)
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (no variants; `platforms any`, `supported_archs noarch`)
