### PR TITLE
fselect: update to 0.10.3

### DIFF
--- a/sysutils/fselect/Portfile
+++ b/sysutils/fselect/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        jhspetersson fselect 0.10.2
+github.setup        jhspetersson fselect 0.10.3
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8cc6690bb37bb88fea102cf34232343ee248af00 \
-                    sha256  3a51225c41ff0fa460abdbf30cb7434769454cbcba8d717ad24a5c8fa005485f \
-                    size    246418
+                    rmd160  e9046b645290e709d9260b95a9b0e588fdbd621f \
+                    sha256  e2dc2d40c58c273a6e9efece80ad14dc05f07ad01bbafd0fba5da3ebd73464e1 \
+                    size    265190
 
 depends_build-append \
                     path:bin/cmake:cmake
@@ -43,26 +43,27 @@ destroot {
 
 cargo.crates \
     adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
-    aes                              0.9.1  f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138 \
+    aes                              0.9.3  35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32 \
     ahash                           0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
-    aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
-    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    aho-corasick                     1.1.5  c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba \
+    android_system_properties        0.1.6  ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    bitflags                        2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
+    base64                          0.23.1  ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5 \
+    bitflags                        2.13.1  b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da \
     bitreader                       0.3.11  886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066 \
     bitstream-io                    4.10.0  7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f \
     block-buffer                    0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     bumpalo                         3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     bytecount                        0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                           1.12.0  8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593 \
+    bytes                           1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
     bzip2                            0.6.1  f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c \
-    cc                              1.2.65  e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96 \
+    cc                               1.4.5  005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
-    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chacha20                        0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
+    cfg_aliases                      0.2.2  f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
+    chacha20                        0.10.2  65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06 \
     chrono                          0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     chrono-english                   0.1.8  38a56613410c9249673f4676ab8d27c70949814accb27b6b738009e2ff1034a1 \
     cipher                           0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
@@ -70,49 +71,48 @@ cargo.crates \
     cmov                             0.5.4  0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a \
     const-oid                       0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     constant_time_eq                 0.4.2  3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b \
-    cookie                          0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
+    cookie                          0.18.2  1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87 \
     cookie_store                    0.22.1  15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpubits                          0.1.1  15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae \
-    cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
-    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
-    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
-    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    cpufeatures                      0.3.1  5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566 \
+    crc32fast                        1.5.1  8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550 \
+    crossbeam-deque                  0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
+    crossbeam-epoch                 0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
+    crossbeam-utils                 0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
     crypto-common                    0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
     csv                              1.4.0  52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938 \
     csv-core                        0.1.13  704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782 \
     ctutils                          0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
-    data-encoding                   2.11.0  a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
+    data-encoding                   2.11.1  4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06 \
     deflate64                       0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
     deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     digest                          0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
     directories                      6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    displaydoc                       0.2.6  1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f \
+    displaydoc                       0.2.7  c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8 \
     document-features               0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
-    either                          1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
+    either                          1.18.0  252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34 \
     endian-type                      0.2.0  869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
-    error-code                       3.3.2  dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59 \
+    error-code                       3.4.0  0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7 \
     etcetera                        0.10.0  26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6 \
     fallible_collections             0.4.9  a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd \
-    fastrand                         2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
-    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    fastrand                         2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
+    find-msvc-tools                 0.1.12  3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d \
     fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
-    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    flate2                          1.1.10  6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
-    futures-channel                 0.3.32  07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
-    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
-    futures-io                      0.3.32  cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718 \
-    futures-sink                    0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
-    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
-    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    futures-channel                 0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
+    futures-core                    0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
+    futures-io                      0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
+    futures-sink                    0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                    0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-util                    0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
-    getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
     getrandom                        0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     git2                            0.21.0  ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e \
     hashbrown                       0.13.2  43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e \
@@ -120,60 +120,60 @@ cargo.crates \
     hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
     hmac                            0.13.0  6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
     home                            0.5.12  cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d \
-    http                             1.4.2  6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425 \
-    http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
-    http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
+    http                             1.5.0  918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0 \
+    http-body                        1.1.0  ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c \
+    http-body-util                   0.1.5  23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     human-time                       0.1.7  5b0a5fa999ffa7197ba6e27254a6a6f96f3f36acdd15adf60fd2a1bb707328ba \
     human-time-macros                0.1.8  a04129f85bfd960234ed3fa53212a4904881e024322e804ac5a48da239e44a09 \
     humansize                        2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
-    hybrid-array                    0.4.13  818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c \
-    hyper                           1.10.1  55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498 \
+    hybrid-array                    0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
+    hyper                           1.11.1  27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43 \
     hyper-rustls                    0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
     iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    icu_collections                  2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
-    icu_locale_core                  2.2.0  92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29 \
-    icu_normalizer                   2.2.0  c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4 \
-    icu_normalizer_data              2.2.0  da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38 \
-    icu_properties                   2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
-    icu_properties_data              2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
-    icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
+    icu_collections                  2.3.0  fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513 \
+    icu_locale_core                  2.3.0  d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb \
+    icu_normalizer                   2.3.0  12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f \
+    icu_normalizer_data              2.3.0  1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0 \
+    icu_properties                   2.3.0  7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148 \
+    icu_properties_data              2.3.0  e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa \
+    icu_provider                     2.3.1  d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
-    imagesize                       0.14.0  09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c \
-    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    imagesize                       0.15.0  65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a \
+    indexmap                        2.14.2  cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855 \
     inout                            0.2.2  4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7 \
-    ipnet                           2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
+    ipnet                           2.12.1  6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78 \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                         0.3.103  53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
+    jobserver                       0.1.35  1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3 \
+    js-sys                         0.3.105  ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e \
     kamadak-exif                     0.6.1  1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837 \
-    keccak                           0.2.0  9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa \
+    keccak                           0.2.2  d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libbz2-rs-sys                    0.2.5  34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c \
-    libc                           0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
-    libgit2-sys               0.18.5+1.9.4  005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2 \
+    libc                           0.2.189  3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2 \
+    libgit2-sys               0.18.8+1.9.7  7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50 \
     libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
     libmimalloc-sys                 0.1.49  6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9 \
-    libredox                        0.1.17  f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3 \
+    libredox                        0.1.23  8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed \
     libz-sys                        1.1.29  85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
-    litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
+    litemap                          0.8.3  47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae \
     litrs                            1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
-    lofty                           0.24.0  dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca \
-    lofty_attr                      0.12.0  458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557 \
-    log                             0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
+    lofty                           0.25.1  e0f052e8f93a76f4b2cd551c38a77d3025c7be1dc473f7acbac0ef1663c9f33b \
+    lofty_attr                      0.13.0  fdbca1b60ba7cea959ffc84ac27f3dbdbacd6dfda168c7eabbc00e48654bb9fd \
+    log                             0.4.34  f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6 \
     lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     lscolors                        0.21.0  d60e266dfb1426eb2d24792602e041131fdc0236bb7007abc0e589acafd60929 \
-    lzma-rust2                      0.16.4  ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02 \
+    lzma-rust2                      0.16.5  ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b \
     matroska                        0.30.1  5d3e606fd165c30a7f5daebca07f9707b2cdca959e0b3dd89538e3e0441b7f52 \
-    memchr                           2.8.2  88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4 \
+    memchr                           2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     mimalloc                        0.1.52  2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862 \
-    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.2.1  02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda \
+    miniz_oxide                      0.9.1  b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c \
+    mio                              1.2.3  4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8 \
     mp4parse                        0.17.0  63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570 \
     mutate_once                      0.1.2  13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af \
     nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
@@ -195,81 +195,78 @@ cargo.crates \
     phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
     phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
     pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
-    pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
+    pkg-config                      0.3.34  f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548 \
+    potential_utf                    0.1.6  d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
-    ppmd-rust                        1.4.0  efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24 \
-    ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
-    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    ppmd-rust                        1.4.1  9e9219bcb9d7aca6b2f63c83cf100cf78bcd619ac46e6ecbd0dd90869a39345d \
+    proc-macro2                    1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     quinn                          0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
-    quinn-proto                    0.11.15  4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e \
-    quinn-udp                       0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
-    quote                           1.0.46  dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
-    r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
+    quinn-proto                    0.11.17  04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83 \
+    quinn-udp                       0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
+    quote                           1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radix_trie                       0.3.0  3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a \
-    rand                             0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
-    rand                            0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
-    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
-    rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    rand                            0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_core                       0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
+    rand_pcg                        0.10.2  caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a \
     rayon                           1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     rbase64                          2.0.3  5b133fdd52a7cbb7619c86d93c8a34ea6e056462f901e08f6cbb6c9baf138b13 \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    regex                           1.12.4  f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba \
-    regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex                           1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                  0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     reqwest                        0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
+    rustc-hash                       2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                         0.23.41  6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f \
-    rustls-pki-types                1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
-    rustls-webpki                 0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
-    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    rustls                         0.23.43  0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06 \
+    rustls-pki-types                1.15.1  2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96 \
+    rustls-webpki                 0.103.15  f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2 \
+    rustversion                     1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
     rustyline                       18.0.1  53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684 \
     ryu                             1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
     scanlex                          0.1.4  088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db \
     semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
-    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    serde                          1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde_core                     1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                   1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                     1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
     serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha1                            0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha2                            0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     sha3                            0.12.0  bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759 \
     shlex                            2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
-    simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
+    simd-adler32                    0.3.10  3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea \
     siphasher                        1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
-    smallvec                        1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
-    socket2                          0.6.4  52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51 \
+    smallvec                        1.16.0  b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f \
+    socket2                          0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
     sponge-cursor                    0.1.0  3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620 \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     svg                             0.18.0  94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                            2.0.118  1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
+    syn                            2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
+    syn                              3.0.5  12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
-    thiserror                       2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
-    thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
-    time                            0.3.51  85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327 \
+    thiserror                       2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
+    thiserror-impl                  2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
+    time                            0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
     time-core                        0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
-    time-macros                     0.2.30  dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935 \
-    tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
-    tinyvec                         1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
+    time-macros                     0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
+    tinystr                          0.8.4  b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643 \
+    tinyvec                         1.13.2  4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
-    tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
-    toml                  1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    tokio                           1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
+    tokio-rustls                    0.26.5  b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67 \
+    toml                  1.1.5+spec-1.1.0  12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785 \
     toml_datetime         1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
-    toml_parser           1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
-    toml_writer           1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
+    toml_parser           1.1.3+spec-1.1.0  1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56 \
+    toml_writer           1.1.2+spec-1.1.0  7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2 \
     tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                      0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -286,8 +283,8 @@ cargo.crates \
     unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     update-informer                  1.3.0  67b27dcf766dc6ad64c2085201626e1a7955dc1983532bfc8406d552903ace2a \
-    ureq                             3.3.0  dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0 \
-    ureq-proto                       0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
+    ureq                             3.4.0  972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d \
+    ureq-proto                       0.6.1  da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613 \
     url                              2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     utf8-zero                        0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
@@ -298,15 +295,14 @@ cargo.crates \
     wana_kana                        5.0.0  377032e42ca0992cc94e7fa7ee6645a125978019a4961f933e3cf5eceb9c4ae0 \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasip2               1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
-    wasm-bindgen                   0.2.126  4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4 \
-    wasm-bindgen-futures            0.4.76  c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d \
-    wasm-bindgen-macro             0.2.126  167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1 \
-    wasm-bindgen-macro-support     0.2.126  f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e \
-    wasm-bindgen-shared            0.2.126  dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24 \
-    web-sys                        0.3.103  8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141 \
+    wasm-bindgen                   0.2.128  aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf \
+    wasm-bindgen-futures            0.4.78  6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928 \
+    wasm-bindgen-macro             0.2.128  a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed \
+    wasm-bindgen-macro-support     0.2.128  411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a \
+    wasm-bindgen-shared            0.2.128  81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e \
+    web-sys                        0.3.105  9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                     1.0.8  bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf \
+    webpki-roots                     1.0.9  7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
     windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
     windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \
     windows-interface               0.59.3  3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358 \
@@ -315,44 +311,33 @@ cargo.crates \
     windows-strings                  0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
-    windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-sys                     0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                 0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
-    windows_aarch64_gnullvm         0.53.1  a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
-    windows_aarch64_msvc            0.53.1  b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
     windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
-    windows_i686_gnu                0.53.1  960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
     windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
-    windows_i686_gnullvm            0.53.1  fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
     windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
-    windows_i686_msvc               0.53.1  1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
-    windows_x86_64_gnu              0.53.1  9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_gnullvm          0.53.1  0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    winnow                           1.0.3  0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
-    wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
-    writeable                        0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
+    winnow                           1.0.4  23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81 \
+    writeable                        0.6.4  3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc \
     xattr                            1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     yoke                             0.8.3  709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5 \
     yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
-    zerocopy                        0.8.52  ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f \
-    zerocopy-derive                 0.8.52  1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930 \
+    zerocopy                        0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
+    zerocopy-derive                 0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
     zerofrom                         0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                          1.9.0  e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e \
-    zerotrie                         0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
-    zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
-    zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
+    zerotrie                         0.2.5  4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f \
+    zerovec                         0.11.8  bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8 \
+    zerovec-derive                  0.11.6  34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da \
     zip                              8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
-    zlib-rs                          0.6.4  977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3 \
-    zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
+    zlib-rs                          0.6.7  34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12 \
+    zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
     zopfli                           0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249 \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
-    zstd-safe                        7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \
-    zstd-sys             2.0.16+zstd.1.5.7  91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748
+    zstd-safe                        7.3.0  64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882 \
+    zstd-sys              2.1.0+zstd.1.5.7  0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted with 299 warnings, built in a pristine VM.

Branch head `bff7106a0cb1`, against the ports tree as of 2026-09-05.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
