### PR TITLE
croc: update to 11.5.1

### DIFF
--- a/net/croc/Portfile
+++ b/net/croc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/schollz/croc 11.3.6 v
+go.setup            github.com/schollz/croc 11.5.1 v
 go.package          github.com/schollz/croc/v11
 go.offline_build    no
 go.toolchain_min    1.27.0
@@ -31,9 +31,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  82e378e38d7c384ab32bf81e8175b62f05ec4bc2 \
-                    sha256  bedca93ce041ed3e5c8d9f7add8cac25d03b97586eac14e54f3f41fe6eb70081 \
-                    size    3116316
+checksums           rmd160  a63cb41b0a1fc0092b9517dd6d2fecdf7ff1928e \
+                    sha256  7f1ff12d55ac971e7ab85e230313fc25a996ac4f4c103d6cf336edb23e0d63b4 \
+                    size    3271227
 
 build.pre_args-append \
     -ldflags \" -s -w \" -o ${name}


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `d3b2bcbf4ff4`, against the ports tree as of 2026-09-08.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) b25c7246a2e7-dirty

