### PR TITLE
zenith: update to 0.15.1

### DIFF
--- a/sysutils/zenith/Portfile
+++ b/sysutils/zenith/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        bvaisvil zenith 0.15.0
+github.setup        bvaisvil zenith 0.15.1
 github.tarball_from archive
 revision            0
 
@@ -33,9 +33,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9d4ecb7a14a1593c873543fb874a784c36419ee4 \
-                    sha256  f92ed87b66f97b1f6c5863a62cc795ec877510dcd0284fba822ef5dc091b9355 \
-                    size    746455
+checksums           rmd160  225ba616e43f1ffced901be7453e13b29fa50ad6 \
+                    sha256  ffa3412c19e99f9ef691f86e4f9b1a342add2b0504bb3ea7f0b57daa17e4b731 \
+                    size    747437
 
 # Issues having zenith 0.12.0 build with vendored cargo.crates
 # Allow it to fetch dependencies as needed during build time


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `1d5cfaf34f55`, against the ports tree as of 2026-09-01.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
