### PR TITLE
dnsmasq: update to 2.93

### DIFF
--- a/net/dnsmasq/Portfile
+++ b/net/dnsmasq/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dnsmasq
-version             2.92
+version             2.93
 categories          net
 license             GPL
 maintainers         {snc @nerdling} openmaintainer
@@ -30,9 +30,9 @@ notes               "A startup item has been generated that will aid in\
 master_sites        http://www.thekelleys.org.uk/dnsmasq/
 use_xz              yes
 
-checksums           rmd160  50d79c46f08389294839065e9a7d66b7a10b7f1f \
-                    sha256  4bf50c2c1018f9fbc26037df51b90ecea0cb73d46162846763b92df0d6c3a458 \
-                    size    637752
+checksums           rmd160  53aa9b04d5983f44ccfa36372652c377d1ded600 \
+                    sha256  0c00d4e5c97c8306e5fb932b348b34269c9c29a0e7df0e8e82958b407092bc19 \
+                    size    642764
 
 patchfiles          0000-underflow.diff \
                     patch-src-config.h.diff \
@@ -59,23 +59,21 @@ livecheck.regex     LATEST_IS_(\\d\\.\\d+)
 
 default_variants    +dhcp +tftp +ipv6
 
-variant dhcp description { Provide built-in DHCP server } {}
-variant tftp description { Provide built-in TFTP server } {}
-variant ipv6 description { Provide IPV6 support } {}
-
 set COPTS {}
-if {![variant_isset dhcp]} {
+
+variant dhcp description { Provide built-in DHCP server } {
     lappend COPTS -DNO_DHCP
 }
-if {![variant_isset tftp]} {
+variant tftp description { Provide built-in TFTP server } {
     lappend COPTS -DNO_TFTP
 }
-if {![variant_isset ipv6]} {
+variant ipv6 description { Provide IPV6 support } {
     lappend COPTS -DNO_IPV6
 }
+
 if {[llength $COPTS] > 0} {
     set mycopts [join $COPTS " "]
-    build.args-append COPTS="$mycopts"
+    build.args-append COPTS="${mycopts}"
 }
 
 post-destroot {
@@ -112,6 +110,10 @@ post-destroot {
     puts ${plist} "    <array>"
     puts ${plist} "      <string>${prefix}/sbin/dnsmasq</string>"
     puts ${plist} "      <string>-k</string>"
+    puts ${plist} "      <string>-a</string>"
+    puts ${plist} "      <string>127.0.0.1</string>"
+    puts ${plist} "      <string>-7</string>"
+    puts ${plist} "      <string>${prefix}/etc/dnsmasq.d</string>"
     puts ${plist} "    </array>"
     puts ${plist} "    <key>RunAtLoad</key>"
     puts ${plist} "    <true/>"


### PR DESCRIPTION
###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560
```