### PR TITLE
gopass: fix build on darwin<23

### DIFF
--- a/devel/gopass-summon-provider/Portfile
+++ b/devel/gopass-summon-provider/Portfile
@@ -3,23 +3,22 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-summon-provider 1.16.1 v
+go.setup            github.com/gopasspw/gopass-summon-provider 1.17.0 v
 go.toolchain_min    1.24.1
 go.offline_build    no
 revision            0
 categories          devel
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
-platforms           {darwin >= 23}
 license             MIT
 
 description         Gopass Summon Provider
 
 long_description    Use gopass as secret provider for summon.
 
-checksums           rmd160  bdc36db9564ee2241991dd51b59dee0858d7e179 \
-                    sha256  5e8acaccb020ac6691157c793937af940444bac77391d5f491b874d30e305da0 \
-                    size    15227
+checksums           rmd160  92c8ddab63796b1bbc1091f7d82244598e85a578 \
+                    sha256  882a4f2eb927e3e256b109400797929560faed14e89737bde6d51f61a62c1005 \
+                    size    14708
 
 build.cmd           ${go.bin} mod tidy \&\& ${go.bin} build
 build.args          -o ${worksrcpath}/${name} \

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -11,7 +11,6 @@ categories          security
 maintainers         {@sikmir disroot.org:sikmir} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
-platforms           {darwin >= 23}
 license             MIT
 
 description         Gopass Browser Bindings
@@ -23,7 +22,7 @@ checksums           rmd160  d3f204b1be6162b738a80cfdd0bf22adc76d2d5b \
                     size    34190
 
 build.cmd           ${go.bin} mod tidy && ${go.bin} build
-build.args          -ldflags '-X main.version=${version}'
+build.args          -ldflags '-X main.version=${version}' -tags=noscreenshot
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -11,7 +11,6 @@ categories          security
 maintainers         {@sikmir disroot.org:sikmir} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
-platforms           {darwin >= 23}
 license             MIT
 
 description         The slightly more awesome Standard Unix Password Manager for Teams
@@ -25,7 +24,7 @@ checksums           rmd160  c49e037b8260146a39edb4e811c74be6c3531477 \
                     size    3153916
 
 set go_ldflags      "-s -w -X main.version=${version}"
-build.args          -ldflags \"${go_ldflags}\" -tags=netgo
+build.args          -ldflags \"${go_ldflags}\" -tags=netgo,noscreenshot
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description
Ref https://github.com/macports/macports-ports/pull/28391#issuecomment-2869681563

As it turned out we can simply disable screen capturing to make gopass build again on older darwins, see https://github.com/gopasspw/gopass/blob/v1.17.0/docs/commands/otp.md#screen-capture-dependency

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
