### PR TITLE
llmfit: update to 1.1.14

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 1.1.12 v
+github.setup            AlexsJones llmfit 1.1.14 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  05279eb7d4bc92f252fe24e7253098f723da46bb \
-                        sha256  3425decb13d7f614f6aeaecd63698c9f6e681e5f696ccd88691d8c0fd2bf230a \
-                        size    8264471
+                        rmd160  07d83dc73b5efeb33f65266719f11c3fae8f9ac1 \
+                        sha256  f44a212a769b52e732212b4bfc7e60de833e6f27b86febe903f4fa54440cf423 \
+                        size    8387500
 
 categories              llm
 platforms               macosx
@@ -132,8 +132,11 @@ cargo.crates \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
+    darling                         0.24.1  ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec \
     darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
+    darling_core                    0.24.1  6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff \
     darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
+    darling_macro                   0.24.1  2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785 \
     data-encoding                   2.11.0  a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
     dbus                            0.9.11  b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73 \
     deltae                           0.3.2  5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4 \
@@ -170,7 +173,7 @@ cargo.crates \
     error-code                       3.3.2  dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59 \
     euclid                         0.22.14  f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06 \
     fancy-regex                     0.11.0  b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2 \
-    fancy-regex                     0.18.0  e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277 \
+    fancy-regex                     0.19.0  476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6 \
     fast-srgb8                       1.0.0  dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1 \
     fastrand                         2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     fax                              0.2.6  f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab \
@@ -273,8 +276,9 @@ cargo.crates \
     js-sys                          0.3.95  2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca \
     json-patch                       3.0.1  863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08 \
     jsonptr                          0.6.3  5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70 \
-    jsonschema                      0.47.0  281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1 \
-    jsonschema-regex                0.47.0  ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045 \
+    jsonschema                      0.49.9  59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2 \
+    jsonschema-regex                0.49.9  91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85 \
+    jsonschema-value                0.49.9  7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb \
     kasuari                         0.4.12  bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899 \
     keyboard-types                   0.7.0  b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a \
     lab                             0.11.0  bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f \
@@ -427,14 +431,14 @@ cargo.crates \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                        1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                   1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    referencing                     0.47.0  348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b \
+    referencing                     0.49.9  6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278 \
     regex                           1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
     regex-automata                  0.4.18  ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2 \
     regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     reqwest                         0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rmcp                             2.2.0  14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af \
-    rmcp-macros                      2.2.0  783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3 \
+    rmcp                             3.1.0  ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695 \
+    rmcp-macros                      3.1.4  a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780 \
     rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
@@ -697,7 +701,7 @@ cargo.crates \
     x11-dl                          2.21.0  38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f \
     x11rb                           0.13.2  9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414 \
     x11rb-protocol                  0.13.2  ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd \
-    yaml_serde                      0.10.6  ad7a8266fc7ce9d77db272ca5b40b704a1753e2a2e2ab7b1f2da22672941bf93 \
+    yaml_serde                      0.10.7  33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918 \
     yoke                             0.8.2  abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
     yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
     zerocopy                        0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
