### PR TITLE
cmark: update to 0.31.2

### DIFF
--- a/devel/cmark/Portfile
+++ b/devel/cmark/Portfile
@@ -7,14 +7,14 @@ PortGroup           github 1.0
 # Any version update requires revbumping all ports that link with the library
 # because the full version number is in the library's install name.
 # See https://github.com/commonmark/cmark/issues/474
-github.setup        commonmark cmark 0.30.3
+github.setup        commonmark cmark 0.31.2
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 revision            0
 
-checksums           rmd160  526aaf6777c0ac377cafa9de661c7166aad065ff \
-                    sha256  79c4273d63ac4835734c3e7567885964d56a4f2e8bccd4321d5e3ead72745cdd \
-                    size    246966
+checksums           rmd160  76065c3b2bc4c5e4d55d89db14aa49cac008f60d \
+                    sha256  abb914edb9755bd6f9996ce2492657e510737ad5dc75110f7a1b61e3b15bd08f \
+                    size    267298
 
 categories          devel
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Sequoia: built in a pristine VM.
  — Tahoe: linted clean, built in a pristine VM.


The comment in devel/cmark/Portfile says:

```
# Any version update requires revbumping all ports that link with the library
# because the full version number is in the library's install name.
# See https://github.com/commonmark/cmark/issues/474
```

Dismissed by hand: no revision bumps were made on it.

Branch head `cdd47395a1fb`, against the ports tree as of 2026-09-08.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Sequoia — built in a pristine VM, via dockhand
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) b25c7246a2e7-dirty

