### PR TITLE
lf: Update to 42

### DIFF
--- a/sysutils/lf/Portfile
+++ b/sysutils/lf/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gokcehan/lf 41 r
+go.setup            github.com/gokcehan/lf 42 r
+go.toolchain_min    1.25.0
 revision            0
 categories          sysutils
 maintainers         {judaew @judaew} openmaintainer
 license             MIT
-platforms           {darwin >= 17}
 
 description         Terminal file manager
 long_description    ${name} (as in \"list files\") is a terminal file manager \
@@ -18,62 +18,62 @@ long_description    ${name} (as in \"list files\") is a terminal file manager \
                     external tools.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  4e802992f27bef90fd186f1b2b05daded8ee2173 \
-                        sha256  55c556d53b5541d5f8691f1309a0166a7a0d8e06cb051c3030c2cd7d8abc6789 \
-                        size    197515
+                        rmd160  1270d10aa9603b6f0853ab14a07d85690ac5c7a0 \
+                        sha256  7a8f7c2c86419270b713b6235dced7b9d0e68732e74a1e0f375f774fff4023ca \
+                        size    205836
 
 build.pre_args      -ldflags \"-s -w -X main.gVersion=${version}\"
 
 go.vendors          golang.org/x/text \
-                        lock    v0.29.0 \
-                        rmd160  5f9ac2f866ae9a0e481eecc66f4a4a2cc4447ab6 \
-                        sha256  05d0a260c209629337dc6db8e49fb4fe57a6e20e21925007b60f183655d27174 \
-                        size    8974653 \
-                    golang.org/x/term \
-                        lock    v0.39.0 \
-                        rmd160  2090fd96a2cf03020445ff6c12a146b233c55628 \
-                        sha256  de9f5aa1cd36db1f5411078495d32c4096866fe11cd09417a302ebb68c9c73d8 \
-                        size    16453 \
-                    golang.org/x/sys \
                         lock    v0.40.0 \
-                        rmd160  c1b624cb03ef33de844391c537ff616763e6a6b3 \
-                        sha256  5ca4e94b4d1e7822df2414ab990885117d7266f1fcddf25e28432ab3aab66665 \
-                        size    1536154 \
-                    github.com/mattn/go-runewidth \
-                        lock    v0.0.19 \
-                        rmd160  b0f62e2f1c2086189f2ed14ad635733c4e5ced56 \
-                        sha256  6f5a00cdfbf4d88d05406a07bb95c34dc0abc2f65f15e9c5ca35814f4008b82f \
-                        size    20550 \
+                        rmd160  75205b5abd0d36bd9508c4cf056b035a02e39739 \
+                        sha256  35fdb039fb974052bc42cd655ee47c141298f1a1962279828e921c6f7130a0d8 \
+                        size    6772390 \
+                    golang.org/x/term \
+                        lock    v0.45.0 \
+                        rmd160  2ff34ce76d39e5ca3ff919a7539d425debb3ebda \
+                        sha256  f71934454e5fc440c2eb43e9739cd9bd91c1014883faf65d65159717ff2bd875 \
+                        size    16446 \
+                    golang.org/x/sys \
+                        lock    v0.47.0 \
+                        rmd160  1be59a8208fd6f7f4319b306138e77f215293e1a \
+                        sha256  2bed220513067f721fc7c19314bab58860c28397f5e48093a8fe35a27a915b06 \
+                        size    1551474 \
                     github.com/lucasb-eyer/go-colorful \
-                        lock    v1.3.0 \
-                        rmd160  f32cca200fcf4db4d0e51cc457baf68f212d8965 \
-                        sha256  4168f7454b19120873f75a67d1eeb7be312ea852542e21db1a96b65e514e56c2 \
-                        size    982361 \
-                    github.com/gdamore/tcell/v2 \
-                        lock    v2.9.0 \
-                        rmd160  42fdfbfc44d5b802ce6190738e53db8779785205 \
-                        sha256  cef3c5c649a976b48002526414775c97ae67a4eb7ea78a6a1ffc53c4f1e65859 \
-                        size    187497 \
+                        lock    v1.4.0 \
+                        rmd160  96dc7dfa29a7e7f4e7b72ccedcd226efe0fbcb94 \
+                        sha256  990b1f3429d6beff3a51c7e534b95999874ea27a61b31b425b5a8ae994843c37 \
+                        size    986501 \
+                    github.com/gdamore/tcell/v3 \
+                        lock    v3.4.1 \
+                        rmd160  f6c603571acafdff9d861cfec0ffe3a051e16641 \
+                        sha256  8c82f2d1c59008a04f2322edca0c490b773d2c5c1f679588b9faaf1965d5ed63 \
+                        size    392441 \
                     github.com/gdamore/encoding \
                         lock    v1.0.1 \
                         rmd160  7e73cab014fe3647552b67678a397ba5ce2475e9 \
                         sha256  dc7a586abe34b2d9562ca2aed225a1db734cc8b548a89bb238e75251d9aa0344 \
                         size    14814 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.9.0 \
-                        rmd160  24b514b003e8a613b938e13f7df3ba60dc755499 \
-                        sha256  46aaaf931594e32ce1e087da58dc8d3e27f0e34eaca38a9280f6c10a198d4166 \
-                        size    73949 \
+                        lock    v1.10.1 \
+                        rmd160  b588a8981513c3c51232591edc94fe223aee7e7c \
+                        sha256  e4a21cb263e96a4598bdfa662e315a0a227b8be58a6525f94c8b531afdbfe66e \
+                        size    76945 \
                     github.com/djherbis/times \
                         lock    v1.6.0 \
                         rmd160  74bbca79275e2c9a5c240f77e906b640b69543a7 \
                         sha256  2b1e000f0c9408eb4d7735547a95e65860d6c2d7411ef70558db6b2b5d526f1f \
                         size    8891 \
                     github.com/clipperhouse/uax29/v2 \
-                        lock    v2.2.0 \
-                        rmd160  9d56b6ecadc9b977922cf1a9763f1c4a8496f995 \
-                        sha256  dd907ccd83af2897b812f34920729d88c31809ea5526973978f4eab7b80b5237 \
-                        size    279573
+                        lock    v2.7.0 \
+                        rmd160  9cd62348ce0722d85ff21f2f91a05a68f877aa08 \
+                        sha256  66d66a451f74709ab74902e7bca146abf376dbf0bc701b713ee600e3d3d6a5b3 \
+                        size    320846 \
+                    github.com/clipperhouse/displaywidth \
+                        lock    v0.11.0 \
+                        rmd160  26a2f5e784f0414e55714156bab744b0d901c5c1 \
+                        sha256  d9587478830f552e284be30f010c2e57be7679d5c883a256b9df4b6889827347 \
+                        size    250271
 
 patchfiles          patch-config-file-in-prefix.diff
 


### PR DESCRIPTION
#### Description

Update lf to 42.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
