### PR TITLE
py-mysqlclient: update to 2.2.8; py313 + py314; DRYing; more DBs

### DIFF
--- a/python/py-mysqlclient/Portfile
+++ b/python/py-mysqlclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-mysqlclient
-version             2.2.7
+version             2.2.8
 revision            0
 
 categories-append   devel databases
@@ -15,56 +15,63 @@ maintainers         nomaintainer
 description         Python3 interface to MySQL/MariaDB, fork of MySQL-python
 long_description    {*}${description}
 
-checksums           rmd160  cc7d8c9892f8ab85b1611a960aea9ef1cde79a90 \
-                    sha256  24ae22b59416d5fcce7e99c9d37548350b4565baac82f95e149cac6ce4163845 \
-                    size    91383
+homepage            https://github.com/PyMySQL/mysqlclient
 
-python.versions     310 311 312
+checksums           rmd160  01f3b69dec3eae353e7ee3d4c47c675dd61f9781 \
+                    sha256  8ed20c5615a915da451bb308c7d0306648a4fd9a2809ba95c992690006306199 \
+                    size    92287
+
+python.versions     310 311 312 313 314
 
 if {${name} ne ${subport}} {
-    set mysql_config {}
-
     depends_build-append \
                     port:pkgconfig \
                     port:py${python.version}-setuptools
 
+    set mysql_vers      {57 8 9}
+    set mariadb_vers    {10.6 10.11 11.4 11.8 12.3}
+
+    set mysql_names     [lmap v ${mysql_vers} {string cat mysql ${v}}]
+    set mariadb_names   [lmap v ${mariadb_vers} {string cat mariadb [string map {. _} ${v}]}]
+    set db_names        [list {*}${mysql_names} {*}${mariadb_names}]
+
+    foreach db_name ${mysql_names} {
+        variant ${db_name} \
+                conflicts {*}[ldelete ${db_names} ${db_name}] \
+                description "Access ${db_name}" "
+            depends_lib-append  port:${db_name}
+            build.env-append    PKG_CONFIG_PATH=${prefix}/lib/${db_name}/mysql/pkgconfig
+        "
+    }
+
+    foreach v ${mariadb_vers} db_name ${mariadb_names} {
+        variant ${db_name} \
+                conflicts {*}[ldelete ${db_names} ${db_name}] \
+                description "Access mariadb-${v}" "
+            depends_lib-append  port:mariadb-${v}
+            build.env-append    PKG_CONFIG_PATH=${prefix}/lib/mariadb-${v}/mysql/pkgconfig
+        "
+    }
+
     pre-configure {
-        if {![variant_isset mysql57] &&
-            ![variant_isset mysql8] &&
-            ![variant_isset mariadb10_6] &&
-            ![variant_isset mariadb10_11]} {
-            return -code error "you must select either mysql57, mysql8, mariadb10_6, or mariadb10_11"
+        global db_names
+        foreach db_name ${db_names} {
+            if {[variant_isset ${db_name}]} {
+                return
+            }
+        }
+        return -code error "you must select one of: [join ${db_names} {, }]"
+    }
+
+    set none_selected 1
+    foreach db_name ${db_names} {
+        if {[variant_isset ${db_name}]} {
+            set none_selected 0
+            break
         }
     }
 
-    variant mysql57 conflicts mysql8 mariadb10_6 mariadb10_11 \
-        description {Access mysql57} {
-        depends_lib-append  port:mysql57
-        build.env-append PKG_CONFIG_PATH=${prefix}/lib/mysql57/mysql/pkgconfig
-    }
-
-    variant mysql8 conflicts mysql57 mariadb10_6 mariadb10_11 \
-        description {Access mysql8} {
-        depends_lib-append  port:mysql8
-        build.env-append PKG_CONFIG_PATH=${prefix}/lib/mysql8/mysql/pkgconfig
-    }
-
-    variant mariadb10_6 conflicts mysql57 mysql8 mariadb10_11 \
-        description {Access mariadb-10.6} {
-        depends_lib-append  port:mariadb-10.6
-        build.env-append PKG_CONFIG_PATH=${prefix}/lib/mariadb-10.6/mysql/pkgconfig
-    }
-
-    variant mariadb10_11 conflicts mysql57 mysql8 mariadb10_6 \
-        description {Access mariadb-10.11} {
-        depends_lib-append  port:mariadb-10.11
-        build.env-append PKG_CONFIG_PATH=${prefix}/lib/mariadb-10.11/mysql/pkgconfig
-    }
-
-    if {![variant_isset mysql57] &&
-            ![variant_isset mysql8] &&
-            ![variant_isset mariadb10_6] &&
-            ![variant_isset mariadb10_11] } {
+    if {${none_selected}} {
         default_variants +mariadb10_11
     }
 }


### PR DESCRIPTION
#### Description

mysqlclient 2.2.8 supports Python 3.10 to 3.14 (`Requires-Python >=3.10`). This updates the port to 2.2.8 and adds the missing `py313` and `py314` subports.

It also adds `mariadb11_4` and `mariadb11_8` variants, for the `mariadb-11.4` and `mariadb-11.8` ports already in the tree. The default variant stays `mariadb10_11`, so nothing changes for current users and no revision bump is needed.

This is the `py-mysqlclient` part of #28046, split out as a single-port change as asked there.

`homepage` was missing: `port lint` fails with `Error: Missing required variable: homepage`. The URL added is the one in the PyPI metadata.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`? (see note on `-t` below)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Details:

- `port lint --nitpick`: 0 errors, 0 warnings on py310, py311, py312, py313 and py314.
- `sudo port -vs install py314-mysqlclient +mariadb11_8`: builds and activates, no broken files. `import MySQLdb` gives version 2.2.8, client 3.4.10.
- No test phase in the Portfile, so `sudo port test` does not apply.
- Trace mode (`-t`) cannot run here: `darwintrace.dylib` is x86_64/arm64, the macOS 26 system binaries are arm64e. See https://trac.macports.org/ticket/60818.
- `mariadb11_4` was not built here. `mariadb-11.4` has the same install layout as `mariadb-11.8`, so the pkgconfig path has the same shape.
- The other variants are unchanged, apart from the two new names in their `conflicts` lists.

cc @BjarneDMat