### PR TITLE
debianutils: Update to 5.24

### DIFF
--- a/sysutils/debianutils/Portfile
+++ b/sysutils/debianutils/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 
 name                debianutils
-version             5.23.2
+version             5.24
+revision            0
 categories          sysutils
 license             GPL-2+
 maintainers         {raimue @raimue} openmaintainer
@@ -23,14 +24,14 @@ long_description \
 #   which                    Unnecessary, /usr/bin/which is provided by the operating system
 
 homepage            https://tracker.debian.org/pkg/debianutils
-master_sites        debian:d/debianutils
+master_sites        debian:d/${name}
 distname            ${name}_${version}
-worksrcdir          work
+worksrcdir          ${name}-${version}
 use_xz              yes
 
-checksums           rmd160  6ea9ee976eb90470bd4e9d06008fa5632fa7864f \
-                    sha256  79e524b7526dba2ec5c409d0ee52ebec135815cf5b2907375d444122e0594b69 \
-                    size    82376
+checksums           rmd160  c78575610190bae01e3ad2e140e89a54b6a58695 \
+                    sha256  bf79c301ad48e82ddb09d8c0770f6d44294ee9529ae5e54164072f7bf5c57016 \
+                    size    83012
 
 use_autoreconf      yes
 
@@ -42,6 +43,11 @@ destroot {
     xinstall -W ${worksrcpath} tempfile    ${destroot}${prefix}/bin
     xinstall -W ${worksrcpath} tempfile.1  ${destroot}${prefix}/share/man/man1
 }
+
+# alignof is C23. Not necessary to build
+configure.checks.implicit_function_declaration.whitelist-append alignof
+configure.checks.implicit_int \
+                    no
 
 livecheck.type      regex
 livecheck.regex     ${name}_(\\d+(?:.\\d+)+).dsc


### PR DESCRIPTION
#### Description

Update debianutils to 5.24.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
