### PR TITLE
delve: update to 1.27.2

### DIFF
--- a/devel/delve/Portfile
+++ b/devel/delve/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-delve/delve 1.27.1 v
+go.setup            github.com/go-delve/delve 1.27.2 v
 go.offline_build    no
 go.toolchain_min    1.25.0
 revision            0
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  3cd7e4d4a6bbc4465a3b91a2ac4362dec84e9fa3 \
-                    sha256  dca9ec6f2c392a00449ad748b3a229e92ba4efa67f4e7582f2cc45974429928f \
-                    size    9521825
+checksums           rmd160  451c6edb3bd02a7d67f1adbb2910ca3a9e1fd5ee \
+                    sha256  8ea5979dfc5978c9690dc1dd533a830815441dd33617f4a61bcdff7d2c3c7e90 \
+                    size    9610147
 
 post-extract {
     reinplace -E s|@go|@${go.bin}| ${worksrcpath}/Makefile


### PR DESCRIPTION
#### Description

Update delve from 1.27.1 to 1.27.2 and refresh the source archive checksums.

[Upstream release notes](https://github.com/go-delve/delve/releases/tag/v1.27.2).

###### Tested on

macOS Tahoe 26.6.2 (25G83), arm64; Xcode 26.6 and Command Line Tools 26.5.0.0.1777544298.

###### Verification

- `port lint`: zero errors and zero warnings.
- Built from source and installed successfully in a pristine VM using dockhand. The verified and published commits have identical Git trees.
- Installed file list matches 1.27.1.
- `dlv version` reports 1.27.2; `dlv --help` works.
- `port test` was requested and invoked, but the Portfile has no enabled tests. The upstream test suite was not run.
- `git diff --check` passed; the PR contains one commit changing only the delve Portfile.

Generated and published by [dockhand](https://github.com/herbygillot/dockhand) `e97c8cc11065`.
