### PR TITLE
nmap: fix build on macOS <10.12

### DIFF
--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -54,7 +54,13 @@ configure.args	--without-zenmap \
                 --mandir=\\\${prefix}/share/man \
                 --infodir=\\\${prefix}/share/info \
                 --with-liblua=included
-		
+
+# static_assert() does not work on older systems
+# (macOS <10.11) with Xcode Clang, but legacysupport doesn't help either
+# El Captain is broken too, so we'll just block older versions
+# of Clang to ensure that <type_traits> is used instead
+compiler.blacklist-append {clang < 900}
+
 # https://trac.macports.org/ticket/58837
 # build system does not pass the stdlib on the link line resulting in link errors
 # for some build configurations using non-default stdlib settings

--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -1,59 +1,60 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 PortGroup           legacysupport 1.0
 
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-name		nmap
-version		7.991
-revision	0
-categories	net
-maintainers	{darkart.com:opendarwin.org @ghosthound} {geeklair.net:dluke @danielluke}
-description	Port scanning utility for large networks
+name                nmap
+version             7.991
+revision            0
+
+categories          net
+maintainers         {darkart.com:opendarwin.org @ghosthound} {geeklair.net:dluke @danielluke}
 # NPSL - https://nmap.org/npsl/
 # gpl-2 with additional restrictions, so not actually gpl-2
-license		{GPL-2 OpenSSLException} Restrictive/Distributable
-homepage	https://nmap.org/
-platforms	darwin freebsd
+license             {GPL-2 OpenSSLException} Restrictive/Distributable
+homepage            https://nmap.org/
+platforms           darwin freebsd
 
-long_description Nmap is a utility for port scanning large networks, although \
-		 it works fine for single hosts. The guiding philosophy for \
-		 the creation of nmap was TMTOWTDI (There's More Than One Way \
-		 To Do It). This is the Perl slogan, but it is equally \
-		 applicable to scanners. Sometimes you need speed, other \
-		 times you may need stealth. In some cases, bypassing \
-		 firewalls may be required. Not to mention the fact that you \
-		 may want to scan different protocols (UDP, TCP, ICMP, etc.). \
-		 You just can't do all this with one scanning mode. And you \
-		 don't want to have 10 different scanners around, all with \
-		 different interfaces and capabilities.
+description         Port scanning utility for large networks
+long_description    Nmap is a utility for port scanning large networks, although \
+                    it works fine for single hosts. The guiding philosophy for \
+                    the creation of nmap was TMTOWTDI (There's More Than One Way \
+                    To Do It). This is the Perl slogan, but it is equally \
+                    applicable to scanners. Sometimes you need speed, other \
+                    times you may need stealth. In some cases, bypassing \
+                    firewalls may be required. Not to mention the fact that you \
+                    may want to scan different protocols (UDP, TCP, ICMP, etc.). \
+                    You just can't do all this with one scanning mode. And you \
+                    don't want to have 10 different scanners around, all with \
+                    different interfaces and capabilities.
 
-master_sites	https://nmap.org/dist/
+master_sites        https://nmap.org/dist/
 
 checksums           rmd160  941be32df1d4deda4f118766252fbc9c082c2439 \
                     sha256  a5d507f29437bef3bedd4771ff9aaa8fc1c2a109ddba1f5b1cf12027456929be \
                     size    12877122
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
-  patchfiles-append pre-cxx11-workarounds.patch
+    patchfiles-append pre-cxx11-workarounds.patch
 }
 
-depends_build port:automake \
-			  port:autoconf
+depends_build       port:automake \
+                    port:autoconf
 
-depends_lib	port:libpcap \
-            port:zlib \
-            port:libssh2
+depends_lib         port:libpcap \
+                    port:zlib \
+                    port:libssh2
 
-use_bzip2	yes
+use_bzip2           yes
 
-configure.args	--without-zenmap \
-                --without-ndiff \
-                --mandir=\\\${prefix}/share/man \
-                --infodir=\\\${prefix}/share/info \
-                --with-liblua=included
+configure.args      --without-zenmap \
+                    --without-ndiff \
+                    --mandir=\\\${prefix}/share/man \
+                    --infodir=\\\${prefix}/share/info \
+                    --with-liblua=included
 
 # static_assert() does not work on older systems
 # (macOS <10.11) with Xcode Clang, but legacysupport doesn't help either
@@ -65,15 +66,15 @@ compiler.blacklist-append {clang < 900}
 # build system does not pass the stdlib on the link line resulting in link errors
 # for some build configurations using non-default stdlib settings
 if {${os.platform} eq "darwin" && ${os.major} < 13} {
-  if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
-    configure.ldflags-append -stdlib=${configure.cxx_stdlib}
-  }
+    if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+        configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+    }
 }
 
 # nmap's configure script in nselib-bin does not respect --with-liblua=included
-configure.env ac_cv_header_lua_h=no
+configure.env       ac_cv_header_lua_h=no
 
-default_variants +ssl +pcre
+default_variants    +ssl +pcre
 
 variant ssl description {build with ssl support} {
     PortGroup openssl 1.0


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?