### PR TITLE
mise: update to 2026.9.1

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.8.8 v
+github.setup        jdx mise 2026.9.1 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  38cf2a4a4d00e41b5e21e552165259d65a633432 \
-                    sha256  f4053c5f98801ea6e35fc0050033ecbeb1c5d6c2142b61e07abbc262f8cccbaa \
-                    size    13552538
+                    rmd160  ac32750aa5b0ef20e2ec86ba0b20cfd5d4dbffae \
+                    sha256  a438ab1357196c996f6f2c15682ab4143ff4e474c05c6d731923b52d5fc25d73 \
+                    size    13936105
 
 depends_build-append \
                     port:bin/cmake:cmake
@@ -98,7 +98,7 @@ cargo.crates \
     aead                                 0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
     aead                                 0.6.1  1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99 \
     aes                                  0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
-    aes                                  0.9.2  f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58 \
+    aes                                  0.9.3  35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32 \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
     aes-kw                               0.2.1  69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c \
     age                                 0.11.5  047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43 \
@@ -111,7 +111,7 @@ cargo.crates \
     alloc-stdlib                         0.2.4  0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195 \
     allocator-api2                      0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     ambient-id                          0.0.11  c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e \
-    android_system_properties            0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    android_system_properties            0.1.6  ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc \
     ansi-str                             0.9.0  060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d \
     ansitok                              0.3.0  c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee \
     anstream                             1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
@@ -124,7 +124,6 @@ cargo.crates \
     arc-swap                             1.9.2  c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b \
     archspec                             0.2.0  3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33 \
     argon2                               0.5.3  3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072 \
-    arrayref                             0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                             0.7.8  d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     astral-reqwest-middleware            0.5.1  98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9 \
@@ -137,48 +136,48 @@ cargo.crates \
     async-fd-lock                        0.2.0  7569377d7062165f6f7834d9cb3051974a2d141433cc201c2f94c149e993cccf \
     async-once-cell                      0.5.4  4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
-    async-trait                         0.1.91  ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec \
+    async-trait                         0.1.92  82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667 \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    aube                                1.41.0  96f32e8b165cd44d00394a0ff19f578a92c99b2cc7ca14575df0da2db69f9eef \
-    aube-codes                          1.41.0  7e4970f4e74d441f91ba6a4a0ac8fd6e46658fe65e12ad7ebfe4873b580aff24 \
-    aube-linker                         1.41.0  162c3a9ff8ee6be148ed9abf3f8b274fe4b2442a54247b258395e69f4a96d7b5 \
-    aube-lockfile                       1.41.0  7f0bb9d924f35f07ccb1ead685e7f45f3a6f488df9b03562e5fbb8ec075d6290 \
-    aube-manifest                       1.41.0  75090ee2a1539bb4130d22f6410c2ab835381dee709913f5fb12c205148a37f0 \
-    aube-registry                       1.41.0  3f8b7bcdbfde52d4ce96c363b99e577ac73093e82f7ea40a23ed680ffda521ce \
-    aube-resolver                       1.41.0  deeda8571e6340e6f9bb8ca3ba39f163463260a8c0e6d8411d84f846fa4101f9 \
-    aube-runtime                        1.41.0  70f9172dbd650d35e6a9b54276998179c9b8a776fc11e0696de2b2a6c1f46110 \
-    aube-scripts                        1.41.0  2526895539b06b2abe99e4e77ed3e37ea54e6aaabf5d3a0d84348ed25d84978e \
-    aube-settings                       1.41.0  5f08726d73039e2fc9407715b3e6c2f97d72a4dbc85256c5ed21fe7b66d0dbaf \
-    aube-store                          1.41.0  f40eaeec4efdf07458340bcd405ec9c4f0034d48f6fbd9af765cc1d81aaae3cd \
-    aube-util                           1.41.0  ac99c4c1451782b818dbd0f197925352362caded0d798214a0e9dc809a146d3e \
-    aube-workspace                      1.41.0  dd585c4e04b176043622fd08a60b3a8f33a0245fa485787d2b01b9747da62d3d \
+    aube                                 2.2.4  0a7c0cbbdeb22323f0c5447fa53d81cff4714d179560b119be2ef9dde9943243 \
+    aube-codes                           2.2.4  3224f21cae2844ac34a0eb189c500525e1cfd40f6a7a914fab222e399056ec9c \
+    aube-linker                          2.2.4  7ba1221a16a85a078335bcc2f9a31c3fde7d263bb325e31230bd3bbe8f770826 \
+    aube-lockfile                        2.2.4  c986b6cae006a67e0b23546235880bd63d033f4bc3f2a43c77dd698f8c0d46e3 \
+    aube-manifest                        2.2.4  2c972004c3d3c1ace55c58eadb746461e0158dcd76ef40af08557ae394257901 \
+    aube-registry                        2.2.4  fd8ae1b32d2e0823ba50451d7997acd7f0eb4ca19d8f0ebe05cb18e4877ff883 \
+    aube-resolver                        2.2.4  3553cc3e7a2fa121297461548c0a23ec5d2851c079f2abc41c2b2f3f14252585 \
+    aube-runtime                         2.2.4  ac05125536a3b55bbd50ccf37210c005576ee6969bacdcc263ddd939d67e2509 \
+    aube-scripts                         2.2.4  767c6e3fc27a056aa6718e83a03f5e505d7d7089982947af6c1bf0566c036c69 \
+    aube-settings                        2.2.4  7f38a9a5547a39c50a2b9d594f1b66ef2680998b5996cfa4071a0c0050ea4ead \
+    aube-store                           2.2.4  b36160d63de4425a9bdf518c7c81da8f0f0d04218014cac655b99d59daa888de \
+    aube-util                            2.2.4  fbc7fd0e85447f421f6f8195c10bb37975120ce2d5b220fd866bd0d152b25c35 \
+    aube-workspace                       2.2.4  5dafdd27480bedff7bcb528a625c2f8bc402fbf88f5e0ff721917860def2d12a \
     autocfg                              1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
-    aws-config                          1.8.18  e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275 \
-    aws-credential-types                1.2.14  8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7 \
+    aws-config                          1.11.0  a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b \
+    aws-credential-types                 1.3.0  e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e \
     aws-lc-fips-sys                     0.14.1  118303cd75f63d1933a90c2ceb7e697281ac6acbdbcc490b46419f25a527ab90 \
     aws-lc-rs                           1.18.0  ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e \
     aws-lc-sys                          0.44.0  f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483 \
-    aws-runtime                          1.7.5  6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39 \
-    aws-sdk-s3                         1.137.0  c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874 \
-    aws-sdk-sso                        1.102.0  8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b \
-    aws-sdk-ssooidc                    1.104.0  321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913 \
-    aws-sdk-sts                        1.107.0  3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560 \
-    aws-sigv4                            1.4.5  bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71 \
-    aws-smithy-async                    1.2.14  2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc \
-    aws-smithy-checksums                0.64.8  e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a \
-    aws-smithy-eventstream             0.60.21  78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706 \
-    aws-smithy-http                     0.63.6  ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231 \
-    aws-smithy-http-client              1.1.13  5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3 \
-    aws-smithy-json                     0.62.7  701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa \
-    aws-smithy-observability             0.2.6  a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c \
-    aws-smithy-query                   0.60.15  1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd \
-    aws-smithy-runtime                  1.11.3  b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182 \
-    aws-smithy-runtime-api              1.12.3  9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c \
-    aws-smithy-runtime-api-macros        1.0.0  8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7 \
-    aws-smithy-schema                    0.1.0  7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5 \
-    aws-smithy-types                     1.5.0  32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85 \
-    aws-smithy-xml                     0.60.15  0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3 \
-    aws-types                           1.3.16  d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531 \
+    aws-runtime                          1.9.1  c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb \
+    aws-sdk-s3                         1.144.0  30dc8bf6baaf7d46336a0ca2c69f223d9b90d7a801fb3e28f7ea17b00dc6b1de \
+    aws-sdk-sso                        1.108.0  c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05 \
+    aws-sdk-ssooidc                    1.110.0  72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899 \
+    aws-sdk-sts                        1.113.0  68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032 \
+    aws-sigv4                            1.5.1  723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f \
+    aws-smithy-async                     1.3.0  f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316 \
+    aws-smithy-checksums                0.65.0  b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307 \
+    aws-smithy-eventstream              0.61.2  6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f \
+    aws-smithy-http                     0.64.0  37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d \
+    aws-smithy-http-client               1.4.0  ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1 \
+    aws-smithy-json                     0.63.0  3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef \
+    aws-smithy-observability             0.3.0  8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c \
+    aws-smithy-query                    0.62.0  512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62 \
+    aws-smithy-runtime                  1.14.0  b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606 \
+    aws-smithy-runtime-api              1.15.0  954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9 \
+    aws-smithy-runtime-api-macros        1.1.0  221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3 \
+    aws-smithy-schema                    0.2.0  7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910 \
+    aws-smithy-types                     1.6.2  fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647 \
+    aws-smithy-xml                      0.62.0  ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8 \
+    aws-types                            1.5.0  eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94 \
     backtrace                           0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
     backtrace-ext                        0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
     base16ct                             0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
@@ -194,8 +193,6 @@ cargo.crates \
     beef                                 0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                             0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
-    bisync                               0.3.0  5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7 \
-    bisync_macros                        0.2.3  d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6 \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
     bitfields                            1.0.3  ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195 \
@@ -204,8 +201,8 @@ cargo.crates \
     bitflags                            2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
     bitvec                               1.1.1  ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837 \
     blake2                              0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
-    blake2                         0.11.0-rc.6  061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690 \
-    blake3                               1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
+    blake2                              0.11.0  5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f \
+    blake3                               1.8.7  6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-buffer                        0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     block-padding                        0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
@@ -213,12 +210,12 @@ cargo.crates \
     brotli                               8.0.4  5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3 \
     brotli-decompressor                  5.0.3  3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583 \
     bs58                                 0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
-    bstr                                1.13.0  1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530 \
+    bstr                                1.13.1  6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f \
     buffer-redux                         1.1.0  431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54 \
     built                                0.8.1  5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9 \
     bumpalo                             3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
-    bytecheck                            0.8.2  0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b \
-    bytecheck_derive                     0.8.2  89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9 \
+    bytecheck                            0.8.3  26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29 \
+    bytecheck_derive                     0.8.3  46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69 \
     bytecount                            0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                               1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
@@ -231,28 +228,23 @@ cargo.crates \
     camellia                             0.1.0  3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30 \
     cast5                               0.11.1  26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                   1.4.2  5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e \
+    cc                                   1.4.4  0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273 \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfb-mode                             0.8.2  738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                          0.2.2  f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
     chacha20                             0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
-    chacha20                            0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
+    chacha20                            0.10.2  65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06 \
     chacha20poly1305                    0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
     chacha20poly1305                    0.11.0  9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb \
     chrono                              0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     chrono-tz                            0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
+    chrono-tz                           0.10.4  a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3 \
     chrono-tz-build                      0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                            0.14.15  7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23 \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     cipher                               0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
     clang-sys                            1.9.1  157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a \
-    clap                                 4.6.5  301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf \
-    clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
-    clap_builder                         4.6.5  94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078 \
-    clap_derive                          4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
-    clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
-    clap_usage                           5.0.0  c3671e15a3e8444d399658989389a0eca99bee6f4aca10b836aad27882d4c4d7 \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
     clx                                  3.0.2  03a65674abcd65c2846d6bfc4c9816ab9177b15277a18a78aa1691683ce63095 \
     cmac                                 0.7.2  8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa \
@@ -267,7 +259,7 @@ cargo.crates \
     color-spantrace                      0.3.0  b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427 \
     colorchoice                          1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     colored                              3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
-    combine                              4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
+    combine                              4.6.8  cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e \
     comfy-table                          8.0.0  136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2 \
     compression-codecs                  0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
     compression-core                    0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
@@ -280,7 +272,7 @@ cargo.crates \
     constant_time_eq                     0.4.2  3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b \
     contracts                           0.6.10  80771e396e09e4d428c6d034440a3fc62f3927334b66e13c8b8689d3f8785e42 \
     convert_case                        0.10.0  633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
-    cookie                              0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
+    cookie                              0.18.2  1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87 \
     cookie-factory                       0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
     cookie_store                        0.22.1  15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206 \
     core-foundation                      0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
@@ -289,10 +281,10 @@ cargo.crates \
     countme                              3.0.1  7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636 \
     cpubits                              0.1.1  15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae \
     cpufeatures                         0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
-    cpufeatures                          0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
+    cpufeatures                          0.3.1  5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566 \
     crc-fast                            1.10.0  e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5 \
     crc24                                0.1.6  fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0 \
-    crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    crc32fast                            1.5.1  8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550 \
     crmf                                 0.2.0  36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92 \
     crossbeam-channel                   0.5.16  d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e \
     crossbeam-deque                      0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
@@ -303,7 +295,7 @@ cargo.crates \
     crypto-bigint                        0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    ctor                                1.0.12  2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f \
+    ctor                                1.0.13  914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -311,10 +303,13 @@ cargo.crates \
     cx448                                0.1.1  b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa \
     darling                            0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
     darling                             0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
+    darling                             0.24.1  ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec \
     darling_core                       0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
     darling_core                        0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
+    darling_core                        0.24.1  6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff \
     darling_macro                      0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
     darling_macro                       0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
+    darling_macro                       0.24.1  2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785 \
     dashmap                              5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                              6.2.1  e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c \
     dbl                                  0.3.2  bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9 \
@@ -325,7 +320,7 @@ cargo.crates \
     defmt                                1.1.1  e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1 \
     defmt-macros                         1.1.1  bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8 \
     defmt-parser                         1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
-    demand                               2.0.5  6c7f0bec8d94f8eb4d2efec0325ef991480abab44dc42f2f3cbf10c41aeb73fc \
+    demand                               2.1.0  c578ab3368e9211f6f8e262c60b105d5e91bd9725a38567ccfe9f1c7d86507f2 \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     der                                  0.8.1  a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
@@ -357,7 +352,7 @@ cargo.crates \
     ecdsa                               0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
     ed25519                              2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                        2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
-    either                              1.17.0  9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d \
+    either                              1.18.0  252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34 \
     elliptic-curve                      0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     elsa                                1.11.2  9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e \
     encode_unicode                       1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
@@ -376,8 +371,8 @@ cargo.crates \
     errno-dragonfly                      0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     event-listener                       5.4.2  5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2 \
     exec                                 0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
-    expr-lang                            1.1.1  e6e6e9a6990c24970375077a97a392146b5be2155a957d9a4e5337ca0bde0c26 \
-    eyre                                0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
+    expr-lang                            2.1.0  0ccbe01093a53933ac2e794bf8de543359ba840520304a6b93b8d00d0b99ceaf \
+    eyre                                0.6.14  c08309dbcc659c5549a24ddb9b27027640641b282ef5768267c7e675558986a3 \
     fancy-regex                         0.18.0  e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277 \
     faster-hex                          0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
     fastrand                             2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
@@ -387,10 +382,10 @@ cargo.crates \
     file_url                             0.3.2  5e68d9ad067554ef18d79494f0e0bcddaf263f41b0126eb7a937f9e942fcbbd8 \
     filetime                            0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
-    find-msvc-tools                     0.1.10  26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de \
+    find-msvc-tools                     0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
     fixedbitset                          0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
     flagset                              0.4.7  b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe \
-    flate2                               1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    flate2                              1.1.10  6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb \
     float-cmp                           0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     fluent                              0.16.1  bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a \
     fluent                              0.17.0  8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477 \
@@ -412,10 +407,10 @@ cargo.crates \
     fsio                                 0.4.1  f4944f16eb6a05b4b2b79986b4786867bb275f52882adea798f17cc2588f25b2 \
     fslock                               0.2.1  04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb \
     funty                                2.0.0  e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c \
-    futures                             0.3.33  a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218 \
+    futures                             0.3.34  9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3 \
     futures-channel                     0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
     futures-core                        0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
-    futures-executor                    0.3.33  6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458 \
+    futures-executor                    0.3.34  031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432 \
     futures-io                          0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
     futures-lite                         2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
     futures-macro                       0.3.34  9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44 \
@@ -430,68 +425,71 @@ cargo.crates \
     getrandom                            0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     ghash                                0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                               0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
-    gix                                 0.86.0  bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce \
-    gix-actor                           0.41.2  33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b \
-    gix-archive                         0.35.0  6760ef6ef4edfa6449918977d59518ff209676f47e89bdce87a36a50be35e834 \
-    gix-attributes                      0.34.0  c31c593692ebdc1e38858d9a2b56f6a594c501e24a38971fe6685571f5a07be0 \
-    gix-bitmap                           0.3.3  7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7 \
-    gix-blame                           0.16.0  b06d20ff0e88ada2dd852b3852727b664ec9baefdf653d1d4e722e858c52cd17 \
-    gix-chunk                            0.7.3  b2a871e5cab12ba568845714473505deefffb3c04eb47f4708ce344cd459c1cc \
-    gix-command                          0.9.1  00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6 \
-    gix-commitgraph                     0.38.0  a2cd7f054ae2727223fe46dd39c012f066b12f532962d336d29ee193261787da \
-    gix-config                          0.59.0  103d11bef95c467577ecfa8b7b86a22e65af3507b2c9bfa3809a4afbae7df301 \
-    gix-config-value                    0.19.0  9f813e312a3f7f327187823cd4c754a3e4d948c98907d11e8f37554a2b6b8059 \
-    gix-credentials                     0.39.0  73b637f873d5f9aa67e672c1b23741a18e046d33028017adede32f4b4087a2e7 \
-    gix-date                            0.15.6  7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567 \
-    gix-diff                            0.66.0  fee7d89a3c507491cdfc57a1d1e0e300214720b4f7709ebc253e422f99822bfc \
-    gix-dir                             0.28.0  f24bc78f283946ac64757c8a61ffa71f0230aa1e8d98cbb0771db479871dd5b6 \
-    gix-discover                        0.54.0  b9f517766fa1101dfe2606c1a19a8ffa699099030995a9194445446dfe261bdf \
-    gix-error                            0.2.5  4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329 \
-    gix-features                        0.49.0  20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc \
-    gix-filter                          0.33.0  5e7b5dbf524d97e839f642930c76d7f011c0791e7d11d8148989ac5af7c76aa8 \
-    gix-fs                              0.22.0  865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80 \
-    gix-glob                            0.27.0  421e92a711554fa5827d1b0599d3389acdd0f6729e97a8c5a57d79af1e50bf36 \
-    gix-hash                            0.26.0  13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e \
+    gix                                 0.87.1  fdefc1465d8631807deaf504dacdeff628b978de515653b47976ca7c28ab2a7a \
+    gix-actor                           0.42.0  e37efa99929ac62f980fb1a7dcd09dea85b3aa6ead6ba0498362add3f4e698de \
+    gix-archive                         0.36.1  1c4ef97efd3920d3525104c5f253dec94dc935f953a50055954939177aed2cdd \
+    gix-attributes                      0.35.0  76b83782ac69ae28921a6e8fbcf2e24069613f1518030b97ae622b079abffa54 \
+    gix-bitmap                           0.4.0  f17013c7ef5cb95ebb4bf4978201e6a8a42ffea9d666fd5388f1b7e742307d80 \
+    gix-blame                           0.17.1  54fe27f8037c58cb4b6d60fe0aacf7ee2c998633cedf4e989351c07d9a3a575d \
+    gix-chunk                            0.8.0  00e32f938b3745ac93d73bc7490b6a15a661b2fc81973bfe90e275cc53c908e1 \
+    gix-command                         0.10.0  0d96b8e8423ce2665232bda1b682a62541f07ab801ffad69a034ef962bed3244 \
+    gix-commitgraph                     0.39.0  6b93c9fb1f5be01bba54a7a3b7455d359efc68555539c75ef74b8021bb6db497 \
+    gix-config                          0.60.0  f973c28c0a4871a7926fc90c8377d4458fd6cbb19692f56582b4d2022313ae90 \
+    gix-config-value                    0.19.1  6f6af5321bfd3711a279d6b244d58532ba1cfabf9eb6374791f19929d8970082 \
+    gix-credentials                     0.40.0  16c11822054fd4b80a1ab722b703f2e7c691b20484d898374289b742c1f49e50 \
+    gix-date                            0.16.0  e63d9aa18f29facd571c8953e66224ee0075b9e16622024794555ed4acceea85 \
+    gix-diff                            0.67.1  1b1689ff5ddeee4acfb2a43e875a1072a76d208624b15a9065c938b39cb0da2a \
+    gix-dir                             0.29.1  8342d5eb0ea054ed6ef807e628e38f06dd51eceeec9529767d8b23e33eff9c09 \
+    gix-discover                        0.55.0  ec32a30ec2934735599c2545f30067e80bd255fd3454b52a5d59bc02b52874a3 \
+    gix-error                            0.3.1  e73b2794a6a746953c24d4ed51e4d408b83d8d599ed4e5c39a47736d75687cf0 \
+    gix-features                        0.49.1  39c0e59d9d253dcccc38c3a46b91bfb9b46bd63eed54fe1a719e12194884d52a \
+    gix-filter                          0.34.0  9c30b28d957e2e6f1e1bbfbfd26b8e0bb0aab68d8a5e730fb4fd3049943575e3 \
+    gix-fs                              0.22.1  ebcfa9fd253f25350a3b21b3dd74034a446098e373c6123d4cee3519894f12ef \
+    gix-glob                            0.27.1  b417cf515fd8c91468b578071f76d6cba716f8a1eccd853906bff4908b2c1413 \
+    gix-hash                            0.26.2  380b9c423a54f0821064b954b5a5ab25c660812f6a91da03c3f1cb4b10762aa5 \
     gix-hashtable                       0.16.0  78fccd6fea3bcf0b39c076bae60ae49b08daaf538b950202101a981f9d3c01d3 \
-    gix-ignore                          0.22.0  12cff8e8aa125e39377456073e63df3334d9e5741372ddcc226198015076dda2 \
-    gix-imara-diff                       0.2.4  1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1 \
-    gix-index                           0.54.0  5009c4e7e9f9b4cfaaab1153e49133eb04d79c015b5702d6c3d2ab94271a89c6 \
+    gix-ignore                          0.22.1  65859a2f7de5e159d4344a5486ebf53b6bac22d5ec6afa836e47c10ae88a7f0f \
+    gix-imara-diff                       0.2.5  1c91d8cffac8849493a82233811bd02b2b183b8cf39bf704de0fa0841b737595 \
+    gix-index                           0.55.0  632e16cb48b0e88a747e106924cb2765194105d8070a7a961b0d080ed806c632 \
     gix-lock                            24.0.0  d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848 \
-    gix-mailmap                         0.33.2  a824767d38b81475059cb01f5020a13fb96e7ed6bbf9851c7112b46ada78db48 \
-    gix-negotiate                       0.34.0  2fa5aa789990f124e4f559b142cecfb60662cb4ae17006684ea9d668f4f07689 \
-    gix-object                          0.63.0  0e48c235e7f886eb819fc878af75be889333dd3c38bee02ed7af48ae2cf596c4 \
-    gix-odb                             0.83.0  8dd494ffb5037e62b8220109e894d2861ff2150a2cacbfccdba57ae1ebab2b96 \
-    gix-pack                            0.73.0  6d5446127b269706e85998065267ddd2ccc3550179da6780b22fe496175ccb20 \
-    gix-packetline                      0.22.0  3766025c72319c4accdd854a18e6f0dd176c8eb0f3bc8a60a7765be2b50cabf2 \
-    gix-path                            0.12.3  1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9 \
-    gix-pathspec                        0.19.0  49f6fa5f8007f008187c3f60b4373209ca83d1cc947f35ede03e16cd15a4d137 \
-    gix-prompt                          0.16.0  5cb1f1eb92d6f4c9d4c105a6ca912cff637fbd5cacbcbafa5deccd88bfaa3565 \
-    gix-protocol                        0.64.0  dede40e89c1e90f548415f50636bb051f6d9c60f68b8b710bc07825722d19588 \
-    gix-quote                            0.7.2  a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef \
-    gix-ref                             0.66.0  eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883 \
-    gix-refspec                         0.44.0  7406282cc0259b51f6aee299ca3d31279a020530363152a2e6c96e8a7f7bbc83 \
-    gix-revision                        0.48.0  e55e09d4a1ecf2beecc8c09cafcad37979e805b31f588b0e957e191df5783681 \
-    gix-revwalk                         0.34.0  36c113c0a53294dc6280ffc06cbcc4f50f820397e97d6a00b429a44b8db26e29 \
+    gix-macros                           0.1.6  d3836b4b051393464a753c5a08fe19c7ce0d8b77574a92bd558972941d4553cb \
+    gix-mailmap                         0.34.1  1a1c6ca2f9481e5e98b3600b859bc595d46cdf3b600709d5f91b8c118ae452a1 \
+    gix-merge                           0.20.1  72fad4279c940a0fa460ffdf3a3c0e48b7ca5ccb2b08f51a02b22ffcd1efb900 \
+    gix-negotiate                       0.35.1  91068ecee956121d663635b873ae87ad9c5d3f2d6788facfd12829140b39c897 \
+    gix-note                             0.1.1  9af6bbdb3f3c62b4920407c479af1cc0beb27fd75a762782d48baed53d330958 \
+    gix-object                          0.64.1  56fef799ca40cdeab4de5a3e74a696d8fa9b9c6264592646bf022e026f13ce2c \
+    gix-odb                             0.84.0  cf45d195b71cb6363886e7b466821bf4dffd7aba1b6b814ff75488e0061d72a7 \
+    gix-pack                            0.74.2  3d199d515cbdcf05f531f3859be9771fc12acac7b7fe0f5b581b2c1ab1c3a61e \
+    gix-packetline                      0.22.2  792bd92bea390087e6223b18d4d023decc36467de31e6b066b69b94beea1b9e2 \
+    gix-path                            0.12.5  2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046 \
+    gix-pathspec                        0.20.0  c92e44c63ba53bb55aa88ee48847664beae9446417621582fb14dfc69b2f8c72 \
+    gix-prompt                          0.17.0  802256e13ecb2133ba5f9e6acbaa6b08bac027b1c5929f85f6adbb56ba3a4f28 \
+    gix-protocol                        0.65.1  68878c37ae168b474c762d70adc8a8e0f9323ed0d80444a672e2eb561fa16691 \
+    gix-quote                            0.8.0  f74795eb76eab8313063849f9cbd2bbcdc6e4692f71c1d7d0244ab11cd777329 \
+    gix-ref                             0.67.1  8328387e7ab354e1dc3afb63e6b4d1866f82d7ce035222bc9d5baaf36bc88020 \
+    gix-refspec                         0.45.1  7de280d46e8fd9e4d3e7e2ab4276b965e377ba68b2b9a8fce56371015e8bb059 \
+    gix-revision                        0.49.1  4577b864c3e134697e91564553e43230c2e401bb1bcc51cfa998edca21c95078 \
+    gix-revwalk                         0.35.0  248823eefe405e2c0754b74f6f43ab6faab68670cdbf2d6e114cb0471f766450 \
     gix-sec                             0.14.2  af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f \
     gix-shallow                         0.13.0  1ecc9f4b40537043e4bbd7d3d1760e74fb8e7b07a546166b558acaa73ad97f4a \
-    gix-status                          0.33.0  5f83b1c74e69b90411fbfe89ccebc47aa49457ce4eb9b942b1311258fc863d22 \
-    gix-submodule                       0.33.0  5fd98077a56d08886112e6b08dc94076d03539f4bc0b9d7880e4be2b8a640d8c \
+    gix-status                          0.34.1  1401d871c01d82add5a9f654439b00722d0c632b332cd2cb63193f94327c8458 \
+    gix-submodule                       0.34.0  da85564d6725c483b8d95d7b31d1db0b78c29e462a2b481949e2f18e1ed55a6a \
     gix-tempfile                        24.0.0  b675b920bd5a61d17ad542772f03ec34c60feb8ff683e1560c03ae967363731e \
     gix-trace                           0.1.21  be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814 \
-    gix-transport                       0.58.0  b7c1bcf30081eb8ab04540a5795c67a2fcb22cb2e976e8b1a4ea657b1ed61469 \
-    gix-traverse                        0.60.0  008c5cd879e46e86b5c2469e633611978b18775d53d05668d691bc13088bd409 \
-    gix-url                             0.37.0  42d10e53b8eae21ee601687f47bbbd6cb2ed7162cb4c1cafdd422fb7ec64cbee \
-    gix-utils                            0.3.5  b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8 \
-    gix-validate                        0.11.3  9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc \
-    gix-worktree                        0.55.0  31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424 \
-    gix-worktree-state                  0.33.0  bc47372fc12b9fbea51b257bcc8d4970326cf5c7e42135bbfb5d72871bb30bd4 \
-    gix-worktree-stream                 0.35.0  3b088c8724e7be120c4798dd86925cf05332c9d356a463542578600c50c7a549 \
+    gix-transport                       0.59.1  b1295b6ada647b5b4ac6eb123d95a82ee80aef11a7d9db6ea9cb38dcbd411362 \
+    gix-traverse                        0.61.0  9af3503668739f4de5dba57fe15cfd9adc443b08bcbbf195e5de16b648872245 \
+    gix-url                             0.38.0  5bda80ccb4bc81fb9fb07a975916eb0c7a889bcbcb0c8a239c3f82a9cc2abdda \
+    gix-utils                            0.3.6  0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97 \
+    gix-validate                        0.11.4  4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a \
+    gix-worktree                        0.56.0  3ed36b627476e2072c129900a17c977a38052b5497e27308159bc881fbf4eecf \
+    gix-worktree-state                  0.34.1  4c14faa5b9527823c656a033e841dde11ca5b774f1bca7a9cdc23db677e55d56 \
+    gix-worktree-stream                 0.36.1  de5ec0ccbab39c9994656ea031ded8ffd90b370a3cc8e360fbe3c4ebe7c64964 \
     gix-zlib                             0.1.0  3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c \
     glob                                 0.3.4  e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
     globset                             0.4.20  07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988 \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     group                               0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
-    h2                                  0.4.15  6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155 \
+    h2                                  0.4.19  ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16 \
     halfbrown                            0.4.0  0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09 \
     hash32                               0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
     hashbrown                           0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
@@ -513,7 +511,7 @@ cargo.crates \
     http-auth                           0.1.10  150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822 \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                            1.1.0  ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
-    http-body-util                       0.1.4  e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2 \
+    http-body-util                       0.1.5  23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c \
     http-cache-semantics                 3.0.0  0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7 \
     http-content-range                   0.2.5  0298eab7a8b2346aa6e6b3502dfddf643735e45864cbe4ce9c73606cecb8b53f \
     http-serde                           2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
@@ -524,7 +522,7 @@ cargo.crates \
     humantime                            2.4.0  15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
     hybrid-array                         0.2.3  f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9 \
     hybrid-array                        0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
-    hyper                               1.11.0  d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72 \
+    hyper                               1.11.1  27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43 \
     hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                          0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
@@ -536,13 +534,13 @@ cargo.crates \
     i18n-embed-impl                      0.8.4  0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2 \
     iana-time-zone                      0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku                 0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    icu_collections                      2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
-    icu_locale_core                      2.2.0  92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29 \
-    icu_normalizer                       2.2.0  c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4 \
-    icu_normalizer_data                  2.2.0  da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38 \
-    icu_properties                       2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
-    icu_properties_data                  2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
-    icu_provider                         2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
+    icu_collections                      2.3.0  fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513 \
+    icu_locale_core                      2.3.0  d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb \
+    icu_normalizer                       2.3.0  12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f \
+    icu_normalizer_data                  2.3.0  1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0 \
+    icu_properties                       2.3.0  7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148 \
+    icu_properties_data                  2.3.0  e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa \
+    icu_provider                         2.3.1  d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73 \
     idea                                 0.5.1  075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477 \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
@@ -552,7 +550,7 @@ cargo.crates \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
     indexmap                             1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                            2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    indexmap                            2.14.1  07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb \
     indicatif                           0.18.6  9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
     indoc                                2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inout                                0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
@@ -571,7 +569,7 @@ cargo.crates \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itertools                           0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jdx-tar                              1.1.0  ea172082e0f86db95eb1eb387cf802b02749322e79219378e59ca390dd0cd284 \
+    jdx-tar                              1.1.1  d559dfeea3f218edf75e79299bd5d3e7f1269fbbba07974a23a3b28e6d95beed \
     jiff                                0.2.35  668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc \
     jiff-core                            0.1.0  7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09 \
     jiff-static                         0.2.35  3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204 \
@@ -582,12 +580,11 @@ cargo.crates \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
-    js-sys                             0.3.103  53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
+    js-sys                             0.3.104  0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
     k256                                0.13.4  f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b \
-    kdl                                  6.5.0  81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e \
     keccak                               0.1.6  cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653 \
     kem                            0.3.0-pre.0  2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
@@ -600,24 +597,24 @@ cargo.crates \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                            0.1.19  2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa \
+    libredox                            0.1.21  d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96 \
     libyaml-rs                           0.3.0  2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777 \
     libz-ng-sys                         1.1.29  879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469 \
-    link-section                        0.19.2  5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4 \
-    linktime-proc-macro                  0.2.2  348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf \
+    link-section                        0.19.3  39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9 \
+    linktime-proc-macro                  0.2.3  7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616 \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
-    litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
+    litemap                              0.8.3  47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae \
     litrs                                1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                            0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                                 0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
+    log                                 0.4.34  f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6 \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
-    lru                                 0.16.4  7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39 \
+    lru                                 0.18.3  0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c \
     lru-slab                             0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
-    lua-src                            550.1.1  75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949 \
-    luajit-src                 210.7.2+b925b3e  920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6 \
+    lua-src                            551.0.1  087097f9936a7d819bda525b32d6e96f9c54f3d35ff23ff72fc0c1697d2127db \
+    luajit-src                 210.7.3+1ee778a  869665372263eb337b14f480cfb864b89f12eade4eb42cb415f71517b4a67572 \
     lzma-rust2                          0.16.5  ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
@@ -633,11 +630,12 @@ cargo.crates \
     minimal-lexical                      0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                      0.2.5  22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e \
     miniz_oxide                          0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    miniz_oxide                          0.9.1  b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c \
     mio                                  1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
     ml-kem                               0.2.3  8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f \
-    mlua                                0.12.0  ad72ffa037cf5970c9860674f32f703fda25d86cf217475fe7a79c5f9961bcaa \
-    mlua-sys                            0.11.0  92136787b906d4e55cfe96cd6c62e010bb1a56889d0d6cf83eb016dbad07576b \
-    mlua_derive                         0.12.0  0232231813b214d44b57c7678e7dbbcfaac35bd1a01acef0dad7c5dfdc1b1973 \
+    mlua                                0.12.1  d96e5d00f19d8c46c71ceaced99593b90c31c57aa1fe2cb3e93a8b1698eedba9 \
+    mlua-sys                            0.12.0  b806d7ade031f5d6607eae3e283fb034cb795a76247dd0d1ba753c8c42debccf \
+    mlua_derive                         0.12.1  87de1e4bdfaa4bb99d8c1449d8a34b0f19e649ef68eb5d4e8dbf1e9ec6f4a084 \
     mockito                              1.7.2  90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0 \
     munge                                0.4.7  5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c \
     munge_macro                          0.4.7  4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931 \
@@ -653,14 +651,10 @@ cargo.crates \
     nonempty                            0.12.0  9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6 \
     nu-ansi-term                        0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
     nucleo-matcher                       0.3.1  bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85 \
-    num                                  0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
-    num-bigint                           0.4.8  c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367 \
     num-bigint-dig                       0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
-    num-complex                          0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                             0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
     num-integer                         0.1.47  7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b \
     num-iter                            0.1.46  c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b \
-    num-rational                         0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                            1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     num_enum                             0.7.6  5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26 \
@@ -678,7 +672,7 @@ cargo.crates \
     ordered-float                       2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os_pipe                              1.2.3  7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967 \
     outref                               0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
-    owo-colors                           4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
+    owo-colors                           4.4.0  13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8 \
     p256                                0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
     p384                                0.13.1  fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6 \
     p521                                0.13.3  0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2 \
@@ -691,7 +685,7 @@ cargo.crates \
     pastey                               0.2.3  2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4 \
     path-absolutize                      4.0.1  f808742975794703469f67a28dd14b1d1009a1743c18b0353b4b951dbb0068ad \
     path-dedot                           4.0.1  03351d0f1c066c114015408dc6a3e101f080fc03ef9d8d799aa58ec760cac5a6 \
-    path_resolver                       0.2.12  87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb \
+    path_resolver                       0.2.13  9994183d6ed25258205ec5612143b3da8cf2a2027d5e532b0af961ebf32ea5a1 \
     pathdiff                             0.2.3  df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3 \
     pbkdf2                              0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     pbkdf2                              0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
@@ -699,19 +693,21 @@ cargo.crates \
     pem-rfc7468                          0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     pem-rfc7468                          1.0.0  a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9 \
     percent-encoding                     2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                                 2.8.8  7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2 \
-    pest_derive                          2.8.8  9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd \
-    pest_generator                       2.8.8  6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6 \
-    pest_meta                            2.8.8  85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c \
+    pest                                 2.9.0  5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf \
+    pest_derive                          2.9.0  b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d \
+    pest_generator                       2.9.0  e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a \
+    pest_meta                            2.9.0  e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496 \
     petgraph                             0.8.3  8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455 \
     pgp                                 0.20.0  1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1 \
     phf                                 0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
+    phf                                 0.12.1  913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7 \
     phf                                 0.14.0  010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6 \
     phf_codegen                         0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
     phf_codegen                         0.14.0  41b585a510fb76fdebead6897982ef2a03a21d8e6cbcca904999742a4afc6ffe \
     phf_generator                       0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
     phf_generator                       0.14.0  aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100 \
     phf_shared                          0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
+    phf_shared                          0.12.1  06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981 \
     phf_shared                          0.14.0  c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89 \
     pin-project                         1.1.13  2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924 \
     pin-project-internal                1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
@@ -719,16 +715,16 @@ cargo.crates \
     pin-utils                            0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
-    pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    platforms                            4.1.0  acff5dfd42135d89cd7ad74a8c52813bbec91bf62c018ddd89390127767caab5 \
+    pkg-config                          0.3.34  f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548 \
+    platforms                            4.1.1  d61aca2e3ac4cf98e4548308d55863a8f4c8b850d0c48440108d63571df91ea4 \
     plist                               1.10.0  7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85 \
     pluralizer                           0.5.0  4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     poly1305                             0.9.1  6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c \
     polyval                              0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
-    portable-atomic                     1.14.0  3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3 \
+    portable-atomic                     1.15.0  05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85 \
     portable-atomic-util                 0.2.7  c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618 \
-    potential_utf                        0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
+    potential_utf                        0.1.6  d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661 \
     powerfmt                             0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppmd-rust                            1.4.0  efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24 \
     ppv-lite86                          0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
@@ -736,27 +732,27 @@ cargo.crates \
     prettyplease                        0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     primeorder                          0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
     proc-macro-error-attr2               2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
-    proc-macro-error-attr3               3.1.0  b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7 \
+    proc-macro-error-attr3               3.1.1  9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da \
     proc-macro-error2                    2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro-error3                    3.1.0  0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50 \
+    proc-macro-error3                    3.1.1  8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233 \
     proc-macro2                        1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     prodash                             31.0.0  962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c \
     proptest                            1.11.0  4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744 \
-    ptr_meta                             0.3.1  0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79 \
-    ptr_meta_derive                      0.3.1  7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1 \
+    ptr_meta                             0.3.2  743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0 \
+    ptr_meta_derive                      0.3.2  1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0 \
     purl                                 0.1.6  60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad \
     quick-error                          1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quick-xml                           0.38.4  b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c \
     quick-xml                           0.41.0  e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1 \
     quinn                              0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
-    quinn-proto                        0.11.16  2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560 \
+    quinn-proto                        0.11.17  04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83 \
     quinn-udp                           0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
     quote                               1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                                5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
-    rancor                               0.1.2  daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c \
-    rand                                 0.8.7  22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a \
+    rancor                               0.1.3  9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572 \
+    rand                                 0.8.8  e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c \
     rand                                 0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
     rand                                0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
@@ -766,26 +762,26 @@ cargo.crates \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_pcg                            0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.48.2  61bfdcb39e1719edbb27e562d40405c1a8130eb3fff8b11b489672b642a488af \
-    rattler_cache                       0.10.5  b1ea7ff3474f2c5aceb5fe741061ad744f164e050de40dc25608c5ae0e66753c \
-    rattler_conda_types                 0.49.1  058c739d6ea6b3f429443f9d7117022330049bdb1cdde7b46622662463bd5cc0 \
+    rattler                             0.48.4  6595b5f9878f0e2787da607235c158c7c125d4c4f145cfcc3febade9c66c3a4f \
+    rattler_cache                       0.10.7  10e0c05d770d92af1f4230f6f549ab6c4cb47d5e5f7a65339f91fca7fc6b3545 \
+    rattler_conda_types                 0.51.0  654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45 \
     rattler_digest                       1.3.2  56538779701395adba456293b22fda6598b079f30c24d9a22c2bb15271bd67f3 \
     rattler_macros                       1.1.2  bc1bde42798a908a8a2609836a062f01117b83a3fba6f8f6be3eb8c1d07bfdf2 \
-    rattler_menuinst                    0.2.73  b6269634b94b5a9be52cf45bf9368819b33268a4372e76f9c8f9c64c9275a64a \
-    rattler_networking                  0.30.4  e668ff6375b364d8835cf15d51179ac7366aced2a39d60877041d099a421fd06 \
-    rattler_package_streaming           0.27.0  e7ca685c8e3a5ffecd6ad1e9c938753993ed05220c050a070a847ae541797a2e \
+    rattler_menuinst                    0.2.75  1a39794d7486efd34a701c4e33abd094cff04d78d1f3a9bf9f539a3193b3406c \
+    rattler_networking                  0.30.6  bad2167f271e0b3ad411a9623de1e948c12dadb05040cd7508015fed78f4e852 \
+    rattler_package_streaming           0.27.2  364ad3b4bac0c95ae1f7c7bdfa33b679c8d64fde14fd47f6fb965836dbc94628 \
     rattler_pty                         0.2.16  c4bb899b6b8d316efe26fe43e003073ef93d230d9009a41d630e22473368c0e4 \
-    rattler_redaction                    0.2.2  068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177 \
-    rattler_repodata_gateway            0.32.0  466a4335b63701b2eeb0888e66c82e034589998007ee68eceb30f75d5bc643b7 \
-    rattler_shell                      0.27.13  27e6d9e4b73759112b0560c85c3fe3c9619386ed11700daa7b068d02fcd0a766 \
-    rattler_solve                        9.0.1  15139fa95d92a22fe4ba6b00ee89ed6b2375550f1c51036b202c51f771c0d29a \
-    rattler_virtual_packages             5.0.0  3fbade435086e26b977cd2e2a06afa6e5815de03c34af6b39e5a309cbc731196 \
+    rattler_redaction                    0.2.3  308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72 \
+    rattler_repodata_gateway            0.33.0  50b705828891a4184451f8c5300b9b123bd946c76fa9f55c0057d81fab3f8d28 \
+    rattler_shell                      0.27.15  1d87277b0a7b7ccba831890810e903c35b56b3c1003952ad07374da9ebb0b46b \
+    rattler_solve                        9.0.3  9c287fe2c2a57e66162cadc4430b7aa300251edd73034b1b7bf222a660a9a45e \
+    rattler_virtual_packages             5.1.0  4c249324b90e9dcf985991ca4a066b6df72c4c9b300a70746c596e90abe8df2f \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     redox_users                          0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    ref-cast                            1.0.26  216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d \
-    ref-cast-impl                       1.0.26  2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c \
+    ref-cast                            1.0.27  7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3 \
+    ref-cast-impl                       1.0.27  92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a \
     reflink-copy                        0.1.30  d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b \
     regex                               1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
     regex-automata                      0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
@@ -795,15 +791,15 @@ cargo.crates \
     rend                                 0.5.4  663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240 \
     replace_with                         0.1.8  51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884 \
     reqwest                             0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
-    resolvo                             0.11.1  cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa \
+    resolvo                             0.12.1  a5d0149e99c7af5382e3da8bb05b23089cf0398e66509f724453ff903004541e \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
     rfc6979                              0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     ripemd                               0.1.3  bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f \
-    rkyv                                0.8.17  815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874 \
-    rkyv_derive                         0.8.17  c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c \
-    rmcp                                 3.1.0  ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695 \
-    rmcp-macros                          3.1.0  41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79 \
+    rkyv                                0.8.18  d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399 \
+    rkyv_derive                         0.8.18  1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e \
+    rmcp                                 3.1.4  1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf \
+    rmcp-macros                          3.1.4  a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
@@ -824,7 +820,7 @@ cargo.crates \
     rustls-pki-types                    1.15.1  2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
-    rustls-webpki                     0.103.14  0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a \
+    rustls-webpki                     0.103.15  f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2 \
     rustversion                         1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     ryu                                 1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
@@ -848,6 +844,7 @@ cargo.crates \
     self_cell                            1.3.0  2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813 \
     self_update                         0.44.0  2e79722b5a505d4ddc77527455a97244e9e8c4c07533ff44cf4421cce7bb6d17 \
     semver                              1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
+    send_wrapper                         0.6.0  cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73 \
     serde                              1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
     serde-untagged                       0.1.9  f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058 \
     serde-value                          0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
@@ -863,8 +860,8 @@ cargo.crates \
     serde_spanned                        0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
     serde_spanned                        1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                     0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                          3.21.0  76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c \
-    serde_with_macros                   3.21.0  84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660 \
+    serde_with                          3.22.0  ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a \
+    serde_with_macros                   3.22.0  8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46 \
     serde_yaml               0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     serdect                              0.2.0  a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177 \
     serdect                              0.3.0  f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53 \
@@ -936,7 +933,7 @@ cargo.crates \
     supports-unicode                     3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
     syn                                1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                                2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
-    syn                                  3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
+    syn                                  3.0.4  e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f \
     sync_wrapper                         1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                        0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     sysctl                               0.5.5  ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea \
@@ -949,7 +946,7 @@ cargo.crates \
     tar                                 0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                            3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     tera                                1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
-    tera                                 2.1.0  511f07fd91a70e92efbe4793d111aaa9035f8474dd157aaa1e31e7c27f5051da \
+    tera                                 2.3.0  52fca06a22977165c6821c26e2bf0387cd7e0822107a6854d5fbb787307c4194 \
     tera-contrib                         0.2.0  a3792553c620406661d510095e5885bfb77b2296db30369bcc8308329a6fe78c \
     termcolor                            1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                        0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
@@ -960,14 +957,14 @@ cargo.crates \
     text-size                            1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     textwrap                            0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                           1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                           2.0.19  09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9 \
+    thiserror                           2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
     thiserror-impl                      1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                      2.0.19  43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd \
+    thiserror-impl                      2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
     thread_local                        1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
     time                                0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
     time-core                            0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
     time-macros                         0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
-    tinystr                              0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
+    tinystr                              0.8.4  b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643 \
     tinyvec                             1.12.0  bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tls_codec                            0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
@@ -1005,7 +1002,7 @@ cargo.crates \
     typed-path                          0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
     typeid                               1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                             1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
-    ubi                                 0.10.0  2a9b94e51ea832e8eee7c3b7c7958efd43b127e435bb95bb6fd5e0539a4ffd3a \
+    ubi                                 0.12.0  38afff39148f8f08efb6d53441c871e39218677eb52ec9aefc1302ca24afdc62 \
     ucd-trie                             0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uluru                                3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unarray                              0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
@@ -1026,15 +1023,21 @@ cargo.crates \
     unsafe-libyaml                      0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                            0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
     untrusted                            0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    ureq                                 3.3.0  dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0 \
-    ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
+    ureq                                 3.4.0  972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d \
+    ureq-proto                           0.6.1  da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613 \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            5.1.0  12698ad30baf6deeaf269f22385352c52dfadc27526e886a07b077e6fb25d17e \
+    usage-argv                           6.6.1  d1f81ea3687bfc1e3f6133acc10d5b39074faad1abebddfb7b45e9f77a4f3294 \
+    usage-cli                            6.6.1  18865f2f8e2b022a4bfb79ebaffb65081b57c6fc9e426ca871bec840883b201d \
+    usage-derive                         6.6.1  da5bd6b4438ed4e7bb56603a25174969989560f77f60677dbbf7d832d8b95bfe \
+    usage-lib                            6.6.1  51885bad73098a961fa7e9e70a54d9065159619b70e485a21e6acecee4a3af49 \
+    usage-rs                             6.6.1  457f6d93071e909c6bca69ab834cd7d0a2b3c5a85000b456431d8c9caed6c86f \
+    usage-test                           6.6.1  54fc305b97dc22cdd0c73622fa7692aea635b7d9ac2ddae2007e68b79cdcfd58 \
+    usage-validation                     6.6.1  ac1ad114756c8800d2b9b6093f9bd38c7c7a747a4a5f94da204eac7ae8b8ad54 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                                1.24.0  bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239 \
+    uuid                                1.26.0  b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812 \
     valuable                             0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     value-trait                         0.12.2  f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc \
     vcpkg                               0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
@@ -1047,18 +1050,18 @@ cargo.crates \
     want                                 0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                   1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
-    wasm-bindgen                       0.2.126  4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4 \
-    wasm-bindgen-futures                0.4.76  c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d \
-    wasm-bindgen-macro                 0.2.126  167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1 \
-    wasm-bindgen-macro-support         0.2.126  f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e \
-    wasm-bindgen-shared                0.2.126  dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24 \
+    wasm-bindgen                       0.2.127  1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70 \
+    wasm-bindgen-futures                0.4.77  6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950 \
+    wasm-bindgen-macro                 0.2.127  77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1 \
+    wasm-bindgen-macro-support         0.2.127  e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284 \
+    wasm-bindgen-shared                0.2.127  7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf \
     wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                            0.3.103  8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
+    web-sys                            0.3.104  c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30 \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-root-certs                    1.0.9  b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b \
     webpki-roots                         1.0.9  7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
-    which                                8.0.5  8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c \
+    which                                8.0.6  bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f \
     widestring                           1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                               0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu           0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -1116,13 +1119,12 @@ cargo.crates \
     windows_x86_64_msvc                 0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc                 0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc                 0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    winnow                              0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
     winnow                              0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
     winnow                               1.0.4  23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81 \
     winver                               1.0.0  9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33 \
     wiremock                             0.6.5  08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031 \
     wit-bindgen                         0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    writeable                            0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
+    writeable                            0.6.4  3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc \
     wyz                                  0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     x25519-dalek                         2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     x509-cert                            0.2.5  1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94 \
@@ -1132,25 +1134,25 @@ cargo.crates \
     xmlparser                           0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     xx                                   2.6.1  f8aff208388ac09afbb2bd20c3db8f7d253c9fbed7076e3618d598bb3deef2c5 \
     xz2                                  0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
-    yaml_serde                          0.10.4  08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975 \
+    yaml_serde                          0.10.7  33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918 \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                 0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                            0.8.55  b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb \
-    zerocopy-derive                     0.8.55  0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb \
+    zerocopy                            0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
+    zerocopy-derive                     0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
     zerofrom                             0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                      0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                              1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
     zeroize_derive                       1.5.0  3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328 \
-    zerotrie                             0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
-    zerovec                             0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
-    zerovec-derive                      0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
+    zerotrie                             0.2.5  4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f \
+    zerovec                             0.11.8  bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8 \
+    zerovec-derive                      0.11.6  34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da \
     zip                                  6.0.0  eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b \
     zip                                  7.2.0  c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0 \
     zip                                  8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zipsign-api                          0.2.1  32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99 \
-    zlib-rs                              0.6.6  b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5 \
+    zlib-rs                              0.6.7  34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12 \
     zmij                                1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
     zopfli                               0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249 \
     zstd                                0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted with 1066 warnings, built in a pristine VM.

Branch head `174475ebef64`, against the ports tree as of 2026-09-03.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
