### PR TITLE
libheif: Update to 1.23.4

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -31,12 +31,12 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libc++"} {
 }
 
 if {${which_version} eq "latest"} {
-    github.setup            strukturag libheif 1.23.3 v
+    github.setup            strukturag libheif 1.23.4 v
     revision                0
 
-    checksums               rmd160  87158d772ce478fab759270539630ce0da94ec47 \
-                            sha256  11c1179e0e4bec33624b87f22ec42c1e993a40d946d44d26f9c431cf1456a863 \
-                            size    2178756
+    checksums               rmd160  e3db18abdadb56888bc1a8402aca557aa7c7fc0d \
+                            sha256  d0c02b4b0e978f34a1974b6f3eea7975a537bf7a9195ffeea38e7242ff316fdd \
+                            size    2217221
 
     compiler.cxx_standard   2020
 } else {


### PR DESCRIPTION
#### Description

* Update libheif 1.23.3 --> 1.23.4.
* Security fixes indicated in release notes:
* https://github.com/strukturag/libheif/releases/tag/v1.23.4
* ABI compatible.  No dependent rev bumps.

###### Type(s)

- [x] security fix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?