### PR TITLE
skalibs, execline, s6: update; add s6-rc 0.7.0.0

### DIFF
--- a/devel/skalibs/Portfile
+++ b/devel/skalibs/Portfile
@@ -10,7 +10,7 @@ version             2.15.1.0
 revision            0
 categories          devel
 license             ISC
-maintainers         nomaintainer
+maintainers         @bjornpagen openmaintainer
 description         general-purpose libraries for C system programming
 
 long_description \

--- a/devel/skalibs/Portfile
+++ b/devel/skalibs/Portfile
@@ -6,8 +6,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy     13
 
 name                skalibs
-version             2.15.0.0
-revision            2
+version             2.15.1.0
+revision            0
 categories          devel
 license             ISC
 maintainers         nomaintainer
@@ -25,12 +25,29 @@ long_description \
 homepage            https://skarnet.org/software/skalibs/
 master_sites        ${homepage}
 
-checksums           rmd160  a8b4e44e2c3680551b1884b2613c6b55967d3cf8 \
-                    sha256  7fde96e8afb4191593a15328883e9c7726c96891cf071222146821e8c87f8007 \
-                    size    267454
+checksums           rmd160  f59b3fefa2ab3b85bac5c9cd4bc99974a9d7b664 \
+                    sha256  f9c905e74935c6fe911c7e344e3e89d5fbd2014c1a04650b524b15ce9b5635d1 \
+                    size    268075
 
 depends_build-append \
                     port:pkgconfig
+
+platform darwin {
+    # The Apple select backend and timeval representation predate Tahoe.
+    # These are source-level corrections, not new macOS API workarounds.
+    patchfiles-append \
+                    patch-iopause-select-read-event.diff \
+                    patch-timeval-rounding.diff
+
+    # The standard spawn chdir actions were introduced in macOS 26. A newer
+    # SDK can otherwise make link-only probes accept them for an older target.
+    # Use the deployment target, not the build host's Darwin major version.
+    # With older SDKs the unavailable declarations are absent anyway; tryflag
+    # also preserves compatibility with compilers lacking this diagnostic.
+    if {[vercmp ${macosx_deployment_target} 26.0] < 0} {
+        patchfiles-append patch-configure-availability.diff
+    }
+}
 
 # Keep the kernel point release out of the recorded target; --build must match
 # --target or configure cross-compiles. https://trac.macports.org/ticket/74350

--- a/devel/skalibs/files/patch-configure-availability.diff
+++ b/devel/skalibs/files/patch-configure-availability.diff
@@ -1,0 +1,28 @@
+MacPorts downstream patch; not submitted to or accepted by Skarnet.
+External tests and results:
+https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48
+
+Reject sysdep probes that use APIs newer than the deployment target.
+A newer Apple SDK may weak-link a function absent on the running/target OS.
+A link-only probe then incorrectly enables it, and consumers can call a null
+symbol. Promote Clang's availability diagnostic to an error, using the
+existing tryflag mechanism to omit the flag if the compiler rejects it.
+The Portfile limits this patch to Darwin deployment targets before macOS 26,
+where the standard spawn directory actions are unavailable. The probe still
+decides each capability; no sysdep value is forced. Builds targeting macOS 26
+or later keep the unmodified configure script.
+
+Applies to skalibs 2.15.1.0. Regression: configure on macOS 15 with SDK 26
+must reject posixspawnchdir and detect the available posixspawnchdirnp.
+test-cspawn.c exercises both directory-change actions at runtime.
+
+--- configure.orig
++++ configure
+@@ -631,6 +631,7 @@
+ tryflag CPPFLAGS_AUTO -Werror=pointer-sign
+ tryflag CPPFLAGS_AUTO -Werror=pointer-arith
+ tryflag CPPFLAGS_AUTO -Werror=incompatible-pointer-types
++tryflag CPPFLAGS_AUTO -Werror=unguarded-availability
+ tryflag CPPFLAGS_AUTO -Wno-unused-value
+ tryflag CPPFLAGS_AUTO -Wno-parentheses
+ tryflag CFLAGS_AUTO -ffunction-sections

--- a/devel/skalibs/files/patch-iopause-select-read-event.diff
+++ b/devel/skalibs/files/patch-iopause-select-read-event.diff
@@ -1,0 +1,24 @@
+MacPorts downstream patch; not submitted to or accepted by Skarnet.
+External tests and results:
+https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48
+
+Return POLLIN for select() read readiness, not the composite request mask.
+IOPAUSE_READ includes POLLHUP; copying it into revents invents a hangup and
+causes s6-svscan to take its crash path on normal self-pipe traffic. select()
+cannot distinguish readable data from EOF, so report POLLIN and let the caller
+attempt a read. The Apple select-backend selection and this output assignment
+are also present in 2.15.0.0; this is not a Tahoe-specific libc change.
+
+Applies to skalibs 2.15.1.0. Regression: test-iopause.c.
+
+--- src/libstddjb/iopause_select.c.orig
++++ src/libstddjb/iopause_select.c
+@@ -57,7 +57,7 @@
+   if (r > 0)
+     for (unsigned int i = 0 ; i < len ; i++) if (x[i].fd >= 0)
+     {
+-      if (FD_ISSET(x[i].fd, &rfds)) x[i].revents |= IOPAUSE_READ ;
++      if (FD_ISSET(x[i].fd, &rfds)) x[i].revents |= POLLIN ;
+       if (FD_ISSET(x[i].fd, &wfds)) x[i].revents |= IOPAUSE_WRITE ;
+       if (FD_ISSET(x[i].fd, &xfds)) x[i].revents |= IOPAUSE_EXCEPT | x[i].events ;
+     }

--- a/devel/skalibs/files/patch-timeval-rounding.diff
+++ b/devel/skalibs/files/patch-timeval-rounding.diff
@@ -1,0 +1,91 @@
+MacPorts downstream patch; not submitted to or accepted by Skarnet.
+External tests and results:
+https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48
+
+Normalize nanosecond rounding before converting to a timeval.
+Rounding 999999500..999999999 ns used to produce an invalid tv_usec of
+1000000. Use the existing unsigned tain arithmetic to carry into seconds,
+then convert. Detect a carry across time_t's upper bound without signed
+overflow. Preserve nearest-microsecond rounding and negative-to-zero carries.
+
+The same conversion code is present in 2.15.0.0. Darwin's rejection of
+tv_usec >= 1000000 is present in both the Catalina and Tahoe XNU sources;
+there is no newer-macOS-only boundary for this correction.
+
+Applies to skalibs 2.15.1.0. Regressions: test-timeval.c and test-iopause.c.
+
+--- src/libstddjb/timeval_from_tain_relative.c.orig
++++ src/libstddjb/timeval_from_tain_relative.c
+@@ -1,11 +1,20 @@
+ /* ISC license. */
+ 
+ #include <sys/time.h>
++#include <errno.h>
+ #include <skalibs/tai.h>
+ 
+ int timeval_from_tain_relative (struct timeval *tv, tain const *t)
+ {
+-  if (!time_from_tai_relative(&tv->tv_sec, &t->sec)) return 0 ;
+-  tv->tv_usec = (t->nano + 500) / 1000 ;
++  tain rounded ;
++  tain_add(&rounded, t, &tain_nano500) ;
++  if (!time_from_tai_relative(&tv->tv_sec, &rounded.sec)) return 0 ;
++  if (rounded.sec.x != t->sec.x)
++  {
++    time_t before ;
++    if (!time_from_tai_relative(&before, &t->sec)) return 0 ;
++    if (tv->tv_sec < before) return (errno = EOVERFLOW, 0) ;
++  }
++  tv->tv_usec = rounded.nano / 1000 ;
+   return 1 ;
+ }
+--- src/libstddjb/timeval_from_tain.c.orig
++++ src/libstddjb/timeval_from_tain.c
+@@ -1,11 +1,20 @@
+ /* ISC license. */
+ 
+ #include <sys/time.h>
++#include <errno.h>
+ #include <skalibs/tai.h>
+ 
+ int timeval_from_tain (struct timeval *tv, tain const *t)
+ {
+-  if (!time_from_tai(&tv->tv_sec, &t->sec)) return 0 ;
+-  tv->tv_usec = (t->nano + 500) / 1000 ;
++  tain rounded ;
++  tain_add(&rounded, t, &tain_nano500) ;
++  if (!time_from_tai(&tv->tv_sec, &rounded.sec)) return 0 ;
++  if (rounded.sec.x != t->sec.x)
++  {
++    time_t before ;
++    if (!time_from_tai(&before, &t->sec)) return 0 ;
++    if (tv->tv_sec < before) return (errno = EOVERFLOW, 0) ;
++  }
++  tv->tv_usec = rounded.nano / 1000 ;
+   return 1 ;
+ }
+--- src/libstddjb/timeval_sysclock_from_tain.c.orig
++++ src/libstddjb/timeval_sysclock_from_tain.c
+@@ -1,11 +1,20 @@
+ /* ISC license. */
+ 
+ #include <sys/time.h>
++#include <errno.h>
+ #include <skalibs/tai.h>
+ 
+ int timeval_sysclock_from_tain (struct timeval *tv, tain const *t)
+ {
+-  if (!time_sysclock_from_tai(&tv->tv_sec, &t->sec)) return 0 ;
+-  tv->tv_usec = (t->nano + 500) / 1000 ;
++  tain rounded ;
++  tain_add(&rounded, t, &tain_nano500) ;
++  if (!time_sysclock_from_tai(&tv->tv_sec, &rounded.sec)) return 0 ;
++  if (rounded.sec.x != t->sec.x)
++  {
++    time_t before ;
++    if (!time_sysclock_from_tai(&before, &t->sec)) return 0 ;
++    if (tv->tv_sec < before) return (errno = EOVERFLOW, 0) ;
++  }
++  tv->tv_usec = rounded.nano / 1000 ;
+   return 1 ;
+ }

--- a/lang/execline/Portfile
+++ b/lang/execline/Portfile
@@ -7,8 +7,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 name                execline
-version             2.9.9.1
-revision            1
+version             2.9.9.2
+revision            0
 categories          lang
 license             ISC
 maintainers         nomaintainer
@@ -29,9 +29,9 @@ master_sites        ${homepage}
 
 depends_build       port:skalibs
 
-checksums           rmd160  609ecff9bb3726a9f0f3ba63c1e8270c4cb4b079 \
-                    sha256  be63533297a93c36fd267195117b4e668687a526f834517a8db47d85b6c7ec6a \
-                    size    119481
+checksums           rmd160  78c88b08e33a70a49a48ae2bf1ca3776f718ccde \
+                    sha256  908ed4db3a6b3a23a205d8fd4cf2a71089156f2aeae0f54656045aafad2dee32 \
+                    size    119488
 
 depends_build-append \
                     port:pkgconfig
@@ -45,6 +45,18 @@ configure.args-append \
                     --target=${build_arch}-apple-darwin${os.major}
 
 post-destroot {
+    if {${os.platform} eq "darwin"} {
+        # Darwin checks read permission on the link itself for readlink().
+        # This predates Tahoe; match skalibs' existing library-link treatment.
+        # The upstream installer creates these command links with umask 077.
+        foreach linkname {cd umask} {
+            set command_link ${destroot}${prefix}/bin/${linkname}
+            set command_target [file readlink ${command_link}]
+            file delete ${command_link}
+            file link -symbolic ${command_link} ${command_target}
+        }
+    }
+
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} \

--- a/lang/execline/Portfile
+++ b/lang/execline/Portfile
@@ -11,7 +11,7 @@ version             2.9.9.2
 revision            0
 categories          lang
 license             ISC
-maintainers         nomaintainer
+maintainers         @bjornpagen openmaintainer
 description         non-interactive scripting language
 
 long_description \

--- a/sysutils/s6-rc/Portfile
+++ b/sysutils/s6-rc/Portfile
@@ -11,7 +11,7 @@ version             0.7.0.0
 revision            0
 categories          sysutils
 license             ISC
-maintainers         nomaintainer
+maintainers         @bjornpagen openmaintainer
 description         dependency-based service manager for s6
 
 long_description    s6-rc compiles service definitions and starts or stops \

--- a/sysutils/s6-rc/Portfile
+++ b/sysutils/s6-rc/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime, through the statically linked Skarnet libraries.
+legacysupport.newest_darwin_requires_legacy 15
+
+name                s6-rc
+version             0.7.0.0
+revision            0
+categories          sysutils
+license             ISC
+maintainers         nomaintainer
+description         dependency-based service manager for s6
+
+long_description    s6-rc compiles service definitions and starts or stops \
+                    supervised daemons and one-shot tasks in dependency \
+                    order. It also supports live service database updates.
+
+homepage            https://skarnet.org/software/s6-rc/
+master_sites        ${homepage}
+
+checksums           rmd160  89aeab44e94a1068ca6f89b36adda06e492d7cbb \
+                    sha256  bf5b8ce0da5a4ee70d642b818b61d9916a7a9b64a457595f388113e54a188688 \
+                    size    157152
+
+depends_build-append \
+                    port:execline \
+                    port:pkgconfig \
+                    port:s6 \
+                    port:skalibs
+
+depends_run         port:execline port:s6
+
+platform darwin {
+    # This fixes an updater/scanner ordering race, not a versioned OS API.
+    # There is no known Darwin release boundary for the affected sequence.
+    patchfiles-append \
+                    patch-update-rollback-directory.diff \
+                    patch-update-supervisor-retirement.diff
+}
+
+# Match the normalized target recorded by skalibs.
+# https://trac.macports.org/ticket/74350
+configure.args-append \
+                    --enable-pkgconfig \
+                    --with-pkgconfig \
+                    --build=${build_arch}-apple-darwin${os.major} \
+                    --target=${build_arch}-apple-darwin${os.major} \
+                    --livedir=${prefix}/var/run/s6-rc \
+                    --repodir=${prefix}/var/lib/s6-rc/repository
+
+# Install tools and documentation, not a database or service instance.
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        AUTHORS \
+        COPYING \
+        INSTALL \
+        NEWS \
+        README \
+        ${destroot}${docdir}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*.html] \
+        ${destroot}${docdir}
+}
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     "${name}-(\[0-9.\]+)\\.tar\\.gz"

--- a/sysutils/s6-rc/files/patch-update-rollback-directory.diff
+++ b/sysutils/s6-rc/files/patch-update-rollback-directory.diff
@@ -1,0 +1,28 @@
+Remove the candidate live directory, not the active one, on rollback.
+
+make_new_livedir stores the old live path at offset 0 and the new candidate
+path at offset pos in sa. After restoring preserved service directories,
+rollback must remove the candidate at pos. Removing offset 0 deletes the
+still-active old directory and leaves the live symlink dangling.
+
+Fault injection at atomic_symlink4 reproduces the failure before the database
+switch. With this correction the original live target and service PID survive,
+and a subsequent normal update succeeds. This is a source-level path-selection
+error, not a versioned OS API; the Portfile limits the correction to Darwin.
+
+MacPorts downstream patch; not submitted to or accepted by Skarnet.
+External tests and results:
+https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48
+Regression evidence is maintained separately from the MacPorts ports tree.
+
+--- src/s6-rc/s6-rc-update.c.orig
++++ src/s6-rc/s6-rc-update.c
+@@ -391,7 +391,7 @@
+     sa->len = newlen ;
+     sa->s[sa->len++] = 0 ;
+     rollback_servicedirs(sa->s + pos, newstate, invimage, olddb, newdb, i) ;
+-    rm_rf_in_tmp(sa, 0) ;
++    rm_rf_in_tmp(sa, pos) ;
+     errno = e ;
+   }
+   strerr_diefu2sys(111, "make new live directory in ", sa->s) ;

--- a/sysutils/s6-rc/files/patch-update-supervisor-retirement.diff
+++ b/sysutils/s6-rc/files/patch-update-supervisor-retirement.diff
@@ -1,0 +1,89 @@
+Retire obsolete supervisors after linking the replacement service directories,
+before updating fdholder storage, using the existing "an" scanner command.
+
+Sending "xd" before the rescan allows s6-svscan to reap an old supervisor
+while it is still marked active and respawn it through an unlinked scan entry.
+This produces spurious "unable to chdir" failures during live updates.
+Keep the old idle supervisors alive until the scanner identifies them as
+inactive. No sleeps, retries, signal masking, or warning suppression are added.
+Request the rescan/prune immediately after successful servicedir management:
+a later fdholder failure or timeout must not bypass supervisor retirement.
+Do not prune on a management failure: its rollback may have removed new links,
+and pruning then could stop preserved services. Interrupted updates still
+require recovery; this is not a transaction or a retirement acknowledgement.
+The ordering is in s6-rc/s6 itself, rather than a versioned Darwin API. The
+Portfile limits this downstream correction to Darwin; no OS-release-specific
+boundary is claimed.
+
+MacPorts downstream patch; not submitted to or accepted by Skarnet.
+External tests and results:
+https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48
+Regression evidence is maintained separately from the MacPorts ports tree.
+
+--- src/s6-rc/s6-rc-update.c.orig
++++ src/s6-rc/s6-rc-update.c
+@@ -308,7 +308,7 @@
+   }
+ }
+ 
+-static inline void make_new_livedir (unsigned char const *oldstate, s6rc_db_t const *olddb, unsigned char const *newstate, s6rc_db_t const *newdb, char const *newcompiled, unsigned int *invimage, char const *prefix, stralloc *sa)
++static inline void make_new_livedir (s6rc_db_t const *olddb, unsigned char const *newstate, s6rc_db_t const *newdb, char const *newcompiled, unsigned int *invimage, char const *prefix, stralloc *sa)
+ {
+   size_t dirlen, pos, newlen, sdlen ;
+   size_t newclen = strlen(newcompiled) ;
+@@ -377,10 +377,12 @@
+   if (!atomic_symlink4(sa->s + dirlen, live, 0, 0)) goto rollback ;
+   if (verbosity >= 2) strerr_warni1x("successfully switched to new database") ;
+ 
+- /* scandir cleanup, then old livedir cleanup */
++ /* Unlink only: exiting supervisors here would let s6-svscan restart them
++    before it rescans. After linking the new servicedirs, request "an"
++    so the scanner rescans before stopping inactive supervisors. */
+   i = olddb->nlong ;
+   while (i--)
+-    s6rc_servicedir_unsupervise(sa->s, prefix, olddb->string + olddb->services[i].name, (oldstate[i] & 33) == 1) ;
++    s6rc_servicedir_unsupervise(sa->s, prefix, olddb->string + olddb->services[i].name, 1) ;
+   rm_rf_in_tmp(sa, 0) ;
+   sa->len = 0 ;
+   return ;
+@@ -786,7 +788,7 @@
+         if (verbosity >= 2)
+           strerr_warni1x("updating state and service directories") ;
+ 
+-        make_new_livedir(oldstate, &olddb, newstate, &newdb, argv[0], invimage, prefix, &sa) ;
++        make_new_livedir(&olddb, newstate, &newdb, argv[0], invimage, prefix, &sa) ;
+         stralloc_free(&sa) ;
+         if (s6rc_servicedir_manage_g(live, prefix, &deadline) < 0)
+         {
+@@ -795,14 +797,9 @@
+            strerr_diefu2sys(111, "manage new service directories in ", live) ;
+         }
+ 
+-       /* Adjust stored pipes */
+-
+-        if (verbosity >= 2)
+-          strerr_warni1x("updating s6rc-fdholder pipe storage") ;
+-
+-        update_fdholder(&olddb, oldstate, &newdb, newstate, invimage, envp, &deadline) ;
+-
+-       /* Clean up scandir */
++       /* Retire obsolete supervisors before a possible fdholder failure.
++          "a" delays "n" until a successful scan; preserved servicedirs
++          have been relinked, so their supervisors remain active. */
+ 
+         if (verbosity >= 2)
+           strerr_warni1x("cleaning up scan directory") ;
+@@ -815,6 +812,13 @@
+           if (s6_svc_writectl(scdir, S6_SVSCAN_CTLDIR, "an", 2) <= 0)
+             strerr_warnwu2sys("send command to s6-svscan on ", scdir) ;
+         }
++
++       /* Adjust stored pipes */
++
++        if (verbosity >= 2)
++          strerr_warni1x("updating s6rc-fdholder pipe storage") ;
++
++        update_fdholder(&olddb, oldstate, &newdb, newstate, invimage, envp, &deadline) ;
+       }
+ 
+ 

--- a/sysutils/s6/Portfile
+++ b/sysutils/s6/Portfile
@@ -11,7 +11,7 @@ version             2.15.1.0
 revision            0
 categories          sysutils
 license             ISC
-maintainers         nomaintainer
+maintainers         @bjornpagen openmaintainer
 description         toolbox for low-level process and service administration
 
 long_description \

--- a/sysutils/s6/Portfile
+++ b/sysutils/s6/Portfile
@@ -7,8 +7,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 name                s6
-version             2.15.0.0
-revision            2
+version             2.15.1.0
+revision            0
 categories          sysutils
 license             ISC
 maintainers         nomaintainer
@@ -34,9 +34,15 @@ depends_build-append \
 
 depends_run         port:execline
 
-checksums           rmd160  0c5633be159049cc473da63898e817717baaab3c \
-                    sha256  27dff73d626285540133e075e75887087f5117fd51de59503ef7d29e96f69e4c \
-                    size    276915
+platform darwin {
+    # fd_lock uses POSIX record locks: closing the old descriptor drops the
+    # lock even if a duplicate remains. This is not a recent macOS change.
+    patchfiles-append patch-setlock-descriptor.diff
+}
+
+checksums           rmd160  280ad6295c9159db87c64b92f60f94f1d0f2d8fb \
+                    sha256  eab9c46e22b66b16135f9a05ec68a0ea287d9060b84d10defaaa2caad158ab52 \
+                    size    281188
 
 # Keep the kernel point release out of the recorded target; --build must match
 # --target or configure cross-compiles. https://trac.macports.org/ticket/74350

--- a/sysutils/s6/files/patch-setlock-descriptor.diff
+++ b/sysutils/s6/files/patch-setlock-descriptor.diff
@@ -1,0 +1,38 @@
+Move the requested descriptor before acquiring the POSIX record lock.
+
+fd_move() closes the original descriptor after dup2(). Closing any descriptor
+for the same file releases this process's POSIX record locks, even when a
+duplicate remains open. Acquire the lock on the final descriptor instead.
+The default descriptor, shared/exclusive, and timeout semantics are unchanged.
+The affected s6-setlock code is identical in 2.15.0.0 and 2.15.1.0. POSIX lock
+release on close also appears in both Catalina and Tahoe XNU sources, so this
+is not conditional on a newly introduced macOS API or kernel behavior.
+
+MacPorts downstream patch; not submitted to or accepted by Skarnet.
+External tests and results:
+https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48
+
+--- src/daemontools-extras/s6-setlock.c.orig
++++ src/daemontools-extras/s6-setlock.c
+@@ -77,6 +77,13 @@
+     }
+   }
+ 
++  if (dest >= 0)
++  {
++    if (fd_move(dest, fd) == -1)
++      strerr_diefu1sys(111, "move lock descriptor") ;
++    fd = dest ;
++  }
++
+   if (timeout)
+   {
+     tain tto ;
+@@ -94,7 +101,5 @@
+   if (!r) errno = EBUSY ;
+   if (r < 1) strerr_diefu2sys(1, "lock ", file) ;
+ 
+-  if (dest >= 0 && fd_move(dest, fd) == -1)
+-    strerr_diefu1sys(111, "move lock descriptor") ;
+   xexec(argv+1) ;
+ }


### PR DESCRIPTION
#### Description

Update skalibs, execline, and s6; add s6-rc, retaining all proposed runtime
corrections. Four per-port commits are followed by a separate maintainer-only
commit proposing `@bjornpagen openmaintainer` for all four ports.

| Port | Previous | Proposed |
| --- | --- | --- |
| skalibs | 2.15.0.0_2 | 2.15.1.0_0 |
| execline | 2.9.9.1_1 | 2.9.9.2_0 |
| s6 | 2.15.0.0_2 | 2.15.1.0_0 |
| s6-rc | not packaged | 0.7.0.0_0 |

This submission is **AI-assisted, including the source patches and tests**.
The patches are explicitly identified as MacPorts downstream changes, not
upstream submissions or accepted upstream backports.

##### Response to review: tests and upstreaming

The standalone C tests, live-update driver, associated test phases, and
test-only dependency have been removed from the proposed ports tree and its
rewritten commit series. They remain reviewable, with before/after logs and
reproduction instructions, at this [immutable evidence commit](https://github.com/bjornpagen/macports-ports/tree/c8f3c8b0da1998378636d1d363823d0cabea2b48).

I cannot submit these LLM-generated changes upstream consistently with Skarnet's
published contribution policy. The policies for
[skalibs](https://github.com/skarnet/skalibs/blob/main/CONTRIBUTING),
[s6](https://github.com/skarnet/s6/blob/main/CONTRIBUTING), and
[s6-rc](https://github.com/skarnet/s6-rc/blob/main/CONTRIBUTING) explicitly reject
LLM-generated contributions and prohibit attempts to bypass that restriction.
No upstream PRs have been opened, and I will not obscure their provenance.

The [MacPorts Guide, section 4.6.2](https://guide.macports.org/#development.patches.source)
says necessary or useful source patches should **generally** be sent to the
application developer and documents carrying separate logical source patches
in `files/`. I am asking for explicit acceptance of these as maintained
downstream corrections in this circumstance—not asserting that the Guide
requires an exception or that maintainer status overrides review.

I volunteer to maintain all four ports and the downstream corrections: handle
tickets and reviews, rebase and rerun regressions for updates, and retire patches
when released upstream code resolves the defects. The
[maintainer policy, section 7.3.3](https://guide.macports.org/#project.contributing)
welcomes volunteers for unmaintained ports, does not require commit access,
and asks that maintainer changes be separate from functional changes. The
[maintainers keyword](https://guide.macports.org/#reference.keywords.maintainers)
supports the proposed GitHub handle and `openmaintainer` arrangement.

##### Corrections and evidence

- **skalibs/select:** return `POLLIN` for read readiness rather than the request
  mask `IOPAUSE_READ`, which includes `POLLHUP`. The original reports `0x11` for
  ordinary pipe data; the correction reports `0x1`. A false hangup can send
  s6-svscan into its crash path.
- **skalibs/timeval:** normalize nearest-microsecond rounding before converting
  seconds. The original produces invalid `tv_usec = 1000000` at the carry
  boundary. Tests cover all three converters, negative/zero/positive seconds,
  rounding boundaries, and relative signed-time overflow.
- **skalibs/availability:** use the existing compiler-flag probe mechanism to
  reject APIs newer than the deployment target. SDK 26 can otherwise enable
  unavailable standard spawn directory actions for macOS 15. The negative
  runtime exits 139; corrected chdir/fchdir actions pass using available `_np`
  functions. The patch is selected only for Darwin targets **below macOS 26**.
- **execline links:** recreate only the staged `cd` and `umask` symlinks with
  native Tcl operations, preserving their relative targets. This corrects the
  installer-created 0700 links to 0755, following the existing skalibs treatment.
- **s6-setlock:** move the selected descriptor before taking its POSIX lock.
  Closing the original after locking releases the process-owned lock even if a
  duplicate remains. With corrected dependencies, original s6-setlock fails all
  four fd 9 shared/exclusive and timed/blocking acquisition cases; the correction
  passes all 12 default/fd 3/fd 9 cases, including competing timeout and release.
- **s6-rc supervisor retirement:** unlink obsolete scan entries without sending
  `xd` to their supervisors. Once replacement management succeeds, request the
  scanner's ordered rescan/prune **before fdholder adjustment**, so its failure,
  timeout, or cancellation cannot skip the request. The scanner defers retirement
  until a successful scan marks obsolete directories inactive. Pristine code
  logs 14 missing-directory restart errors in the 30-update regression; corrected
  native and x86_64 runs each pass 100 updates plus service-state transitions
  with empty supervision logs.
- **s6-rc rollback:** additional failure testing found that rollback removes
  the old active live directory at offset 0 rather than the failed candidate at
  `pos`. A separate one-line patch corrects the cleanup target. Injected failure
  before the symlink switch now preserves the old target and running PID, and a
  subsequent normal update succeeds. The prior patch fails this test.

The updater has five passing injected failure/recovery cases on arm64 and
x86_64: pre-switch failure, pre-management failure, fdholder restart-spawn
failure, fdholder timeout, and cancellation at fdholder entry. Fault injection
exists only in external test builds. Production patches add no sleeps, retries,
signal masking, test hooks, or warning suppression. An interrupted update is
still not a transaction; a control write is not a retirement acknowledgement,
and not every partial failure or interruption point is covered.

The patches are Darwin-only. Apart from the explicitly deployment-gated
availability probe, these are source-level defects, not new Tahoe APIs.
The select/timeval/setlock defects are already present in the previously
packaged source; no newer-only Darwin boundary has been established.

##### Packaging scope and history

Preserve existing normalized build/target tuples, legacy support, and linking
choices. Retain s6's optional StartupItem and empty scandir without enabling
them. s6-rc creates no database, repository, service definitions, StartupItem,
account, or running service. No personal configuration or mount setup is shipped.

- Preserve the resolved coordinated tuple correction from [ticket 74350](https://trac.macports.org/ticket/74350).
- Preserve the optional startup integration discussed in [PR 12382](https://github.com/macports/macports-ports/pull/12382).
- Follow the [accepted skalibs symlink-permission treatment](https://github.com/macports/macports-ports/commit/7e20704c884a42335270e265a0bb8f5afb95c90b).

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Testing and limitations

macOS 15.7.7 (24G720), arm64, Xcode 26.3, MacPorts 2.12.6. The normal MacPorts
builds select the installed macOS 15 SDK; the separate availability reproduction
uses SDK 26. Testing is in an **unprivileged disposable prefix**, with its own
registry, two build jobs, and StartupItem installation/autostart disabled.
No host live MacPorts installation or services were changed.

All four final Portfiles lint with zero errors/warnings and build/stage with
`+universal` (arm64/x86_64). Fresh build-tree regressions pass for skalibs and s6;
the staged updater passes the live-update suite. x86_64 regressions execute under
Rosetta with extracted x86_64 s6-rc/core-supervision tools. The evidence identifies
earlier SDK configure and source-level sanitizer logs separately from new runs.

Earlier native and universal isolated installs are recorded in the prior PR
revision; this revision newly rebuilds/stages all four ports and tests the changed
updater, rather than claiming a fresh privileged install. Native Intel hardware,
older macOS/Tahoe runtime, root-owned activation, trace mode, all utility binaries,
and cross-host universal sysdeps reuse remain untested locally. CI/reviewer
approval is still required; local results do not imply green MacPorts CI.

###### Verification

- [x] Logical per-port commits; maintainer-only change separate.
- [x] Source patches separated by logical correction.
- [x] No standalone test source or custom test phase in the proposed ports tree.
- [x] All four Portfiles pass `port lint --nitpick`.
- [x] Revised universal source builds and staging complete.
- [x] Targeted native and x86_64 regressions, negative controls, and failure/recovery tests.
- [x] Relevant existing history and downstream-maintenance rationale linked.
- [ ] Basic functionality of every binary (targeted coverage only).
- [ ] Privileged trace-mode install.
- [ ] MacPorts CI/reviewer approval.
