### PR TITLE
oh-my-posh: update to 31.2.1

### DIFF
--- a/sysutils/oh-my-posh/Portfile
+++ b/sysutils/oh-my-posh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/JanDeDobbeleer/oh-my-posh 31.2.0 v
+go.setup            github.com/JanDeDobbeleer/oh-my-posh 31.2.1 v
 go.offline_build    no
 go.toolchain_min    1.27.0
 revision            0
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {duck.com:ihj3s1wy @PinoTucana} \
                     openmaintainer
 
-checksums           rmd160  0f60208c60608dd503e449c7d16545c1c10bf916 \
-                    sha256  bca38f2cb1643224042c32310f851c907d60b05af6167b87cd52f890a554530b \
-                    size    7708932
+checksums           rmd160  3fc5fbaaa17c56e7f71a6f0de6dd1b95ed807e6b \
+                    sha256  19d8d17995d01291c3bc922074cea973659b0899b5e4d6bf1e3dabe6691bcf4e \
+                    size    7709262
 
 build.dir           ${worksrcpath}/src
 


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `97c883f3a9d1`, against the ports tree as of 2026-09-08.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 75737361dfde-dirty
