### PR TITLE
google-guava: update to 33.7.1

### DIFF
--- a/java/google-guava/Portfile
+++ b/java/google-guava/Portfile
@@ -1,15 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- vim:fenc=utf-8:ft=tcl:et:sw=8:ts=8:sts=8
 
 PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               maven 1.0
 
 name                    google-guava
-version                 13.0.1
+github.setup            google guava 33.7.1 v
+github.tarball_from     archive
+
 categories              java
 license                 Apache-2
 platforms               any
 supported_archs         noarch
-maintainers             nomaintainer
-description             Google's core libraries for Java 1.6
+maintainers             {sethm.id.au:dev @McDaMastR} \
+                        openmaintainer
+
+description             Google's core libraries for Java
 long_description        Google Guava replaces and includes Google Collections \
                         plus many other important core libraries.  It is a \
                         strict, backward-compatible superset of the Google \
@@ -18,38 +24,62 @@ long_description        Google Guava replaces and includes Google Collections \
                         performance fixes, so it is strongly encouraged to \
                         instead of Google Collections.
 
-homepage                https://github.com/google/guava
+homepage                https://guava.dev
 
-depends_lib             bin:java:kaffe
+# ${min_jdk} <= ${min_jdk_lts}
+if {[variant_isset gwt]} {
+        set min_jdk     24
+        set min_jdk_lts 25
+} else {
+        set min_jdk     22
+        set min_jdk_lts 25
+}
 
-master_sites            http://search.maven.org/remotecontent?filepath=com/google/guava/guava/${version}
-distfiles               guava-${version}.jar \
-                        guava-${version}-javadoc.jar
-extract.cmd             unzip
-extract.pre_args        -q
-extract.post_args       -d ${workpath}/api
-extract.only            guava-${version}-javadoc.jar
+java.version            ${min_jdk}+
+java.fallback           openjdk${min_jdk_lts}
 
-checksums               guava-${version}.jar \
-                                sha1 0d6f22b1e60a2f1ef99e22c9f5fde270b2088365 \
-                                rmd160 02855a27ffc659c3bd0a834b7023e9da08bcfc85 \
-                                sha256 feb4b5b2e79a63b72ec47a693b1cf35cf1cea1f60a2bb2615bf21f74c7a60bb0 \
-                        guava-${version}-javadoc.jar \
-                                sha1 adb5f5700edd5a7cba8f3121e9d58884cea8cd50 \
-                                rmd160 c6ad3b2c04452eda9d248e1af77f4d2064be08cb \
-                                sha256 0ee2e83e7b54ebb6633423e554c22508a2e7bcc9769607d13e5182b99d801a0e
+checksums               rmd160  566348e632502bb007d43189742ba3b7586adf5b \
+                        sha256  3cfb130a0389972dacfff54d545f95b4f8de0d6a6355ac1b1f4e5ea18f43e768 \
+                        size    5955350
 
-use_configure           no
+patchfiles              use-installed-jdk.diff
 
-build { }
+build.args-append       --define maven.javadoc.skip \
+                        --define toolchain.jdk.version="\[${min_jdk},)" \
+                        --define toolchain.skip \
+                        --projects guava \
+                        --projects guava-testlib
 
 destroot {
-        set javadir ${destroot}${prefix}/share/java
-        set docdir ${destroot}${prefix}/share/doc/${name}
+        set destdocdir  ${destroot}${prefix}/share/doc/${name}
+        set destjavadir ${destroot}${prefix}/share/java/${name}
 
-        xinstall -d ${docdir} ${javadir}
+        xinstall -d ${destjavadir}
+        xinstall -m 644 \
+            ${worksrcpath}/guava/target/guava-${version}-jre.jar \
+            ${destjavadir}/guava-jre.jar
+        xinstall -m 644 \
+            ${worksrcpath}/guava-testlib/target/guava-testlib-${version}-jre.jar \
+            ${destjavadir}/guava-testlib-jre.jar
 
-        file copy ${distpath}/guava-${version}.jar \
-                ${javadir}/google-guava.jar
-        file copy ${workpath}/api ${docdir}
+        if {[variant_isset gwt]} {
+                xinstall -m 644 \
+                        ${worksrcpath}/guava-gwt/target/guava-gwt-${version}-jre.jar \
+                        ${destjavadir}/guava-gwt-jre.jar
+        }
+
+        xinstall -d ${destdocdir}
+        xinstall -m 644 \
+                ${worksrcpath}/CONTRIBUTING.md \
+                ${worksrcpath}/CONTRIBUTORS \
+                ${worksrcpath}/LICENSE \
+                ${worksrcpath}/README.md \
+                ${destdocdir}
+}
+
+variant gwt description {Add GWT support} {
+        # Bypass build system bug w/ package goal
+        build.target            install
+        build.args-append       --projects guava-gwt \
+                                --projects guava-tests
 }

--- a/java/google-guava/Portfile
+++ b/java/google-guava/Portfile
@@ -1,4 +1,6 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- vim:fenc=utf-8:ft=tcl:et:sw=8:ts=8:sts=8
+
+PortSystem              1.0
 
 name                    google-guava
 version                 13.0.1
@@ -29,13 +31,13 @@ extract.post_args       -d ${workpath}/api
 extract.only            guava-${version}-javadoc.jar
 
 checksums               guava-${version}.jar \
-                        sha1 0d6f22b1e60a2f1ef99e22c9f5fde270b2088365 \
-                        rmd160 02855a27ffc659c3bd0a834b7023e9da08bcfc85 \
-                        sha256 feb4b5b2e79a63b72ec47a693b1cf35cf1cea1f60a2bb2615bf21f74c7a60bb0 \
+                                sha1 0d6f22b1e60a2f1ef99e22c9f5fde270b2088365 \
+                                rmd160 02855a27ffc659c3bd0a834b7023e9da08bcfc85 \
+                                sha256 feb4b5b2e79a63b72ec47a693b1cf35cf1cea1f60a2bb2615bf21f74c7a60bb0 \
                         guava-${version}-javadoc.jar \
-                        sha1 adb5f5700edd5a7cba8f3121e9d58884cea8cd50 \
-                        rmd160 c6ad3b2c04452eda9d248e1af77f4d2064be08cb \
-                        sha256 0ee2e83e7b54ebb6633423e554c22508a2e7bcc9769607d13e5182b99d801a0e
+                                sha1 adb5f5700edd5a7cba8f3121e9d58884cea8cd50 \
+                                rmd160 c6ad3b2c04452eda9d248e1af77f4d2064be08cb \
+                                sha256 0ee2e83e7b54ebb6633423e554c22508a2e7bcc9769607d13e5182b99d801a0e
 
 use_configure           no
 

--- a/java/google-guava/files/use-installed-jdk.diff
+++ b/java/google-guava/files/use-installed-jdk.diff
@@ -1,0 +1,25 @@
+By default, the build system will download an appropriate JDK to build
+the project.  Alter the build system to instead search for an installed
+JDK.
+
+--- pom.xml.orig	2026-08-18 13:13:06
++++ pom.xml	2026-09-01 16:50:12
+@@ -390,17 +390,10 @@
+           <executions>
+             <execution>
+               <goals>
+-                <goal>toolchain</goal>
++                <goal>select-jdk-toolchain</goal>
+               </goals>
+             </execution>
+           </executions>
+-          <configuration>
+-            <toolchains>
+-              <jdk>
+-                <version>26</version>
+-              </jdk>
+-            </toolchains>
+-          </configuration>
+         </plugin>
+         <plugin>
+           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
#### Description

Add myself to the maintainers of `google-guava` and update the port to version 33.7.1.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?