### PR TITLE
gh: update to 2.100.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             2.99.0
+version             2.100.0
 revision            0
 
 # Github CLI is failing to build on 10.12 and below.
@@ -55,9 +55,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  88a057128e6554b345047aaba87c5313bdb0c823 \
-                        sha256  65fff9aa7eb4410689c4c4c6756d2ef58492b1a6ce985e97dfd1b61588aa52f9 \
-                        size    15023512
+    checksums           rmd160  b1bbc2324093f3ba62d500999eaddeee445cce33 \
+                        sha256  39d5123f08a553a6fa69e46de86c22d04d97a217e03d0e6584b66d0fea50f1fe \
+                        size    15067137
 
     dist_subdir         ${name}
 
@@ -75,9 +75,9 @@ if ${source_build} {
 
     distname        gh_${version}_macOS_amd64
 
-    checksums       rmd160  96c0be5f82c7ef79ef8d8ac806198859c1531418 \
-                    sha256  70c05750c75df9465bc73b994e8bc379243bb494271f1b51f54ead2e19e45471 \
-                    size    15586528
+    checksums       rmd160  7c896361a1c51b111ed9dc58d1fc6322eb30074f \
+                    sha256  fcd7799e85eb575f3c7d2b1679bfbfedaefa1269d4bc7d096b51e10939b4812b \
+                    size    15818005
 
     use_configure   no
     use_zip         yes


### PR DESCRIPTION
#### Description

Not verified:
  — Tahoe: verification was asked for and is still queued.

Branch head `2e0d047459b8`, against the ports tree as of 2026-09-03.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
