### PR TITLE
git[-devel]: fix osxkeychain revert patch

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -12,7 +12,7 @@ name                git
 # NOTE: Update the DEVEL version first before updating this RELEASE version,
 #       to verify that the intended version builds on all platforms.
 version             2.55.0
-revision            0
+revision            1
 
 description         A fast version control system
 
@@ -25,7 +25,7 @@ subport ${name}-devel {
 
     github.setup        git git 2.56.0-rc0 v
     github.tarball_from archive
-    revision            0
+    revision            1
     epoch               1
 
     description     \

--- a/devel/git/files/patch-Revert-breaking-osxkeychain.diff
+++ b/devel/git/files/patch-Revert-breaking-osxkeychain.diff
@@ -17,12 +17,13 @@ This reverts commit 9abe31f5f161be4d69118bdfae00103cd6efa510.
 
 This reverts commit b201316835bbf2c49c2780f23cfd6146f6b8d1a2.
 
+Leave the test target and .PHONY declarations intact so the Makefile hunk
+applies to both git and git-devel.
+
 ---
 --- a/contrib/credential/osxkeychain/Makefile
 +++ b/contrib/credential/osxkeychain/Makefile
-@@ -1,13 +1,26 @@
- # The default target of this Makefile is...
- all:: git-credential-osxkeychain
+@@ -3,10 +3,23 @@
  
 -git-credential-osxkeychain:
 -	$(MAKE) -C ../../.. contrib/credential/osxkeychain/git-credential-osxkeychain
@@ -51,8 +52,6 @@ This reverts commit b201316835bbf2c49c2780f23cfd6146f6b8d1a2.
 -	$(MAKE) -C ../../.. clean-git-credential-osxkeychain
 +	$(RM) git-credential-osxkeychain git-credential-osxkeychain.o
  
--.PHONY: all git-credential-osxkeychain install clean
-+.PHONY: all install clean
 --- a/contrib/credential/osxkeychain/git-credential-osxkeychain.c
 +++ b/contrib/credential/osxkeychain/git-credential-osxkeychain.c
 @@ -2,390 +2,113 @@


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
