### PR TITLE
log4jdbc: update to 1.4

### DIFF
--- a/java/log4jdbc/Portfile
+++ b/java/log4jdbc/Portfile
@@ -1,45 +1,48 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			log4jdbc
-version			1.1
+PortSystem          1.0
 
-categories		java
-maintainers		nomaintainer
-platforms		any
-supported_archs	noarch
+name                log4jdbc
+version             1.1
 
-description		JDBC driver that can log SQL and/or JDBC calls
-long_description	Log4jdbc is a Java JDBC driver that can log SQL \
-			and/or JDBC calls (and optionally SQL timing \
-			information) for other JDBC drivers using the \
-			Simple Logging Facade For Java (SLF4J) logging \				system.
-homepage		http://log4jdbc.sourceforge.net/
+categories          java
+maintainers         nomaintainer
+platforms           any
+supported_archs     noarch
 
-master_sites		sourceforge
-use_zip			yes
-checksums		md5 50ac9cb62a9bb05d001f0a670fc043f1 \
-			sha1 c8311c87e96d90b54615428be7d11539d8900c84 \
-			rmd160 64282b67b4b87f979711495690c7b60044367716
+description         JDBC driver that can log SQL and/or JDBC calls
+long_description    Log4jdbc is a Java JDBC driver that can log SQL \
+                    and/or JDBC calls (and optionally SQL timing \
+                    information) for other JDBC drivers using the \
+                    Simple Logging Facade For Java (SLF4J) logging \
+                    system.
+homepage            http://log4jdbc.sourceforge.net/
 
-depends_lib		bin:java:kaffe \
-			port:slf4j
+master_sites        sourceforge
+use_zip             yes
+checksums           md5 50ac9cb62a9bb05d001f0a670fc043f1 \
+                    sha1 c8311c87e96d90b54615428be7d11539d8900c84 \
+                    rmd160 64282b67b4b87f979711495690c7b60044367716
 
-use_configure		no
+depends_lib         bin:java:kaffe \
+                    port:slf4j
+
+use_configure       no
 
 build {}
 
 destroot {
-	# Ensure needed directories
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc/
+    # Ensure needed directories
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc/
 
-	foreach f { 3 4 } {
-		file copy ${worksrcpath}/build/${name}${f}-${version}.jar \
-			${destroot}${prefix}/share/java/${name}${f}.jar
-	}
+    foreach f { 3 4 } {
+        file copy ${worksrcpath}/build/${name}${f}-${version}.jar \
+            ${destroot}${prefix}/share/java/${name}${f}.jar
+    }
 
-	file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
 }
 
-livecheck.type		sourceforge
-livecheck.name		${name}
+livecheck.type      sourceforge
+livecheck.name      ${name}

--- a/java/log4jdbc/Portfile
+++ b/java/log4jdbc/Portfile
@@ -1,14 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           java 1.0
 
-name                log4jdbc
-version             1.1
+github.setup        arthurblake log4jdbc 8f78a368f158a1e10b8a10b46c30d84abdaffc09
+github.tarball_from archive
+
+# Until upstream tags the version
+version             1.4
+livecheck.type      none
 
 categories          java
 maintainers         nomaintainer
 platforms           any
 supported_archs     noarch
+license             Apache-2
 
 description         JDBC driver that can log SQL and/or JDBC calls
 long_description    Log4jdbc is a Java JDBC driver that can log SQL \
@@ -16,33 +23,41 @@ long_description    Log4jdbc is a Java JDBC driver that can log SQL \
                     information) for other JDBC drivers using the \
                     Simple Logging Facade For Java (SLF4J) logging \
                     system.
-homepage            http://log4jdbc.sourceforge.net/
 
-master_sites        sourceforge
-use_zip             yes
-checksums           md5 50ac9cb62a9bb05d001f0a670fc043f1 \
-                    sha1 c8311c87e96d90b54615428be7d11539d8900c84 \
-                    rmd160 64282b67b4b87f979711495690c7b60044367716
+checksums           rmd160  aa56889e8c2f3239b5892a79e38dd6480843ccd2 \
+                    sha256  e1fb6ef8d59b1ed4ac153f9d836ea8588717b4af14bacc77f5ab00b63b9a060d \
+                    size    114150
 
-depends_lib         bin:java:kaffe \
-                    port:slf4j
+depends_build       bin:ant:apache-ant
+depends_lib         port:slf4j
+
+java.version        1.8+
+java.fallback       openjdk11
+
+pre-patch {
+    # Use installed .jar files
+    delete {*}[glob -directory ${worksrcpath}/lib *.jar]
+    ln -s ${prefix}/share/java/slf4j/slf4j-api.jar ${worksrcpath}/lib
+}
 
 use_configure       no
 
-build {}
+build.cmd           ant
+build.target        all
+build.args          -buildfile scripts/build.xml
 
 destroot {
-    # Ensure needed directories
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc/
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java
 
-    foreach f { 3 4 } {
-        file copy ${worksrcpath}/build/${name}${f}-${version}.jar \
-            ${destroot}${prefix}/share/java/${name}${f}.jar
-    }
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/build/${name}4-${version}.jar \
+        ${destjavadir}/${name}4.jar
 
-    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        {*}[glob -directory ${worksrcpath} *.md] \
+        {*}[glob -directory ${worksrcpath}/doc *] \
+        ${destdocdir}
 }
-
-livecheck.type      sourceforge
-livecheck.name      ${name}


### PR DESCRIPTION
#### Description

Update the `log4jdbc` port to version 1.4 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?