### PR TITLE
pgroll: update to 0.16.3

### DIFF
--- a/databases/pgroll/Portfile
+++ b/databases/pgroll/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/xataio/pgroll 0.16.2 v
+go.setup            github.com/xataio/pgroll 0.16.3 v
 go.toolchain_min    1.26.3
 go.offline_build    no
 revision            0
@@ -29,9 +29,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  b01a19e6302c55eef442f788e1f95fe1855e4d22 \
-                    sha256  d944b31c6a4b90eeb170db249c1a012b85663ff25f438f007068efc76e4546a7 \
-                    size    605182
+checksums           rmd160  26e00f6f132c523e1bd4ab011b1894e2cfcf5f30 \
+                    sha256  28531c0021773e82867c7d0df8859d4fc2eadfc444c6e451f39c58265c9c2a69 \
+                    size    603995
 
 github.livecheck.regex \
                     {([0-9.]+)}


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `09b21dfa87bd`, against the ports tree as of 2026-09-09.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) f19a23cecdf3-dirty
