### PR TITLE
py-uharfbuzz: update to 0.56.1; use depended-on harfbuzz port

### DIFF
--- a/python/py-uharfbuzz/Portfile
+++ b/python/py-uharfbuzz/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-uharfbuzz
-version             0.56.0
+version             0.56.1
 revision            0
 categories          python graphics
 license             Apache-2
@@ -13,9 +13,9 @@ description         Streamlined Cython bindings for the HarfBuzz shaping engine.
 long_description    {*}${description}
 homepage            https://github.com/harfbuzz/uharfbuzz
 
-checksums           rmd160  f5584aca43ab1b7cc5ba24d8598c235b7758afd8 \
-                    sha256  77f4ad1c9f32f44cc6f0c0c4f98fab54587719c96c810a043d01669f704d3e0c \
-                    size    38643044
+checksums           rmd160  ea04e819b628699c019c76f8654210b8383d602c \
+                    sha256  a0a6928ed66b166a931ebe5df9ac551b9c42983513030233dcd95b41fa827f97 \
+                    size    39249661
 
 python.versions     310 311 312 313 314
 
@@ -26,4 +26,8 @@ if {${name} ne ${subport}} {
                      port:py${python.version}-setuptools_scm \
                      port:py${python.version}-wheel \
                      path:bin/pkg-config:pkgconfig
+
+    build.env-append USE_SYSTEM_LIBS=1
+
+    test.run         yes
 }


### PR DESCRIPTION
py-uharfbuzz already depended on harfbuzz, but did not use that dependency. This update sets USE_SYSTEM_LIBS=1 during its build, causing py-uharfbuzz to depend on dylibs from harfbuzz instead of building a copy for internal use.

This change also enables tests for py-uharfbuzz.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
