### PR TITLE
golang-1.0.tcl: fix test.env and configure.env

### DIFF
--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -388,8 +388,8 @@ proc go.append_env {} {
                 "CGO_LDFLAGS=${configure.cflags} ${configure.ldflags} [get_canonical_archflags ld]" \
                 "GO_LDFLAGS=-extldflags='${configure.ldflags} [get_canonical_archflags ld]'"
         }
-        configure.env-append ${build.env}
-        test.env-append      ${build.env}
+        configure.env-append {*}${build.env}
+        test.env-append      {*}${build.env}
     }
 
     if { ! ${go.offline_build} } {


### PR DESCRIPTION
#### Description

`configure.env-append` and `test.env-append` take one variable per argument, so
passing `${build.env}` unexpanded appends it as a single element. Base splits an
element at its first `=`, so `GOPATH` receives the whole environment as its value
and no vendored package resolves. `build.env` composes its own list and is
unaffected, which is why this has gone unnoticed.

No existing port changes behaviour. Of the six golang ports running the default
`go test`, four vendor nothing, so a corrupt `GOPATH` costs them nothing, and
`mos`/`mos-devel` do not get that far (stale checksum for a vendor). No golang
port sets `use_configure yes`. Verified on a new port that does vendor:
`FAIL [setup failed]` before, `ok` after.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?

Trace mode is unavailable on this arm64 machine, so `-vs` rather than `-vst`.
Patch written with AI assistance; I can explain and defend every line.
