### PR TITLE
xorg-server: fix dependency classifications

### DIFF
--- a/x11/xorg-server/Portfile
+++ b/x11/xorg-server/Portfile
@@ -12,6 +12,7 @@ github.tarball_from archive
 name            xorg-server
 conflicts       xorg-server-legacy xorg-server-devel xorg-server-1.18
 version         21.1.24
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -24,11 +25,11 @@ checksums       rmd160  fca793a79f312be75923721f1f92b7dd19c6c9e9 \
                 sha256  f9e5dcdc0ff52cb159c8fa97d2de8def9e5505a84552f41136cb77dd9855033c \
                 size    5445200
 
-# Yes, mesa is a *BUILD* dependency (GL headers and gl.pc for GLX)
+# xorg-libxkbfile is required at configure time but not linked
 depends_build-append \
         port:pkgconfig \
-        port:mesa \
         port:xorg-font-util \
+        port:xorg-libxkbfile \
         port:xorg-xorgproto \
         port:xorg-xtrans
 
@@ -39,17 +40,17 @@ depends_run-append \
         port:xorg-fonts \
         port:xkeyboard-config
 
+# mesa is a library dependency: Xvfb links libGL
 depends_lib-append \
         path:lib/pkgconfig/pixman-1.pc:libpixman \
+        port:mesa \
         port:xorg-libX11 \
         port:xorg-libXau \
         port:xorg-libXdmcp \
         port:xorg-libAppleWM \
         port:xorg-libXext \
         port:xorg-libXfixes \
-        port:xorg-libXfont2 \
-        port:xorg-libxkbfile \
-        port:xorg-libxshmfence
+        port:xorg-libXfont2
 
 # The chown-bundle.sh install script ignores DESTDIR, so it fails in destroot.
 # MacPorts sets ownership at activation time anyway.


### PR DESCRIPTION
Since the meson/21.1.24 update, Xvfb links libGL, so mesa must be a library dependency; as a build dependency it is absent from binary archive installs, leaving Xvfb unable to load. xorg-libxkbfile is required by meson at configure time but nothing links it, so return it to depends_build. xorg-libxshmfence is neither linked nor used with DRI3 disabled, so drop it.

Verified by inspecting otool -L output for all installed Mach-O files: only Xvfb links libGL; nothing links xkbfile or xshmfence.

Reported in
https://github.com/macports/macports-ports/pull/34063#issuecomment-5543895523

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
