### PR TITLE
libblake3: new port

### DIFF
--- a/security/libblake3/Portfile
+++ b/security/libblake3/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+github.setup            BLAKE3-team BLAKE3 1.8.7
+github.tarball_from     archive
+name                    libblake3
+revision                0
+categories              security devel
+license                 {public-domain Apache-2}
+maintainers             {@commitmaniac} openmaintainer
+
+description             ${github.project} crytographic hash function
+long_description        ${name} is the C implementation of the {*}${description}. It is \
+                        much faster than MD5, SHA-1, SHA-2, SHA-3, and BLAKE2\; secure, \
+                        unlike MD5 and SHA-1\; secure against length extensions, unlike \
+                        SHA-2\; highly parallelizable, and capable of verified streaming \
+                        and incremental updates.
+
+checksums               rmd160  6afc0d73f9616bcc486bfd316bf53fd1fdf7e2e2 \
+                        sha256  c6782a28842b1c0478524ac06a4f2ede784038ee298d6e2162c0b089c4306a3c \
+                        size    268353
+
+patchfiles              cxx_std_20_on_tbb_only.patch
+
+cmake.source_dir        ${worksrcpath}/c
+compiler.c_standard     1999
+
+# error: invalid instruction mnemonic 'jc', 'jnc', 'jnz'
+# error: invalid operand for instruction 'jne', 'je', 'jz'
+# error: unknown use of instruction mnemonic without a size suffix 'jmp'
+compiler.blacklist-append \
+                        {clang < 1100}
+
+configure.args-append   -DBUILD_SHARED_LIBS=ON
+
+# Force portable C SIMD support on legacy platforms
+# See: https://trac.macports.org/ticket/63885#comment:24
+if {${configure.build_arch} in [list i386 ppc ppc64]} {
+    patchfiles-append   support_legacy_platforms.patch
+    configure.args-append \
+                        -DBLAKE3_SIMD_TYPE=none
+}

--- a/security/libblake3/files/cxx_std_20_on_tbb_only.patch
+++ b/security/libblake3/files/cxx_std_20_on_tbb_only.patch
@@ -1,0 +1,23 @@
+Only use C++20 when enabling BLAKE3_USE_TBB
+
+oneTBB parallelism is noted to require a C++20 capable
+compiler. Thus, the standard should not be enforced unless
+BLAKE3_USE_TBB is being used.
+
+See: https://github.com/BLAKE3-team/BLAKE3/tree/1.8.7/c#cmake
+===================================================================
+--- c/CMakeLists.txt.orig	2026-08-20 04:50:34.000000000 -0400
++++ c/CMakeLists.txt	2026-09-03 21:50:24.000000000 -0400
+@@ -155,8 +155,10 @@
+ )
+ target_compile_features(blake3 PUBLIC c_std_99)
+ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+-  target_compile_features(blake3 PUBLIC cxx_std_20)
+-  # else: add it further below through `BLAKE3_CMAKE_CXXFLAGS_*`
++  if(BLAKE3_USE_TBB)
++    target_compile_features(blake3 PUBLIC cxx_std_20)
++    # else: add it further below through `BLAKE3_CMAKE_CXXFLAGS_*`
++  endif()
+ endif()
+
+ # ensure C_EXTENSIONS OFF is respected without overriding CMAKE_C_STANDARD

--- a/security/libblake3/files/support_legacy_platforms.patch
+++ b/security/libblake3/files/support_legacy_platforms.patch
@@ -1,0 +1,34 @@
+Patches for blake3_dispatch.c to support old macOS toolchains.
+
+1. Remove #include <immintrin.h> from the GCC path.  Nothing in the
+   dispatch code uses intrinsics from that header, and it fails to
+   compile on old Xcode/GCC versions that ship with OS X 10.5-10.6.
+
+2. Encode the xgetbv instruction as raw bytes (.byte 0x0f, 0x01, 0xd0)
+   instead of using the "xgetbv" mnemonic.  Assemblers bundled with
+   Xcode 3.x do not recognize the mnemonic.
+
+From: https://github.com/macports/macports-base/pull/400
+===================================================================
+--- c/blake3_dispatch.c.orig	2026-04-04 21:39:16
++++ c/blake3_dispatch.c	2026-04-04 21:39:44
+@@ -11,9 +11,7 @@
+ #if defined(IS_X86)
+ #if defined(_MSC_VER)
+ #include <intrin.h>
+-#elif defined(__GNUC__)
+-#include <immintrin.h>
+-#else
++#elif !defined(__GNUC__)
+ #undef IS_X86 /* Unimplemented! */
+ #endif
+ #endif
+@@ -52,7 +50,7 @@
+   return _xgetbv(0);
+ #else
+   uint32_t eax = 0, edx = 0;
+-  __asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
++  __asm__ __volatile__(".byte 0x0f, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(0));
+   return ((uint64_t)edx << 32) | eax;
+ #endif
+ }


### PR DESCRIPTION
#### Description

Add the BLAKE3 C hash function implementation as a new port.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
