### PR TITLE
pv: Update to 1.11.0

### DIFF
--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -8,7 +8,7 @@ PortGroup           codeberg 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-codeberg.setup      a-j-wood pv 1.10.5 v
+codeberg.setup      ivarch pv 1.11.0 v
 
 revision            0
 categories          sysutils
@@ -28,9 +28,9 @@ homepage            https://www.ivarch.com/programs/pv.shtml
 master_sites        ${codeberg.homepage}/releases/download/v${version}
 
 distname            ${name}-${version}
-checksums           rmd160  d8ac435f8ff85d40febf3290532388a72ec70942 \
-                    sha256  ab21b4f8662280646b6a02e1b9f096790918f89c952bbe0d06fef75d3b52fb15 \
-                    size    439611
+checksums           rmd160  8a200149d8ca145adc0a04dfe91bfab143fda9f6 \
+                    sha256  fc02c9fc2b82b20a92cc8d98f844be63f22abd98751a8e4abc875e1d803662eb \
+                    size    477407
 
 patch.pre_args-replace  -p0 -p1
 patchfiles          fix-modifiers-direct-io-test.diff
@@ -40,6 +40,7 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 
 depends_build-append \
                     port:gettext
-depends_lib-append  port:gettext-runtime
+depends_lib-append  port:gettext-runtime \
+                    port:ncurses
 
 test.run            yes


### PR DESCRIPTION
#### Description

Update pv to 1.11.0. While the repo was moved, a "change in upstream" is inaccurate as the same upstream maintains the project.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
