### PR TITLE
pi-coding-agent: update to 0.85.1

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.84.4
+version             0.85.1
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  a42a2080da1e080742f8b8a8caf7c3fb91c4fe60 \
-                    sha256  5bce766d19c3ceba18f3fbaad91c449c9f9d73981f9e3400ecef932006f06968 \
-                    size    6882502
+checksums           rmd160  6b4c084746be495566f3e4066fb9143ea1f20fb9 \
+                    sha256  1f498729649bdce647d1160993b4d92bf3c614cc819213bee2f91dd34f2a7af4 \
+                    size    6986356
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
