### PR TITLE
repgrep: update to 0.17.1

### DIFF
--- a/textproc/repgrep/Portfile
+++ b/textproc/repgrep/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        acheronfail repgrep 0.17.0
+github.setup        acheronfail repgrep 0.17.1
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  56e3a827b7214adb997fc6e1404ff71f0cb472c4 \
-                    sha256  d0fa90f25247a0cc6f586bc14ad636cfaa1f212ffa49c9c01ebe98e72f647313 \
-                    size    1237023
+                    rmd160  8a9b3659b197236cf00509a24ac7d0422e8dd3e1 \
+                    sha256  317be5207a64bcd5aa29215c6e4c8016b6d099453fc3ef3c365af01ab500935e \
+                    size    1237030
 
 depends_build-append \
                     port:asciidoctor


### PR DESCRIPTION
#### Description

Update repgrep from 0.17.0 to 0.17.1 and refresh the source archive checksums. The regenerated Cargo dependency list is unchanged.

[Upstream release notes](https://github.com/acheronfail/repgrep/releases/tag/0.17.1): this release changes CI and release packaging, with no application changes.

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted with 203 warnings, built from source and installed in a pristine VM.

Branch head `eb47b3bd6825`, against the ports tree as of 2026-09-09.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

- macOS Tahoe 26.6.2 (25G83), arm64
- Command Line Tools 26.5.0.0.1777544298
- Pristine VM verification with dockhand; `rgr --version` reports `repgrep 0.17.1`

Additional checks: `rgr --help`, automatic replacement of both `foo` matches in a temporary file while preserving an unrelated line, and integrity of the installed compressed manual page all passed. The installed file list is unchanged from 0.17.0.

`port lint` reported zero errors and 203 existing warnings about Cargo crates lacking the recommended rmd160 checksum. `port test` was invoked successfully, but this Portfile does not enable a test command, so the upstream test suite was not run.

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] invoked `sudo port test`? (No test command is enabled by this Portfile; see above.)
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM
- [x] tested basic functionality of the installed `rgr` binary?

Automated by [dockhand](https://github.com/herbygillot/dockhand) 06bdd7eee896-recovery

