### PR TITLE
libxml2: Update to 2.15.4

### DIFF
--- a/textproc/libxml2/Portfile
+++ b/textproc/libxml2/Portfile
@@ -6,11 +6,11 @@ PortGroup           clang_dependency 1.0
 # Please keep the version of the libxml2 and py-libxml2 ports the same.
 
 name                libxml2
-version             2.15.3
+version             2.15.4
 revision            0
-checksums           rmd160  f5a7b99dcedafe78055942d6e3f6dd2b3ab8dc32 \
-                    sha256  78262a6e7ac170d6528ebfe2efccdf220191a5af6a6cd61ea4a9a9a5042c7a07 \
-                    size    3152452
+checksums           rmd160  c4436efbf807c2e57f1639e95615df41273b6e02 \
+                    sha256  98087fd181d9070724f3fbc65c7377db03038eb92bd882374daff44940138821 \
+                    size    3177444
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          textproc


### PR DESCRIPTION
#### Description

Release notes:
https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.4.news

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?