### PR TITLE
hugo: update to 0.166.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.165.0 v
+go.setup            github.com/gohugoio/hugo 0.166.0 v
 go.offline_build    no
-go.toolchain_min    1.26.0
+go.toolchain_min    1.27.0
 revision            0
 
-checksums           rmd160  d0e7edc1b1559a23660d2eb041cbf0a68631128d \
-                    sha256  e9c1e7d8e6e09356cc56317fd01b7493d712692390b89b3d33810cfe1305650e \
-                    size    11641321
+checksums           rmd160  0abbca374f4752a35d2d07171107fd65f43facc3 \
+                    sha256  599566b8270a0872061f43564d81961a5f1a02857022078d1fcb3a601189f573 \
+                    size    12012388
 
 categories          www
 installs_libs       no


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM.

Branch head `78fe4602ab69`, against the ports tree as of 2026-09-09.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 89149a25a3c8-dirty
