### PR TITLE
lagrange: update to 1.21.1

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           codeberg 1.0
 
-codeberg.setup      skyjake lagrange 1.21.0 v
+codeberg.setup      skyjake lagrange 1.21.1 v
 revision            0
 categories          net gemini
 license             BSD
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  4dc60d4bf5bcf1e94dec90ed325306a6ac989711 \
-                    sha256  2d65611537c4ee028e37d069b680053b80fa94c6b8068c39fe3ec2b451b2772a \
-                    size    9837726
+checksums           rmd160  08ce193b4ec389e7a05783c57a165631b6ecd938 \
+                    sha256  2746f8d1e285c2f404fb7cd32098a5007176ebe6958d77186a504c4b4663d67d \
+                    size    9842322
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
* https://codeberg.org/skyjake/lagrange/releases/tag/v1.21.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
