### PR TITLE
[TESTING - please ignore] libraw: update to 0.22.2

### DIFF
--- a/gnome/gthumb/Portfile
+++ b/gnome/gthumb/Portfile
@@ -5,7 +5,7 @@ PortGroup           yelp 1.0
 
 name                gthumb
 version             3.4.5
-revision            3
+revision            4
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Image viewer and browser for the GNOME desktop.

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -15,7 +15,7 @@ legacysupport.newest_darwin_requires_legacy 11
 
 name                        ImageMagick
 github.setup                ImageMagick ImageMagick6 6.9.13-55
-revision                    0
+revision                    1
 
 github.tarball_from         releases
 distname                    ${name}-${version}

--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -22,7 +22,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                ImageMagick7
 github.setup        ImageMagick ImageMagick 7.1.2-30
 github.tarball_from releases
-revision            0
+revision            1
 use_xz              yes
 checksums           rmd160  43e16101dabcb07ac37ebe925646a18beb4832f3 \
                     sha256  55100ca72b2332df6b2df4769bc153afcfcf588753dfc49b6fb8afa8ead59b23 \

--- a/graphics/Pangolin/Portfile
+++ b/graphics/Pangolin/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        stevenlovegrove Pangolin 0.9.5 v
 github.tarball_from archive
-revision            1
+revision            2
 categories          graphics
 license             MIT
 maintainers         {@ierofant gmail.com:aw.kornilov} openmaintainer

--- a/graphics/geeqie/Portfile
+++ b/graphics/geeqie/Portfile
@@ -11,7 +11,7 @@ PortGroup           meson 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        BestImageViewer geeqie 2.5 v
-revision            1
+revision            2
 github.tarball_from releases
 checksums           rmd160  9eea18861617224088327873e0baa4d730210a06 \
                     sha256  cc991c9d4c78c58668105a15f7ece953bfc21b6b78cedc26ccbaaee6a12b8952 \

--- a/graphics/gegl-0.3/Portfile
+++ b/graphics/gegl-0.3/Portfile
@@ -9,7 +9,7 @@ PortGroup           limit_flags 1.0
 name                gegl-0.3
 set gname           gegl
 version             0.3.34
-revision            18
+revision            19
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             {GPL-3+ LGPL-3+}
 categories          graphics

--- a/graphics/gegl-devel/Portfile
+++ b/graphics/gegl-devel/Portfile
@@ -10,7 +10,7 @@ name                gegl-devel
 conflicts           gegl
 set my_name         gegl
 version             0.4.70
-revision            0
+revision            1
 epoch               0
 
 license             {GPL-3+ LGPL-3+}

--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -10,7 +10,7 @@ name                gegl
 conflicts           gegl-devel
 set my_name         gegl
 version             0.4.70
-revision            1
+revision            2
 epoch               1
 
 license             {GPL-3+ LGPL-3+}

--- a/graphics/libraw/Portfile
+++ b/graphics/libraw/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 
 name                libraw
-version             0.21.4
+version             0.22.2
 revision            0
 
-checksums           rmd160  17e00654b27c95f537e320a6ba2579fab5a17fa4 \
-                    sha256  6be43f19397e43214ff56aab056bf3ff4925ca14012ce5a1538a172406a09e63 \
-                    size    1383350
+checksums           rmd160  67d0d08c93eca06d84b401d8ab1698e8b36f2abf \
+                    sha256  de86b035655accff8d4010f1a221fdf50d353cb7b1422ba26f14a0db92612cfa \
+                    size    1682962
 
 description         Library for RAW image manipulation
 long_description    A library for reading RAW files obtained from digital photo \


### PR DESCRIPTION
> **⚠️ TESTING — please disregard. Not a submission for review.**
>
> This pull request was opened to exercise a tooling change end to end
> (dockhand) and is being closed immediately. It is deliberately
> incomplete: `gthumb` does not build on this platform for reasons
> unrelated to this change, `gegl-devel` was never built, and eight
> further dependents are not included. Sorry for the noise.

---

#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — libraw on Tahoe: linted clean, built in a pristine VM.
  — ImageMagick on Tahoe: linted clean, built in a pristine VM.
  — ImageMagick7 on Tahoe: linted clean, built in a pristine VM.
  — Pangolin on Tahoe: linted clean, built in a pristine VM.
  — geeqie on Tahoe: linted clean, built in a pristine VM.
  — gegl on Tahoe: linted clean, built in a pristine VM.
  — gegl-0.3 on Tahoe: linted with 1 warning, built in a pristine VM.
  — gegl-devel on Tahoe: not built here, and bumped anyway.
  — gthumb on Tahoe: the build failed, and this was promoted anyway.

ABI changed: install name /opt/local/lib/libraw.23.dylib → /opt/local/lib/libraw.25.dylib; libraw compatibility_version 24.0.0 → 26.0.0 (widened); install name /opt/local/lib/libraw_r.23.dylib → /opt/local/lib/libraw_r.25.dylib; libraw_r compatibility_version 24.0.0 → 26.0.0 (widened), measured between libraw@0.21.4_0 (binary archive) and @0.22.2_0 (source not recorded) on 26.6.2 arm64.
this criterion is necessary and not sufficient: an install name and a compatibility version can sit still while symbols are removed, and a break confined to a header or to a plugin's own contract is invisible to otool.

Revision bumped in this change:
  — ImageMagick (graphics/ImageMagick): depends_lib; /opt/local/lib/ImageMagick-6.9.13/modules-Q16/coders/dng.so links against /opt/local/lib/libraw_r.25.dylib
  — ImageMagick7 (graphics/ImageMagick7): depends_lib; /opt/local/lib/ImageMagick7/lib/ImageMagick-7.1.2/modules-Q16/coders/dng.so links against /opt/local/lib/libraw_r.25.dylib
  — Pangolin (graphics/Pangolin): depends_lib; /opt/local/lib/libpango_image.0.9.5.dylib links against /opt/local/lib/libraw_r.25.dylib, /opt/local/lib/libpango_image.0.dylib links against /opt/local/lib/libraw_r.25.dylib, /opt/local/lib/libpango_image.dylib links against /opt/local/lib/libraw_r.25.dylib
  — geeqie (graphics/geeqie): depends_lib; nomaintainer; /Applications/MacPorts/Geeqie.app/Contents/MacOS/Geeqie links against /opt/local/lib/libraw.25.dylib, /opt/local/bin/geeqie links against /opt/local/lib/libraw.25.dylib
  — gegl (graphics/gegl): depends_lib; /opt/local/lib/gegl-0.4/raw-load.dylib links against /opt/local/lib/libraw.25.dylib
  — gegl-0.3 (graphics/gegl-0.3): depends_lib; /opt/local/lib/gegl-0.3/raw-load.so links against /opt/local/lib/libraw.25.dylib
  — gegl-devel (graphics/gegl-devel): depends_lib; conflicts with gegl, which this cohort builds — bumped here, and needing a verification of its own
  — gthumb (gnome/gthumb): depends_lib; nomaintainer

Examined and not bumped:
  — libkdcraw (kde/libkdcraw): depends_lib; nomaintainer; beyond the cohort cap of 8 — a second cohort, after this one lands
  — luminance-hdr (aqua/luminance-hdr): depends_lib; beyond the cohort cap of 8 — a second cohort, after this one lands
  — nomacs (aqua/nomacs): depends_lib; nomaintainer; beyond the cohort cap of 8 — a second cohort, after this one lands
  — openimageio (graphics/openimageio): depends_lib; beyond the cohort cap of 8 — a second cohort, after this one lands
  — photoqt (graphics/photoqt): depends_lib; nomaintainer; beyond the cohort cap of 8 — a second cohort, after this one lands
  — py310-rawpy (python/py-rawpy): depends_lib; beyond the cohort cap of 8 — a second cohort, after this one lands
  — py311-rawpy (python/py-rawpy): depends_lib; beyond the cohort cap of 8 — a second cohort, after this one lands
  — rawproc (graphics/rawproc): depends_lib; nomaintainer; beyond the cohort cap of 8 — a second cohort, after this one lands

Branch head `cfb528e433a4`, against the ports tree as of 2026-09-04.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev

