### PR TITLE
xml-commons-resolver: update to 1.2

### DIFF
--- a/java/xml-commons-resolver/Portfile
+++ b/java/xml-commons-resolver/Portfile
@@ -1,11 +1,13 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 
 name                xml-commons-resolver
-version		        1.1
+version             1.1
 
-categories	        java devel
-platforms	        darwin
-maintainers	        nomaintainer
+categories          java devel
+platforms           darwin
+maintainers         nomaintainer
 
 description         Java library for XML entity resolution
 long_description    It is very common for web resources to be related to other resources. These \
@@ -22,35 +24,37 @@ long_description    It is very common for web resources to be related to other r
 homepage            http://xml.apache.org/commons/components/resolver/index.html
 
 master_sites        apache
-master_sites.mirror_subdir xml/commons
+master_sites.mirror_subdir \
+                    xml/commons
 
 checksums           md5 deb95bdf88687430445d34e8c11d475e
 
 depends_lib         bin:java:kaffe
-depends_build	    bin:ant:apache-ant
+depends_build       bin:ant:apache-ant
+
+
+post-patch {
+    # Allow to compile on javac 1.5
+    reinplace "s|<javac|<javac source='1.4'|" ${worksrcpath}/resolver.xml
+}
 
 use_configure       no
 
-post-patch {
-	# Allow to compile on javac 1.5
-	reinplace "s|<javac|<javac source='1.4'|" ${worksrcpath}/resolver.xml
-}
-
 build.cmd           ant
+build.target        jar
 build.args          -f resolver.xml
-build.target	    jar
 
 destroot {
-	xinstall -d -m 755 \
-		${destroot}${prefix}/share/java/apache-ant/lib \
-		${destroot}${prefix}/share/doc
-		
-	xinstall -m 644 ${worksrcpath}/resolver.jar \
-		${destroot}${prefix}/share/java/
-		
-	file copy ${worksrcpath}/docs \
-		${destroot}${prefix}/share/doc/${name}
-		
-	system "cd ${destroot}${prefix}/share/java/apache-ant/lib/ && \
-		ln -sf ../../resolver.jar"
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/share/java/apache-ant/lib \
+        ${destroot}${prefix}/share/doc
+
+    xinstall -m 644 ${worksrcpath}/resolver.jar \
+        ${destroot}${prefix}/share/java/
+
+    file copy ${worksrcpath}/docs \
+        ${destroot}${prefix}/share/doc/${name}
+
+    system "cd ${destroot}${prefix}/share/java/apache-ant/lib/ && \
+        ln -sf ../../resolver.jar"
 }

--- a/java/xml-commons-resolver/Portfile
+++ b/java/xml-commons-resolver/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           java 1.0
 
 name                xml-commons-resolver
-version             1.1
+version             1.2
 
 categories          java devel
-platforms           darwin
+license             Apache-2
+platforms           any
+supported_archs     noarch
 maintainers         nomaintainer
 
 description         Java library for XML entity resolution
@@ -21,21 +24,23 @@ long_description    It is very common for web resources to be related to other r
                     files" can be used to map public and system identifiers and other URIs to local \
                     files (or just other URIs). The XML Commons Resolver classes greatly simplify \
                     the task of using catalog files to perform entity resolution.
-homepage            http://xml.apache.org/commons/components/resolver/index.html
+homepage            https://xerces.apache.org/xml-commons/components/resolver
 
-master_sites        apache
-master_sites.mirror_subdir \
-                    xml/commons
+master_sites        apache:xerces/xml-commons
 
-checksums           md5 deb95bdf88687430445d34e8c11d475e
+checksums           rmd160  b4e9ac205e62a5bb97d23424a3aedeb70aa1908a \
+                    sha256  55dbe7bd56452c175320ce9a97b752252c5537427221323c72e9b9c1ac221efe \
+                    size    262701
 
-depends_lib         bin:java:kaffe
 depends_build       bin:ant:apache-ant
 
+java.version        1.8+
+java.fallback       openjdk11
+
+patchfiles          specify-java-version.diff
 
 post-patch {
-    # Allow to compile on javac 1.5
-    reinplace "s|<javac|<javac source='1.4'|" ${worksrcpath}/resolver.xml
+    reinplace "s|@@JAVA_VERSION@@|1.8|g" ${worksrcpath}/resolver.xml
 }
 
 use_configure       no
@@ -45,16 +50,38 @@ build.target        jar
 build.args          -f resolver.xml
 
 destroot {
-    xinstall -d -m 755 \
-        ${destroot}${prefix}/share/java/apache-ant/lib \
-        ${destroot}${prefix}/share/doc
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
 
-    xinstall -m 644 ${worksrcpath}/resolver.jar \
-        ${destroot}${prefix}/share/java/
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        ${worksrcpath}/build/resolver.jar \
+        ${destjavadir}
 
-    file copy ${worksrcpath}/docs \
-        ${destroot}${prefix}/share/doc/${name}
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE.resolver.txt \
+        ${worksrcpath}/NOTICE-resolver.txt \
+        ${worksrcpath}/build/manifest.resolver \
+        ${destdocdir}
 
-    system "cd ${destroot}${prefix}/share/java/apache-ant/lib/ && \
-        ln -sf ../../resolver.jar"
+    if {[variant_isset doc]} {
+        xinstall -m 644 \
+            {*}[glob -directory ${worksrcpath}/docs *] \
+            ${destdocdir}
+        copy \
+            ${worksrcpath}/apidocs \
+            ${destdocdir}
+    }
 }
+
+variant doc \
+        description {Install documentation} {
+    # Install pre-built documentation.
+    # Building htmldocs assumes files not included in distfile.
+    # Building javadocs fails with invalid HTML errors.
+}
+
+livecheck.type      regex
+livecheck.url       https://downloads.apache.org/xerces/xml-commons/
+livecheck.regex     "${name}-(\[0-9]+(\\.\[0-9])*)(-\[a-z]+)*\\.tar\\.gz"

--- a/java/xml-commons-resolver/files/specify-java-version.diff
+++ b/java/xml-commons-resolver/files/specify-java-version.diff
@@ -1,0 +1,11 @@
+--- resolver.xml.orig	2006-11-21 06:23:07
++++ resolver.xml	2026-09-08 12:58:22
+@@ -88,7 +88,7 @@
+ 
+    <echo message="Compiling..." />
+ 
+-   <javac srcdir="${src.dir}" destdir="${build.classes.dir}" debug="true" optimize="true" deprecation="true" verbose="false">
++   <javac srcdir="${src.dir}" destdir="${build.classes.dir}" debug="true" optimize="true" deprecation="true" verbose="false" source="@@JAVA_VERSION@@" target="@@JAVA_VERSION@@">
+      <!-- <classpath> not needed since Ant already supplies these Sep-03 -sc -->
+      <include name="${resolver.subdir}/*.java"/>
+      <include name="${resolver.subdir}/helpers/*.java"/>


### PR DESCRIPTION
#### Description

Update the `xml-commons-resolver` port to version 1.2 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?