### PR TITLE
py-mlx: pin nanobind version to 2.15.0

### DIFF
--- a/llm/mlx/Portfile
+++ b/llm/mlx/Portfile
@@ -96,7 +96,7 @@ post-extract {
 
 set pyversions {310 311 312 313 314}
 
-set nanobind_version    2.12.0
+set nanobind_version    2.15.0
 set nanobind_commit     ${nanobind_version}
 set robin_map_commit    4ec1bf19c6a96125ea22062f38c2cf5b958e448e
 
@@ -124,9 +124,9 @@ foreach v ${pyversions} {
         master_sites-append https://github.com/wjakob/nanobind/archive/refs/tags/v${nanobind_version}:nanobind
         distfiles-append    nanobind-${nanobind_version}.tar.gz:nanobind
         checksums-append    nanobind-${nanobind_version}.tar.gz \
-                            rmd160  cb6db5c51dba53f8b76142a60cd18f64fb373f49 \
-                            sha256  01f1f0cd0398743c18f33d07ae36ad410bd7f4a1e90683b508504de897d6e629 \
-                            size    940575
+                            rmd160  dfecadda000234c28e71a73817e63fa75b505c64 \
+                            sha256  36c8760b3acb25643cd89d549782d8c67bd82ce54c6238608787c22a34fd490f \
+                            size    999019
 
         # robin-map (nanobind submodule dependency)
         master_sites-append https://github.com/Tessil/robin-map/archive/${robin_map_commit}:robin_map


### PR DESCRIPTION
#### Description

Update the pinned version of nanobind to 2.15.0 (it changed from 2.12.0 in mlx-0.32.2).

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
