### PR TITLE
gopass: update to 1.17.2

### DIFF
--- a/devel/gopass-summon-provider/Portfile
+++ b/devel/gopass-summon-provider/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-summon-provider 1.17.0 v
+go.setup            github.com/gopasspw/gopass-summon-provider 1.17.2 v
 go.toolchain_min    1.24.1
 go.offline_build    no
 revision            0
@@ -16,9 +16,9 @@ description         Gopass Summon Provider
 
 long_description    Use gopass as secret provider for summon.
 
-checksums           rmd160  92c8ddab63796b1bbc1091f7d82244598e85a578 \
-                    sha256  882a4f2eb927e3e256b109400797929560faed14e89737bde6d51f61a62c1005 \
-                    size    14708
+checksums           rmd160  448773523288d389d0380293e7e22d557553f870 \
+                    sha256  50ed201e50fd77a8225fc26ed526914f19754558bfbb3ec52d7bb84eb414771b \
+                    size    16260
 
 build.cmd           ${go.bin} mod tidy \&\& ${go.bin} build
 build.args          -o ${worksrcpath}/${name} \

--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.17.0 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.17.2 v
 go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
@@ -19,9 +19,9 @@ description         Gopass git-credentials helper
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
-checksums           rmd160  e116eb0c4ffd13b272f1bf935e4f4beb2bc39705 \
-                    sha256  2efe7cc34ad18f4e12368d24528c5b589c9d0796a606ede8154ad6a412b05ad0 \
-                    size    24889
+checksums           rmd160  feb9572f4040bf3cf4db52fc717944dc4a12c0f0 \
+                    sha256  d73a0d7f9a062a2297b31f7aa2ba48447614fe194716d1034532ab9a6acacc06 \
+                    size    27167
 
 build.cmd           ${go.bin} mod tidy \&\& ${go.bin} build
 build.args          -ldflags '-X main.version=${version}'

--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.17.0 v
+go.setup            github.com/gopasspw/gopass-hibp 1.17.2 v
 go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
@@ -17,9 +17,9 @@ description         Gopass haveibeenpwnd.com integration
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
-checksums           rmd160  0c20604f7d787e07bfc254903f9a6da38d0dfa28 \
-                    sha256  db4ece704ea3ec62735da34967347206215674668ab8992567654dd4751940c0 \
-                    size    22303
+checksums           rmd160  9fc92f9e2d8302fda3c861726d1f4df80eeadb63 \
+                    sha256  4b7931ba62de64ef83565ade258830ec2f99acf2f403f913827cc2d78667f0f9 \
+                    size    24154
 
 build.cmd           ${go.bin} mod tidy \&\& ${go.bin} build
 build.args          -ldflags '-X main.version=${version}'

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.17.0 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.17.2 v
 go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
@@ -17,9 +17,9 @@ description         Gopass Browser Bindings
 long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
-checksums           rmd160  d3f204b1be6162b738a80cfdd0bf22adc76d2d5b \
-                    sha256  eb8f48f23219ef4cbc16944976a42bdcd5f1e74cb892cde3bd8a5aacf451f094 \
-                    size    34190
+checksums           rmd160  d75a842347ceb9bb93125e6a40944d8f17544f19 \
+                    sha256  b1369a2bad432386455d7aa3002f93910f9e275fc3c33e3f37f5731aa918f07a \
+                    size    35724
 
 build.cmd           ${go.bin} mod tidy && ${go.bin} build
 build.args          -ldflags '-X main.version=${version}' -tags=noscreenshot

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.17.0 v
+go.setup            github.com/gopasspw/gopass 1.17.2 v
 go.toolchain_min    1.25.0
 go.offline_build    no
 revision            0
@@ -19,9 +19,9 @@ homepage            https://www.gopass.pw
 
 depends_lib-append  port:gnupg2
 
-checksums           rmd160  c49e037b8260146a39edb4e811c74be6c3531477 \
-                    sha256  ce004c82b65ffac44de2991020843828b38bb510909506f2fa0f40bec05b7c75 \
-                    size    3153916
+checksums           rmd160  e1046cfbea0a9dab8a277134897ac2160ff08c47 \
+                    sha256  27a2fd9039d535282b3fb9160644dea97366c7c4e4d3dccc2706e20732b7ad67 \
+                    size    3157408
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -tags=netgo,noscreenshot


### PR DESCRIPTION
#### Description
* https://github.com/gopasspw/gopass/releases/tag/v1.17.2

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
