### PR TITLE
litestream: update to 0.5.17

### DIFF
--- a/databases/litestream/Portfile
+++ b/databases/litestream/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/benbjohnson/litestream 0.5.16 v
+go.setup            github.com/benbjohnson/litestream 0.5.17 v
 go.offline_build    no
 go.toolchain_min    1.25.0
 revision            0
@@ -24,9 +24,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  55554ebb6cf9dac3395af2881a2ed86a96a8902e \
-                    sha256  9cab807c37c4726a72a9bd33ba3f690765724cc4ec4a37b5b788abffd23331f6 \
-                    size    831414
+checksums           rmd160  3a7ba50a137483f2620e53adb4af0627a7c9cb07 \
+                    sha256  cf347231b6ee7ef28b5e3d80b6202edd16da29f29f66c339fe4a5c82f78d13f0 \
+                    size    844163
 
 build.pre_args-append \
     -ldflags \" -X main.Version=${github.tag_prefix}${version} \"


### PR DESCRIPTION
#### Description

Not verified: this branch was minted with --no-verify, so no verification was ever asked for.

Branch head `566f10b7e9cb`, against the ports tree as of 2026-09-09.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

Automated by [dockhand](https://github.com/herbygillot/dockhand) f19a23cecdf3-dirty
