### PR TITLE
age: update to 1.3.2

### DIFF
--- a/security/age/Portfile
+++ b/security/age/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/FiloSottile/age 1.3.1 v
+go.setup            github.com/FiloSottile/age 1.3.2 v
 go.package          filippo.io/age
-go.toolchain_min    1.24.0
+go.toolchain_min    1.25.0
 revision            0
 
 homepage            https://age-encryption.org
@@ -42,35 +42,35 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  ecdbbb2393fb7dae1ce16a46e0e87e11f749c304 \
-                        sha256  396007bc0bc53de253391493bda1252757ba63af1a19db86cfb60a35cb9d290a \
-                        size    247789
+                        rmd160  63825a288d561fe52114efcc87ac42f0b8737a13 \
+                        sha256  b07c28c6c4bdafa272073a310b75bc22c49da8904585a89c30e5ca4233e63843 \
+                        size    252561
 
 go.vendors          golang.org/x/tools \
-                        lock    v0.39.0 \
-                        rmd160  709ceb0817539220bd256f8646c8837aa1adf55f \
-                        sha256  55ed1e9dfff57ad77abaf2b1fc6db34205aebe4375f7dd8215f06d98bd662168 \
-                        size    8312159 \
+                        lock    v0.49.0 \
+                        rmd160  75fdb95ddade5f35a4edab60301aa3c8cc8bf377 \
+                        sha256  9d7c6a94bdfeb87bcf19bcf310d95ea432525dfa08a1acb136b7fc3ad37fea34 \
+                        size    8584700 \
                     golang.org/x/term \
-                        lock    v0.37.0 \
-                        rmd160  3759f4d1753501eddc200d9470abbc5532628b4d \
-                        sha256  5c843cde30cc5db1f4f91029922acfef7ef7b2f25e8de668a9810bb6eb6b8920 \
-                        size    15933 \
-                    golang.org/x/sys \
-                        lock    v0.38.0 \
-                        rmd160  116c6683aefacc223a60af4811ab8d97c4d3f6b0 \
-                        sha256  5a63f5eb3814a66b1988ad9ff703c8d54d79463eed52a49f546091e17682cbc7 \
-                        size    1535499 \
-                    golang.org/x/crypto \
                         lock    v0.45.0 \
-                        rmd160  5e8c5670b4ae9f82c9bc4e41dd2863beab2bd7e0 \
-                        sha256  bd578b01007a7eccb50a26722812150c25361e900f329d961dcb1e52fa121ef0 \
-                        size    2152069 \
+                        rmd160  2ff34ce76d39e5ca3ff919a7539d425debb3ebda \
+                        sha256  f71934454e5fc440c2eb43e9739cd9bd91c1014883faf65d65159717ff2bd875 \
+                        size    16446 \
+                    golang.org/x/sys \
+                        lock    v0.47.0 \
+                        rmd160  1be59a8208fd6f7f4319b306138e77f215293e1a \
+                        sha256  2bed220513067f721fc7c19314bab58860c28397f5e48093a8fe35a27a915b06 \
+                        size    1551474 \
+                    golang.org/x/crypto \
+                        lock    v0.55.0 \
+                        rmd160  ce0f3da5d5c5780d191ad6ccf2d539f82430e21b \
+                        sha256  520171df87af2cad518bfbb189c470490970fa0ae16a73cf8a5993dd4d0d9ec6 \
+                        size    2166006 \
                     github.com/rogpeppe/go-internal \
-                        lock    v1.14.1 \
-                        rmd160  73e6c350ebee85f1124b04a1d0efecfa724a8835 \
-                        sha256  32749548af3fe11d55ec86ce24a089e1611224a0e302058695961498e73cac8a \
-                        size    116406 \
+                        lock    v1.16.0 \
+                        rmd160  1690653379051865df81608043ca3b1d3b702d40 \
+                        sha256  20b5d9cddf8c6f993614f5b7bcf9f3ebb315a67c765400f1467f215422034d85 \
+                        size    130678 \
                     filippo.io/nistec \
                         repo    github.com/FiloSottile/nistec \
                         lock    v0.0.4 \
@@ -85,13 +85,13 @@ go.vendors          golang.org/x/tools \
                         size    78232 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
-                        lock    v1.1.0 \
-                        rmd160  32e76862168e566190f9be95e5a88dcb10b3a6a2 \
-                        sha256  a68a54423370e136bf03e4217d2fba807b4d041f873f6ebbcfc8ad4ba9925f5d \
-                        size    47132 \
+                        lock    v1.2.0 \
+                        rmd160  10eba0c92439662b5f60514a1a6d7529e4edddfc \
+                        sha256  82d745328974d29c0e11ee0be3431e1115391f4293947fb61da7179c30479611 \
+                        size    46984 \
                     c2sp.org/CCTV/age \
                         repo    github.com/C2SP/CCTV \
-                        lock    e9274a7bdbfd \
-                        rmd160  d9ed215a87b8286bf78080bc03200ead5df017dd \
-                        sha256  fa8750df366002d1fed8e4e67a6e1e15bcd164e82549c3e3ab491d966f48d705 \
-                        size    399064
+                        lock    4448f2097b2d \
+                        rmd160  f371844990c0cb978de4b266584575e1cfc4323c \
+                        sha256  6fc74ab5dfd47f8e207824984768646008829914f0bb6d4968906b6c19a47c12 \
+                        size    1352052


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted clean, built in a pristine VM, and the port enables no test command.

Branch head `738c89c0603e`, against the ports tree as of 2026-09-09.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 0a622c166559
