### PR TITLE
cloudflared: Update to 2026.8.3

### DIFF
--- a/net/cloudflared/Portfile
+++ b/net/cloudflared/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/cloudflare/cloudflared 2026.8.2
+go.setup            github.com/cloudflare/cloudflared 2026.8.3
 go.toolchain_min    1.26
 revision            0
 categories          net security
@@ -16,9 +16,9 @@ long_description    Contains the command-line client for Cloudflare Tunnel, a tu
 
 homepage            https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
 
-checksums           rmd160  0ab3effd2fe6a1b4b02c70b84d85e47fffe66ff6 \
-                    sha256  acdf125b7e872be6e1d13116e8054d27b2c4755760b0cdc3b4ee3910edd37b93 \
-                    size    6326795
+checksums           rmd160  f79147183afb945bdd7be1a05ed9cbd516008eb1 \
+                    sha256  04cd85af52c2c012f08212c878b4c403eadf410865f2356a80f361d475d2fc92 \
+                    size    6317855
 
 go.offline_build    no
 


### PR DESCRIPTION
#### Description

Update cloudflared to 2026.8.3.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
