### PR TITLE
git-cliff: update to 2.14.1

### DIFF
--- a/devel/git-cliff/Portfile
+++ b/devel/git-cliff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        orhun git-cliff 2.13.1 v
+github.setup        orhun git-cliff 2.14.1 v
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ecda51efae7daf89d65b9516bc90e52477b7668e \
-                    sha256  3dd3138a009ade1085dd2f001f836c2bb406462a99512dbcb573bda1f2166274 \
-                    size    13353151
+                    rmd160  c760860d4e6307eff079c4683b92701bc3b7e605 \
+                    sha256  22f01e016a02d674eb23afee3f0169a725352cc42d54549ecdb031e8f59e87e6 \
+                    size    13387344
 
 github.livecheck.regex \
                     {([0-9.]+)}
@@ -46,9 +46,9 @@ cargo.crates \
     aligned-vec                      0.6.4  dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                        0.6.21  43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a \
-    anstyle                         1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
-    anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
+    anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
+    anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
     anyhow                          1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
@@ -69,6 +69,7 @@ cargo.crates \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                        2.10.0  812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    block-buffer                    0.12.1  d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa \
     bstr                            1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
     bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
     bytemuck                        1.23.2  3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677 \
@@ -77,38 +78,41 @@ cargo.crates \
     cc                              1.2.49  90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chrono                          0.4.42  145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2 \
+    chrono                          0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
     chrono-tz                        0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
-    clap                            4.5.53  c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8 \
-    clap_builder                    4.5.53  d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00 \
-    clap_complete                   4.5.61  39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992 \
-    clap_derive                     4.5.49  2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671 \
-    clap_lex                         0.7.6  a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d \
-    clap_mangen                     0.2.31  439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301 \
+    clap                             4.6.6  473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca \
+    clap_builder                     4.6.6  7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889 \
+    clap_complete                    4.6.9  3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19 \
+    clap_derive                      4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
+    clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    clap_mangen                     0.2.33  7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78 \
     colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     compression-codecs              0.4.30  485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64 \
     compression-core                0.4.29  e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb \
-    config                         0.15.19  b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6 \
-    console                         0.16.1  b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4 \
+    config                         0.15.25  b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139 \
+    console                         0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
+    const-oid                       0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     cookie                          0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
     cookie_store                    0.22.0  3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f \
     core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    core2                            0.4.0  b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505 \
     cpp_demangle                     0.4.4  96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
+    cpufeatures                      0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
     crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
+    crypto-common                    0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
     dary_heap                        0.3.8  06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04 \
     debugid                          0.8.0  bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d \
-    deranged                         0.5.5  ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587 \
+    deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     deunicode                        1.6.2  abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    digest                          0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
     dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
@@ -130,30 +134,30 @@ cargo.crates \
     findshlibs                      0.10.2  40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64 \
     flate2                           1.1.2  4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
-    futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
-    futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
-    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
-    futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
-    futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
-    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
-    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
-    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    futures                         0.3.34  9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3 \
+    futures-channel                 0.3.34  b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4 \
+    futures-core                    0.3.34  92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e \
+    futures-executor                0.3.34  031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432 \
+    futures-io                      0.3.34  53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed \
+    futures-macro                   0.3.34  9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44 \
+    futures-sink                    0.3.34  1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d \
+    futures-task                    0.3.34  cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd \
+    futures-util                    0.3.34  0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     git-conventional                0.12.9  f6a949b7fcc81df22526032dcddb006e78c8575e47b0e7ba57d9960570a57bc4 \
-    git2                            0.20.3  3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c \
+    git-conventional                 1.1.0  7079e0e98895b810e042ef90b667d8d0a28c172fb3212e777b2d279ec2b29f25 \
+    git2                            0.21.0  ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e \
     glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     globset                         0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
-    hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
-    hashlink                        0.10.0  7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1 \
+    hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
+    hashlink                        0.11.1  824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
@@ -161,13 +165,16 @@ cargo.crates \
     http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
-    http-cache                      0.20.0  33b65cd1687caf2c7fff496741a2f264c26f54e6d6cec03dac8f276fa4e5430e \
-    http-cache-reqwest              0.15.0  735586904a5ce0c13877c57cb4eb8195eb7c11ec1ffd64d4db053fb8559ca62e \
+    http-cache                      0.21.0  1437561a949a2168929d7559aecd2f0ecb18b9e676080396388cdc399ddb723a \
+    http-cache-reqwest              0.16.0  8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886 \
     http-cache-semantics             2.1.0  92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c \
     http-serde                       2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     humansize                        2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
+    humantime                        2.4.0  15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15 \
+    humantime-serde                  1.1.1  57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c \
+    hybrid-array                    0.4.14  707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b \
     hyper                            1.7.0  eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e \
     hyper-rustls                    0.27.7  e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58 \
     hyper-util                      0.1.16  8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e \
@@ -183,11 +190,11 @@ cargo.crates \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     ignore                          0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
-    include-flate                    0.3.1  e01b7cb6ca682a621e7cda1c358c9724b53a7b4409be9be1dd443b7f3a26f998 \
-    include-flate-codegen            0.3.1  4f49bf5274aebe468d6e6eba14a977eaf1efa481dc173f361020de70c1c48050 \
-    include-flate-compress           0.3.1  eae6a40e716bcd5931f5dbb79cd921512a4f647e2e9413fded3171fca3824dbc \
-    indexmap                        2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
-    indicatif                       0.18.3  9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88 \
+    include-flate                    0.3.4  48f173716febb1ad596c16ea5637b5f1790ea32de8e627493ff82bc73b0876ce \
+    include-flate-codegen            0.3.4  4a7875b62a72ad3f3203cdd8950d4cf9947db036030b974b8b37ceae90c8d8c0 \
+    include-flate-compress           0.3.4  44fbb9c5ccb9a5b67b4afa2974c27e5507ea1bf6d22828cef418e4dfaeca51dd \
+    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    indicatif                       0.18.6  9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c \
     inferno                        0.11.21  232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88 \
     ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
     iri-string                       0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
@@ -198,9 +205,9 @@ cargo.crates \
     js-sys                          0.3.78  0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libc                           0.2.184  48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af \
-    libflate                         2.2.1  e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74 \
-    libflate_lz77                    2.2.0  a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c \
-    libgit2-sys               0.18.3+1.9.2  c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487 \
+    libflate                         2.3.1  a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c \
+    libflate_lz77                    2.3.0  ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd \
+    libgit2-sys               0.18.8+1.9.7  7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50 \
     libm                            0.2.15  f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de \
     libredox                        0.1.10  416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb \
     libz-sys                        1.1.22  8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d \
@@ -216,12 +223,15 @@ cargo.crates \
     memmap2                          0.9.8  843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7 \
     miette                          5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
     miette-derive                   5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.1.1  a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc \
-    next_version                    0.2.26  cc89399c10a3de3a18971b961e9fea788eb252d887c1c2f740f351a907088d0c \
+    mio                              1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
+    next_version                     0.3.2  f4d5b15eae9d89526dcd42a9d3e3ebdf4a15664843348dd3e664b8102e42b7d5 \
     nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
+    no_std_io2                       0.9.4  418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003 \
     nu-ansi-term                    0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
-    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
+    num-conv                         0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
     num-format                       0.4.4  a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
@@ -229,7 +239,7 @@ cargo.crates \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
-    owo-colors                       4.2.3  9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52 \
+    owo-colors                       4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
     parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     parse-zoneinfo                   0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
@@ -246,23 +256,25 @@ cargo.crates \
     pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkg-config                      0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
-    portable-atomic                 1.11.1  f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
+    portable-atomic                 1.15.0  05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85 \
     potential_utf                    0.1.4  b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     pprof                           0.15.0  38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
-    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
-    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro2                    1.0.103  5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8 \
+    proc-macro-error-attr3           3.1.0  b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7 \
+    proc-macro-error3                3.1.0  0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50 \
+    proc-macro2                    1.0.107  985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9 \
+    pulldown-cmark                  0.13.4  e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e \
+    pulldown-cmark-to-cmark         22.0.1  ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60 \
     quick-xml                       0.26.0  7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd \
     quinn                           0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
     quinn-proto                    0.11.13  f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31 \
     quinn-udp                       0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
-    quote                           1.0.42  a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f \
+    quote                           1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
-    rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
+    rand                             0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
@@ -278,10 +290,10 @@ cargo.crates \
     rgb                             0.8.52  0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rle-decode-fast                  1.0.3  3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422 \
-    roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
-    rust-embed                      8.11.0  04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27 \
-    rust-embed-impl                  8.9.0  5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2 \
-    rust-embed-utils                 8.9.0  60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475 \
+    roff                             1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
+    rust-embed                      8.12.0  e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9 \
+    rust-embed-impl                 8.12.0  3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097 \
+    rust-embed-utils                8.12.0  42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0 \
     rustc-demangle                  0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
@@ -293,34 +305,33 @@ cargo.crates \
     rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    scc                              2.4.0  46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc \
     schannel                        0.1.28  891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    sdd                             3.0.10  490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
     secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
     security-framework               3.4.0  60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640 \
     security-framework-sys          2.15.0  cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0 \
-    semver                          1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
-    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
-    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                     1.0.145  402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c \
-    serde_regex                      1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
-    serde_spanned                    1.0.3  e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392 \
+    semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
+    serde                          1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
+    serde_core                     1.0.229  67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48 \
+    serde_derive                   1.0.229  e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348 \
+    serde_json                     1.0.151  c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14 \
+    serde_regex                      1.2.0  bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012 \
+    serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serial_test                      3.4.0  911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f \
-    serial_test_derive               3.4.0  0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9 \
+    serial_test                      3.5.0  699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d \
+    serial_test_derive               3.5.0  94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c \
     sha-1                           0.10.1  f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
+    sha2                            0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
-    shellexpand                      3.1.1  8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb \
+    shellexpand                      3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
     slab                            0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    socket2                          0.6.1  17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881 \
+    socket2                          0.6.5  c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4 \
     spin                            0.10.0  d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591 \
     ssri                             9.2.0  da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082 \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
@@ -329,34 +340,36 @@ cargo.crates \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     symbolic-common                12.16.2  9da12f8fecbbeaa1ee62c1d50dc656407e007c3ee7b2a41afce4b5089eaef15e \
     symbolic-demangle              12.16.2  6fd35afe0ef9d35d3dcd41c67ddf882fc832a387221338153b7cd685a105495c \
-    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                            2.0.111  390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87 \
+    syn                              3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     temp-dir                        0.1.16  83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964 \
     tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     tera                            1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
-    terminal_size                    0.4.3  60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0 \
+    terminal_size                    0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.17  f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8 \
+    thiserror                       2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.17  3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913 \
+    thiserror-impl                  2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
     thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    time                            0.3.44  91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d \
-    time-core                        0.1.6  40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b \
-    time-macros                     0.2.24  30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3 \
+    time                            0.3.55  cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134 \
+    time-core                        0.1.9  9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109 \
+    time-macros                     0.2.32  7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85 \
     tinystr                          0.8.2  42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869 \
     tinyvec                         1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.49.0  72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86 \
-    tokio-macros                     2.6.0  af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5 \
+    tokio                           1.53.1  202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed \
+    tokio-macros                     2.7.2  78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e \
     tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
     tokio-stream                    0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
     tokio-util                      0.7.16  14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5 \
-    toml                             0.9.8  f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8 \
-    toml_datetime                    0.7.3  f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533 \
-    toml_parser                      1.0.4  c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e \
-    toml_writer                      1.0.4  df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2 \
+    toml                 0.9.12+spec-1.1.0  cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863 \
+    toml                  1.1.4+spec-1.1.0  3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5 \
+    toml_datetime         0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
+    toml_datetime         1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
+    toml_parser           1.1.3+spec-1.1.0  1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56 \
+    toml_writer           1.1.2+spec-1.1.0  7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2 \
     tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
     tower-http                       0.6.8  d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -367,9 +380,9 @@ cargo.crates \
     tracing-indicatif               0.3.14  e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-serde                    0.2.0  704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1 \
-    tracing-subscriber              0.3.22  2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e \
+    tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    typenum                         1.19.0  562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb \
+    typenum                         1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
     unicode-ident                   1.0.22  9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5 \
@@ -445,10 +458,11 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
     winnow                          0.7.14  5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829 \
+    winnow                           1.0.2  2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0 \
     wit-bindgen                     0.46.0  f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59 \
     writeable                        0.6.2  9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9 \
     xxhash-rust                     0.8.15  fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3 \
-    yaml-rust2                      0.10.4  2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9 \
+    yaml-rust2                      0.11.1  b36710ce3a279cfce8465dbab826f161675a262950b922cb2c3663852dfe9eb0 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.8.1  72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954 \
     yoke-derive                      0.8.1  b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d \
@@ -460,6 +474,7 @@ cargo.crates \
     zerotrie                         0.2.3  2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851 \
     zerovec                         0.11.5  6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002 \
     zerovec-derive                  0.11.2  eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3 \
+    zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
     zstd-safe                        7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \
     zstd-sys             2.0.16+zstd.1.5.7  91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748


### PR DESCRIPTION
#### Description

Verified with [dockhand](https://github.com/herbygillot/dockhand):
  — Tahoe: linted with 440 warnings, built in a pristine VM.

Branch head `da898bf0e0ef`, against the ports tree as of 2026-09-09.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

Automated by [dockhand](https://github.com/herbygillot/dockhand) 5dbf45a9b47c
