### PR TITLE
keywise: new port

### DIFF
--- a/security/keywise/Portfile
+++ b/security/keywise/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           zig_toolchain 1.0
+
+github.setup        lkraider keywise 2.4.0 v
+github.tarball_from releases
+revision            0
+distname            keywise-${version}-source
+worksrcdir          keywise-${version}
+categories          security
+license             MIT
+maintainers         {gmail.com:lkraider+ports @lkraider} openmaintainer
+description         Terminal UI to view Firefox saved logins
+long_description    Keywise reads a local Firefox profile's saved logins \
+                    and displays them in an interactive terminal UI.
+
+set zig_series      0.16
+set lv_commit       6cab03f8a3faeb58bddf334343889a7f685ba7a7
+set lv_hash         vaxis-0.6.0-BWNV_FcoCgB3Q_LTiQet_GeS23Bd7e224eHloS8PanKZ
+
+master_sites-append https://github.com/rockorager/libvaxis/archive/:lv
+distfiles-append    ${lv_commit}.tar.gz:lv
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  ac2e8c6c0d96bdb4ac33ab4f362ff8da66b7b8fd \
+                    sha256  c1a48d5e0aab88d8b4fdc4a4a1d640f09d03c74beb3461bd89c0fedf31b5cc8b \
+                    size    548775 \
+                    ${lv_commit}.tar.gz \
+                    rmd160  5f52e9c33e778fbc449f53adf3776a878f48d1ed \
+                    sha256  a6059a94facbcc8a44c2fb37f3dfde9b0dfd26c173ccf8bc57f337f8fc9f97e8 \
+                    size    1223487
+
+depends_build-append port:zig-${zig_series}
+
+use_configure       no
+
+post-extract {
+    file mkdir ${workpath}/deps
+    file rename ${workpath}/libvaxis-${lv_commit} ${workpath}/deps/${lv_hash}
+}
+
+build.cmd           [zig_toolchain.bin ${zig_series}]
+build.target        build
+build.args          --system ${workpath}/deps -Doptimize=ReleaseSafe
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/zig-out/bin/keywise ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
[Keywise](https://github.com/lkraider/keywise) reads a local Firefox profile's saved logins and displays them in an interactive terminal UI. It reads `key4.db` and `logins.json` directly with its own SQLite parser and AES-256-CBC unwrap. It links no libsqlite3 and no NSS.

The build uses `zig build --system` to supply the one vendored dependency (libvaxis) from a fetched tarball.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 arm64
Xcode 16.4

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?