### PR TITLE
lazygit: update to 0.65.0

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.64.1 v
+go.setup            github.com/jesseduffield/lazygit 0.65.0 v
 go.toolchain_min    1.25.0
 revision            0
 
@@ -16,9 +16,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  2c1d8cf619b4f9b494f7bfaba2faf159a05f1bbd \
-                    sha256  b1df6ee72f17efc0ef95fc20a64821cd9eda3935b81cb98b1719c8266163bd07 \
-                    size    4842708
+checksums           rmd160  7286e3ac47e68690a71b7ba0f0d802f5a7637722 \
+                    sha256  972151d83d8fdfa5c7c881c34349ba4a38c37b7085667696b85c443d2fca97ed \
+                    size    4900491
 
 # lazygit's dependencies are already vendored in the source code
 # Allow Go modules so that we can build vendored dependencies


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `dbfce40bca36`, against the ports tree as of 2026-09-05.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
