### PR TITLE
gearmand: update to 2.1.0

### DIFF
--- a/sysutils/gearmand/Portfile
+++ b/sysutils/gearmand/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.0
 PortGroup           openssl 1.0
 
-github.setup        gearman gearmand 1.1.20
+github.setup        gearman gearmand 2.1.0
 revision            0
 categories          sysutils net devel
 maintainers         nomaintainer
@@ -22,12 +22,12 @@ long_description    \
         database replication events. In other words, it is the nervous system \
         for how distributed processing communicates.
 
-homepage            http://gearman.org/
+homepage            https://gearman.org/
 github.tarball_from releases
 
-checksums           rmd160  f2276d881fa2a8ffd5181a30dcf9afb8df680487 \
-                    sha256  2f60fa207dcd730595ef96a9dc3ca899566707c8176106b3c63ecf47edc147a6 \
-                    size    1103071
+checksums           rmd160  555d894e4c62f3c3bf493c8ad7f9e05df2e1ae07 \
+                    sha256  4d24340ab39be851b40d895687c17d6d16e730ece1fa9d9294d6b2b0a8cb1261 \
+                    size    1127335
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560
```
Checked that `php-gearman` still installs