### PR TITLE
rust: update to 1.98.1

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -17,8 +17,8 @@ name                    cargo
 if {${os.platform} eq "darwin" && ${os.major} > 15} {
     # (CURRENT) macOS 10.12 and later
     github.setup        rust-lang ${name} 0.99.0
-    rust_build.version  1.98.0
-    revision            0
+    rust_build.version  1.98.1
+    revision            1
 } else {
     # macOS 10.11 and earlier
     github.setup        rust-lang ${name} 0.79.0

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -43,7 +43,7 @@ name                        rust
 # 1.97.  Sierra i386 users would need the frozen 1.78.0.
 if {${os.platform} eq "darwin" && ${os.major} > 15} {
     # (CURRENT) macOS 10.12 and later
-    version                 1.98.0
+    version                 1.98.1
     revision                0
 } else {
     # macOS 10.11 and earlier
@@ -147,9 +147,9 @@ dist_subdir                 cargo-crates
 if {${os.platform} eq "darwin" && ${os.major} > 15} {
     # (CURRENT) macOS 10.12 and later
     checksums-append        rustc-${version}-src${extract.suffix} \
-                            rmd160  341e5c5eeb456cc617d9562fe162c988f44d7fa1 \
-                            sha256  b226aef375ffbe9fbe2b85fde996b50716d59d55268e240d052396534b75e929 \
-                            size    529275763
+                            rmd160  9d2f72915a9061a11e2580468cfb2cc909062e9e \
+                            sha256  dc9f8b917b32444d6c7ac43cc1b409013d3a9a633338bb60c14cdae1d15ee65a \
+                            size    529289329
 
     patchfiles-append       patch-symlink.diff
 } else {


### PR DESCRIPTION
#### Description

`rust` 1.98.0 → 1.98.1. A point release with a single fix: a rustc
miscompilation that emitted zero-valued vtable slots for some boxed dynamic
dispatch, segfaulting at runtime ([rust-lang/rust#161441][issue]).

[Changelog](https://github.com/rust-lang/rust/releases/tag/1.98.1)

- No portgroup change: `src/stage0` for 1.98.1 still names 1.97.1, so the
  stage0 versions and checksums are already correct.

- `cargo` stays at 0.99.0 — rust-lang/cargo has no 0.99.1 tag — but
  `rust_build.version` moves to 1.98.1 and it gets a revision bump so it is
  rebuilt. cargo is compiled by `${prefix}/bin/rustc`, not by a stage0
  (`rust_build.components cargo` fetches only the driver), so the current
  archives were produced by the compiler this release fixes.

Both patches that apply to the current branch still apply to 1.98.1, and the
tarball still ships `vendor/` with a `.cargo/config.toml` replacing crates-io.

Not build-tested; the source checksum was verified against upstream's `.sha256`.

[issue]: https://github.com/rust-lang/rust/issues/161441
