### PR TITLE
k3sup: update to 0.13.13

### DIFF
--- a/sysutils/k3sup/Portfile
+++ b/sysutils/k3sup/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/alexellis/k3sup 0.13.12
-go.toolchain_min    1.25.6
+go.setup            github.com/alexellis/k3sup 0.13.13
+go.toolchain_min    1.26.0
 go.offline_build    no
 revision            0
 
@@ -23,9 +23,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  3eadc30140ddb4d488c0ac889b0b5f0bf40c084d \
-                    sha256  35ce7ea737255a61329f60d1d078a11d7f50707580b1615acdc30b6f0a4c48bb \
-                    size    3312600
+checksums           rmd160  a1ced18b144b3237d5765ab146170fb80796cacb \
+                    sha256  6d0f208d2ec541f88693048e3bab99ae155924c3a6c1f1ac1c338411923cc8e1 \
+                    size    3300268
 
 patchfiles          patch-Makefile.diff
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `8db84d90fb49`, against the ports tree as of 2026-09-01.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — pristine tart VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
