### PR TITLE
rclone: update to 1.75.1

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/rclone/rclone 1.75.0 v
+go.setup            github.com/rclone/rclone 1.75.1 v
 go.offline_build    no
-go.toolchain_min    1.25.0
-revision            1
+go.toolchain_min    1.26.0
+revision            0
 
 homepage            https://rclone.org
 
@@ -19,9 +19,9 @@ long_description \
     Backblaze B2, Yandex Disk, SFTP, and the local filesystem.
 
 checksums \
-    rmd160  b9be3b475d2b7e2672cba25a4e4b813c32fb03eb \
-    sha256  1292c5fae9d10d6df3ea0c2ba96de42336e96e2e878729af1f02f86900434ee0 \
-    size    16702176
+    rmd160  28330aa79ecf411bccf95bcf48036b5378d6d1c1 \
+    sha256  fcc9351ab3976c73b4824cf7919f98f911f2442a606e2910fc2bd562111da220 \
+    size    16826573
 
 categories          net
 installs_libs       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `3780e10ae87e`, against the ports tree as of 2026-09-04.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
