### PR TITLE
cracklib: updated to 2.10.3

### DIFF
--- a/security/cracklib/Portfile
+++ b/security/cracklib/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cracklib cracklib 2.9.11 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        cracklib cracklib 2.10.3 v
+github.tarball_from archive
 revision            0
 
 categories          security
@@ -30,9 +29,9 @@ depends_lib-append  port:gettext-runtime \
                     port:libiconv \
                     port:zlib
 
-checksums           rmd160  80661d1221bee6a21af01a238d3cdfc4f8b10c02 \
-                    sha256  78807c1a81ddfee0452b94a603975a468874e7e24804a1ee1c364f9c5c979f66 \
-                    size    8672605
+checksums           rmd160  5ad64a9cc87879dc856829dda39fb33a54d24419 \
+                    sha256  e320d5bbd84872e1f3a68a923084c68e360b9cfce090d3281af32d810dea0cf1 \
+                    size    8675534
 
 worksrcdir          ${distname}/src
 


### PR DESCRIPTION
###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560

Model Identifier: Macmini6,1    macOS 10.15.8 19H2036 x86_64
Xcode 12.4 12D4e                Command Line Tools 12.4.0.0.1.161013581

Model Identifier: Mac14,3       macOS 26.6.2 25G83 arm64
Xcode not installed             Command Line Tools 26.6.0.0.1781586589
```
