### PR TITLE
claude-code: update to 2.1.258

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.257
+version             2.1.258
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  3aebcafa5768f9096abd32a3feb0e7f63154c82f \
-                 sha256  8f90c000b1e265dcd92b12c6d9d13bb5d354c495e6ba15c56eb171002923d80b \
-                 size    207778720
+    checksums    rmd160  4baca49c64c638b178768ae041f076eb4afe8656 \
+                 sha256  c857db5cd712865623bd61e806cf3f7e8e279c9e5c7c0af5eca06ca6717fc7fb \
+                 size    207778640
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  8a9bc99a51326ea511d6cd775d0764b24ea21341 \
-                 sha256  64590d7d9d9c189d33fb3dfa58c5408eaf2a10fe556bd84155d95efaab46b60e \
-                 size    199011264
+    checksums    rmd160  c1c0b2fedd6c0642c5c36af17eb0ea306f0ae9ea \
+                 sha256  b63136194160791c27cfa7b0403060d85eb0752991625fde8c09f9acacb17c78 \
+                 size    199027600
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.258.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?