### PR TITLE
enchant2: update to 2.8.21

### DIFF
--- a/textproc/enchant2/Portfile
+++ b/textproc/enchant2/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rrthomas enchant 2.8.15 v
-revision            1
-checksums           rmd160  91d1ba588e2d517a791fffeabf16ddd83c55e2b9 \
-                    sha256  d3fd9e4170bfb5110b0bda577fe764a38fb606b3c25d2f0c3840234521ff1252 \
-                    size    1273237
+github.setup        rrthomas enchant 2.8.21 v
+revision            0
+checksums           rmd160  87239be8d4f8b61cd7372b417d809c079b6ead8f \
+                    sha256  dd2a762697c463148a8f59867089a5ebf2dd1449d869f93764b76c12bcf8acc0 \
+                    size    1315249
 
 name                enchant2
 categories          textproc devel


### PR DESCRIPTION
###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560

Model Identifier: Macmini6,1    macOS 10.15.8 19H2036 x86_64
Xcode 12.4 12D4e                Command Line Tools 12.4.0.0.1.161013581
```

