### PR TITLE
oh-my-pi: update to 18.1.15

### DIFF
--- a/llm/oh-my-pi/Portfile
+++ b/llm/oh-my-pi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           bun 1.0
 
 name                oh-my-pi
-version             18.0.11
+version             18.1.15
 revision            0
 
 categories          llm
@@ -25,7 +25,10 @@ long_description    oh-my-pi (omp) is a coding agent CLI that wires the IDE in, 
 homepage            https://omp.sh
 
 bun.rootname        @oh-my-pi/pi-coding-agent
+# Monorepo packages are co-published at the same version; the PortGroup
+# default 3-day minimum-release-age blocks those exact pins until they age.
+bun.minimum_release_age 0
 
-checksums           rmd160  09c9f5e6889f5d0c101298697dbcb26ec28f6cde \
-                    sha256  a5757dccfc4b2c6101cd3a4e09e98a51e795e700e0e4f6be930ce9de595f33b6 \
-                    size    11561535
+checksums           rmd160  efbf29f9eb035e25b206f7f3082cfcc3c90e86bd \
+                    sha256  6247811119c5af37bfab9a983d20ccd3e4d2a608c0ec1eebd6946062af30745b \
+                    size    11677115


### PR DESCRIPTION
#### Description

Update `llm/oh-my-pi` from 18.0.11 to 18.1.15.
Latest upstream is 18.1.15 per `https://registry.npmjs.org/@oh-my-pi/pi-coding-agent/latest` (`livecheck`).

Also set `bun.minimum_release_age 0`. The bun PortGroup default (3 days) blocks destroot for this port: the top-level tarball is checksummed and installed from a local file, but monorepo dependencies are exact pins at the same version (`@oh-my-pi/pi-utils`, `pi-ai`, `pi-tui`, `pi-natives`, `pi-agent-core`, `pi-wire`, `pi-catalog`, `pi-mnemopi`, `omp-stats`, `omptype`, `snapcompact`, …) and fail with `blocked by minimum-release-age: 259200 seconds` until they age.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

*auto-detected as `type: update` via title `oh-my-pi: update to 18.1.15`*

###### Tested on

macOS 15.7.9 24G830 arm64
Xcode 26.3 17C529

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)? (`oh-my-pi: update to 18.1.15`)
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)? (single commit; `git diff --stat` = 1 file)
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? (no open oh-my-pi update; prior #34031 merged)
- [x] checked your Portfile with `port lint`? (`port lint --nitpick` in category layout → 0 errors, 0 warnings)
- [x] tried existing tests with `sudo port test`? (no `test` phase for `bun` PortGroup — no-op)
- [x] tried a full install with `sudo port -vst install`? (`sudo port -v install` succeeded with `bun.minimum_release_age 0`; checksum verified)
- [x] tested basic functionality of all binary files? (`omp --version` → `omp/18.1.15`; checksums `rmd160 efbf29f9eb035e25b206f7f3082cfcc3c90e86bd` `sha256 6247811119c5af37bfab9a983d20ccd3e4d2a608c0ec1eebd6946062af30745b` `size 11677115` from `https://registry.npmjs.org/@oh-my-pi/pi-coding-agent/-/pi-coding-agent-18.1.15.tgz`)
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (no variants)
