### PR TITLE
ralphex: update to 1.7.0

### DIFF
--- a/llm/ralphex/Portfile
+++ b/llm/ralphex/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/umputun/ralphex 1.6.1 v
+go.setup            github.com/umputun/ralphex 1.7.0 v
 revision            0
 categories          llm
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -19,9 +19,9 @@ build.pre_args-append \
                     TAG=v${version}
 build.args          build
 
-checksums           rmd160  16337580c7fe38866ca04c083cadf81760f12969 \
-                    sha256  634fd66449b340400464cd8e29269da1e4d4344baa5a01d3a70cb595e444603b \
-                    size    8257016
+checksums           rmd160  b955812b10f418a4901dd3890db2ac18580e5ce8 \
+                    sha256  edfcb9f34b14eb020561056d0e11950bb7ee4c5bea9ebe865523debb2bf706b9 \
+                    size    8461989
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/.bin/ralphex.v${version} ${destroot}${prefix}/bin/ralphex


### PR DESCRIPTION
#### Description
https://github.com/umputun/ralphex/blob/v1.7.0/CHANGELOG.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
