### PR TITLE
curl: update to 8.22.0, curl-ca-bundle to 20260716 [CVE]

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -6,10 +6,10 @@ PortGroup                       clang_dependency 1.0
 # Increase the revision of p5-www-curl whenever the version of curl gets updated.
 
 name                            curl
-version                         8.21.0
-checksums                       rmd160  df939533d1123463686413c87b4c5c4079466536 \
-                                sha256  aa1b66a70eace83dc624508745646c08ae561de512ab403adffb93ac87fc72e6 \
-                                size    2882336
+version                         8.22.0
+checksums                       rmd160  24a8a9165641cb3e0416cf7c8f65f0be4184f01d \
+                                sha256  f7ef3ae8a22e521f289803fe93543eb64c329b58aa73a9e224dfd915a2a5f4f7 \
+                                size    2953092
 
 categories                      net www
 platforms                       darwin freebsd
@@ -49,7 +49,6 @@ if {${name} eq ${subport}} {
                                 --without-libgsasl \
                                 --without-libidn2 \
                                 --without-libpsl \
-                                --without-librtmp \
                                 --without-libssh2 \
                                 --without-mbedtls \
                                 --without-nghttp2 \
@@ -125,6 +124,7 @@ if {${name} eq ${subport}} {
             CODE_OF_CONDUCT.md \
             CONTRIBUTE.md \
             CURL-DISABLE.md \
+            DEPENDENCIES.md \
             DEPRECATE.md \
             FAQ.md \
             FEATURES.md \
@@ -132,7 +132,6 @@ if {${name} eq ${subport}} {
             HELP-US.md \
             HISTORY.md \
             HTTP-COOKIES.md \
-            INTERNALS.md \
             KNOWN_BUGS.md \
             MAIL-ETIQUETTE.md \
             ROADMAP.md \
@@ -241,11 +240,6 @@ if {${name} eq ${subport}} {
         configure.args-replace  --without-libpsl --with-libpsl
     }
 
-    variant rtmp description {Support RTMP media streams} {
-        depends_lib-append      port:rtmpdump
-        configure.args-replace  --without-librtmp --with-librtmp
-    }
-
     variant sftp_scp description {Support SFTP/SCP connections via libssh2} {
         depends_lib-append      port:libssh2
         configure.args-replace  --without-libssh2 --with-libssh2
@@ -331,11 +325,11 @@ subport curl-ca-bundle {
 
     # The approximate time (in seconds since the epoch) when the port maintainer
     # updated the certdata.txt file in this port. (The output of "date +%s".)
-    set certdata_updated        1783270248
+    set certdata_updated        1788471586
     # The upstream commit in which certdata.txt was last updated.
-    set certdata_commit         ae3b4f24dc1b54f8b7770eea1e44d7123ebdb131
+    set certdata_commit         bbf69a8de82f48b2044d15b783abb977ae02a200
     # The date (in YYYYMMDD format) that commit was pushed.
-    set certdata_date           20260612
+    set certdata_date           20260716
     set certdata_file           certdata.txt
     # Using tar.bz2 would be preferable because it's smaller but upstream has
     # disabled the creation of all but zip archives:
@@ -356,9 +350,9 @@ subport curl-ca-bundle {
     distfiles-append            ${certdata_distfile}:certdata
 
     checksums-append            ${certdata_distfile} \
-                                rmd160  2a5e1e82fbac7c14e7739db74efc880682a820b7 \
-                                sha256  fae8fabae99a59fe9fc8d6e1599fd8a173b17e357ed51b80b44a4b620f4f6ac6 \
-                                size    279727
+                                rmd160  856ba4eef27316c1c4f947900ec1e99e206fd647 \
+                                sha256  8f8a5a538f9de3d432d573399aee9b54d433fed410a3b231ec2764fbac114fba \
+                                size    288569
 
     extract.only                ${curl_distfile}
     extract.post_args-append    ${worksrcdir}/scripts/mk-ca-bundle.pl

--- a/perl/p5-www-curl/Portfile
+++ b/perl/p5-www-curl/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         WWW-Curl 4.17
-revision            15
+revision            16
 license             MIT
 maintainers         {alum.wpi.edu:arno+macports @fracai} openmaintainer
 description         Perl extension interface for libcurl

--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -583,7 +583,7 @@ TLS_PRIVOXY_ROOT_CA
 
 subport ${name}-pki-bundle {
     # Please increase the revision whenever curl-ca-bundle contents change
-    revision        3
+    revision        4
 
     license         MIT
     supported_archs noarch


### PR DESCRIPTION
#### Description

**This is a security update.** curl 8.22.0 was released 2026-09-02 and fixes 9 CVEs in curl/libcurl.

Release notes: https://curl.se/ch/8.22.0.html — announcement: https://daniel.haxx.se/blog/2026/09/02/curl-8-22-0/

| CVE | Issue | Severity | Affects default MacPorts variants? |
| --- | --- | --- | --- |
| [CVE-2026-19931](https://curl.se/docs/CVE-2026-19931.html) | Negotiate ambient user conn reuse | Medium | No — requires `+gss` |
| [CVE-2026-80229](https://curl.se/docs/CVE-2026-80229.html) | OpenSSL provider use-after-free | Low | **Yes** (`+ssl`) |
| [CVE-2026-80230](https://curl.se/docs/CVE-2026-80230.html) | OpenSSL pinning bypass | Low | **Yes** (`+ssl`) |
| [CVE-2026-18924](https://curl.se/docs/CVE-2026-18924.html) | HTTP/2 server push use-after-free | Low | **Yes** (`+http2`) |
| [CVE-2026-80255](https://curl.se/docs/CVE-2026-80255.html) | Secure cookie attribute bypass with tab | Low | **Yes** |
| [CVE-2026-82209](https://curl.se/docs/CVE-2026-82209.html) | Domain-scoped PSL domain cookie | Low | **Yes** (`+psl`) |
| [CVE-2026-80231](https://curl.se/docs/CVE-2026-80231.html) | Native CA store conn reuse | Low | Only `+sectrust` / `+darwinssl` |
| [CVE-2026-13608](https://curl.se/docs/CVE-2026-13608.html) | OpenLDAP SASL authentication bypass | Low | No — requires `+openldap` |
| [CVE-2026-82208](https://curl.se/docs/CVE-2026-82208.html) | wolfSSL CA-cache hit overrides callback | Low | No — requires `+wolfssl` |

Default variants are `+brotli +http2 +idn +psl +zstd +ssl`, so five of these reach a default install.

The upstream tarball was verified against Daniel Stenberg's release signature (key `27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2`, matching https://curl.se/docs/verify.html).

##### Also in this PR

**`curl-ca-bundle` updated to certdata 20260716** (Mozilla commit `bbf69a8`, previously 20260612). Net effect on the generated bundle, 119 → 121 certs:

* Added: SECOM TLS RSA Root CA 2024, SECOM TLS ECC Root CA 2024, Telia RSA TLS Root CA v3, Telia EC TLS Root CA v3
* Removed: ePKI Root Certification Authority, Atos TrustedRoot 2011

**`docs/INTERNALS.md` → `docs/DEPENDENCIES.md`.** Upstream renamed this file in 8.22.0. `post-destroot` installs a hardcoded doc list, so without this the destroot phase fails — a version-and-checksum-only bump does not build.

**The `rtmp` variant is dropped.** Upstream removed RTMP support in 8.20.0 (`docs/DEPRECATE.md`: "RTMP (removed in 8.20.0)"), and `rtmp` appears nowhere in `configure` in either 8.21.0 or 8.22.0. The variant only added a `rtmpdump` dependency and passed `--with-librtmp`, which configure no longer recognises. Confirmed against the built binary — `curl -V` lists `rtsp` but no `rtmp`. No stub variant is needed: MacPorts silently drops an unrecognised requested variant (`portutil.tcl`, `eval_variants`), so existing `+rtmp` users are unaffected on upgrade.

**Revbumps** for the two ports the Portfiles ask to be bumped: `p5-www-curl` (curl version changed) and `privoxy-pki-bundle` (curl-ca-bundle contents changed — it cats `curl-ca-bundle.crt` into its own `trustedCAs.pem`).

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Command Line Tools 26.6.0.0.1781586589

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? — **not run.** curl's `test-full` suite was not executed; happy to run it if you would like it before merge.
- [x] tried a full install with `sudo port -vst install`? — ran as `port -d -N install` in a clean, disposable macOS 26 VM for `curl`, `curl-ca-bundle`, `p5-www-curl` and `privoxy-pki-bundle`; all four install cleanly. Not run under `-t` (trace), which is broken in my environment.
- [x] tested basic functionality of all binary files? — `curl -V` reports 8.22.0 with OpenSSL/3.6.4, HTTP/2 and the expected feature set; HTTPS GETs against `curl.se` and `github.com` return 200 over HTTP/2 with `ssl_verify_result=0` using the newly generated CA bundle.
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? — **only the default variant set was built** (`+brotli +http2 +idn +psl +zstd +ssl`). The alternative TLS variants (`+gnutls`, `+mbedtls`, `+wolfssl`, `+darwinssl`, `+sectrust`) were not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
