### PR TITLE
objectweb-asm: update to 9.10.1

### DIFF
--- a/java/objectweb-asm/Portfile
+++ b/java/objectweb-asm/Portfile
@@ -1,49 +1,51 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			objectweb-asm
-version			2.1
-categories		java devel
-platforms		darwin
-maintainers		nomaintainer
-description		Java bytecode manipulation framework.
-long_description	ASM is a Java bytecode manipulation framework. It \
-			offers similar functionalities as BCEL or SERP, but \
-			is much smaller and faster than these tools.
+PortSystem              1.0
 
-set project		asm
-set realname		${project}
+name                    objectweb-asm
+version                 2.1
+categories              java devel
+platforms               darwin
+maintainers             nomaintainer
+description             Java bytecode manipulation framework.
+long_description        ASM is a Java bytecode manipulation framework. It \
+                        offers similar functionalities as BCEL or SERP, but \
+                        is much smaller and faster than these tools.
 
-homepage		http://asm.objectweb.org/
-master_sites		http://download.us.forge.objectweb.org/${project} \
-			http://download.forge.objectweb.org/${project} \
-			http://download.fr2.forge.objectweb.org/${project}
-distname		${realname}-${version}
-checksums		md5 dfd62160a88f13e236f9da7d2485c9ec
+set project             asm
+set realname            ${project}
 
-depends_build		port:objectweb-anttasks \
-			bin:ant:apache-ant
+homepage                http://asm.objectweb.org/
+master_sites            http://download.us.forge.objectweb.org/${project} \
+                        http://download.forge.objectweb.org/${project} \
+                        http://download.fr2.forge.objectweb.org/${project}
+distname                ${realname}-${version}
+checksums               md5 dfd62160a88f13e236f9da7d2485c9ec
 
-worksrcdir		${realname}-${version}
+depends_build           port:objectweb-anttasks \
+                        bin:ant:apache-ant
 
-use_configure		no
+worksrcdir              ${realname}-${version}
+
+use_configure           no
 
 pre-build {
-	  reinplace s|^.*objectweb.ant.tasks.path.*ow_util_ant_tasks.jar|objectweb.ant.tasks.path\ ${prefix}/share/java/objectweb-anttasks.jar| ${worksrcpath}/build.properties
+    reinplace s|^.*objectweb.ant.tasks.path.*ow_util_ant_tasks.jar|objectweb.ant.tasks.path\ ${prefix}/share/java/objectweb-anttasks.jar| ${worksrcpath}/build.properties
 }
 
-build.cmd		ant
-build.target		jar jdoc
-build.env		CLASSPATH=${prefix}/share/java/objectweb-anttasks.jar
+build.cmd               ant
+build.target            jar jdoc
+build.env               CLASSPATH=${prefix}/share/java/objectweb-anttasks.jar
 
 variant debug {
-	build.args-append		-debug
+    build.args-append   -debug
 }
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/output/dist/lib/asm-${version}.jar \
-		${destroot}${prefix}/share/java/${name}.jar
-	file copy ${worksrcpath}/output/dist/doc/javadoc/user \
-		${destroot}${prefix}/share/doc/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/output/dist/lib/asm-${version}.jar \
+        ${destroot}${prefix}/share/java/${name}.jar
+    file copy ${worksrcpath}/output/dist/doc/javadoc/user \
+        ${destroot}${prefix}/share/doc/${name}
 }

--- a/java/objectweb-asm/Portfile
+++ b/java/objectweb-asm/Portfile
@@ -1,51 +1,71 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               gitlab 1.0
+PortGroup               java 1.0
 
 name                    objectweb-asm
-version                 2.1
+gitlab.instance         https://gitlab.ow2.org
+gitlab.setup            asm asm 9.10.1 ASM_
+livecheck.version       [string map {. _} ${version}]
+git.branch              [join ${gitlab.tag_prefix}]${livecheck.version}[join ${gitlab.tag_suffix}]
+
 categories              java devel
-platforms               darwin
+license                 BSD
+platforms               any
+supported_archs         noarch
 maintainers             nomaintainer
+
 description             Java bytecode manipulation framework.
 long_description        ASM is a Java bytecode manipulation framework. It \
                         offers similar functionalities as BCEL or SERP, but \
                         is much smaller and faster than these tools.
 
-set project             asm
-set realname            ${project}
+homepage                https://asm.ow2.io
+checksums               rmd160  d3356aaeeb3d1aeda86df1f078f49580e4493035 \
+                        sha256  fdf5a43245d1e46833e83128151fb8b3f9f434d845d04edbc7c0af4fa7829d33 \
+                        size    1389862
 
-homepage                http://asm.objectweb.org/
-master_sites            http://download.us.forge.objectweb.org/${project} \
-                        http://download.forge.objectweb.org/${project} \
-                        http://download.fr2.forge.objectweb.org/${project}
-distname                ${realname}-${version}
-checksums               md5 dfd62160a88f13e236f9da7d2485c9ec
+depends_build-append    bin:gradle:gradle
 
-depends_build           port:objectweb-anttasks \
-                        bin:ant:apache-ant
+java.version            11+
+java.fallback           openjdk25
 
-worksrcdir              ${realname}-${version}
+patchfiles              fix-google-java-format-on-jdk-25.diff \
+                        fix-spotless-java-check.diff \
+                        silence-pmd.diff
 
 use_configure           no
 
-pre-build {
-    reinplace s|^.*objectweb.ant.tasks.path.*ow_util_ant_tasks.jar|objectweb.ant.tasks.path\ ${prefix}/share/java/objectweb-anttasks.jar| ${worksrcpath}/build.properties
-}
-
-build.cmd               ant
-build.target            jar jdoc
-build.env               CLASSPATH=${prefix}/share/java/objectweb-anttasks.jar
-
-variant debug {
-    build.args-append   -debug
-}
+build.cmd               gradle
+build.target            build
+build.args              --exclude-task :benchmarks:build \
+                        --gradle-user-home ${worksrcpath}/.gradle
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java \
-        ${destroot}${prefix}/share/doc
-    xinstall -m 644 ${worksrcpath}/output/dist/lib/asm-${version}.jar \
-        ${destroot}${prefix}/share/java/${name}.jar
-    file copy ${worksrcpath}/output/dist/doc/javadoc/user \
-        ${destroot}${prefix}/share/doc/${name}
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
+
+    set modules {
+        asm
+        asm-analysis
+        asm-commons
+        asm-test
+        asm-tree
+        asm-util
+        tools
+    }
+
+    xinstall -d ${destjavadir}
+    foreach module ${modules} {
+        xinstall -m 644 \
+            ${worksrcpath}/${module}/build/libs/${module}-${version}-SNAPSHOT.jar \
+            ${destjavadir}/${module}.jar
+    }
+
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.txt \
+        ${worksrcpath}/README.md \
+        ${destdocdir}
 }

--- a/java/objectweb-asm/files/fix-google-java-format-on-jdk-25.diff
+++ b/java/objectweb-asm/files/fix-google-java-format-on-jdk-25.diff
@@ -1,0 +1,11 @@
+--- build.gradle.orig	2026-05-23 23:02:17
++++ build.gradle	2026-09-07 09:23:40
+@@ -191,7 +191,7 @@
+     java {
+       target '**/*.java'
+       targetExclude 'src/resources/java/**/*'
+-      googleJavaFormat('1.18.1')
++      googleJavaFormat('1.27.0')
+     }
+   }
+   

--- a/java/objectweb-asm/files/fix-spotless-java-check.diff
+++ b/java/objectweb-asm/files/fix-spotless-java-check.diff
@@ -1,0 +1,11 @@
+--- asm-util/src/main/java/org/objectweb/asm/util/CheckFrameAnalyzer.java.orig	2026-05-23 23:02:17
++++ asm-util/src/main/java/org/objectweb/asm/util/CheckFrameAnalyzer.java	2026-09-07 10:17:49
+@@ -270,7 +270,7 @@
+       case Opcodes.F_NEW:
+       case Opcodes.F_FULL:
+         currentLocal = 0;
+-        // fall through
++      // fall through
+       case Opcodes.F_APPEND:
+         for (Object type : locals) {
+           V value = newFrameValue(owner, frameNode, type);

--- a/java/objectweb-asm/files/silence-pmd.diff
+++ b/java/objectweb-asm/files/silence-pmd.diff
@@ -1,0 +1,24 @@
+--- tools/pmd.xml.orig	2026-05-23 23:02:17
++++ tools/pmd.xml	2026-09-07 10:13:00
+@@ -37,6 +37,10 @@
+     <!-- Already covered with google-java-format. -->
+     <!-- Too many false positives. -->
+     <exclude name="UseVarargs" />
++    <!-- Added by MacPorts to fix build. -->
++    <exclude name="EnumComparison" />
++    <exclude name="RelianceOnDefaultCharset" />
++    <exclude name="UnnecessaryWarningSuppression" />
+   </rule>
+   <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly">
+     <properties>
+@@ -82,6 +86,10 @@
+     <exclude name="SimpleDateFormatNeedsLocale" />
+     <exclude name="StaticEJBFieldShouldBeFinal" />
+     <exclude name="UseProperClassLoader" />
++    <!-- Added by MacPorts to fix build. -->
++    <exclude name="AvoidCatchingGenericException" />
++    <exclude name="OverrideBothEqualsAndHashCodeOnComparable" />
++    <exclude name="UselessPureMethodCall" />
+   </rule>
+   <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull">
+     <properties>


### PR DESCRIPTION
#### Description

Update the `objectweb-asm` port to version 9.10.1 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?