### PR TITLE
aom: update to 3.15.0

### DIFF
--- a/multimedia/aom/Portfile
+++ b/multimedia/aom/Portfile
@@ -10,7 +10,7 @@ PortGroup               legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 14
 
 name                    aom
-version                 3.14.1
+version                 3.15.0
 revision                0
 categories              multimedia
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -34,9 +34,9 @@ compiler.cxx_standard   2017
 compiler.c_standard     2011
 
 set pyver               3.14
-set python_version      [string index ${pyver} 0][string range ${pyver} 2 end]
+set python_version      [string map {. {}} ${pyver}]
 
-depends_build-append    bin:git:git \
+depends_build-append    path:bin/git:git \
                         port:perl5 \
                         port:python${python_version}
 


### PR DESCRIPTION
###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560

Model Identifier: Macmini6,1    macOS 10.15.8 19H2036 x86_64
Xcode 12.4 12D4e                Command Line Tools 12.4.0.0.1.161013581

Model Identifier: Mac14,3       macOS 26.6.2 25G83 arm64
Xcode not installed             Command Line Tools 26.6.0.0.1781586589
```
