### PR TITLE
gost: Update to 3.3.0

### DIFF
--- a/net/gost/Portfile
+++ b/net/gost/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-gost/gost 3.2.6 v
+go.setup            github.com/go-gost/gost 3.3.0 v
 go.toolchain_min    1.26.3
 revision            0
 
@@ -15,9 +15,9 @@ description         GO Simple Tunnel - a simple tunnel written in golang.
 long_description    ${description}
 homepage            https://gost.run/en/
 
-checksums           rmd160  2c4c39920514bf57592eda81d674226114a3c05a \
-                    sha256  79874354530b899576dd4866d3b1400651d0b17c1e7a90ad30c44686a0642600 \
-                    size    31234
+checksums           rmd160  011a8121b6988c6e5743220385bdc78cd8247183 \
+                    sha256  2a65e2da14fef6b6da8d4e32a8bc62e39970dbb141db42bc6f5821f90ac1e9a3 \
+                    size    96968
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 go.offline_build    no
@@ -34,7 +34,7 @@ startupitem.name    ${name}
 startupitem.logfile ${prefix}/var/log/${name}.log
 startupitem.start   "${prefix}/bin/${name} -C ${prefix}/etc/${name}.yml"
 startupitem.stop    "kill \$(cat ${prefix}/var/run/${name}.pid)"
-startupitem.pidfile auto ${prefix}/var/run/${name}.pid
+startupitem.pidfile manual ${prefix}/var/run/${name}.pid
 
 notes-append "
 A configuration must be created at


### PR DESCRIPTION
#### Description

Update gost to 3.3.0.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
