### PR TITLE
epic-lore: update to 0.9.0

### DIFF
--- a/devel/epic-lore/Portfile
+++ b/devel/epic-lore/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        EpicGames lore 0.8.6 v
+github.setup        EpicGames lore 0.9.0 v
 github.tarball_from archive
 name                epic-lore
 revision            0
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9d2e26cde7b14608cf1fda348089fe26b6233c2e \
-                    sha256  970db12225658bc4b97cb92c43381117778e26609e4bde85f49dbed9553e8b09 \
-                    size    3514749
+                    rmd160  47d9928b2ff678b3638d210c669a715aa9efab0b \
+                    sha256  155b3e39c70f704449485ea440d0e681ded0a997e5cb465cd17b7709f8bea2ca \
+                    size    4451785
 
 build.args-append   --package lore-client \
                     --package lore-server
@@ -229,7 +229,7 @@ cargo.crates \
     glob                                    0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     glob-match                              0.2.1  9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d \
     governor                               0.10.4  9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8 \
-    h2                                     0.4.14  171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733 \
+    h2                                     0.4.19  ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16 \
     hashbrown                              0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                              0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                              0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
@@ -265,6 +265,7 @@ cargo.crates \
     indexmap                               2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     infer                                  0.19.0  a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7 \
     inventory                              0.3.24  a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b \
+    io-uring                               0.7.13  9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0 \
     ipnet                                  2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
     is-docker                               0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                                  0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
@@ -293,7 +294,6 @@ cargo.crates \
     matchit                                 0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
     md-5                                   0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
     memchr                                  2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
-    memmap2                                0.9.11  d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0 \
     mime                                   0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                         0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                             0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
@@ -369,8 +369,6 @@ cargo.crates \
     rand_core                               0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_distr                              0.5.1  6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463 \
     raw-cpuid                              11.6.0  498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186 \
-    rayon                                  1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
-    rayon-core                             1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     rcgen                                  0.14.8  57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055 \
     redox_syscall                          0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     redox_users                             0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
@@ -429,7 +427,7 @@ cargo.crates \
     smallvec                               1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     smart-default                           0.7.1  0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1 \
     socket2                                 0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
-    spin                                   0.10.0  d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591 \
+    spin                                   0.10.1  023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3 \
     spinning_top                            0.3.0  d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300 \
     stable_deref_trait                      1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     strsim                                 0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand) at commit `9403c0b33d60`
  — Tahoe: linted with 533 warnings, built in a pristine VM.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Automated by [dockhand](https://github.com/herbygillot/dockhand)
