### PR TITLE
blosc2: Update to 3.3.3

### DIFF
--- a/archivers/blosc2/Portfile
+++ b/archivers/blosc2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        Blosc c-blosc2 3.3.2 v
+github.setup        Blosc c-blosc2 3.3.3 v
 revision            0
 
 name                blosc2
@@ -18,9 +18,9 @@ long_description    {*}${description}.
 
 homepage            https://www.blosc.org
 
-checksums           rmd160  561d6056b8dbcee9467aa4bcafcb5a83fae52880 \
-                    sha256  a8fb27bae6403872bb6e5bb8672e79a5b7eb6b3d8fd7c3e6aa7b888436b68ee2 \
-                    size    1946986
+checksums           rmd160  967eba53987df0feae1cd31c8450d40c0c618158 \
+                    sha256  3ab395116eae3ce0b7488e994224f85cbc858a7a71663af1f938cc5997a7dddd \
+                    size    1949337
 github.tarball_from archive
 
 depends_lib-append  port:lz4 \


### PR DESCRIPTION
#### Description

Update blosc2 to 3.3.3.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
