### PR TITLE
legacy-support: Update -devel to latest master (v20260910) + other tweaks

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -40,14 +40,14 @@ subport ${name} {
 subport ${name}-devel {
     conflicts           ${name}
     github.setup        macports macports-legacy-support \
-                        f89c155cbc2ca8714e4ada66c11b222353e8d87a
+                        d7744801e5d53b6134443968e96401d5e8ab5900
     github.tarball_from archive
-    version             20250924
+    version             20260910
     revision            0
     livecheck.type      none
-    checksums           rmd160  3d6ca0af242f859e201c387bde0b0e9aa6ce7883 \
-                        sha256  37c8483ac0594a009e1509f4ddd2eff42c4707cedba58a8ec34bcf779834e144 \
-                        size    228476
+    checksums           rmd160  2c6d5813f0b63bf650769d370f94963e6ca23461 \
+                        sha256  8381bf91ab5221650d284bc2c11f9bcd1320e3536cc23eb76afa57739e21dd6a \
+                        size    317452
     set v_split         [split ${release_ver} .]
     set so_curversion   [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }

--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           makefile 1.0
 
 name                legacy-support
 categories          devel
@@ -20,20 +19,22 @@ long_description    {*}${description}
 # Must now stay.
 epoch               1
 
+github.setup        macports macports-legacy-support 1.5.2 v
+revision            0
+github.tarball_from archive
+checksums           rmd160  58a9837f78a72cb2204d674cc41e028b10bff71b \
+                    sha256  16da882281d26d8ddfb434acfde0828fc3e4119aab332445f65688ae879e9962 \
+                    size    228427
+
 # Primary release version
-set release_ver     1.5.2
+set release_ver     ${github.version}
 
 # Binary compatibility version
 set compat_ver      1.0.0
 
 subport ${name} {
     conflicts           ${name}-devel
-    github.setup        macports macports-legacy-support ${release_ver} v
-    github.tarball_from archive
-    revision            0
-    checksums           rmd160  58a9837f78a72cb2204d674cc41e028b10bff71b \
-                        sha256  16da882281d26d8ddfb434acfde0828fc3e4119aab332445f65688ae879e9962 \
-                        size    228427
+    set so_curversion   ${release_ver}
 }
 
 subport ${name}-devel {
@@ -48,8 +49,14 @@ subport ${name}-devel {
                         sha256  37c8483ac0594a009e1509f4ddd2eff42c4707cedba58a8ec34bcf779834e144 \
                         size    228476
     set v_split         [split ${release_ver} .]
-    set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
+    set so_curversion   [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }
+
+# This port doesn't use C++ at all, except for two very limited tests
+# that are manual-only.  Disabling cxx_stdlib avoids unnessary compiler
+# constraints on some platforms.
+#
+configure.cxx_stdlib
 
 # Set up proper arch list for build and test
 if {![variant_isset universal]} {
@@ -58,40 +65,37 @@ if {![variant_isset universal]} {
     set archs       ${configure.universal_archs}
 }
 
-# Let the Makefile handle the archs setup
-configure.cc_archflags
-configure.cxx_archflags
-configure.ld_archflags
-configure.universal_cflags
-configure.universal_cxxflags
-configure.universal_ldflags
+# Simple make-based setup, with natural universal support
+use_configure       no
+universal_variant   yes
 
-# Pass the arch list to the Makefile
-build.env-append        ARCHS=${archs}
-destroot.env-append     ARCHS=${archs}
-test.env-append         ARCHS=${archs}
+# Set up the needed portion of the standard environment, plus our ARCHS
+foreach phase {build destroot} {
+    ${phase}.env-append    ARCHS=${archs} \
+                           CC=${configure.cc} \
+                           CXX=${configure.cxx} \
+                           PREFIX=${prefix}
 
-# Set test target for optional universal handling
+    # For some reason, omitting the unnecessary LDFLAGS definition causes
+    # a benign discrepancy in some otherwise reproducible builds on 11.x.
+    # For maximum consistency of installed content, we keep this for the
+    # release version for now.  This can be removed as of the next release.
+    #
+    if {${subport} eq ${name}} {
+        ${phase}.env-append    LDFLAGS=${configure.ldflags}
+    }
+}
+
+build.env-append    SOCURVERSION=${so_curversion} \
+                    SOCOMPATVERSION=${compat_ver}
+
+# Set test target for optional universal handling and testing all libs
 # For some reason, setting test.target doesn't work.
-test.pre_args       test_unv
+test.pre_args       test_all_unv
 
 # Enable parallel tests
 default test.jobs   ${build.jobs}
 test.post_args      -j${test.jobs}
-
-# The makefile PG brings in the unnecessary compiler_wrapper PG.
-# Disable it to reduce logfile clutter and obfuscation.
-#
-compwrap.compilers_to_wrap
-
-# This port doesn't use C++ at all, except for two very limited tests
-# that are manual-only.  Disabling cxx_stdlib avoids unnessary compiler
-# constraints on some platforms.
-#
-configure.cxx_stdlib
-
-build.env-append    SOCURVERSION=${release_ver} \
-                    SOCOMPATVERSION=${compat_ver}
 
 # Include Tiger-specific additions
 platform darwin 8 {


### PR DESCRIPTION
#### Description

Notable changes:

- Adds & fixes CommonDigest macros for <10.6
- Fixes some issues with SDK 27

- Implements aligned_alloc() for <10.15
- Updates "at" calls, to eliminate signal unsafety
- Implements mkfifoat(), mknodat() for <10.13
    See: https://trac.macports.org/ticket/72609
- Adds dummy ____chkstk_darwin for <10.14

- Implements O_CLOEXEC for <10.7
- Implements mkostemp[s] for <10.12
    See: https://trac.macports.org/ticket/73396
- Implements __exp10[f] for <10.9
    See: https://trac.macports.org/ticket/72977
- Handles unimplemented fsgetpath (<10.6) better
- Adds pkgconfig file

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.9 23J631, arm64, Xcode 16.2 16C5032a
macOS 15.7.9 24G830, arm64, Xcode 26.3 17C529
macOS 26.6.2 25G83, arm64, Xcode 26.6 17F113
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
