### PR TITLE
llama-swap: update to 255

### DIFF
--- a/llm/llama-swap/Portfile
+++ b/llm/llama-swap/Portfile
@@ -3,16 +3,16 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/mostlygeek/llama-swap 252 v
+go.setup                github.com/mostlygeek/llama-swap 255 v
 go.offline_build        no
-go.toolchain_min        1.26.1
+go.toolchain_min        1.27.1
 revision                0
-set git-commit          e31a1ad
+set git-commit          7761aa1
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  caaacd67c265621dadbaf243d69b8af7ba042fa0 \
-                        sha256  8681d563ea2766a9348aee6ae1b20f6c792a3945fb91f72e7ce712ab335d078f \
-                        size    3913834
+                        rmd160  ddbfaae9e929ffd15d71743fb248eb1b44b4b936 \
+                        sha256  efa72c067b2789016c231984e63267f69e048949c80d87d4b6a9656fec58350e \
+                        size    3984931
 
 categories              llm
 license                 MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
