### PR TITLE
atuin: update to 18.22.0

### DIFF
--- a/sysutils/atuin/Portfile
+++ b/sysutils/atuin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        atuinsh atuin 18.21.0 v
+github.setup        atuinsh atuin 18.22.0 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  503b3746cdf9569f40efd898735c24055f28e35c \
-                    sha256  05b18e62430f12cf55cb33edae98eb494eefce9ee124d48d2777ee0b1b8abede \
-                    size    3436583
+                    rmd160  f8b7b9d3c59e08a7be0d52bd1c5cce79a2925df6 \
+                    sha256  a1798f99dcd10864099ec8cd7d4f8babaedb9062017c50cddd197c05b637d965 \
+                    size    3587145
 
 depends_build-append \
                     port:protobuf3-cpp
@@ -117,6 +117,7 @@ cargo.crates \
     aho-corasick                       1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     allocator-api2                    0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android_system_properties          0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    ansi-to-tui                        8.0.1  e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd \
     anstream                           1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
     anstyle                           1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
     anstyle-parse                      1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
@@ -136,7 +137,7 @@ cargo.crates \
     atoi                               2.0.0  f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528 \
     atomic                             0.6.1  a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340 \
     atomic-waker                       1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    atuin-vt100                       0.17.1  5e1ab415760f579e398bed1931668a5a6866b5c1c7cf3718c889605534a76bab \
+    atuin-vt100                       0.19.0  4865fe19f666db926b68f57ed09b58af0a5da97ade148687c2c695fffad0765a \
     autocfg                            1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     axoprocess                         0.2.1  8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b \
     axotag                             0.3.0  dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b \
@@ -162,6 +163,8 @@ cargo.crates \
     byteorder                          1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                     0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                             1.12.1  fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04 \
+    bytesize                           2.7.0  7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b \
+    byteview                          0.10.2  0d74937895e761d5984206f82ca8ff7725d0fd8021921011921894b41ab1b9f7 \
     camino                             1.2.5  bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d \
     castaway                           0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
     cc                                1.2.64  dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f \
@@ -189,6 +192,7 @@ cargo.crates \
     colored                            2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     colored                            3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
     compact_str                        0.9.0  3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a \
+    compare                            0.0.6  ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7 \
     compression-codecs                0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
     compression-core                  0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
     condtype                           1.3.0  baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af \
@@ -208,6 +212,7 @@ cargo.crates \
     crossbeam-deque                    0.8.7  5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb \
     crossbeam-epoch                   0.9.20  2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f \
     crossbeam-queue                   0.3.12  0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115 \
+    crossbeam-skiplist                 0.1.3  df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b \
     crossbeam-utils                   0.8.22  61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17 \
     crossterm                         0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                   0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
@@ -243,6 +248,7 @@ cargo.crates \
     dotenvy                           0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     downcast-rs                        1.2.1  75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2 \
     dyn-clone                         1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
+    easy-cast                          0.7.1  eae1c5aaf1bfdc24a9b5bf6daf3afee62c478afe08706a6bd9fd996f73630494 \
     ed25519                            2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                      2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     either                            1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
@@ -268,6 +274,7 @@ cargo.crates \
     finl_unicode                       1.4.0  9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5 \
     fixedbitset                        0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     fixedbitset                        0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
+    fjall                             3.1.10  cd201c93927cdf4712e8f7d4c9c8d34d68c7534380c05d4a58864a309f91c33f \
     flate2                             1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
     flume                             0.12.0  5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be \
     fnv                                1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -347,6 +354,7 @@ cargo.crates \
     inout                              0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
     instability                       0.3.12  5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971 \
     interim                            0.2.1  a9ce9099a85f468663d3225bf87e85d0548968441e1db12248b996b24f0f5b5a \
+    interval-heap                      0.0.5  11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6 \
     ipnet                             2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
     is_terminal_polyfill              1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     iso8601                            0.6.3  e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46 \
@@ -376,6 +384,8 @@ cargo.crates \
     logos-codegen                     0.15.1  192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c \
     logos-derive                      0.15.1  605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470 \
     lru                               0.18.2  5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a \
+    lsm-tree                          3.1.10  5498808f4d41cf785079d3ef3f28716f1b4364af1b512f3097bfb651bded1b3e \
+    lz4_flex                          0.13.1  7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e \
     mac_address                        1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
     matchers                           0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     matchit                            0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
@@ -488,6 +498,7 @@ cargo.crates \
     quanta                            0.12.6  f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7 \
     quick-error                        1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quick-xml                         0.39.4  cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e \
+    quick_cache                       0.6.24  b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9 \
     quote                             1.0.47  1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001 \
     r-efi                              5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                              6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
@@ -524,12 +535,13 @@ cargo.crates \
     ring                             0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rmcp                               2.1.0  f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433 \
     rmp                               0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
-    rpassword                          7.4.0  66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39 \
+    rpassword                          7.5.4  2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196 \
     rstest                            0.26.1  f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49 \
     rstest_macros                     0.26.1  9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0 \
     rtoolbox                           0.0.3  a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f \
     runtime-format                     0.1.3  09958d5b38bca768ede7928c767c89a08ba568144a7b61992aecae79b03c8c94 \
     rustc-hash                         1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    rustc-hash                         2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                      0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                             1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls-pki-types                  1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
@@ -548,6 +560,7 @@ cargo.crates \
     security-framework                 3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys            2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
     self-replace                       1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
+    self_cell                          1.3.0  2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813 \
     semver                            1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                            1.0.229  4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba \
     serde_bytes                      0.11.19  a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8 \
@@ -562,6 +575,7 @@ cargo.crates \
     serde_with                        3.21.0  76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c \
     serde_with_macros                 3.21.0  84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660 \
     serial2                           0.2.36  fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3 \
+    sfa                                1.0.0  a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175 \
     sha1                              0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha2                              0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sha2                              0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
@@ -662,6 +676,7 @@ cargo.crates \
     tree_magic_mini                    3.2.2  b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6 \
     try-lock                           0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     tui-textarea-2                    0.10.2  74a31ca0965e3ff6a7ac5ecb02b20a88b4f68ebf138d8ae438e8510b27a1f00f \
+    twox-hash                          2.1.4  5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a \
     typed-builder                     0.23.2  31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda \
     typed-builder-macro               0.23.2  076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26 \
     typenum                           1.20.1  b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20 \
@@ -685,6 +700,7 @@ cargo.crates \
     utf8parse                          0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                              1.25.0  f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc \
     valuable                           0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
+    varint-rs                          2.2.1  bfa6c38708f6257f1ec2ca7e5a11f9bbf58a27d7060078b6b333624968183d96 \
     vcpkg                             0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                      0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vte                               0.15.0  a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd \


### PR DESCRIPTION
Submitted by [dockhand](https://github.com/herbygillot/dockhand):

Build **verified** at commit `ca56bc608710`
  — Tahoe: linted with 692 warnings, built in a pristine VM.
  — on macOS 26.6.2 (25G83), Xcode 26.6.

Written against the ports tree as of 2026-09-10.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

dockhand does not classify changes; the maintainer ticks the one that applies.

###### Tested on
- macOS Tahoe — built in a pristine VM, via dockhand

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port install` in a pristine VM

[dockhand](https://github.com/herbygillot/dockhand) 61ac0c827e0b-dirty
