### PR TITLE
mp3rgain: update to 3.7.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 3.6.1 v
+github.setup        M-Igashi mp3rgain 3.7.0 v
 github.tarball_from archive
 revision            0
 
@@ -28,9 +28,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  43fc27dd578c99b18cda3bb78ba93048301014f3 \
-                    sha256  8d926c3665f7a6c09c91ce1bcc34cba92d822f9bff10bef6def0c048975cd3d3 \
-                    size    592915
+                    rmd160  d188e2b529189e0b9ebc8eca3492d87b3f0b9083 \
+                    sha256  aa3970087692f98b5724f5e78c9eef680faf437d756b4955c3b729b39f85017f \
+                    size    621396
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 3.7.0.

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.7.0

Upstream highlights: a data-safety fix for video MP4 files whose audio track was not detected and which could be corrupted by the MP3 code path, support for raw ADTS `.aac` streams, and formats mp3rgain cannot adjust (ALAC, DRM-protected M4P) are now reported as skipped instead of failing a batch.

Changes in this Portfile:

- `github.setup` bumped to 3.7.0, `revision` stays 0.
- All three distfile checksums recomputed (rmd160 / sha256 / size).
- `cargo.crates` regenerated from the 3.7.0 `Cargo.lock`. No dependency changed between 3.6.1 and 3.7.0, so the block is byte-identical to the merged one.

`port lint --nitpick` reports 0 errors. The 128 warnings are all "missing recommended checksum type: rmd160 / size" for the `cargo.crates` entries, which carry sha256 only by design; the currently merged 3.6.1 Portfile lints identically.