### PR TITLE
mp3rgain: update to 3.6.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.5.1 v
+github.setup        M-Igashi mp3rgain 3.6.0 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  39b24e7d687325008506974144bedcd264e86530 \
-                    sha256  e7d6b2fc1fb42dbbe29ec98fde845869e8241bc632bacc1a804badd9f53bfa7f \
-                    size    581529
+                    rmd160  dfca4e0e07ea15600fad1df5606f75a7a4a138b4 \
+                    sha256  2a99f3ee2eba1dea4a0948121592d619ee9032f0087ee4438ed04ae567cd2ebc \
+                    size    586304
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 3.6.0.

Upstream release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.0

The dependency set is unchanged from 3.5.1, so the `cargo.crates` block is identical; only `github.setup` and the three distfile checksums move.

- `port lint --nitpick`: 0 errors. The 128 warnings are the usual "missing recommended checksum type: rmd160 / size" pairs that `cargo.crates` produces for each of the 64 crates, the same as on the merged 3.5.1 update.
- Checksums recomputed from the published GitHub tag tarball with `shasum -a 256`, `openssl dgst -rmd160` and `wc -c`.