### PR TITLE
mp3rgain: update to 3.6.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.6.0 v
+github.setup        M-Igashi mp3rgain 3.6.1 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dfca4e0e07ea15600fad1df5606f75a7a4a138b4 \
-                    sha256  2a99f3ee2eba1dea4a0948121592d619ee9032f0087ee4438ed04ae567cd2ebc \
-                    size    586304
+                    rmd160  43fc27dd578c99b18cda3bb78ba93048301014f3 \
+                    sha256  8d926c3665f7a6c09c91ce1bcc34cba92d822f9bff10bef6def0c048975cd3d3 \
+                    size    592915
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 3.6.1.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.1

#### Changes in this version

- `-a --per-directory` computes one album gain per folder instead of pooling every input file into a single album.
- `-o tsv` prints the ReplayGain float peak under `--rg2` / `--r128`, matching the value written to `REPLAYGAIN_*_PEAK`.

#### Portfile changes

- `github.setup` bumped to 3.6.1, `revision` stays 0.
- Checksums (rmd160 / sha256 / size) recomputed for the new source tarball.
- `cargo.crates` is unchanged: the only difference in `Cargo.lock` between 3.6.0 and 3.6.1 is the version of the `mp3rgain` package itself. All 63 crate entries were verified against `Cargo.lock`.

#### Verification

- Checksums computed locally from the GitHub archive tarball with `shasum -a 256`, `openssl dgst -rmd160` and `wc -c`.
- `cargo.crates` diffed programmatically against `Cargo.lock`: no missing, extra or mismatched entries.
- MacPorts is not installed on the machine used to prepare this update, so `port lint --nitpick` and a local build were not run. The change is limited to the version line and the four checksum/size values.