### PR TITLE
cdxgen: new port, version 13.1.0

### DIFF
--- a/security/cdxgen/Portfile
+++ b/security/cdxgen/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                cdxgen
+version             13.1.0
+revision            0
+
+npm.rootname        @cdxgen/cdxgen
+# The tarball is named after the unscoped part of the package.
+distname            ${name}-${version}
+
+# package.json requires node >= 24; the PortGroup defaults to 22.
+npm.nodejs_version  24
+# npm10 depends on nodejs22, which conflicts with nodejs24.
+npm.version         11
+
+description         Creates CycloneDX Bills of Materials from source and \
+                    container images
+
+long_description    ${name} generates CycloneDX Software Bills of Materials \
+                    (SBOM) for projects in many languages, reading manifests \
+                    and lockfiles rather than requiring a build. Companion \
+                    commands produce operations (obom), hardware (hbom), \
+                    cryptography (cbom), SaaS (saasbom) and AI (aibom) bills \
+                    of materials, emit SPDX, and convert, validate and sign \
+                    the results.
+
+categories          security
+license             Apache-2
+maintainers         @jrjsmrtn openmaintainer
+homepage            https://cyclonedx.github.io/cdxgen/
+
+platforms           any
+supported_archs     noarch
+
+checksums           rmd160  3257a625dc7849af9745a6f2bfc639d03b79f450 \
+                    sha256  c5de3e648b261ad2a273f960ffac31153e6832b9d5c587be33d2395bd46fdaf3 \
+                    size    3093006
+
+set osquery_bin     ${prefix}/bin/osqueryi
+set cdxgen_js       ${prefix}/lib/node_modules/@cdxgen/cdxgen/bin/cdxgen.js
+set osq_libexec_dir ${prefix}/libexec/${name}
+
+# A variant, not a dependency: only obom uses osquery. Untouched, cdxgen
+# downloads its own osquery binary at run time, which a port must not do.
+# No hbom counterpart -- its macOS collectors call /usr/sbin tools directly.
+variant obom description {Support operations BOMs (obom) using the osquery port} {
+    depends_run-append  port:osquery
+
+    post-destroot {
+        # cdxgen.js picks its mode from basename(process.argv[1]), so each
+        # wrapper execs a correctly named symlink rather than cdxgen.js --
+        # otherwise obom degrades to an ordinary scan.
+        xinstall -d ${destroot}${osq_libexec_dir}
+
+        foreach launcher {cdxgen obom} {
+            set alias ${osq_libexec_dir}/${launcher}
+            ln -s ${cdxgen_js} ${destroot}${alias}
+
+            set target ${destroot}${prefix}/bin/${launcher}
+            delete ${target}
+            set fd [open ${target} w]
+            puts ${fd} "#!/bin/sh"
+            puts ${fd} "# Prefer the osquery port over a downloaded plugin binary."
+            puts ${fd} ": \"\${OSQUERY_CMD:=${osquery_bin}}\""
+            puts ${fd} "export OSQUERY_CMD"
+            puts ${fd} "exec ${alias} \"\$@\""
+            close ${fd}
+            file attributes ${target} -permissions 0755
+        }
+    }
+
+    notes-append "
+The obom and cdxgen commands default OSQUERY_CMD to ${osquery_bin}; set it
+yourself to override.
+"
+}
+
+notes "
+Operations BOMs (obom) need osquery. Install with +obom to use the osquery
+port; otherwise ${name} looks for a plugin binary it does not ship.
+
+Container image scans (-t oci) use trivy for OS packages, and quietly omit
+them when it is absent. To include them, install the trivy port and set
+TRIVY_CMD=${prefix}/bin/trivy.
+"

--- a/security/cdxgen/Portfile
+++ b/security/cdxgen/Portfile
@@ -49,7 +49,25 @@ set osq_libexec_dir ${prefix}/libexec/${name}
 variant obom description {Support operations BOMs (obom) using the osquery port} {
     depends_run-append  port:osquery
 
+    # cdxgen's macOS profile queries homebrew_packages but has no MacPorts
+    # equivalent, so an OBOM on a MacPorts system lists applications and
+    # installer receipts while every installed port is invisible. The query
+    # needs a macports_packages table, which osquery does not ship yet
+    # (osquery/osquery#9074); until it does, an Automatic Table Construction
+    # config over ${prefix}/var/macports/registry/registry.db supplies it.
+    # Where neither is present cdxgen skips the query silently: executeOsQuery
+    # suppresses "no such table".
+    # Applied in post-destroot, not via patchfiles: the npm PortGroup installs
+    # the package during destroot, so worksrcpath is empty at patch time and
+    # patchfiles has nothing to act on.
     post-destroot {
+        set queries ${destroot}${prefix}/lib/node_modules/${npm.rootname}/data/queries-darwin.json
+        if {![file exists ${queries}]} {
+            return -code error "${queries} is missing; has cdxgen moved its query profiles?"
+        }
+        system -W [file dirname ${queries}] \
+            "/usr/bin/patch -p0 < ${filespath}/patch-macports-query.diff"
+
         # cdxgen.js picks its mode from basename(process.argv[1]), so each
         # wrapper execs a correctly named symlink rather than cdxgen.js --
         # otherwise obom degrades to an ordinary scan.

--- a/security/cdxgen/files/patch-macports-query.diff
+++ b/security/cdxgen/files/patch-macports-query.diff
@@ -1,0 +1,15 @@
+--- queries-darwin.json	2026-09-06 13:30:13
++++ queries-darwin.json	2026-09-06 13:30:13
+@@ -77,6 +77,12 @@
+     "purlType": "swid",
+     "componentType": "application"
+   },
++  "macports_packages": {
++    "query": "SELECT * FROM macports_packages;",
++    "description": "MacPorts port inventory. Needs a macports_packages table in osquery (osquery/osquery#9074), or an Automatic Table Construction table over the MacPorts registry; the query is a no-op where neither is present.",
++    "purlType": "swid",
++    "componentType": "application"
++  },
+   "npm_packages": {
+     "query": "SELECT * FROM npm_packages;",
+     "description": "Node packages installed on the system, including recursively discovered modern package manager layouts.",


### PR DESCRIPTION
#### Description

New port: `cdxgen`, which generates CycloneDX bills of materials from manifests and
lockfiles.

Related to #34515: the `+obom` variant needs `port:osquery`, and only the update in that
PR is installable. The default variant has no such dependency, so this can merge either
way — only `+obom` is affected.

Only `obom` uses osquery, hence a variant rather than a dependency of every SBOM; it also
wraps the `cdxgen` and `obom` launchers so `OSQUERY_CMD` defaults to the port, since
cdxgen otherwise downloads its own binary at run time. `package.json` requires node 24,
which `path:bin/node` does not guarantee, so a `pre-fetch` check reports an older one.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Both variants tested: default gave a 334-component SBOM, `+obom` a 3227-component
operations BOM. Trace mode is unavailable on arm64, so `-vs` rather than `-vst`.
