### PR TITLE
liberasurecode: update to 1.8.0

### DIFF
--- a/devel/liberasurecode/Portfile
+++ b/devel/liberasurecode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           openssl 1.0
 
-github.setup        openstack liberasurecode 1.7.1
+github.setup        openstack liberasurecode 1.8.0
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ license             BSD
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  322cd003701fcde04ef13547d95d41728ebe4fe8 \
-                    sha256  b99e76bff6497c2d52698ac7a4fae15d98db58550485ef34f81eb5130e95749d \
-                    size    216691
+checksums           rmd160  c67c1fbcfb52f7bb4529a5956c88ce157c3d7afa \
+                    sha256  2bb7bf4fe285888058ce07e4e8f8d0345d4d7aefe06395f46f5f39e0c6914614 \
+                    size    228602
 
 patchfiles-append   patch-makefile.am.diff
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `98e202a2a1f1`, against the ports tree as of 2026-09-03.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
