### PR TITLE
gmsh: Update to 4.15.2

### DIFF
--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -12,8 +12,8 @@ PortGroup               legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 name                    gmsh
-version                 4.15.0
-revision                2
+version                 4.15.2
+revision                0
 categories              science
 license                 GPL-2+
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -32,9 +32,9 @@ master_sites            https://gmsh.info/src/
 distname                gmsh-${version}-source
 extract.suffix          .tgz
 
-checksums               rmd160  c09338be3b016e64ac3ecc728c80b20b271368fc \
-                        sha256  abb2632715bd7d0130ded7144fd6263635cd7dea883b8df61ba4da58ce6a1dfe \
-                        size    18490150
+checksums               rmd160  f5a638a0e336c7d352bdfa5fce1473008498e5f4 \
+                        sha256  be3f66f225d27ba9fa014f07e83169285da8a051b0e8ab7103d88066b39bdd3e \
+                        size    18496049
 
 compiler.cxx_standard   2014
 compiler.c_standard     1999

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -73,6 +73,11 @@ configure.args-append   -DENABLE_BUILD_LIB=ON \
                         -DENABLE_BUILD_DYNAMIC=ON \
                         -DENABLE_SYSTEM_CONTRIB=ON
 
+# https://trac.macports.org/ticket/74406
+# Temporary workaround
+configure.args-append   -DENABLE_EIGEN=OFF \
+                        -DENABLE_BLAS_LAPACK=ON
+
 # ACIS is proprietary
 # avoid circular dependencies
 configure.args-append   -DENABLE_ACIS=OFF \

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -43,7 +43,6 @@ mpi.setup
 veclibfort              no
 
 depends_lib-append      port:alglib \
-                        path:share/pkgconfig/eigen3.pc:eigen3 \
                         path:lib/libfltk.dylib:fltk \
                         port:gmp \
                         port:mathex \


### PR DESCRIPTION
#### Description

* Update gmsh 4.15.0 --> 4.15.2.
* Fix builds, enable BLAS/LAPACK instead of eigen3.
* See: https://trac.macports.org/ticket/74406

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
