### PR TITLE
1password-cli: update to 2.39.0

### DIFF
--- a/security/1password-cli/Portfile
+++ b/security/1password-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                1password-cli
-version             2.38.1
+version             2.39.0
 revision            0
 
 homepage            https://support.1password.com/command-line
@@ -35,9 +35,9 @@ master_sites        https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/
 distfiles           ${archive}_v${version}${extract.suffix}
 supported_archs     arm64 x86_64
 
-checksums           rmd160  0144eba37abc21b715e7acbb8ecf08c19c359865 \
-                    sha256  a4b944b2a08be63f500ae2e44312bf326cfae3b94a6c262139488f721d8c32e1 \
-                    size    28695095
+checksums           rmd160  557f48ad3b9d0cb311d0078727f3f1d77d7a758f \
+                    sha256  bde261468f3232484e2738e337e39c674c11a4537f4c6ed314f933eae558a405 \
+                    size    29276761
 
 # Pre-built binary
 use_configure       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `c1d970b3012c`
  — Tahoe: linted clean, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
