### PR TITLE
termscp: update to 1.2.0

### DIFF
--- a/sysutils/termscp/Portfile
+++ b/sysutils/termscp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        veeso termscp 1.1.1 v
+github.setup        veeso termscp 1.2.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,20 +19,14 @@ maintainers         {@sikmir disroot.org:sikmir} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  15526a7dca07b85a15acb00d47c598a3172b8f56 \
-                    sha256  cf3570c396ba36987059729f2704a88b87e4f154914062cf390b038694496be9 \
-                    size    8686144
+                    rmd160  d294b97e312a8b9bba6f7573e693b588b7827b2e \
+                    sha256  fe35ae14d72a3e40f43532c44ffbced9667ca515c82b93ce2b4398b768fd1113 \
+                    size    8713398
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
 depends_lib-append \
                     path:lib/pkgconfig/smbclient.pc:samba4
-
-
-patch {
-    # Set correct version in Cargo.lock
-    reinplace -E "6137s/.*/version = \"${version}\"/" ${worksrcpath}/Cargo.lock
-}
 
 destroot {
     xinstall -m 0755 \
@@ -42,89 +36,89 @@ destroot {
 
 cargo.crates \
     adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
-    aead                             0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
-    aead                          0.6.0-rc.10  6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe \
+    aead                             0.6.1  1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99 \
     aes                              0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
-    aes                              0.9.1  f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138 \
-    aes-gcm                         0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
-    aes-gcm                       0.11.0-rc.4  da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8 \
-    aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    aes                              0.9.3  35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32 \
+    aes-gcm                         0.11.1  7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f \
+    aho-corasick                     1.1.5  c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
-    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
-    apple-native-keyring-store       1.0.0  a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72 \
+    android_system_properties        0.1.6  ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc \
+    anyhow                         1.0.104  330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470 \
+    apple-native-keyring-store       1.0.2  2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a \
     approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
+    arc-swap                         1.9.2  c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b \
     argh                            0.1.19  211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033 \
     argh_derive                     0.1.19  c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d \
     argh_shared                     0.1.19  e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1 \
-    argon2                        0.6.0-rc.8  7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5 \
-    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    argon2                           0.6.0  134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c \
+    arrayvec                         0.7.8  d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56 \
+    async-trait                     0.1.92  82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
-    aws-config                      1.8.13  c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5 \
-    aws-credential-types            1.2.11  3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3 \
-    aws-lc-rs                       1.17.0  5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00 \
-    aws-lc-sys                      0.41.0  1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4 \
-    aws-runtime                      1.6.0  c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5 \
-    aws-sdk-s3                     1.122.0  94c2ca0cba97e8e279eb6c0b2d0aa10db5959000e602ab2b7c02de6b85d4c19b \
-    aws-sdk-sso                     1.93.0  9dcb38bb33fc0a11f1ffc3e3e85669e0a11a37690b86f77e75306d8f369146a0 \
-    aws-sdk-ssooidc                 1.95.0  2ada8ffbea7bd1be1f53df1dadb0f8fdb04badb13185b3321b929d1ee3caad09 \
-    aws-sdk-sts                     1.97.0  e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad \
-    aws-sigv4                        1.3.8  efa49f3c607b92daae0c078d48a4571f599f966dce3caee5f1ea55c4d9073f99 \
-    aws-smithy-async                1.2.11  52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c \
-    aws-smithy-checksums            0.64.3  ddcf418858f9f3edd228acb8759d77394fed7531cce78d02bdda499025368439 \
-    aws-smithy-eventstream         0.60.18  35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588 \
-    aws-smithy-http                 0.63.3  630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc \
-    aws-smithy-http-client           1.1.9  12fb0abf49ff0cab20fd31ac1215ed7ce0ea92286ba09e2854b42ba5cabe7525 \
-    aws-smithy-json                 0.62.3  3cb96aa208d62ee94104645f7b2ecaf77bf27edf161590b6224bfbac2832f979 \
-    aws-smithy-observability         0.2.4  c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d \
-    aws-smithy-query               0.60.13  0cebbddb6f3a5bd81553643e9c7daf3cc3dc5b0b5f398ac668630e8a84e6fff0 \
-    aws-smithy-runtime              1.10.0  f3df87c14f0127a0d77eb261c3bc45d5b4833e2a1f63583ebfb728e4852134ee \
-    aws-smithy-runtime-api          1.11.3  49952c52f7eebb72ce2a754d3866cc0f87b97d2a46146b79f80f3a93fb2b3716 \
-    aws-smithy-types                 1.4.3  3b3a26048eeab0ddeba4b4f9d51654c79af8c3b32357dc5f336cee85ab331c33 \
-    aws-smithy-xml                 0.60.13  11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57 \
-    aws-types                       1.3.11  1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164 \
-    base16ct                         0.1.1  349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce \
+    aws-config                      1.11.0  a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b \
+    aws-credential-types             1.3.0  e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e \
+    aws-lc-rs                       1.18.1  b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e \
+    aws-lc-sys                      0.45.0  9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27 \
+    aws-runtime                      1.9.1  c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb \
+    aws-sdk-s3                     1.144.0  30dc8bf6baaf7d46336a0ca2c69f223d9b90d7a801fb3e28f7ea17b00dc6b1de \
+    aws-sdk-sso                    1.108.0  c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05 \
+    aws-sdk-ssooidc                1.110.0  72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899 \
+    aws-sdk-sts                    1.113.0  68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032 \
+    aws-sigv4                        1.5.1  723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f \
+    aws-smithy-async                 1.3.0  f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316 \
+    aws-smithy-checksums            0.65.0  b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307 \
+    aws-smithy-eventstream          0.61.2  6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f \
+    aws-smithy-http                 0.64.0  37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d \
+    aws-smithy-http-client           1.4.0  ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1 \
+    aws-smithy-json                 0.63.0  3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef \
+    aws-smithy-observability         0.3.0  8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c \
+    aws-smithy-query                0.62.0  512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62 \
+    aws-smithy-runtime              1.14.0  b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606 \
+    aws-smithy-runtime-api          1.15.0  954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9 \
+    aws-smithy-runtime-api-macros     1.1.0  221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3 \
+    aws-smithy-schema                0.2.0  7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910 \
+    aws-smithy-types                 1.6.2  fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647 \
+    aws-smithy-xml                  0.62.0  ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8 \
+    aws-types                        1.5.0  eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94 \
     base16ct                         0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
     base16ct                         1.0.0  fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    base64                          0.23.1  ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5 \
     base64-simd                      0.8.0  339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195 \
     base64ct                         1.8.3  2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06 \
-    bcrypt-pbkdf                    0.10.0  6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2 \
     bcrypt-pbkdf                    0.11.0  144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                        2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
-    blake2                        0.11.0-rc.6  061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690 \
+    bitflags                        2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
+    blake2                          0.11.0  5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    block-buffer                    0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
+    block-buffer                    0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     block-padding                    0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     block-padding                    0.4.2  710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
-    blowfish                         0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     blowfish                        0.10.0  62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298 \
+    bs58                             0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
     bumpalo                         3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     by_address                       1.2.1  64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06 \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                           1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
+    bytes                           1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
     bytes-utils                      0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
-    bytesize                         2.3.1  6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3 \
+    bytesize                         2.7.0  7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b \
     bytestring                       1.5.1  86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9 \
     castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
     cbc                              0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
     cbc                              0.2.1  ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896 \
-    cc                              1.2.63  556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f \
+    cc                               1.4.4  0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
-    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
-    chacha20                        0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
+    cfg_aliases                      0.2.2  f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
+    chacha20                        0.10.2  65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06 \
     chrono                          0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     cipher                           0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
     cmake                           0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
     cmov                             0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
+    combine                          4.6.8  cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e \
     compact_str                      0.9.1  9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab \
     console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
@@ -136,41 +130,43 @@ cargo.crates \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpubits                          0.1.1  15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
-    cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
-    crc                              3.3.0  9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675 \
-    crc-catalog                      2.5.0  217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
-    crc-fast                         1.9.0  2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d \
-    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    cpufeatures                      0.3.1  5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566 \
+    crc-fast                        1.10.0  e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5 \
+    crc32c                           0.6.8  3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47 \
+    crc32fast                        1.5.1  8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550 \
     critical-section                 1.2.0  790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b \
-    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
-    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    crossbeam-deque                  0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
+    crossbeam-epoch                 0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
+    crossbeam-utils                 0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
     crossterm                       0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
-    crypto-bigint                    0.4.9  ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef \
     crypto-bigint                    0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
-    crypto-bigint                    0.7.3  42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3 \
+    crypto-bigint                    0.7.5  1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271 \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                    0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
-    crypto-primes                    0.7.0  21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a \
-    ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
+    crypto-primes                    0.7.2  3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f \
     ctr                             0.10.1  baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21 \
     ctutils                          0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
-    curve25519-dalek              5.0.0-rc.0  4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf \
+    curve25519-dalek                 5.0.0  b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23 \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
+    darling                         0.24.1  ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec \
     darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
+    darling_core                    0.24.1  6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff \
     darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
+    darling_macro                   0.24.1  2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785 \
     dashmap                          6.2.1  e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c \
-    data-encoding                   2.11.0  a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
-    dbus                            0.9.11  b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73 \
+    data-encoding                   2.11.1  4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06 \
+    dbus                            0.9.12  3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e \
     dbus-secret-service              4.1.0  708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6 \
-    dbus-secret-service-keyring-store     1.0.0  21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757 \
+    dbus-secret-service-keyring-store     1.0.1  7227ffd3b4896266bbc100348025cebe51d9aea94ce118a1d68f4a6463963dae \
+    defmt                            1.1.1  e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1 \
+    defmt-macros                     1.1.1  bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8 \
+    defmt-parser                     1.0.0  10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e \
     delegate                        0.13.5  780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370 \
-    der                              0.6.1  f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de \
     der                             0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
-    der                              0.8.0  71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b \
+    der                              0.8.1  a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d \
     deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     derive_arbitrary                 1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
     derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
@@ -182,72 +178,75 @@ cargo.crates \
     dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     dispatch2                        0.3.1  1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38 \
-    displaydoc                       0.2.6  1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
+    displaydoc                       0.2.7  c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8 \
     document-features               0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
-    ecdsa                           0.14.8  413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c \
     ecdsa                           0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
-    ecdsa                         0.17.0-rc.18  54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96 \
+    ecdsa                           0.17.0  c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0 \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519                          3.0.0  29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a \
     ed25519-dalek                    2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
-    ed25519-dalek                 3.0.0-rc.0  b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60 \
+    ed25519-dalek                    3.0.0  6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de \
     edit                             0.1.5  f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09 \
-    either                          1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
-    elliptic-curve                  0.12.3  e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3 \
+    either                          1.18.0  252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34 \
     elliptic-curve                  0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
-    elliptic-curve                0.14.0-rc.33  102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935 \
+    elliptic-curve                  0.14.1  9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65 \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     enum_dispatch                   0.3.13  aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
-    fast-srgb8                       1.0.0  dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1 \
-    fastrand                         2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
-    ff                              0.12.1  d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160 \
+    fastrand                         2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
     ff                              0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     ff                              0.14.0  a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     fiat-crypto                      0.3.0  64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24 \
     filetime                        0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
-    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
-    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    find-msvc-tools                 0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
+    flate2                          1.1.10  6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     fs_extra                         1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
-    futures                         0.3.32  8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d \
-    futures-channel                 0.3.32  07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
-    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
-    futures-executor                0.3.32  baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d \
-    futures-io                      0.3.32  cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718 \
+    futures                         0.3.34  9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3 \
+    futures-channel                 0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
+    futures-core                    0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
+    futures-executor                0.3.34  031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432 \
+    futures-io                      0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
     futures-lite                     2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
-    futures-macro                   0.3.32  e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b \
-    futures-sink                    0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
-    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
-    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    futures-macro                   0.3.34  9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44 \
+    futures-sink                    0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                    0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-util                    0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    generic-array                    1.4.3  c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351 \
+    generic-array                    1.4.5  337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
-    getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
-    ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
+    getrandom                        0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     ghash                            0.6.0  2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5 \
-    git2                            0.20.4  7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b \
-    glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
+    git2                            0.21.0  ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e \
+    glob                             0.3.4  e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b \
     gloo-timers                      0.4.0  482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d \
-    group                           0.12.1  5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7 \
+    google-cloud-auth               1.16.0  ff461519b1a948200f163574be072753bcfb462a323f0eb426629d89872dd685 \
+    google-cloud-gax                1.14.0  c5615cff28ee59cfe52fbb4c11b8b1e77f650296e2ea4f4c2b7757ac6b19e752 \
+    google-cloud-gax-internal       0.7.18  d2766757d877a7a8ac23da9884cb0e3f10ed9b75a0ce59801ce6b19bf9d5819e \
+    google-cloud-iam-v1             1.12.0  5f962b40234b1531e6ef73f7558871c96e117231e962086c98804323fb8d2c82 \
+    google-cloud-longrunning        1.13.0  1c0363c5389ffda2b55cd8a86eef4b19a3481a48467c91dc5d77f626a9572766 \
+    google-cloud-lro                1.10.0  47af3deef75c14a2983c430898d960c765bddbcc9f9188ca0563108e9227cfe7 \
+    google-cloud-rpc                 1.6.0  e2162c08a89118130979ba261080e960e44cdcb2d6e2ab8ca9b1da245285d353 \
+    google-cloud-storage            1.18.0  973399251b245c63f1d02d0768772833dcf1372ee358f593fb9159de8fe9c7d4 \
+    google-cloud-type                1.6.0  63acc3a92a85f96bab021c3a3e29b53bbacc97651e1b524d4c2991960a63eb82 \
+    google-cloud-wkt                 1.7.0  7fccf98cfd5481a5f5a285181ab0c62123d7d47cd2bb7299448440649349e4e7 \
     group                           0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
     group                           0.14.0  7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4 \
     h2                              0.3.27  0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d \
-    h2                              0.4.14  171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733 \
+    h2                              0.4.19  ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16 \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
     hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
     headers                          0.4.1  b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb \
@@ -261,108 +260,113 @@ cargo.crates \
     hmac                            0.13.0  6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
     home                            0.5.12  cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d \
     http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
-    http                             1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
+    http                             1.5.0  918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0 \
     http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
-    http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
-    http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
+    http-body                        1.1.0  ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
+    http-body-util                   0.1.5  23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    hybrid-array                    0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
+    hybrid-array                    0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
     hyper                          0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
-    hyper                           1.10.1  55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
-    hyper-http-proxy                 1.1.0  7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08 \
-    hyper-rustls                    0.24.2  ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590 \
+    hyper                           1.11.1  27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43 \
+    hyper-http-proxy                 1.2.0  bd1d471ea2f65ba45eddb1d6ab7d58ac2671d2d4ac14da5c6516ae1d97e1327a \
     hyper-rustls                    0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-timeout                    0.5.2  2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0 \
     hyper-tls                        0.5.0  d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
     hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
     iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    icu_collections                  2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
-    icu_locale_core                  2.2.0  92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29 \
-    icu_normalizer                   2.2.0  c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4 \
-    icu_normalizer_data              2.2.0  da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38 \
-    icu_properties                   2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
-    icu_properties_data              2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
-    icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
-    id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
+    icu_collections                  2.3.0  fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513 \
+    icu_locale_core                  2.3.0  d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb \
+    icu_normalizer                   2.3.0  12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f \
+    icu_normalizer_data              2.3.0  1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0 \
+    icu_properties                   2.3.0  7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148 \
+    icu_properties_data              2.3.0  e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa \
+    icu_provider                     2.3.1  d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73 \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
-    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    if-addrs                        0.15.0  c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b \
+    indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    indexmap                        2.14.1  07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     indoc                            2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
-    inotify                         0.11.2  533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1 \
-    inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
+    inotify                         0.11.5  4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592 \
+    inotify-sys                      0.1.8  c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d \
     inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
     inout                            0.2.2  4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7 \
-    instability                     0.3.12  5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971 \
+    instability                     0.3.13  2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8 \
     internal-russh-num-bigint        0.5.0  ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8 \
-    ipnet                           2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
+    ipnet                           2.12.1  6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78 \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                          0.3.99  142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11 \
+    jiff                            0.2.35  668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc \
+    jiff-core                        0.1.0  7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09 \
+    jiff-static                     0.2.35  3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204 \
+    jiff-tzdb                        0.1.8  142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e \
+    jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
+    jni                             0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
+    jni-macros                      0.22.4  a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
+    jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
+    jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
+    jobserver                       0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
+    js-sys                         0.3.104  0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a \
     jsonpath-rust                    0.5.1  19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200 \
+    jsonwebtoken                    11.0.0  881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65 \
     k8s-openapi                     0.22.0  19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755 \
     kasuari                         0.4.12  bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899 \
-    keccak                           0.2.0  9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa \
+    keccak                           0.2.2  d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598 \
     kem                              0.3.0  01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd \
     keyring-core                     1.0.0  fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d \
-    kqueue                           1.2.0  273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5 \
+    kqueue                           1.2.1  8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea \
     kqueue-sys                       1.1.2  07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087 \
     kube                            0.92.1  231c5a5392d9e2a9b0d923199760d3f1dd73b95288f2871d16c7c90ba4954506 \
     kube-client                     0.92.1  8f4bf54135062ff60e2a0dfb3e7a9c8e931fc4a535b4d6bd561e0a1371321c61 \
     kube-core                       0.92.1  40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975 \
-    lazy-regex                       3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
-    lazy-regex-proc_macros           3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
+    lazy-regex                       3.6.1  4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9 \
+    lazy-regex-proc_macros           3.6.1  fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
-    libc                           0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
+    libc                           0.2.189  3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
     libdbus-sys                      0.2.7  328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043 \
-    libgit2-sys                   0.18.5+1.9.4  005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2 \
+    libgit2-sys                   0.18.8+1.9.7  7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50 \
     libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                        0.1.17  f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3 \
-    libssh2-sys                      0.3.1  220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9 \
+    libredox                        0.1.23  8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed \
     libz-sys                        1.1.29  85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9 \
-    line-clipping                    0.3.7  3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8 \
+    line-clipping                    0.3.8  e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
-    litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
+    litemap                          0.8.3  47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae \
     litrs                            1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                             0.4.32  953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a \
-    lru                             0.16.4  7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39 \
-    lru                             0.18.0  8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9 \
+    log                             0.4.34  f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6 \
+    lru                             0.18.4  ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25 \
     lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
-    mac-notification-sys            0.6.13  50efa634682b3fc5a1ab6f3dd5b2bce7b848011fc485b53b063dc68f2f74feae \
-    md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
+    mac-notification-sys            0.6.15  fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca \
     md-5                            0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
-    md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
-    md5                              0.8.0  ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0 \
-    memchr                           2.8.1  6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8 \
+    md5                              0.8.1  7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c \
+    memchr                           2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
-    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.2.1  02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
+    mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
+    miniz_oxide                      0.9.1  b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c \
+    mio                              1.2.3  4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8 \
     ml-kem                           0.3.2  5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66 \
     module-lattice                   0.2.3  0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe \
     native-tls                      0.2.18  465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
     nix                             0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
     nonempty                         0.9.0  995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6 \
     notify                           8.2.0  4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3 \
-    notify-rust                     4.17.0  50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00 \
+    notify-rust                     4.18.0  c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891 \
     notify-types                     2.1.0  42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a \
     nucleo                           0.5.0  5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4 \
     nucleo-matcher                   0.3.1  bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85 \
     num                              0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
-    num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
-    num-bigint-dig                   0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
+    num-bigint                       0.4.8  c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367 \
     num-complex                      0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                         0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
-    num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
-    num-iter                        0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
+    num-integer                     0.1.47  7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b \
+    num-iter                        0.1.46  c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b \
     num-rational                     0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
@@ -373,244 +377,239 @@ cargo.crates \
     objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
     objc2-system-configuration       0.3.2  7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396 \
     once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
-    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    open                             5.3.5  2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c \
-    openssl                        0.10.80  a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967 \
+    open                             5.4.3  7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634 \
+    openssl                        0.10.81  77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
     openssl-probe                    0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
-    openssl-src                   300.6.0+3.6.2  a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4 \
-    openssl-sys                    0.9.116  f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4 \
+    openssl-src                   300.6.1+3.6.3  46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846 \
+    openssl-sys                    0.9.117  b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695 \
+    opentelemetry                   0.32.0  b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682 \
+    opentelemetry-semantic-conventions    0.32.1  c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47 \
+    opentelemetry_sdk               0.32.1  9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     outref                           0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
-    p256                            0.11.1  51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594 \
     p256                            0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
-    p256                          0.14.0-rc.10  41adc63effe99d48837a8cc0e6d7a77e32ae6a07f6000df466178dbc2193093e \
-    p384                            0.13.1  fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6 \
-    p384                          0.14.0-rc.10  9bd5333afa5ae0347f39e6a0f2c9c155da431583fd71fe5555bd0521b4ccaf02 \
-    p521                            0.13.3  0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2 \
-    p521                          0.14.0-rc.10  a3a5297f53dc16d35909060ba3032cff7867e8809f01e273ff325579d5f0ceae \
-    pageant                          0.0.1  032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc \
-    pageant                          0.2.1  4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5 \
-    palette                          0.7.6  4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6 \
-    palette_derive                   0.7.6  f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30 \
+    p256                            0.14.0  d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a \
+    p384                            0.14.0  d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f \
+    p521                            0.14.0  4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449 \
+    pageant                          0.2.2  3adadc44070da6f464b0918655a12f5792c156e088d8c4082d13e27d94c3e791 \
+    palette                          0.7.7  ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64 \
+    palette_derive                   0.7.7  88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be \
+    palette_math                     0.7.7  6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12 \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     password-hash                    0.6.1  aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
-    pathdiff                         0.2.3  df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3 \
-    pavao                           0.2.16  cca8302d5f1b5dc7a8dfb04e5ea7185b43571db5811e084746bf0aeb0d7b18f1 \
-    pavao-src                     4.22.0-4  30b8c63418f1e7dfbb786268ae0927537b87d90b1211216c1ba50ce25d8d9495 \
-    pavao-sys                       0.2.16  07b390d8c7372e94c7e0f7d92e36c98404634c554a52b1cb9ae030b4e7888cde \
-    pbkdf2                          0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
+    pavao                            0.3.1  637444e8cbc91d23a07688c41df5dcf5136c34964c8b746c4e40fc2127ef320d \
+    pavao-src                       4.24.6  70a3972383d24edd11da87205cae6d81894919821deb3c336bd715027a630b0b \
+    pavao-sys                        0.3.1  9d77a20ad3376d6f0194f02b7314b4e89402eef920a7c78d7d970d3f2dcd4ac5 \
     pbkdf2                          0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
     pem                              3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
     pem-rfc7468                      0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     pem-rfc7468                      1.0.0  a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9 \
     percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                             2.8.6  e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662 \
-    pest_derive                      2.8.6  11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77 \
-    pest_generator                   2.8.6  8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f \
-    pest_meta                        2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
+    pest                             2.9.0  5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf \
+    pest_derive                      2.9.0  b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d \
+    pest_generator                   2.9.0  e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a \
+    pest_meta                        2.9.0  e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496 \
     phc                              0.6.1  44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892 \
     pin-project                     1.1.13  2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924 \
     pin-project-internal            1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
     pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pkcs1                            0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs1                         0.8.0-rc.4  986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e \
-    pkcs5                            0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
-    pkcs5                            0.8.0  279a91971a1d8eb1260a30938eae3be9cb67b472dffecb222fbbbe2fd2dc1453 \
-    pkcs8                            0.9.0  9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba \
+    pkcs5                            0.8.1  63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkcs8                           0.11.0  451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7 \
-    pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    poly1305                         0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
-    poly1305                         0.9.0  a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e \
-    polyval                          0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
-    polyval                          0.7.1  7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede \
-    portable-atomic                 1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
-    potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
+    pkg-config                      0.3.34  f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548 \
+    poly1305                         0.9.1  6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c \
+    polyval                          0.7.3  f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd \
+    portable-atomic                 1.15.0  05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85 \
+    portable-atomic-util             0.2.7  c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618 \
+    potential_utf                    0.1.6  d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
-    prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
-    primefield                    0.14.0-rc.10  f845ec3240cd5ed5e1e31cf3ff633a5bf47c698dc4092ba9e767415b3d393406 \
+    primefield                      0.14.0  c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4 \
     primeorder                      0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
-    primeorder                    0.14.0-rc.10  7d2793f22b9b6fd11ef3ac1d59bf003c2573593e4968702341605c2748fd90bf \
-    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    primeorder                      0.14.0  5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06 \
+    proc-macro2                    1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
+    prost                           0.14.4  528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1 \
+    prost-derive                    0.14.4  b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf \
+    prost-types                     0.14.4  f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
     quick-xml                       0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
-    quinn                           0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
-    quinn-proto                    0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
-    quinn-udp                       0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
-    quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    quinn                          0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
+    quinn-proto                    0.11.17  04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83 \
+    quinn-udp                       0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
+    quote                           1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
-    rand                             0.8.6  5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
-    rand                             0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
-    rand                            0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
+    rand                             0.8.8  e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c \
+    rand                             0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
+    rand                            0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                       0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
-    ratatui                         0.30.1  1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68 \
-    ratatui-core                     0.1.1  42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44 \
-    ratatui-crossterm                0.1.1  2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c \
-    ratatui-widgets                  0.3.1  7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c \
+    rand_pcg                        0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
+    ratatui                         0.30.2  3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d \
+    ratatui-core                     0.1.2  cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c \
+    ratatui-crossterm                0.1.2  567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0 \
+    ratatui-widgets                  0.3.2  66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1 \
     rayon                           1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                   0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
-    regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    ref-cast                        1.0.27  7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3 \
+    ref-cast-impl                   1.0.27  92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a \
+    regex                           1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                  0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-lite                       0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
-    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     remotefs                         0.3.1  b229ef0bf00ce8ae4cbe349bd8d71f3473e26de30efa637cfc53e08eaf6867f0 \
-    remotefs-aws-s3                  0.4.3  26a12e6cbd233e9443127029a373bca1daff5372def8fa96b28ea0a2e69b8057 \
-    remotefs-ftp                     0.4.0  107c234184fd822d1270c482eb8a42354887479cb9fe7834c29655f31e80a4bb \
+    remotefs-aws-s3                  0.4.4  35899af55d8a847ee9ffb101677f42a3ff33d0ec21e33679e47fbfefa9dfc68c \
+    remotefs-ftp                     0.4.1  6af3d379199986cf5435240a0a4b159548897b6301536f33e25f81ffe6f5b2fb \
+    remotefs-gcs                     0.1.0  efaa6054c3e3da035b241a62f10d069928be5fbd7afcd0762cbf7aa0a8e90884 \
     remotefs-kube                    0.4.0  a7ca6df262715fd3c88b58bcc9d219ed46ace67bf73e4216b9fa9b73eafd8426 \
-    remotefs-smb                     0.3.1  c077c88aecf906b0267def951277dc4f6fd1f368edb73d333771a24c0b47970a \
-    remotefs-ssh                     0.8.5  7fa1336153fb7e11d6cf013b279aae115a8454d9f496afb7bccaab1466085253 \
+    remotefs-smb                     0.5.1  63d9b82c3ca50c6a7cbc923b286192178a6c675476802524e37b41a27c414c57 \
+    remotefs-ssh                     0.9.0  32db5bde9ec8d2f0154745200dc8fc9e6319ef5befd22860ca94c7321f413888 \
     remotefs-webdav                  0.2.0  5d2b34f3ac2069b106c65b2d0c91b9b4b24a0b5fe9585b49f50fff4135f2cff8 \
     reqwest                        0.11.27  dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62 \
     reqwest                        0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
-    rfc6979                          0.3.1  7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb \
+    reqwest                         0.13.4  219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3 \
     rfc6979                          0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
-    rfc6979                          0.5.0  5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3 \
+    rfc6979                          0.6.0  b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rpassword                        7.5.4  2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196 \
-    rsa                             0.9.10  b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
     rsa                           0.10.0-rc.18  30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf \
-    rtoolbox                         0.0.5  50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844 \
-    russh                           0.61.2  bbf893f64684e58da8a68d56a5e84d1cf0440226274c515770fe267707a7d0b0 \
-    russh-cryptovec                 0.48.0  4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98 \
-    russh-cryptovec                 0.61.0  443f6bbcfacb34a1aab2b12b99bf08e0c63abdc5a0db261901365df9d57fff51 \
-    russh-keys                      0.49.2  788a2439ce385856585346beb37c48e7c9eb5de5f4f00736720a19ffdb3f5bb5 \
-    russh-sftp                       2.3.0  9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9 \
-    russh-util                      0.48.0  92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f \
+    rtoolbox                         0.0.6  9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d \
+    russh                           0.63.1  35bab1b87d915817d5d9cc352637cd40d5f0b298a48c6309af9156a4addc3031 \
+    russh-cryptovec                 0.62.0  3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438 \
+    russh-sftp                       2.4.0  9de67aace74530a29086db0671fa200c470a58eb380081f28ad512ffb0c5356b \
     russh-util                      0.52.0  668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6 \
-    rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
+    rustc-hash                       2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                         0.21.12  3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e \
-    rustls                         0.23.40  ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
-    rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
+    rustls                         0.23.43  0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06 \
     rustls-native-certs              0.8.4  dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d \
     rustls-pemfile                   1.0.4  1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
-    rustls-pki-types                1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
-    rustls-webpki                  0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
-    rustls-webpki                 0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
-    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    rustls-pki-types                1.15.1  2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
+    rustls-platform-verifier         0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
+    rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
+    rustls-webpki                 0.103.15  f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2 \
+    rustversion                     1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     rustydav                         0.1.3  bc4c86c47126ac8bfc573084610e93f4ca8726f3ae7bf6c64bd60476731b6e42 \
     ryu                             1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
-    salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     salsa20                         0.11.0  2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
+    schemars                         0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
+    schemars                         1.2.2  687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
     scrypt                          0.12.0  d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0 \
-    sct                              0.7.1  da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414 \
-    sec1                             0.3.0  3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928 \
     sec1                             0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     sec1                             0.8.1  d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d \
     secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
-    security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys          2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_update                     0.42.0  d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c \
     semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
-    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde                          1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
     serde_bytes                    0.11.19  a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8 \
-    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde_core                     1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                   1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                     1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    serde_with                      3.22.0  ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a \
+    serde_with_macros               3.22.0  8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46 \
     serde_yaml                    0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     serdect                          0.4.3  66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e \
-    serial_test                      3.5.0  699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
-    serial_test_derive               3.5.0  94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
-    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    serial_test                      4.0.1  a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11 \
+    serial_test_derive               4.0.1  a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae \
+    sha1                            0.10.7  a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8 \
     sha1                            0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sha2                            0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     sha3                            0.11.0  be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1 \
+    sha3                            0.12.0  bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759 \
+    sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shellexpand                      3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                            2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
     signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-mio                  0.2.5  b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc \
     signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
-    signature                        1.6.4  74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c \
     signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     signature                        3.0.0  28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5 \
-    simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
+    simd-adler32                    0.3.10  3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea \
+    simd_cesu8                       1.2.0  11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520 \
+    simdutf8                         0.1.5  e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
     simplelog                       0.12.2  16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0 \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
-    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
+    smallvec                        1.16.0  b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f \
+    smawk                            0.3.3  e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100 \
     socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
-    socket2                          0.6.4  52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
-    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
-    spin                            0.10.0  d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591 \
-    spki                             0.6.0  67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b \
+    socket2                          0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
+    spin                            0.10.1  023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3 \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     spki                             0.8.0  1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f \
-    ssh-cipher                       0.2.0  caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f \
-    ssh-cipher                    0.3.0-rc.9  10db6f219196a8528f9ec904d9d45cdad692d65b0e57e72be4dedd1c5fddce36 \
-    ssh-encoding                     0.2.0  eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15 \
-    ssh-encoding                  0.3.0-rc.9  7abf34aa716da5d5b4c496936d042ea282ab392092cd68a72ef6a8863ff8c96a \
-    ssh-key                          0.6.7  3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3 \
-    ssh-key                       0.7.0-rc.10  45735ce3dea95690e4a9e414c4cfde7f79835063c3dcd35881df85a84118e74b \
-    ssh2-config                      0.7.1  a2e5a3352c5c624ed815d37c1c4c760aeaa119352091ca93ca5566f4ad48562c \
+    sponge-cursor                    0.1.0  3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620 \
+    ssh-cipher                       0.3.0  d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597 \
+    ssh-encoding                     0.3.0  7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e \
+    ssh-key                       0.7.0-rc.11  f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3 \
+    ssh2-config                      0.8.0  16d2108aade44855426db8417ee923f1cfc0c4b38b4bb4bd26d936f0d0f79e0f \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                    0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    suppaftp                         8.0.4  4cf00e4d8418c477a8cb3c13ae5396a68d31658e760c74280bdbd34926e3b94b \
-    syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    suppaftp                        11.0.0  46c5095831abc0d7944a2d50d6ec6abcd75b9d165d9377deb3e45798cae2343a \
+    syn                            2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
+    syn                              3.0.4  e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f \
     sync_wrapper                     0.1.2  2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     system-configuration             0.5.1  ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7 \
     system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
     tar                             0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
-    tauri-winrt-notification         0.7.2  0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9 \
+    tauri-winrt-notification         0.7.3  9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade \
     tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     textwrap                        0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror                       2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
-    time                            0.3.47  743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c \
-    time-core                        0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
-    time-macros                     0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
-    tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
-    tinyvec                         1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
+    thiserror-impl                  2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
+    thread_local                    1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
+    time                            0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
+    time-core                        0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
+    time-macros                     0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
+    tinystr                          0.8.4  b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643 \
+    tinyvec                         1.12.0  bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
-    tokio-macros                     2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
+    tokio                           1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
+    tokio-macros                     2.7.2  78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
-    tokio-rustls                    0.24.1  c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081 \
     tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
-    tokio-stream                    0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
+    tokio-stream                    0.1.19  a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b \
     tokio-tungstenite               0.23.1  c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd \
-    tokio-util                      0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
-    toml                          1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    tokio-util                      0.7.19  494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52 \
+    toml                          1.1.5+spec-1.1.0  12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785 \
     toml_datetime                 1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
-    toml_parser                   1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
-    toml_writer                   1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
+    toml_parser                   1.1.3+spec-1.1.0  1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56 \
+    toml_writer                   1.1.2+spec-1.1.0  7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2 \
+    tonic                           0.14.6  ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef \
+    tonic-prost                     0.14.6  50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0 \
     tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
     tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                       0.5.2  1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5 \
@@ -620,6 +619,8 @@ cargo.crates \
     tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
     tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
+    tracing-opentelemetry           0.33.0  adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26 \
+    tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     tui-realm-stdlib                 4.1.0  1d2fd2ea3ea191daa2e22773d7dee9c7d6a33efc95204afcd319c60da57ee13b \
     tui-term                         0.3.4  a338ded85dbe7f9ea2298321d126244f54e531e2b2006b97abdab8e47d6f3c88 \
@@ -628,13 +629,12 @@ cargo.crates \
     tungstenite                     0.23.0  6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8 \
     typenum                         1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
+    unicase                          2.9.0  dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142 \
     unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
     unicode-segmentation            1.13.3  c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8 \
     unicode-truncate                 2.0.1  16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5 \
     unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
-    unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
-    universal-hash                   0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
     universal-hash                   0.6.1  f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96 \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
@@ -643,8 +643,9 @@ cargo.crates \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
-    uuid                            1.23.2  d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7 \
+    uuid                            1.26.0  b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812 \
     uzers                           0.12.2  0b8275fb1afee25b4111d2dc8b5c505dbbc4afd0b990cb96deb2d88bff8be18d \
+    valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vsimd                            0.8.0  5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64 \
@@ -654,50 +655,42 @@ cargo.crates \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasi                          0.14.7+wasi-0.2.4  883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c \
-    wasip2                        1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
-    wasip3                        0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
+    wasip2                        1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
     wasite                           1.0.2  66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42 \
-    wasm-bindgen                   0.2.122  3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409 \
-    wasm-bindgen-futures            0.4.72  9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f \
-    wasm-bindgen-macro             0.2.122  916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6 \
-    wasm-bindgen-macro-support     0.2.122  299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e \
-    wasm-bindgen-shared            0.2.122  9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437 \
-    wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
-    wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
-    wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
-    web-sys                         0.3.99  6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436 \
+    wasm-bindgen                   0.2.127  1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70 \
+    wasm-bindgen-futures            0.4.77  6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950 \
+    wasm-bindgen-macro             0.2.127  77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1 \
+    wasm-bindgen-macro-support     0.2.127  e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284 \
+    wasm-bindgen-shared            0.2.127  7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf \
+    wasm-streams                     0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
+    web-sys                        0.3.104  c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                     1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
+    webpki-root-certs                1.0.9  b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b \
+    webpki-roots                     1.0.9  7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
     which                            4.4.2  87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7 \
-    whoami                           2.1.2  998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d \
+    whoami                           2.1.3  626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c \
     wildmatch                        2.6.1  29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
     windows                         0.61.3  9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893 \
     windows                         0.62.2  527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580 \
     windows-collections              0.2.0  3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8 \
     windows-collections              0.3.2  23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610 \
-    windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
     windows-core                    0.61.2  c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3 \
     windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
     windows-future                   0.2.1  fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e \
     windows-future                   0.3.2  e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb \
-    windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
     windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \
-    windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
     windows-interface               0.59.3  3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358 \
     windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
     windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
     windows-native-keyring-store     1.1.0  063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8 \
     windows-numerics                 0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-numerics                 0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
-    windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
     windows-result                   0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                   0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
-    windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
     windows-strings                  0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
@@ -734,31 +727,27 @@ cargo.crates \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    winnow                           1.0.3  0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
+    winnow                           1.0.4  23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81 \
     winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
-    wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
     wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    wit-bindgen-core                0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
-    wit-bindgen-rust                0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
-    wit-bindgen-rust-macro          0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
-    wit-component                  0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
-    wit-parser                     0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
-    writeable                        0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
+    wnaf                            0.14.0  ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1 \
+    writeable                        0.6.4  3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc \
     xattr                            1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                        0.8.50  3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1 \
-    zerocopy-derive                 0.8.50  0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639 \
+    zerocopy                        0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
+    zerocopy-derive                 0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
     zerofrom                         0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
-    zeroize                          1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
-    zeroize_derive                   1.4.3  85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e \
-    zerotrie                         0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
-    zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
-    zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
+    zeroize                          1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
+    zeroize_derive                   1.5.0  3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328 \
+    zerotrie                         0.2.5  4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f \
+    zerovec                         0.11.8  bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8 \
+    zerovec-derive                  0.11.6  34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da \
     zip                              2.4.2  fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50 \
     zipsign-api                      0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
-    zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
+    zlib-rs                          0.6.7  34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12 \
+    zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
     zopfli                           0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249


### PR DESCRIPTION
#### Description
https://github.com/veeso/termscp/releases/tag/v1.2.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
