### PR TITLE
media-control: new port

### DIFF
--- a/audio/media-control/Portfile
+++ b/audio/media-control/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        ungive media-control 0.7.6 v
+github.tarball_from archive
+revision            0
+
+categories          audio
+license             BSD
+maintainers         {@Yudaotor} openmaintainer
+
+description         Control and observe media playback from the command-line
+
+long_description    media-control reads and controls what is currently \
+                    playing on macOS through the private MediaRemote \
+                    framework, without requiring any per-application \
+                    scripting support. It reports now-playing metadata and \
+                    playback position, streams change events, and can send \
+                    play, pause and skip commands. Applications that need to \
+                    follow playback of players which expose no scripting \
+                    interface can use it as a helper process.
+
+# The adapter that talks to MediaRemote lives in a git submodule, pinned to
+# the commit recorded in the v${version} tag.
+set mra_commit      3ac3d4bdf862c7b5399b4fba4df5689f5c38609a
+
+distfiles-append    mediaremote-adapter-${mra_commit}.tar.gz:mra
+master_sites-append https://github.com/ungive/mediaremote-adapter/archive/${mra_commit}.tar.gz?dummy=:mra
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  827d180800dc6bc75aa2327698e6bd2fdd90f238 \
+                        sha256  beec425be7d5fa148019fdf3edf71674d342f5ac8fa212153fb2baab2784dccf \
+                        size    178389 \
+                    mediaremote-adapter-${mra_commit}.tar.gz \
+                        rmd160  d213369970cfc2697253c9edd89e97d447cfe041 \
+                        sha256  111e285e7a8acfb05b7339883e303a360f8a7a9b7acb4f0f5c01b647deb8ceb5 \
+                        size    33519
+
+extract.only        ${distname}${extract.suffix}
+
+post-extract {
+    system -W ${workpath} "/usr/bin/tar -xzf ${distpath}/mediaremote-adapter-${mra_commit}.tar.gz"
+    delete ${worksrcpath}/mediaremote-adapter
+    move ${workpath}/mediaremote-adapter-${mra_commit} ${worksrcpath}/mediaremote-adapter
+}
+
+post-patch {
+    # The adapter framework hardcodes a universal build; honour the port's own
+    # architecture selection instead.
+    reinplace {/set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")/d} \
+        ${worksrcpath}/mediaremote-adapter/CMakeLists.txt
+
+    # Upstream installs the framework into ${prefix}/Frameworks, which is not
+    # part of the ports filesystem layout; move it to Library/Frameworks and
+    # keep the launcher's relative lookup in step with it.
+    reinplace {s|set(FRAMEWORKS_DIR "Frameworks")|set(FRAMEWORKS_DIR "Library/Frameworks")|} \
+        ${worksrcpath}/CMakeLists.txt
+    reinplace {s|'\.\.', 'Frameworks', 'MediaRemoteAdapter.framework'|'..', 'Library', 'Frameworks', 'MediaRemoteAdapter.framework'|} \
+        ${worksrcpath}/bin/media-control
+}
+
+# The Perl adapter script locates the framework and the test client by paths
+# relative to the installed bin/ directory, so the whole tree must stay put.
+depends_run-append  path:bin/perl:perl5


### PR DESCRIPTION
New port: **media-control** (BSD-3-Clause) — https://github.com/ungive/media-control

Reads and controls what is currently playing on macOS through the private MediaRemote framework, so applications can follow playback of players that expose no scripting interface. Reports now-playing metadata and position, streams change events, and sends play/pause/skip commands. Already packaged in homebrew-core.

I am submitting this because `aqua/lyrimuse` (#34547) needs it as a dependency; it was bundled into that Portfile until @herbygillot rightly asked for it to be decomposed into its own port.

Two things worth flagging:

- The adapter that talks to MediaRemote is a **git submodule**, pinned to the commit recorded in the v0.7.6 tag and fetched as a separate checksummed distfile.
- Upstream installs its framework into `${prefix}/Frameworks`, which trips the ports-filesystem layout check ("violates the layout of the ports-filesystems"). The port relocates it to `Library/Frameworks` and patches the launcher's relative lookup to match, since the perl launcher resolves the framework by a path relative to `bin/`.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 27.0 26A5416b arm64
Xcode 26.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick` (0 errors, 0 warnings)?
- [x] tried a full install (run in an unprivileged from-source MacPorts 2.12.6 prefix rather than `sudo port -vst install` against the system MacPorts)?
- [x] tested basic functionality of all binary files? (`media-control version` runs from the installed prefix; the relocated framework is still resolved by the launcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)