### PR TITLE
luit: update to 2.0.20260907

### DIFF
--- a/x11/luit/Portfile
+++ b/x11/luit/Portfile
@@ -1,7 +1,9 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 
 name                luit
-version             2.0.20250912
+version             2.0.20260907
 categories          x11
 license             X11
 maintainers         {invisible-island.net:dickey @ThomasDickey} openmaintainer
@@ -15,14 +17,16 @@ master_sites        https://invisible-island.net/archives/${name}/current/ \
 
 extract.suffix      .tgz
 
-checksums           rmd160  c54901d23a11768f052aba0e254827292c0ce609 \
-                    sha256  7c4208326e231f72e1fc98f9c11be895e8ce84cb5888b7c7548834ad730e8404 \
-                    size    213320
+checksums           rmd160  f7e59971320447d711208217b10fddd83cdaee9b \
+                    sha256  82e3e9d5a9fd81a1035901b2522250504460a6f84e695546f224999d7270b4ee \
+                    size    214111
+
+configure.args-append --with-encodings-dir=${prefix}/share/fonts/encodings/encodings.dir
 
 installs_libs       no
 
 depends_build \
-	port:pkgconfig
+        port:pkgconfig
 
 livecheck.type    regex
 livecheck.regex   ${name}-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description

Update to latest release 2.0.20260907

###### Type(s)
minor compiler-warning and bug-fixes

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.9 24G830 x86_64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
