### PR TITLE
go ports: fetch renamed vendors from their current repo

### DIFF
--- a/devel/gig/Portfile
+++ b/devel/gig/Portfile
@@ -165,10 +165,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/sergi/go-diff \
                         lock    v1.1.0 \
                         rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
@@ -240,9 +241,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
                         size    2291 \
                     github.com/imdario/mergo \
+                        repo    github.com/darccio/mergo \
                         lock    v0.3.12 \
-                        rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
-                        sha256  dadb5b52d2de5fe7336eda4c331eefb0d4be716a5844cc7ab15c96b9b6e07b2d \
+                        rmd160  92146df5e8cd63505a96de7ae6acb66051afd211 \
+                        sha256  b9d17589da0e392f6da103b4b4007f53dad384f26cd9468b602c02cec717f2b2 \
                         size    22341 \
                     github.com/hashicorp/hcl \
                         lock    v1.0.0 \

--- a/devel/gokart/Portfile
+++ b/devel/gokart/Portfile
@@ -197,9 +197,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
                         size    2291 \
                     github.com/imdario/mergo \
+                        repo    github.com/darccio/mergo \
                         lock    v0.3.12 \
-                        rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
-                        sha256  dadb5b52d2de5fe7336eda4c331eefb0d4be716a5844cc7ab15c96b9b6e07b2d \
+                        rmd160  92146df5e8cd63505a96de7ae6acb66051afd211 \
+                        sha256  b9d17589da0e392f6da103b4b4007f53dad384f26cd9468b602c02cec717f2b2 \
                         size    22341 \
                     github.com/google/go-cmp \
                         lock    v0.5.5 \

--- a/devel/sampler/Portfile
+++ b/devel/sampler/Portfile
@@ -80,10 +80,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  407533a2bca7c9b49b2ef5860350f0533227335191dc90995ca880091e35b503 \
                         size    55476 \
                     github.com/hajimehoshi/oto \
+                        repo    github.com/ebitengine/oto \
                         lock    v0.1.1 \
-                        rmd160  0a9e18c46a8c20302b8eec27c6d1dfa17622ec79 \
-                        sha256  32e1735ebb3fe1489569a9b565b4f924f8e27cb3a33e5dfca09a6f7a2c2cba90 \
-                        size    15022 \
+                        rmd160  bf32cb036f48e83fc715003fc24054f82b1de4cb \
+                        sha256  66956dbce4bf44afb159de3e92515b40f62e596ccbdae6571a11b0f59e1ef85c \
+                        size    15033 \
                     github.com/hajimehoshi/go-mp3 \
                         lock    v0.1.1 \
                         rmd160  47ebe163a40dbe31e2f5614cf5ec555d30312470 \

--- a/net/ec2-ls-hosts/Portfile
+++ b/net/ec2-ls-hosts/Portfile
@@ -40,20 +40,22 @@ go.vendors          github.com/aws/aws-sdk-go \
                         sha256  08f16ad09da5b3d22b2500d1b37abd7170654184292f6869c551f0de13ad9013 \
                         size    48224 \
                     github.com/jtolds/gls \
+                        repo    github.com/jtolio/gls \
                         lock    v4.20.0 \
-                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
-                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
-                        size    7305 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/smartystreets/goconvey \
                         lock    v1.6.4 \
                         rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \

--- a/net/trojan-go/Portfile
+++ b/net/trojan-go/Portfile
@@ -165,6 +165,7 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
                         rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
                         sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \

--- a/office/geek-life/Portfile
+++ b/office/geek-life/Portfile
@@ -86,10 +86,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  ca218846d724343915b264d1c246c34eb39e81ed14535931f370c2db838d4d99 \
                         size    96543 \
                     github.com/zyedidia/micro \
+                        repo    github.com/micro-editor/micro \
                         lock    v1.4.1 \
-                        rmd160  1ae3d761a93085b749a8be80236d926cd1505e00 \
-                        sha256  8ef2903a6fb9c6282e3b85e573f76e611c879fcab626b30e9cc43c7bdbea15d5 \
-                        size    520317 \
+                        rmd160  e604e29669d5c91f65dec41ba23c697fb758f90c \
+                        sha256  aebda3eebb41f9a116caf1db1ccf3d6a05278e08fc83a33825f469b8e7224ca9 \
+                        size    520333 \
                     github.com/vmihailenco/msgpack \
                         lock    v4.0.4 \
                         rmd160  89df770ec853d2f63af382d7ebb109ad43a694cd \

--- a/sysutils/chaakoo/Portfile
+++ b/sysutils/chaakoo/Portfile
@@ -118,10 +118,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/rs/zerolog \
                         lock    v1.24.0 \
                         rmd160  0f8ff236e6872e7c2d412cc67a254c7c06369fb5 \

--- a/sysutils/lporg/Portfile
+++ b/sysutils/lporg/Portfile
@@ -216,11 +216,11 @@ go.vendors          howett.net/plist \
                         sha256  81d106311b0a7a4971c45c14786451136bf238263fbb57d42977ecfd6f84a3a3 \
                         size    15320 \
                     github.com/AlecAivazis/survey \
-                        repo    github.com/go-survey/survey \
+                        repo    github.com/AlecAivazis/survey \
                         lock    v2.3.6 \
-                        rmd160  8af519d0839cac947b44f67b037d930e41227690 \
-                        sha256  d692ec0dedfa6fdcd440c83829072cc3da69e6f2ddaa153f5a340f7f8d86fe0e \
-                        size    1466690
+                        rmd160  97bd1054dbfc5abbd79110fb2fdf2a86ebbd9925 \
+                        sha256  679ca475b1865187681d0600e49df8a3501fb361c13606aedf8aec4b7498fd6a \
+                        size    1466976
 
 patchfiles          patch-rm-buildtime-in-version.diff
 


### PR DESCRIPTION
#### Description

Six vendored projects moved to a new GitHub owner: `smartystreets/assertions` →
`smarty`, `imdario/mergo` → `darccio`, `jtolds/gls` → `jtolio`, `hajimehoshi/oto` →
`ebitengine`, `zyedidia/micro` → `micro-editor`, `go-survey/survey` → `AlecAivazis`.
GitHub embeds the repository name in the tarball's top-level directory, so the bytes
changed while the commit did not.

Updating the checksums alone is wrong for some of these: `distfiles.macports.org`
still serves the pre-rename tarball for `imdario-mergo-*` and `jtolds-gls-*` but the
post-rename one for `smartystreets-assertions-*`, so a recorded value can match the
mirror or upstream but not both. That is why these fail only when the mirror is
missed. Naming the current repo gives the distfile a name no stale copy answers to.

Found by resolving all 1040 GitHub repos vendored by go ports through the API. Ports
whose vendors are also stale but which fail to build for unrelated reasons are left
out: `mos`, `mos-devel`, `leaf`, `gomodctl` and `kubeval` pin a `golang.org/x/sys`
that no longer compiles, and `please` fails in `gopsutil`'s cgo.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?

`sudo port destroot` passes for all seven after `port clean --dist`, which is the cold
state CI fetches in. Each extracted tarball was diffed against a checkout of its
pinned ref and is identical, so only the packaging changed. Three remaining `port
lint` warnings are pre-existing and identical on master. Trace mode is unavailable on
this arm64 machine, so `-vs` rather than `-vst`. Patch written with AI assistance; I
can explain and defend every line.
