### PR TITLE
uni2ascii: Update to 4.20

### DIFF
--- a/textproc/uni2ascii/Portfile
+++ b/textproc/uni2ascii/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 
 name                uni2ascii
-version             4.18
-revision            1
-checksums           rmd160  4cc1ab903b182bbb7f40c58c8eb5d77cb12b5c33 \
-                    sha256  59228212f81dfadf9fee87c37a0ce138e4fc503144492403b807e6e666f855c8 \
-                    size    127125
+version             4.20
+revision            0
+checksums           rmd160  27db1cbd14c2e2d3f51b566399a9912b4cd802b6 \
+                    sha256  0c5002f54b262d937ba3a8249dd3148791a3f6ec383d80ec479ae60ee0de681a \
+                    size    166554
 
 categories          textproc
 maintainers         nomaintainer
@@ -22,11 +22,13 @@ long_description    \
     included in program source, when entering text into Web programs that can \
     handle the Unicode character set but are not 8-bit safe, and when debugging.
 
-homepage            http://billposer.org/Software/uni2ascii.html
-master_sites        http://billposer.org/Software/Downloads/
+homepage            https://billposer.org/Software/uni2ascii.html
+master_sites        https://billposer.org/Software/Downloads/
 use_bzip2           yes
 
-depends_lib         port:gettext
+depends_build-append \
+                    port:gettext
+depends_lib-append  port:gettext-runtime
 
 patchfiles          patch-configure.ac.diff \
                     implicit-int.patch \
@@ -35,7 +37,16 @@ patchfiles          patch-configure.ac.diff \
 # We are patching configure.ac.
 use_autoreconf      yes
 
+# alignof is C23. Not neccessary to build
+configure.checks.implicit_function_declaration.whitelist-append alignof
+configure.checks.implicit_int \
+                    no
+
 configure.ldflags-append -lintl
+
+post-destroot {
+    xinstall -m 644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}
+}
 
 livecheck.type      regex
 livecheck.url       ${homepage}

--- a/textproc/uni2ascii/files/patch-configure.ac.diff
+++ b/textproc/uni2ascii/files/patch-configure.ac.diff
@@ -1,13 +1,5 @@
 --- configure.ac.orig	2011-05-14 21:13:46.000000000 -0500
 +++ configure.ac	2013-02-12 01:47:15.000000000 -0600
-@@ -1,6 +1,6 @@
- AC_PREREQ(2.59)
- AC_INIT(uni2ascii, 4.18, billposer@alum.mit.edu)
--AM_CONFIG_HEADER(config.h)
-+AC_CONFIG_HEADERS([config.h])
- AM_INIT_AUTOMAKE
- 
- AC_ARG_ENABLE(newsummary,
 @@ -26,9 +26,9 @@
  # Checks for programs.
  AC_PROG_CC


### PR DESCRIPTION
#### Description

Update uni2ascii to 4.20.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
