### PR TITLE
ladybug: update to 0.20.3

### DIFF
--- a/databases/ladybug/Portfile
+++ b/databases/ladybug/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           openssl 1.0
 
-github.setup        LadybugDB ladybug 0.20.2 v
+github.setup        LadybugDB ladybug 0.20.3 v
 github.tarball_from archive
 revision            0
 
@@ -13,7 +13,7 @@ homepage            https://ladybugdb.com/
 
 categories          databases
 license             MIT
-maintainers         @jrjsmrtn openmaintainer
+maintainers         {@jrjsmrtn gmail.com:jrjsmrtn} openmaintainer
 
 description         Embedded graph database built for query speed and scalability
 
@@ -25,15 +25,28 @@ long_description    LadybugDB is an embedded property-graph database with a \
                     It reads and writes Parquet, Arrow and DuckDB. This port \
                     installs the lbug shell and the C and C++ libraries.
 
-checksums           rmd160  1058544332c43cced047131c808bea05401c19c6 \
-                    sha256  c4dc6844479a799247f0cdf749522bb7597b78a97b90dbde0706601b207c928f \
-                    size    15691963
+checksums           rmd160  12d6112c9db53edb6e55ef23db92862fcd8e8a5a \
+                    sha256  22f2988274a43309676e2e996d3b2da6e2ca3e074c5bb7a69c5f9d484d98d511 \
+                    size    15700674
+
+# https://github.com/macports/macports-ports/pull/31641
+# too complex to build on old macOSes even with patched fresh LLVM headers
+platforms           {darwin >= 23}
 
 # std::atomic_ref and std::format need libc++ 17, which arrived with Xcode
 # 16.3; compiler.cxx_standard alone does not express a runtime requirement.
 compiler.cxx_standard 2020
 compiler.blacklist-append \
                     {clang < 1700}
+
+# Build auto-detects ccache if it is installed and attempts to write
+# to CCACHE_DIR, which is not allowed if configure.ccache=off.
+# Set CCACHE_DIR to the build directory instead.
+if {![option configure.ccache]} {
+    configure.env-append   CCACHE_DIR=${workpath}/.ccache
+    build.env-append       CCACHE_DIR=${workpath}/.ccache
+    destroot.env-append    CCACHE_DIR=${workpath}/.ccache
+}
 
 # scripts/collect-single-file-header.py assembles the installed lbug.hpp. It
 # imports only the standard library, and upstream asks for Python 3.9...4.


### PR DESCRIPTION
CC @barracuda156
No matter how hard I tried, LLVM version 16 wasn't enough on my machine (the code requires nearly full C++20 support); maybe it will work on your PowerPC with GCC.

###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
