### PR TITLE
fluent-bit: update to 5.1.2

### DIFF
--- a/sysutils/fluent-bit/Portfile
+++ b/sysutils/fluent-bit/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport               1.1
 
 legacysupport.newest_darwin_requires_legacy     15
 
-github.setup        fluent fluent-bit 5.1.1 v
+github.setup        fluent fluent-bit 5.1.2 v
 github.tarball_from archive
 revision            0
 categories          sysutils
@@ -31,9 +31,9 @@ maintainers         {l2dy @l2dy} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  ccca7175fef97c651ebf6ca5e4999da5962321df \
-                    sha256  bbc05936d6981575520596f151978146beb8119c7ab720efd3e3275cc54c13b1 \
-                    size    43931451
+checksums           rmd160  ffeb0dede957afd70ba43cd59bee7824119f3fa7 \
+                    sha256  1971d86c7dc0f3e6b906890297635d6a3a84e5e7ad64d36521b74da202fda62f \
+                    size    43997491
 
 patchfiles-append   0001-macos-setup-do-not-use-clang-flag-with-gcc.patch \
                     0002-posix_file.c-add-a-missing-header.patch \

--- a/sysutils/fluent-bit/files/0003-libatomic-gcc.patch
+++ b/sysutils/fluent-bit/files/0003-libatomic-gcc.patch
@@ -7,7 +7,7 @@ diff --git CMakeLists.txt CMakeLists.txt
 index fa6393f35..eca403d27 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -67,7 +67,7 @@ endif()
+@@ -106,7 +106,7 @@ endif()
  
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FLB_FILENAME__=__FILE__")
  

--- a/sysutils/fluent-bit/files/0005-mk_scheduler-fix-for-missing-pthread_threadid_np.patch
+++ b/sysutils/fluent-bit/files/0005-mk_scheduler-fix-for-missing-pthread_threadid_np.patch
@@ -11,7 +11,7 @@ diff --git lib/monkey/mk_server/mk_scheduler.c lib/monkey/mk_server/mk_scheduler
 index a680d3cdf..2ccec3bed 100644
 --- lib/monkey/mk_server/mk_scheduler.c
 +++ lib/monkey/mk_server/mk_scheduler.c
-@@ -37,6 +37,10 @@
+@@ -38,6 +38,10 @@
  
  #include <signal.h>
  
@@ -22,7 +22,7 @@ index a680d3cdf..2ccec3bed 100644
  #ifndef _WIN32
  #include <sys/syscall.h>
  #endif
-@@ -288,7 +292,17 @@ static int mk_sched_register_thread(struct mk_server *server)
+@@ -289,7 +293,17 @@ static int mk_sched_register_thread(struct mk_server *server)
      worker->pid = syscall(__NR_gettid);
  #elif defined(__APPLE__)
      uint64_t tid;


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `b89d722ebf7d`, against the ports tree as of 2026-09-05.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
