### PR TITLE
webdump: new port

### DIFF
--- a/textproc/webdump/Portfile
+++ b/textproc/webdump/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+
+name                webdump
+version             0.3
+revision            0
+license             MIT
+
+categories          textproc
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         HTML to plain-text converter for webpages
+long_description    {*}${description}
+
+homepage            https://codemadness.org/webdump.html
+
+master_sites        https://codemadness.org/releases/${name}/
+
+checksums           rmd160  c9bba82412800f051725a1f1611ad3c176da8ede \
+                    sha256  8aebd3164c804c58c693d5a4ae35165c6ab7d7d61cc4d9ea8cf317058679c51d \
+                    size    52268
+
+makefile.override   PREFIX
+
+livecheck.type      regex
+livecheck.url       [lindex ${master_sites} 0]
+livecheck.regex     href=\"webdump-(.*)\\.tar\\.gz\"


### PR DESCRIPTION
#### Description
[webdump](https://codemadness.org/webdump.html) is (yet another) HTML to plain-text converter tool.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
