### PR TITLE
commons-codec: update to 1.22.1

### DIFF
--- a/java/commons-codec/Portfile
+++ b/java/commons-codec/Portfile
@@ -1,21 +1,23 @@
-PortSystem			1.0
-PortGroup			java 1.0
-PortGroup 			maven 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name				commons-codec
-version				1.22.0
+PortSystem          1.0
+PortGroup           java 1.0
+PortGroup           maven 1.0
 
-categories			java
-license				Apache-2
-maintainers			nomaintainer
+name                commons-codec
+version             1.22.0
 
-description			Jakarta Commons-Codec
-long_description	Commons Codec provides implementations of common encoders and \
-					decoders such as Base64, Hex, various phonetic encodings, and URLs.
-homepage			https://commons.apache.org/codec/
-				
-distname			${name}-${version}-src
-master_sites		apache:commons/codec/source/
+categories          java
+license             Apache-2
+maintainers         nomaintainer
+
+description         Jakarta Commons-Codec
+long_description    Commons Codec provides implementations of common encoders and \
+                    decoders such as Base64, Hex, various phonetic encodings, and URLs.
+homepage            https://commons.apache.org/codec/
+
+distname            ${name}-${version}-src
+master_sites        apache:commons/codec/source/
 
 checksums           rmd160  26339cd533cc6836e3bb6e9c5ec9e7a96c320559 \
                     sha256  6339ca5b3e3f14549accb0b21743f89c2b93cbc08fbb2bb8a80540b6985cbf76 \
@@ -24,14 +26,14 @@ checksums           rmd160  26339cd533cc6836e3bb6e9c5ec9e7a96c320559 \
 java.version        11+
 java.fallback       openjdk11
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 \
-		${worksrcpath}/target/${name}-${version}.jar \
-		${destroot}${prefix}/share/java/
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}-${version}.jar \
+        ${destroot}${prefix}/share/java/
 }
 
-livecheck.type		regex
-livecheck.url		https://commons.apache.org/proper/commons-codec/download_codec.cgi
-livecheck.regex		"${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.type      regex
+livecheck.url       https://commons.apache.org/proper/commons-codec/download_codec.cgi
+livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"

--- a/java/commons-codec/Portfile
+++ b/java/commons-codec/Portfile
@@ -1,39 +1,53 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           java 1.0
 PortGroup           maven 1.0
 
 name                commons-codec
-version             1.22.0
+version             1.22.1
 
 categories          java
 license             Apache-2
 maintainers         nomaintainer
+platforms           any
+supported_archs     noarch
 
 description         Jakarta Commons-Codec
 long_description    Commons Codec provides implementations of common encoders and \
                     decoders such as Base64, Hex, various phonetic encodings, and URLs.
-homepage            https://commons.apache.org/codec/
+homepage            https://commons.apache.org/proper/commons-codec/
 
 distname            ${name}-${version}-src
 master_sites        apache:commons/codec/source/
 
-checksums           rmd160  26339cd533cc6836e3bb6e9c5ec9e7a96c320559 \
-                    sha256  6339ca5b3e3f14549accb0b21743f89c2b93cbc08fbb2bb8a80540b6985cbf76 \
-                    size    589200
+checksums           rmd160  90a50538336fd1c2e1919e487814b3a48b74f32c \
+                    sha256  eb16c29286ee8dde0f77777404b6e3c485af1c6212f4f472792c64ffbe00ad81 \
+                    size    596318
 
 java.version        11+
 java.fallback       openjdk11
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
     xinstall -m 644 \
         ${worksrcpath}/target/${name}-${version}.jar \
-        ${destroot}${prefix}/share/java/
+        ${destjavadir}/${name}.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/CODE_OF_CONDUCT.md \
+        ${worksrcpath}/CONTRIBUTING.md \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/NOTICE.txt \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/RELEASE-NOTES.txt \
+        ${worksrcpath}/SECURITY.md \
+        ${destdocdir}
 }
 
 livecheck.type      regex
 livecheck.url       https://commons.apache.org/proper/commons-codec/download_codec.cgi
-livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src\\.tar\\.gz"


### PR DESCRIPTION
#### Description

Update the `commons-codec` port to version 1.22.1 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?