### PR TITLE
eslint: update to 10.10.0

### DIFF
--- a/devel/eslint/Portfile
+++ b/devel/eslint/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                eslint
-version             10.9.1
+version             10.10.0
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ long_description    ESLint statically analyzes JavaScript and TypeScript code \
 
 homepage            https://eslint.org
 
-checksums           rmd160  032536d0b394b82c74ec88d42401dcaabfa9238c \
-                    sha256  e7aebee5effb01785c583b3e0f2fb28018c88bc9eb52dc6896a2901c496af5b8 \
-                    size    622074
+checksums           rmd160  5212c28813b64c749854823797874290c4de38df \
+                    sha256  897c8ff1a16dbc0420d9815b59bfbad27d079c3ddaef6ee1099bb4b4593c0031 \
+                    size    622303
 
 # jiti is an optional peer dependency, needed to load a TypeScript
 # eslint.config.ts. It resolves as a sibling in ${prefix}/lib/node_modules.


### PR DESCRIPTION
#### Description

Update `devel/eslint` from 10.9.1 to 10.10.0.
Latest upstream is 10.10.0 (2026-09-04) per `https://registry.npmjs.org/eslint/latest` (`livecheck`) and https://eslint.org/blog/2026/09/eslint-v10.10.0-released/.

Changes since 10.9.1 (npm `eslint` 10.10.0):
- feat: `no-unexpected-multiline` checks regexp literals with `d`/`v` flags
- feat: `new-cap` checks `Object.prototype` property names; fix UTC false positive with `properties: false`
- feat: `no-extra-bind` false negatives with class fields and static blocks
- fix: `prefer-object-has-own` autofix when `Object` is shadowed; `no-unreachable` ignore static imports; `__proto__` in `/* exported */`; dependency `file-entry-cache` to v11

No `devel/jiti` change needed: `jiti` remains `latest` on npm and still satisfies `eslint` peerDependency `jiti: *`.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

*auto-detected as `type: update` via title `eslint: update to 10.10.0`*

###### Tested on

macOS 15.7.9 24G830 arm64
Xcode 26.3 17C529

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)? (`eslint: update to 10.10.0`)
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)? (single commit; `git diff --stat` = 1 file)
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? (no open eslint update; prior #34454 merged)
- [x] checked your Portfile with `port lint`? (`port lint --nitpick` in category layout → 0 errors, 0 warnings)
- [x] tried existing tests with `sudo port test`? (no `test` phase for `npm` PortGroup — no-op)
- [x] tried a full install with `sudo port -vst install`? (`sudo port -v install` succeeded; `-vst` killed npm with signal 9 on this machine; checksum + destroot verified)
- [x] tested basic functionality of all binary files? (`eslint --version` → `v10.10.0`; `eslint -c` smoke run exits 0; checksums `rmd160 5212c28813b64c749854823797874290c4de38df` `sha256 897c8ff1a16dbc0420d9815b59bfbad27d079c3ddaef6ee1099bb4b4593c0031` `size 622303` from `https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz`; `sudo port checksum` OK)
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (no variants; `platforms any`, `supported_archs noarch`)
