### PR TITLE
doggo: update to 1.4.0

### DIFF
--- a/net/doggo/Portfile
+++ b/net/doggo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mr-karan/doggo 1.3.0 v
+go.setup            github.com/mr-karan/doggo 1.4.0 v
 go.offline_build    no
 go.toolchain_min    1.26.5
 revision            0
@@ -23,9 +23,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  b400fe772e0eb4eb680a64526c1ece95aae2c050 \
-                    sha256  877f047fe81185d4fbeec870d54233f7ebf7c707a41cb98d023c34e089f9a0c0 \
-                    size    2509840
+checksums           rmd160  94d7b8ee16a920e237715281901432738481610f \
+                    sha256  e0d043aa34fb8daa44df07558fd32fe2686eba6644d5f6834edbc8a789d42e1d \
+                    size    2551351
 
 build.cmd           make
 build.pre_args      VERSION=${version}


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `7fcf4090688f`, against the ports tree as of 2026-09-03.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
