### PR TITLE
okf: update to 0.5.0

### DIFF
--- a/textproc/okf/Portfile
+++ b/textproc/okf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/okfcli/okf 0.4.0 v
+go.setup            github.com/okfcli/okf 0.5.0 v
 go.toolchain_min    1.27
 revision            0
 
@@ -20,9 +20,9 @@ license             Apache-2
 maintainers         @jrjsmrtn openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  aa8e89b28b4eddaa504bb28bb09910ef0a4623a8 \
-                    sha256  8bc65074db3e195e8627032e2df9244b798d162d300e2472bfb815dd84894eb0 \
-                    size    59184
+                    rmd160  6024005df9dd17621ee4cb13d9ae7d812d28b26f \
+                    sha256  361241b528e09ed16a300dce148660ad175ac3957ab5b5625c56589233bd7d88 \
+                    size    65509
 
 # The main package lives in cmd/, not at the repository root. The version is
 # injected the way upstream's Makefile does; commit and date are left at their


### PR DESCRIPTION
#### Description

Routine version update. `go.mod` is unchanged — same Go 1.27.0 and the same single
dependency — so only the version and distfile checksums move.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`okf --version` reports 0.5.0 and `okf validate` runs clean against a real bundle. Trace
mode is not available on this arm64 machine, so `-vs` rather than `-vst`.
