### PR TITLE
mp3rgain: update to 3.5.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.4.0 v
+github.setup        M-Igashi mp3rgain 3.5.1 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  387980048d5144f4d3eb143a31764ac11a2ea815 \
-                    sha256  3ef5e9a7b059059e525f63188e0b5acab232c9b42a7530cfea3d2228cbf0cbe1 \
-                    size    564720
+                    rmd160  39b24e7d687325008506974144bedcd264e86530 \
+                    sha256  e7d6b2fc1fb42dbbe29ec98fde845869e8241bc632bacc1a804badd9f53bfa7f \
+                    size    581529
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 3.5.1.

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.5.1

This is a maintenance release: every tag write in the apply and undo paths now rides the single temp-file rewrite (the default layout used to rewrite each file three times), plus shared library helpers replacing logic the CLI and GUI had duplicated. No dependency changes.

- `github.setup` bumped to 3.5.1, `revision` stays 0
- `rmd160` / `sha256` / `size` recomputed from the GitHub archive tarball for v3.5.1
- `cargo.crates` unchanged: all 63 entries verified against the release's `Cargo.lock`

Verification: `port lint --nitpick` reports 0 errors and 128 warnings, the same pre-existing "missing recommended checksum type: rmd160 / size" notices on the `cargo.crates` entries that the current Portfile produces. I have not run `port install` for this revision.