### PR TITLE
derby: update to 10.17.1.0

### DIFF
--- a/java/derby/Portfile
+++ b/java/derby/Portfile
@@ -1,13 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               java 1.0
 
 name                    derby
-version                 10.9.1.0
+version                 10.17.1.0
 
 categories              java
 maintainers             nomaintainer
-platforms               darwin
+platforms               any
+supported_archs         noarch
+license                 Apache-2
+homepage                https://db.apache.org/derby
 
 description             Relational database implemented entirely in Java
 long_description        Apache Derby, an Apache DB subproject, is an open \
@@ -23,46 +27,82 @@ long_description        Apache Derby, an Apache DB subproject, is an open \
                         with the Derby Network Client JDBC driver and Derby \
                         Network Server.  5) Derby is easy to install, deploy, \
                         and use.
-homepage                https://db.apache.org/derby/
 
-master_sites            apache:db/derby/db-${name}-${version}
-distname                db-${name}-${version}-bin
-checksums               md5    32d81d803fd8ce449205dda1405ef6d3 \
-                        sha1   3d9e4f7b54e28c741277a41589ff8cd6ed74a07c \
-                        sha256 2f84bcddfd54aaab08aea431c93b8bf24b731aa343434923042ef57d6c6d8b30
+depends_build           bin:ant:apache-ant \
+                        port:junit
 
-depends_lib             bin:java:kaffe
-depends_run             port:rlwrap
+java.version            21+
+java.fallback           openjdk21
+
+master_sites            apache:db/${name}/db-${name}-${version}
+distname                db-${name}-${version}-src
+
+checksums               rmd160  7570006f4f641471ce11eaf9c1bcea3273b3f290 \
+                        sha256  7f8581d16b8815f6e2799620e7f109abd5a44e4979558a033ee3ba1280ec8739 \
+                        size    28204066
 
 use_configure           no
 
-build {}
+build.cmd               ant
+build.target            buildsource buildjars
+build.args              -Djunit="${prefix}/share/java/junit.jar"
 
 destroot {
-    set sharedir ${destroot}${prefix}/share
-    set man1dir ${sharedir}/man/man1
-    set derbydir ${sharedir}/derby
-    set docderbydir ${sharedir}/doc/derby
+    set destbindir  ${destroot}${prefix}/bin
+    set destdocdir  ${destroot}${prefix}/share/doc/${name}
+    set desthomedir ${destroot}${prefix}/share/${name}
+    set destjavadir ${destroot}${prefix}/share/java/${name}
 
-    # Ensure needed directories
-    xinstall -d -m 755 ${sharedir}/java ${docderbydir}
+    xinstall -d ${destjavadir}
+    xinstall -m 644 \
+        {*}[glob -directory ${worksrcpath}/jars/sane "*.\[jw]ar"] \
+        ${destjavadir}
 
-    file copy ${worksrcpath} ${derbydir}
+    xinstall -d ${destdocdir}
+    xinstall -m 644 \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/NOTICE \
+        ${worksrcpath}/README \
+        ${worksrcpath}/RELEASE-NOTES.html \
+        ${worksrcpath}/STATUS \
+        ${destdocdir}
 
-    foreach f { dblook ij sysinfo } {
-        xinstall -m 755 ${filespath}/${f} ${destroot}${prefix}/bin/${f}
-        reinplace "s|@PREFIX@|${prefix}|" ${destroot}${prefix}/bin/${f}
+    # Partially mimic the contents of the upstream binary distribution;
+    # needed for scripts as the value of $DERBY_HOME.
+    xinstall -d ${desthomedir}
+    copy ${worksrcpath}/generated/bin ${desthomedir}
+    ln -s ../java/${name} ${desthomedir}/lib
+
+    if {[variant_isset bin]} {
+        xinstall -d ${destbindir}
+        foreach script [glob -tails -directory ${desthomedir}/bin *] {
+            ln -s ../share/${name}/bin/${script} ${destbindir}
+        }
     }
 
-    foreach f { KEYS LICENSE NOTICE RELEASE-NOTES.html docs index.html javadoc } {
-        ln -s ../../derby/${f} ${docderbydir}/${f}
-    }
-
-    foreach f [ glob -tails -directory ${derbydir}/lib *.\[jw\]ar ] {
-        ln -s ../derby/lib/${f} ${sharedir}/java/${f}
+    if {[variant_isset doc]} {
+        copy ${worksrcpath}/javadoc ${destdocdir}
+        ln -s ../doc/${name}/javadoc/publishedapi ${desthomedir}/javadoc
     }
 }
 
+notes-append "
+The installed scripts require the environment variable DERBY_HOME to be
+set to \"${prefix}/share/${name}\".
+"
+
 livecheck.type          regex
-livecheck.url           "https://db.apache.org/derby/derby_downloads.html"
-livecheck.regex         release-(\[0-9.\]+)\.cgi
+livecheck.url           ${homepage}/derby_downloads.html
+livecheck.regex         "release-(\[0-9]+(\[._]\[0-9]+)*)\\.(cgi|html)"
+livecheck.version       [string map {. _} ${version}]
+
+variant bin \
+        description {Install symlinks to scripts} {
+    # Keep as variant due to scripts having generic names,
+    # increasing chances of a name conflict with another port.
+}
+
+variant doc \
+        description {Install javadoc} {
+    build.target-append javadoc
+}

--- a/java/derby/Portfile
+++ b/java/derby/Portfile
@@ -1,4 +1,6 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
 
 name                    derby
 version                 10.9.1.0
@@ -37,28 +39,28 @@ use_configure           no
 build {}
 
 destroot {
-        set sharedir ${destroot}${prefix}/share
-        set man1dir ${sharedir}/man/man1
-        set derbydir ${sharedir}/derby
-        set docderbydir ${sharedir}/doc/derby
+    set sharedir ${destroot}${prefix}/share
+    set man1dir ${sharedir}/man/man1
+    set derbydir ${sharedir}/derby
+    set docderbydir ${sharedir}/doc/derby
 
-        # Ensure needed directories
-        xinstall -d -m 755 ${sharedir}/java ${docderbydir}
+    # Ensure needed directories
+    xinstall -d -m 755 ${sharedir}/java ${docderbydir}
 
-        file copy ${worksrcpath} ${derbydir}
+    file copy ${worksrcpath} ${derbydir}
 
-        foreach f { dblook ij sysinfo } {
-                xinstall -m 755 ${filespath}/${f} ${destroot}${prefix}/bin/${f}
-                reinplace "s|@PREFIX@|${prefix}|" ${destroot}${prefix}/bin/${f}
-        }
+    foreach f { dblook ij sysinfo } {
+        xinstall -m 755 ${filespath}/${f} ${destroot}${prefix}/bin/${f}
+        reinplace "s|@PREFIX@|${prefix}|" ${destroot}${prefix}/bin/${f}
+    }
 
-        foreach f { KEYS LICENSE NOTICE RELEASE-NOTES.html docs index.html javadoc } {
-                ln -s ../../derby/${f} ${docderbydir}/${f}
-        }
+    foreach f { KEYS LICENSE NOTICE RELEASE-NOTES.html docs index.html javadoc } {
+        ln -s ../../derby/${f} ${docderbydir}/${f}
+    }
 
-        foreach f [ glob -tails -directory ${derbydir}/lib *.\[jw\]ar ] {
-                ln -s ../derby/lib/${f} ${sharedir}/java/${f}
-        }
+    foreach f [ glob -tails -directory ${derbydir}/lib *.\[jw\]ar ] {
+        ln -s ../derby/lib/${f} ${sharedir}/java/${f}
+    }
 }
 
 livecheck.type          regex

--- a/java/derby/files/dblook
+++ b/java/derby/files/dblook
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export DERBY_HOME=@PREFIX@/share/derby
-
-exec $DERBY_HOME/bin/dblook ${1+"$@"}

--- a/java/derby/files/ij
+++ b/java/derby/files/ij
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export DERBY_HOME=@PREFIX@/share/derby
-
-exec @PREFIX@/bin/rlwrap $DERBY_HOME/bin/ij ${1+"$@"}

--- a/java/derby/files/sysinfo
+++ b/java/derby/files/sysinfo
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export DERBY_HOME=@PREFIX@/share/derby
-
-exec $DERBY_HOME/bin/sysinfo ${1+"$@"}


### PR DESCRIPTION
#### Description

Update the `derby` port to version 10.17.1.0 and reformat the Portfile.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?