### PR TITLE
flash: update to 2.7.2

### DIFF
--- a/sysutils/flash/Portfile
+++ b/sysutils/flash/Portfile
@@ -3,9 +3,8 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    hypriot flash 2.7.1
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup    hypriot flash 2.7.2
+github.tarball_from archive
 revision        0
 
 platforms       any
@@ -17,16 +16,16 @@ maintainers     @jrjsmrtn openmaintainer
 description     Command line script to flash SD card images of any kind
 long_description    {*}${description}
 
-checksums       rmd160  a6766670fef1f0152c7109d1ed8fa1d051e9183c \
-                sha256  ff727ccd7042c95a26093fb528bb2a9b0b1d2e71c1b3fa9ced459315a02273a2 \
-                size    18080
+checksums       rmd160  79515fe8602204971a29499ac5705b55668383b6 \
+                sha256  2d6b40158a277c77d8f9aabbb7d8ff4e4ae4f61b62107be83e69a430b3208c54 \
+                size    18075
 
 depends_run     port:unzip \
                 port:curl \
                 port:pv
 
 notes           "If you want to flash directly from an AWS S3 bucket,\
-                install the py38-awscli port."
+                install awscli for your python, e.g. py314-awscli."
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Update 2.7.1 → 2.7.2.

Also switches `github.tarball_from` to `archive`, which the Portfile's own comment asked
for at the next update, drops `platforms any` as the lint default, and stops naming
`py38-awscli` in the notes — that port no longer exists.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`flash --version` reports 2.7.2, confirming the build's `dirty` substitution still applies.
Trace mode is unavailable on this arm64 machine, so `-vs` rather than `-vst`.
