### PR TITLE
commons-cli: update to 1.11.0

### DIFF
--- a/java/commons-cli/Portfile
+++ b/java/commons-cli/Portfile
@@ -1,47 +1,49 @@
-PortSystem 1.0
-PortGroup java 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name				commons-cli
-version				1.1
-revision			1
+PortSystem          1.0
+PortGroup           java 1.0
 
-categories			java
-license				Apache-2
-maintainers			nomaintainer
-platforms			any
-supported_archs		noarch
+name                commons-cli
+version             1.1
+revision            1
 
-description			Jakarta Commons-CLI
-long_description	The Jakarta Commons CLI library provides an API for \
-					processing command line interfaces. It was formed by \
-					the merger of ideas and code from three different \
-					libraries - Werken, Avalon and Optz.
-homepage			https://commons.apache.org/cli/
-				
-distname			${name}-${version}-src
-master_sites		apache:commons/cli/source/
-checksums			md5 ccc1aa194132e2387557bbb7f65391f4
+categories          java
+license             Apache-2
+maintainers         nomaintainer
+platforms           any
+supported_archs     noarch
 
-depends_build		port:apache-ant
+description         Jakarta Commons-CLI
+long_description    The Jakarta Commons CLI library provides an API for \
+                    processing command line interfaces. It was formed by \
+                    the merger of ideas and code from three different \
+                    libraries - Werken, Avalon and Optz.
+homepage            https://commons.apache.org/cli/
 
-depends_lib			bin:java:kaffe \
-					port:commons-logging \
-					port:commons-lang \
-					port:junit
+distname            ${name}-${version}-src
+master_sites        apache:commons/cli/source/
+checksums           md5 ccc1aa194132e2387557bbb7f65391f4
 
-use_configure		no
+depends_build       port:apache-ant
 
-build.env			CLASSPATH=${prefix}/share/java/commons-logging.jar:${prefix}/share/java/commons-lang.jar:${prefix}/share/java/junit.jar
-build.cmd			ant
+depends_lib         bin:java:kaffe \
+                    port:commons-logging \
+                    port:commons-lang \
+                    port:junit
+
+use_configure       no
+
+build.env           CLASSPATH=${prefix}/share/java/commons-logging.jar:${prefix}/share/java/commons-lang.jar:${prefix}/share/java/junit.jar
+build.cmd           ant
 build.target        dist
 build.args          -Dfinal.name=${name} -Djunit.jar=${prefix}/share/java/junit.jar
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java ${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/dist/${name}.jar ${destroot}${prefix}/share/java/
-	file copy ${worksrcpath}/dist/docs ${destroot}${prefix}/share/doc/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/dist/${name}.jar ${destroot}${prefix}/share/java/
+    file copy ${worksrcpath}/dist/docs ${destroot}${prefix}/share/doc/${name}
 }
 
-livecheck.type  regex
-livecheck.url   https://commons.apache.org/proper/commons-cli/download_cli.cgi
-livecheck.regex "cli-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.type      regex
+livecheck.url       https://commons.apache.org/proper/commons-cli/download_cli.cgi
+livecheck.regex     "cli-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"

--- a/java/commons-cli/Portfile
+++ b/java/commons-cli/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           java 1.0
+PortGroup           maven 1.0
 
 name                commons-cli
-version             1.1
-revision            1
+version             1.11.0
+revision            0
 
 categories          java
 license             Apache-2
@@ -18,32 +18,36 @@ long_description    The Jakarta Commons CLI library provides an API for \
                     processing command line interfaces. It was formed by \
                     the merger of ideas and code from three different \
                     libraries - Werken, Avalon and Optz.
-homepage            https://commons.apache.org/cli/
+homepage            https://commons.apache.org/proper/commons-cli/
 
 distname            ${name}-${version}-src
 master_sites        apache:commons/cli/source/
-checksums           md5 ccc1aa194132e2387557bbb7f65391f4
+checksums           rmd160  1fff8f025f8295b45ba2cde15ebcd66d1dc0dd0b \
+                    sha256  b2bb70c9e1103590e4371319bd404e96f74f5b14bd8c4b023498326608d2e96e \
+                    size    302658
 
-depends_build       port:apache-ant
-
-depends_lib         bin:java:kaffe \
-                    port:commons-logging \
-                    port:commons-lang \
-                    port:junit
-
-use_configure       no
-
-build.env           CLASSPATH=${prefix}/share/java/commons-logging.jar:${prefix}/share/java/commons-lang.jar:${prefix}/share/java/junit.jar
-build.cmd           ant
-build.target        dist
-build.args          -Dfinal.name=${name} -Djunit.jar=${prefix}/share/java/junit.jar
+java.version        1.8+
+java.fallback       openjdk11
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/dist/${name}.jar ${destroot}${prefix}/share/java/
-    file copy ${worksrcpath}/dist/docs ${destroot}${prefix}/share/doc/${name}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destjavadir}/${name}.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/CONTRIBUTING.md \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/NOTICE.txt \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/RELEASE-NOTES.txt \
+        ${destdocdir}
 }
 
 livecheck.type      regex
 livecheck.url       https://commons.apache.org/proper/commons-cli/download_cli.cgi
-livecheck.regex     "cli-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src\\.tar\\.gz"


### PR DESCRIPTION
#### Description

Update the `commons-cli` port to version 1.11.0 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?