### PR TITLE
patchelf: Update to 0.19.1

### DIFF
--- a/devel/patchelf/Portfile
+++ b/devel/patchelf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        NixOS patchelf 0.18.0
+github.setup        NixOS patchelf 0.19.1
 github.tarball_from releases
 revision            0
 
@@ -13,9 +13,9 @@ maintainers         {kollar.me:laszlo @lkollar} openmaintainer
 description         Modify dynamic ELF executables
 long_description    PatchELF is a simple utility for modifying existing ELF executables and libraries
 
-checksums           sha256  1952b2a782ba576279c211ee942e341748fdb44997f704dd53def46cd055470b \
-                    rmd160  542cf448a6cd8f6177758d325c30be3299f37b09 \
-                    size    423290
+checksums           sha256  2cce01de93653829f6ab68a20c2ec275e1c00a946110704a27e928d2e6e88716 \
+                    rmd160  593b964fd6518b94f4187a4779fdd1131619fa9f \
+                    size    441280
 
 compiler.cxx_standard \
                     2017
@@ -24,3 +24,7 @@ use_bzip2           yes
 
 configure.args      --disable-dependency-tracking \
                     --disable-silent-rules
+
+post-destroot {
+    xinstall -m 644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

Update patchelf to 0.19.1.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
