### PR TITLE
lnav: update to 0.14.1

### DIFF
--- a/sysutils/lnav/Portfile
+++ b/sysutils/lnav/Portfile
@@ -26,16 +26,16 @@ subport ${name}-devel {}
 
 if {${name} eq ${subport}} {
     # Main Port
-    github.setup        tstack lnav 0.12.4 v
+    github.setup        tstack lnav 0.14.1 v
     github.tarball_from archive
     revision            0
 
     conflicts           lnav-devel
 
     checksums           ${distname}${extract.suffix} \
-                        rmd160  56cd862cf38839db6af05baa500972d6b589fe17 \
-                        sha256  ee6ea75cbfd736f6ad8b32212883e45a1a64e48085a14757d2cfffa90ebb8e75 \
-                        size    21550635
+                        rmd160  cf25052eede2b4c93112143acde513f725b1eac2 \
+                        sha256  9eddf42dbbbd59af423cd25f49e744969c95a3901f9aba07e48481d4c41c4c4e \
+                        size    34997196
 
     github.livecheck.regex {([0-9.]+)}
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `0ccbd20f271a`, against the ports tree as of 2026-09-05.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
