### PR TITLE
ipatool: Update to 2.5.0

### DIFF
--- a/sysutils/ipatool/Portfile
+++ b/sysutils/ipatool/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/majd/ipatool 2.4.0 v
+go.setup                github.com/majd/ipatool 2.5.0 v
 go.toolchain_min        1.25.0
 revision                0
 categories              sysutils
@@ -14,9 +14,9 @@ maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 description             CLI for searching and downloading iOS app packages from the App Store
 long_description        {*}${description}.
 
-checksums               rmd160  74c776eaa313726a37f1e0d584c2837f592d0a25 \
-                        sha256  95bb79d983b30a90d10bd4b326fc384ce7896abaf0626989ff463a36930c9f12 \
-                        size    761939
+checksums               rmd160  256cc6b2cfae69b5513136f2e1859998be04bcc0 \
+                        sha256  c44b6bc36cef8364e685d7a290d10d0120f26f2bb3644ebad4cf28dafb417cd6 \
+                        size    775939
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no


### PR DESCRIPTION
#### Description

Update ipatool to 2.5.0.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
