### PR TITLE
tree-sitter-tcl: new port

### DIFF
--- a/devel/tree-sitter-tcl/Portfile
+++ b/devel/tree-sitter-tcl/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           tree_sitter 1.0
+
+github.setup        tree-sitter-grammars tree-sitter-tcl 850a72ab6436e06645b33b11cfa60cbdb04b1f01
+github.tarball_from archive
+# no upstream releases so date derived version
+version             20260805
+revision            0
+
+description         A tree-sitter parser for TCL
+
+long_description    {*}${description}
+
+categories          devel
+license             MIT
+maintainers         @oytech openmaintainer
+
+checksums           rmd160  a6c69d9e78313c42edd151bf5b2caee8eff314e9 \
+                    sha256  4d3bbc7db5fd3398af714afc3dd4a0b4aba0b372bf30192bc4cff00d5acf54fa \
+                    size    79714
+
+worksrcdir          ${worksrcdir}/src


### PR DESCRIPTION
#### Description

New port for https://github.com/tree-sitter-grammars/tree-sitter-tcl

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
