### PR TITLE
LibreCAD(-devel): 2.2.1.5, sign app

### DIFF
--- a/cad/LibreCAD/Portfile
+++ b/cad/LibreCAD/Portfile
@@ -18,47 +18,30 @@ long_description    LibreCAD is a free Open Source CAD application for \
                     contributors and developers. You, too, can also get \
                     involved!
 
-
 categories          cad
 license             GPL-2+
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
+conflicts           LibreCAD-devel
+github.setup        LibreCAD LibreCAD 2.2.1.5 v
+github.tarball_from archive
+revision            0
+checksums           rmd160  ae3c498308b9cbef3e0470ac9c42ab9c84c86488 \
+                    sha256  703f6e6701b7ee47769b6def271fa025ef32e31ee193e2ba69a2c47fff8da459 \
+                    size    20192101
+
+if {${subport} eq "${name}"} {
+    conflicts       ${name}-devel
+} elseif {${subport} eq "${name}-devel"} {
+    conflicts       ${name}
+}
+
 # Needed for Boost
 compiler.thread_local_storage \
                     yes
 
-qt5.depends_component qtsvg qttranslations qttools
-
-if {${subport} eq "${name}"} {
-
-    conflicts           LibreCAD-devel
-    github.setup        LibreCAD LibreCAD 2.2.0.2
-    github.tarball_from archive
-    revision            0
-    checksums           rmd160  2092675c79c2da85ba66319f08c3c0f017aa4da8 \
-                        sha256  fcb888a550f1f515ef6a2f7af2dd02605dd5c6da8a23f6c3a52479f8532ac109 \
-                        size    13645528
-
-    boost.version       1.81
-
-    post-extract {
-        reinplace "s|lrelease|${qt_bins_dir}/lrelease|g" scripts/postprocess-osx.sh
-    }
-
-} elseif {${subport} eq "${name}-devel"} {
-
-    conflicts           LibreCAD
-    github.setup        LibreCAD LibreCAD 2.2.1_alpha
-    github.tarball_from archive
-    revision            0
-
-    boost.version       1.81
-
-    checksums           rmd160  85605cb0cf0b082b8939911460603ba0d7b59712 \
-                        sha256  ac91396da5823e5b58efacbbeed6bf5f669477df7a6755615a8f9290d9cd3a9d \
-                        size    13840866
-}
+boost.version       1.88
 
 # the default destructor cannot be created in all cases
 # see https://marc.info/?l=pkgsrc-changes&m=150505264620416&w=2
@@ -72,18 +55,27 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
     }
 }
 
+qt5.depends_component \
+                    qtsvg qttranslations qttools
+
 depends_lib-append  port:freetype \
                     port:libxmlxx2
 
-compiler.cxx_standard   2011
+compiler.cxx_standard \
+                    2011
 
-configure.args-append CONFIG+=\"build_muparser\"
+configure.args-append \
+                    CONFIG+=\"build_muparser\"
+# stop muparser port headers from shadowing the bundled headers
+configure.cppflags-prepend \
+                    -I${worksrcpath}/libraries/muparser/include
 
 destroot {
     # to make a self-contained application for deployment, the following command can be uncommented
     # system -W ${worksrcpath} "${qt_bins_dir}/macdeployqt LibreCAD.app"
 
-    copy ${worksrcpath}/LibreCAD.app ${destroot}${applications_dir}
+    system -W ${worksrcpath} "/usr/bin/codesign --sign - ${name}.app"
+    copy ${worksrcpath}/${name}.app ${destroot}${applications_dir}
 }
 
 github.livecheck.regex \


### PR DESCRIPTION
Upstream is moving to qt6, and a new devel port based on qt6 is in the works. For now the main port and the devel port are identical.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
