### PR TITLE
oh-my-posh: update to 31.1.3

### DIFF
--- a/sysutils/oh-my-posh/Portfile
+++ b/sysutils/oh-my-posh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/JanDeDobbeleer/oh-my-posh 31.1.2 v
+go.setup            github.com/JanDeDobbeleer/oh-my-posh 31.1.3 v
 go.offline_build    no
 go.toolchain_min    1.27.0
 revision            0
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {duck.com:ihj3s1wy @PinoTucana} \
                     openmaintainer
 
-checksums           rmd160  5edbadd9080d96877e957c80aa58267549f34c7c \
-                    sha256  fe81ce9f0d496e7b474dbf03c772a0970e78675f7cc94387fc89908be13f54a9 \
-                    size    7687914
+checksums           rmd160  a6c13c40a84cc078f52150c4154c753c09ab1085 \
+                    sha256  8899edaf6df046a0510f26219324485bd3b15517855c35c34bd7be799a98465e \
+                    size    7691087
 
 build.dir           ${worksrcpath}/src
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `f0ecfc48ec6e`, against the ports tree as of 2026-09-05.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
