### PR TITLE
apache-ivy: update to 2.6.0

### DIFF
--- a/devel/apache-ivy/Portfile
+++ b/devel/apache-ivy/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                apache-ivy
-version             2.4.0
+version             2.6.0
 categories          devel java
-platforms           darwin freebsd
+platforms           any
+supported_archs     noarch
 license             Apache-2
 maintainers         nomaintainer
 
@@ -20,34 +21,46 @@ long_description    Apache Ivy is a transitive dependency manager that \
                     or one publicly available on the Internet.
 homepage            https://ant.apache.org/ivy
 
-depends_build       port:apache-ant
-
 master_sites        apache:ant/ivy/${version}
 distname            ${name}-${version}-src
-
-checksums           md5     bd16ef9a402859522606ed9edd468f1f \
-                    sha1    1efa73e73b5fc14ef003ff2fcb182f039db33ce2 \
-                    sha256  202f08ca41f4bdf1c081aa8b2e531565be6c73e9e5e0d68137f454f14eb16ef6 \
-                    rmd160  f878b4c76d1fc6b42419eee47eb1bf28008408a8
-
 worksrcdir          ${name}-${version}
 
+checksums           rmd160  d96696b2c731af8e1ad468aed5127be4cf6dd6d5 \
+                    sha256  7a1c4056af114ef7ed61f3665a614ce7085a442d5712a85a5bbebf84b217d29c \
+                    size    2757508
+
+depends_build       bin:ant:apache-ant
+
+java.version        1.8+
+java.fallback       openjdk25
+
 use_configure       no
+
 build.cmd           ant
-build.target        /localivy jar
+build.target        /localivy \
+                    /nojavadoc \
+                    jar
 
 destroot {
-    set javadir ${destroot}${prefix}/share/java/
-    set docdir ${destroot}${prefix}/share/doc/
-    xinstall -d ${javadir}/apache-ant/lib/ ${docdir}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
 
-    xinstall ${worksrcpath}/build/artifact/jars/ivy.jar ${javadir}
-    ln -s ${prefix}/share/java/ivy.jar ${javadir}/apache-ant/lib/ivy.jar
-    file delete -force ${worksrcpath}/build/artifact
-    move ${worksrcpath}/doc ${docdir}/${name}
-    # move ${worksrcpath} ${javadir}/${name}
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/build/artifact/jars/ivy.jar \
+        ${destjavadir}/ivy.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/NOTICE \
+        ${worksrcpath}/README.adoc \
+        ${destdocdir}
+    copy \
+        {*}[glob -directory ${worksrcpath}/asciidoc *] \
+        ${destdocdir}
 }
 
-livecheck.type  regex
-livecheck.url   https://ant.apache.org/ivy/index.html
-livecheck.regex ">(\\d+(?:\\.\\d+)*)<"
+livecheck.type      regex
+livecheck.url       https://ant.apache.org/ivy/download.cgi
+livecheck.regex     "${name}-(\\d+(\\.\\d+)*)(-\[a-z]+)*\\.tar\\.gz"


### PR DESCRIPTION
#### Description

Update the `apache-ivy` port to version 2.6.0 and fix a couple related trac tickets.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?