### PR TITLE
skim: update to 5.7.0

### DIFF
--- a/sysutils/skim/Portfile
+++ b/sysutils/skim/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        skim-rs skim 5.6.6 v
+github.setup        skim-rs skim 5.7.0 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  1ded05253ec623e29ac04e5b4f3fea6b1be14cc7 \
-                    sha256  4f988bf6da4a5e1f71e296d7f96047db2d24253a06a5597b179206f7ecd034d7 \
-                    size    1181674
+                    rmd160  0b26fe612f6a8560efa3214d9d809ec7617712a8 \
+                    sha256  3a239d8ee284206e5a3891b2fd4e9dfe9150d120a63912b4b764bec2e6ef3966 \
+                    size    1217876
 
 set sk_share_dir    ${prefix}/share/${name}
 
@@ -85,11 +85,11 @@ cargo.crates \
     bytes                           1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
-    cc                               1.4.4  0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273 \
+    cc                               1.4.5  005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
     cfg_aliases                      0.2.2  f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527 \
-    chacha20                        0.10.1  d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81 \
+    chacha20                        0.10.2  65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06 \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
@@ -106,14 +106,14 @@ cargo.crates \
     console                         0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     convert_case                    0.10.0  633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
-    cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
-    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    cpufeatures                      0.3.1  5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566 \
+    crc32fast                        1.5.1  8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550 \
     criterion                        0.8.2  950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3 \
     criterion-plot                   0.8.2  d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea \
     critical-section                 1.2.0  790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b \
-    crossbeam-deque                  0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
-    crossbeam-epoch                 0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
-    crossbeam-utils                 0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
+    crossbeam-deque                  0.8.8  622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a \
+    crossbeam-epoch                 0.9.21  dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d \
+    crossbeam-utils                 0.8.23  a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6 \
     crossterm                       0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
@@ -152,10 +152,10 @@ cargo.crates \
     fastrand                         2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
     fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
     filedescriptor                   0.8.3  e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d \
-    find-msvc-tools                 0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
+    find-msvc-tools                 0.1.12  3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d \
     finl_unicode                     1.4.0  9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
-    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    flate2                          1.1.10  6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     frizbee                         0.13.0  19435f276a44d90570cb403d22fbe4b20c80eabc134f718d6ec0ae888eb47edc \
@@ -188,11 +188,11 @@ cargo.crates \
     image                          0.25.10  85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104 \
     image-webp                       0.2.4  525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3 \
     indenter                         0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
-    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    indexmap                        2.14.2  cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855 \
     indoc                            2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     insta                           1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
     instability                     0.3.13  2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8 \
-    interprocess                     2.4.3  798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572 \
+    interprocess                     2.4.4  6cb02ffbf25e8ef0f4a95bff054eef75f6d1bf16919474cf2caa63b21997478a \
     is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
@@ -200,7 +200,7 @@ cargo.crates \
     jiff                            0.2.35  668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc \
     jiff-core                        0.1.0  7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09 \
     jiff-static                     0.2.35  3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204 \
-    js-sys                         0.3.104  0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a \
+    js-sys                         0.3.105  ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e \
     kanal                            0.1.1  9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574 \
     kasuari                         0.4.12  bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899 \
     lab                             0.11.0  bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f \
@@ -214,7 +214,7 @@ cargo.crates \
     litrs                            1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
     log                             0.4.34  f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6 \
-    lru                             0.18.2  5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a \
+    lru                             0.18.4  ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25 \
     mac_address                      1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
     memchr                           2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     memmem                           0.1.1  a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15 \
@@ -222,7 +222,8 @@ cargo.crates \
     mimalloc                        0.1.48  e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
+    miniz_oxide                      0.9.1  b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c \
+    mio                              1.2.3  4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8 \
     moxcms                           0.8.1  bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b \
     nix                             0.28.0  ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
@@ -246,10 +247,10 @@ cargo.crates \
     parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     pastey                           0.2.3  2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4 \
-    pest                             2.9.0  5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf \
-    pest_derive                      2.9.0  b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d \
-    pest_generator                   2.9.0  e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a \
-    pest_meta                        2.9.0  e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496 \
+    pest                             2.9.1  6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad \
+    pest_derive                      2.9.1  89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f \
+    pest_generator                   2.9.1  7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5 \
+    pest_meta                        2.9.1  adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e \
     phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
     phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
     phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
@@ -261,12 +262,12 @@ cargo.crates \
     plotters-svg                     0.3.7  51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670 \
     png                             0.18.1  60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61 \
     portable-atomic                 1.15.0  05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85 \
-    portable-atomic-util             0.2.7  c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618 \
+    portable-atomic-util             0.2.8  10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715 \
     portable-pty                     0.9.0  b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
-    proc-macro-error-attr3           3.1.0  b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7 \
-    proc-macro-error3                3.1.0  0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50 \
+    proc-macro-error-attr3           3.1.1  9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da \
+    proc-macro-error3                3.1.1  8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233 \
     proc-macro2                    1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
     pulldown-cmark                  0.13.4  e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e \
     pxfm                            0.1.30  d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea \
@@ -276,7 +277,7 @@ cargo.crates \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                           0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
-    rand                             0.8.7  22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a \
+    rand                             0.8.8  e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c \
     rand                            0.10.2  c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
@@ -286,7 +287,7 @@ cargo.crates \
     ratatui                         0.30.2  3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d \
     ratatui-core                     0.1.2  cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c \
     ratatui-crossterm                0.1.2  567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0 \
-    ratatui-image                   11.0.6  e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86 \
+    ratatui-image                   11.0.8  399baa06251282b0c1bbb5762848cf98a6b7b84f44af7f0daf3213ace16df4f0 \
     ratatui-macros                   0.7.2  ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814 \
     ratatui-termina                  0.1.0  c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2 \
     ratatui-termwiz                  0.1.2  faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977 \
@@ -332,7 +333,7 @@ cargo.crates \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     siphasher                        1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
-    smallvec                        1.15.2  8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90 \
+    smallvec                        1.16.0  b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f \
     socket2                          0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
@@ -340,7 +341,7 @@ cargo.crates \
     strum_macros                    0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                            2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
-    syn                              3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
+    syn                              3.0.5  12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9 \
     tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termina                          0.3.3  9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e \
@@ -355,7 +356,7 @@ cargo.crates \
     time                            0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
     time-core                        0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
-    tinyvec                         1.12.0  bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f \
+    tinyvec                         1.13.2  4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tokio                           1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
     tokio-macros                     2.7.2  78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e \
@@ -374,7 +375,7 @@ cargo.crates \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     unty-next                        0.1.2  16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.25.0  f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc \
+    uuid                            1.26.0  b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vsimd                            0.8.0  5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64 \
     vt100                           0.16.2  054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9 \
@@ -383,11 +384,11 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2               1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
-    wasm-bindgen                   0.2.127  1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70 \
-    wasm-bindgen-macro             0.2.127  77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1 \
-    wasm-bindgen-macro-support     0.2.127  e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284 \
-    wasm-bindgen-shared            0.2.127  7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf \
-    web-sys                        0.3.104  c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30 \
+    wasm-bindgen                   0.2.128  aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf \
+    wasm-bindgen-macro             0.2.128  a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed \
+    wasm-bindgen-macro-support     0.2.128  411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a \
+    wasm-bindgen-shared            0.2.128  81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e \
+    web-sys                        0.3.105  9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8 \
     weezl                           0.1.12  a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88 \
     wezterm-bidi                     0.2.3  0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec \
     wezterm-blob-leases              0.1.1  692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7 \
@@ -395,8 +396,8 @@ cargo.crates \
     wezterm-dynamic                  0.2.1  5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac \
     wezterm-dynamic-derive           0.1.1  46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b \
     wezterm-input-types              0.1.0  7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e \
-    which                            8.0.5  8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c \
-    wide                             1.6.1  de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e \
+    which                            8.0.6  bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f \
+    wide                             1.7.0  8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be \
     widestring                       1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -425,6 +426,7 @@ cargo.crates \
     wyz                              0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     zerocopy                        0.8.56  556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb \
     zerocopy-derive                 0.8.56  f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1 \
+    zlib-rs                          0.6.7  34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12 \
     zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
     zune-core                        0.5.3  d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b \
     zune-jpeg                       0.5.15  27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296


### PR DESCRIPTION
#### Description

Not verified: this branch was minted with --no-verify, so no verification was ever asked for.

Branch head `f45b30ab0d59`, against the ports tree as of 2026-09-08.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0.0.0-dev
