### PR TITLE
geos: update to 3.15.0

### DIFF
--- a/science/geos/Portfile
+++ b/science/geos/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.1
 # changes. If so, all dependents will need to be rev-bumped.
 
 name                geos
-version             3.14.1
+version             3.15.0
 revision            0
 categories          science math gis
 license             LGPL-2.1
@@ -26,9 +26,9 @@ master_sites        https://download.osgeo.org/geos/
 
 use_bzip2           yes
 
-checksums           rmd160  3cb6514e8e5c32e0477c037114b46fe9ba2e8fd3 \
-                    sha256  3c20919cda9a505db07b5216baa980bacdaa0702da715b43f176fb07eff7e716 \
-                    size    7013834
+checksums           rmd160  849bce8cc5f6ab4893d18dfa13ebafe76eaa9e0b \
+                    sha256  d5e5192a686d065eaed082de14dd26244c5c8e02bff16b2c6cce3265f648e00e \
+                    size    7120409
 
 compiler.cxx_standard 2017
 
@@ -38,8 +38,6 @@ compiler.cxx_standard 2017
 # Also avoid compilation errors observed for Xcode 6, 7, and 8.
 # See also https://trac.macports.org/ticket/73172
 compiler.blacklist-append {clang < 1205}
-
-use_parallel_build  yes
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description
The feedback from testers & maintainers are, that revbumping isn't necessary despite the note in the Portfile
```
# NOTE: When updating this port, check whether the dylib name and/or version
# changes. If so, all dependents will need to be rev-bumped.
```
 ```
 /opt/local/lib/libgeos.3.14.1.dylib             /opt/local/lib/libgeos.3.15.0.dylib
  /opt/local/lib/libgeos.dylib                    /opt/local/lib/libgeos.dylib
  /opt/local/lib/libgeos_c.1.20.5.dylib           /opt/local/lib/libgeos_c.1.21.0.dylib
  /opt/local/lib/libgeos_c.1.dylib                /opt/local/lib/libgeos_c.1.dylib
  /opt/local/lib/libgeos_c.dylib                  /opt/local/lib/libgeos_c.dylib

=> ~macuser/MacPorts/bin/updated revbump geos
revBUMPing Ports dependent on geos ...
              R/R-exactextractr        revision   1 ->  2
              R/R-sf                   revision   4 ->  5
              R/R-terra                revision   3 ->  4
              R/R-rgeos                revision   1 ->  2
              R/R-lwgeom               revision   0 ->  1
            gis/qgis3                  revision   0 ->  1
            gis/gdal                   revision   0 ->  1
            gis/pdal                   revision   0 ->  1
            gis/mapserver              revision   5 ->  6
            gis/imposm                 revision   0 ->  1
            gis/grass7                 revision  13 -> 14
            gis/librttopo              revision   3 ->  4
            gis/grass                  revision   2 ->  3
      databases/librasterlite2         revision   4 ->  5
      databases/postgis                revision   1 ->  2
      databases/spatialite             revision   2 ->  3
      databases/postgis2               revision   2 ->  3
      databases/spatialite-tools       revision   1 ->  2
         python/py-pygeos              revision   0 ->  1
         python/py-matplotlib-basemap  revision   0 ->  1
         python/py-spatialite          revision   8 ->  9
         python/py-shapely             revision   0 ->  1
       textproc/zorba                  revision  18 -> 19
```
###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560
```

