### PR TITLE
commons-pool: update to 2.13.1

### DIFF
--- a/java/commons-pool/Portfile
+++ b/java/commons-pool/Portfile
@@ -1,51 +1,55 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       java 1.0
+PortGroup       maven 1.0
 
 name            commons-pool
-version         1.5.4
+version         2.13.1
 
 categories      java
 license         Apache-2
 maintainers     nomaintainer
-platforms       darwin
+platforms       any
+supported_archs noarch
 
 description     Jakarta Commons-Pool
 long_description    Commons-Pool provides a generic object pooling \
                 interface, a toolkit for creating modular \
                 object pools and several general purpose \
                 pool implementations.
-homepage        https://commons.apache.org/pool/
+homepage        https://commons.apache.org/proper/commons-pool/
 
-distname        ${name}-${version}-src
+distname        ${name}2-${version}-src
 master_sites    apache:commons/pool/source/
 
-checksums       md5     4216bb6eca49e7b3db9f287d7b0c0cd8 \
-                sha1    18279249c27fee5bdedeaff169b9d1b70d135839 \
-                rmd160  bb72683ef378e6e6741e6c6eea93b6077571edec
+checksums       rmd160  e3b8c288b8375d41406f1e0412f154db79ad1147 \
+                sha256  2b88f1b47d233b0b5a8a20ec798e5324540506c8cc1767a4c8f2318b16918cd1 \
+                size    341630
 
-depends_build   bin:ant:apache-ant
-depends_lib     bin:java:kaffe \
-                port:junit
-
-use_configure   no
-
-worksrcdir      ${name}-${version}-src
-
-build.cmd       ant
-build.target    dist
-build.args      -Djunit.jar=${prefix}/share/java/junit.jar
+java.version    1.8+
+java.fallback   openjdk11
 
 destroot {
-    xinstall -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/dist/commons-pool.jar \
-        ${destroot}${prefix}/share/java/commons-pool.jar
-    file copy ${worksrcpath}/dist/docs ${destroot}${prefix}/share/doc/${name}
-    file attributes ${destroot}${prefix}/share/doc/${name} -permissions goa+r
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
+
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/target/${name}2-${version}.jar \
+        ${destjavadir}/${name}2.jar
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/CODE_OF_CONDUCT.md \
+        ${worksrcpath}/CONTRIBUTING.md \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/NOTICE.txt \
+        ${worksrcpath}/README.md \
+        ${worksrcpath}/RELEASE-NOTES.txt \
+        ${worksrcpath}/SECURITY.md \
+        ${destdocdir}
 }
 
 livecheck.type  regex
-livecheck.url   https://commons.apache.org/proper/commons-pool/download_pool.cgi
-livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"
+livecheck.url   ${homepage}download_pool.cgi
+livecheck.regex "${name}\\d*-(\\d+\\.\\d+(\\.\\d+)?)-src\\.tar\\.gz"

--- a/java/commons-pool/Portfile
+++ b/java/commons-pool/Portfile
@@ -1,47 +1,49 @@
-PortSystem 1.0
-PortGroup java 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			commons-pool
-version			1.5.4
+PortSystem      1.0
+PortGroup       java 1.0
 
-categories		java
-license			Apache-2
-maintainers		nomaintainer
-platforms		darwin
+name            commons-pool
+version         1.5.4
 
-description		Jakarta Commons-Pool
-long_description	Commons-Pool provides a generic object pooling \
-				interface, a toolkit for creating modular \
-				object pools and several general purpose \
-				pool implementations.
-homepage		https://commons.apache.org/pool/
+categories      java
+license         Apache-2
+maintainers     nomaintainer
+platforms       darwin
 
-distname		${name}-${version}-src
-master_sites		apache:commons/pool/source/
+description     Jakarta Commons-Pool
+long_description    Commons-Pool provides a generic object pooling \
+                interface, a toolkit for creating modular \
+                object pools and several general purpose \
+                pool implementations.
+homepage        https://commons.apache.org/pool/
+
+distname        ${name}-${version}-src
+master_sites    apache:commons/pool/source/
 
 checksums       md5     4216bb6eca49e7b3db9f287d7b0c0cd8 \
                 sha1    18279249c27fee5bdedeaff169b9d1b70d135839 \
                 rmd160  bb72683ef378e6e6741e6c6eea93b6077571edec
 
-depends_build		bin:ant:apache-ant
-depends_lib		bin:java:kaffe \
-				port:junit
+depends_build   bin:ant:apache-ant
+depends_lib     bin:java:kaffe \
+                port:junit
 
-use_configure		no
+use_configure   no
 
-worksrcdir		${name}-${version}-src
+worksrcdir      ${name}-${version}-src
 
-build.cmd		ant
-build.target		dist
-build.args		-Djunit.jar=${prefix}/share/java/junit.jar
+build.cmd       ant
+build.target    dist
+build.args      -Djunit.jar=${prefix}/share/java/junit.jar
 
-destroot	{
-	xinstall -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/dist/commons-pool.jar \
-		${destroot}${prefix}/share/java/commons-pool.jar
-	file copy ${worksrcpath}/dist/docs ${destroot}${prefix}/share/doc/${name}
-	file attributes ${destroot}${prefix}/share/doc/${name} -permissions goa+r
+destroot {
+    xinstall -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/dist/commons-pool.jar \
+        ${destroot}${prefix}/share/java/commons-pool.jar
+    file copy ${worksrcpath}/dist/docs ${destroot}${prefix}/share/doc/${name}
+    file attributes ${destroot}${prefix}/share/doc/${name} -permissions goa+r
 }
 
 livecheck.type  regex


### PR DESCRIPTION
#### Description

Update the `commons-pool` port to version 2.13.1 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?