### PR TITLE
google-cloud-sdk: update to 583.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             582.0.0
+version             583.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  efa00508d347ce8a25bdfaa3b01674827a5b043f \
-                    sha256  378b5a4cfda519fa81a71373e6cfb1c89d1dfbcac8453b12dc3e431ed5552e3e \
-                    size    50690547
+    checksums       rmd160  15e331081da11f77c8b583da4ba46486e23208b6 \
+                    sha256  3e9932d93a9ef01d2e2a35362939721d1c368e131906e3b239a4a1e69c1539a3 \
+                    size    50783628
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  7c6135bb12c073286e8c7d718a6b389c77db03e8 \
-                    sha256  44c3c0e429a764b9634f203478b436feeb5b1c84c513950ca961c436c1432598 \
-                    size    52349186
+    checksums       rmd160  82c94324a9809c4ee5cf1550422e93e1475e64d4 \
+                    sha256  44c73d179d9e61aa3a191bedb852d580d78049c35134749755abd21b9bd4bdf0 \
+                    size    52441930
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  489ef5111da3ecd5b967b9feb328bfa17310dd67 \
-                    sha256  7ed2c24d1a5f288e0079339634b340085622ea229dfbdbb6c436b12a36a9c650 \
-                    size    52255332
+    checksums       rmd160  09d232316aa0049ec530d0b9f821e95254dcedff \
+                    sha256  d2fce00d0ad59ebecfe2b8184765d6eab041ec9f415ef52573aae85fc04be79f \
+                    size    52346298
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 583.0.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?