### PR TITLE
mp3rgain: update to 3.5.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.4.0 v
+github.setup        M-Igashi mp3rgain 3.5.0 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  387980048d5144f4d3eb143a31764ac11a2ea815 \
-                    sha256  3ef5e9a7b059059e525f63188e0b5acab232c9b42a7530cfea3d2228cbf0cbe1 \
-                    size    564720
+                    rmd160  ff5d625057a79d6b2df589f9eab05ed464050b09 \
+                    sha256  7c3474d910a3f933f0a06e59ad34cc0a3e268ce0743ae5ed4374e07b29e32614 \
+                    size    577856
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 3.5.0.

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.5.0

Highlights of this version are a new `--tags-only` mode (writes absolute `REPLAYGAIN_*` values without rewriting any audio frames, the way `loudgain` and `rsgain` do) and three tag-writing correctness fixes, including one where a failed ID3v2 write could leave a file with no ReplayGain tags in either container.

- `github.setup` bumped to 3.5.0, `revision` stays 0
- `rmd160` / `sha256` / `size` recomputed from the GitHub archive tarball for v3.5.0
- `cargo.crates` is unchanged: this release adds no dependencies and bumps none, and all 63 entries were verified against the release's `Cargo.lock`

Verification: `port lint --nitpick` reports 0 errors and 128 warnings, all of them the pre-existing "missing recommended checksum type: rmd160 / size" notices on the `cargo.crates` entries. Linting the current upstream 3.4.0 Portfile gives the identical count, so this change introduces none. I have not run `port install` for this revision.