### PR TITLE
boxes: update to 2.3.2

### DIFF
--- a/textproc/boxes/Portfile
+++ b/textproc/boxes/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            ascii-boxes boxes 2.3.1 v
+github.setup            ascii-boxes boxes 2.3.2 v
 github.tarball_from     archive
 
 categories              textproc
@@ -18,9 +18,9 @@ long_description        boxes is a text filter which can draw various \
 
 homepage                https://boxes.thomasjensen.com
 
-checksums               rmd160  733bb03492a97948ae9daf74fc6e2c6a5cca82c9 \
-                        sha256  0834e54c0d5293950412729cabf16ada3076a804eacba8f1aacc5381dfe3a96a \
-                        size    299074
+checksums               rmd160  954b15bd61752cfdd1b5a163d965e73fedb61df3 \
+                        sha256  9318ef65f555ee3d893176349a4219f1f1260ce24d4100aeb667a546f61fc183 \
+                        size    310068
 
 depends_build-append    port:bison \
                         port:flex \


### PR DESCRIPTION
#### Description

Update boxes from 2.3.1 to 2.3.2.

- [v2.3.2 release notes](https://github.com/ascii-boxes/boxes/releases/tag/v2.3.2) ([full announcement](https://boxes.thomasjensen.com/2026/08/boxes-v2.3.2-released.html))

A maintenance release: fixes big-endian support, fixes box misalignment for emoji with variation selectors, allows command-line designs with `-c` without a config file, and fixes right padding removal on blank lines when `killblank`=`false`. The remaining changes are Windows-specific and do not affect the macOS build.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?