### PR TITLE
mergiraf: Update to 0.19.1

### DIFF
--- a/devel/mergiraf/Portfile
+++ b/devel/mergiraf/Portfile
@@ -4,11 +4,11 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               codeberg 1.0
 
-codeberg.setup          mergiraf mergiraf 0.16.3 v
+codeberg.setup          mergiraf mergiraf 0.19.1 v
 revision                0
 categories              devel
 license                 GPL-3
-platforms               {darwin >= 18}
+platforms               {darwin >= 17}
 maintainers             {@commitmaniac} openmaintainer
 
 description             Syntax-aware merger driver for Git
@@ -19,9 +19,9 @@ long_description        {*}${description}. ${name} is a syntax-aware git merge \
 homepage                https://mergiraf.org/
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  64d2790cd72cd6742d6bbb796fd84f4c5b596ae8 \
-                        sha256  c2f3f6b50496cbadb7d9caeb6cfc4e0dab8f99aaed5d9a560b30208cb68108f0 \
-                        size    1224487
+                        rmd160  b33fadecf471865d4beb54d9c265784a93f7043d \
+                        sha256  36ccbbd80a3f79bdb23e9e087c9109aeaaed9cc80d85a7722c8db0c0295d107f \
+                        size    1248653
 
 # See: https://trac.macports.org/ticket/73654
 depends_lib-append      port:libiconv
@@ -35,167 +35,190 @@ destroot {
 
 cargo.crates \
     adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
-    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                        0.6.21  43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a \
-    anstyle                         1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
-    anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
-    anstyle-query                    1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
-    anstyle-wincon                  3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
-    arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
-    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    bitflags                        2.10.0  812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3 \
+    anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
+    anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
+    anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
+    anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
+    arrayvec                         0.7.8  d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56 \
+    assert_cmd                       2.2.2  2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6 \
+    autocfg                          1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
+    bitflags                        2.13.0  b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8 \
     boxcar                          0.2.14  36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e \
-    bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
+    bstr                            1.12.3  5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79 \
+    bumpalo                         3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     caplog                           0.3.0  bbdcb96238cde014df69c939f039f328ce2fc58b717ad57188a3c2a3f62e7c0c \
-    cc                              1.2.43  739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2 \
+    cc                               1.4.3  509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
-    chrono                          0.4.42  145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2 \
-    clap                            4.5.50  0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623 \
-    clap_builder                    4.5.50  0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0 \
-    clap_derive                     4.5.49  2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671 \
-    clap_lex                         0.7.6  a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d \
-    colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
-    console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
+    chrono                          0.4.45  1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327 \
+    clap                             4.6.6  473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca \
+    clap_builder                     4.6.6  7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889 \
+    clap_derive                      4.6.4  d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061 \
+    clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
+    console                         0.16.4  4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
-    derive_arbitrary                 1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
     derive_more                    0.99.20  6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f \
     derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                 2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
+    diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     diffy-imara                      0.3.2  4429f9205ee235ccaac635400e19507240477be615c4631e3f18a0690881d6db \
-    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    either                          1.17.0  9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
-    etcetera                        0.10.0  26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6 \
-    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
-    find-msvc-tools                  0.1.4  52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127 \
+    etcetera                        0.11.0  de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96 \
+    fastrand                         2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
+    find-msvc-tools                 0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
-    flate2                           1.1.5  bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb \
+    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    float-cmp                       0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
+    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
+    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
+    getrandom                        0.4.3  300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099 \
     glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
-    hashbrown                       0.16.0  5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d \
+    hashbrown                       0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
-    home                            0.5.12  cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d \
-    iana-time-zone                  0.1.64  33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb \
+    iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     imara-diff                       0.1.8  17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                        2.12.0  6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f \
-    insta                           1.43.2  46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0 \
+    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
+    insta                           1.48.0  86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82 \
     integer-sqrt                     0.1.5  276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770 \
     is-terminal                     0.4.17  3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46 \
     is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
-    itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
-    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-    js-sys                          0.3.81  ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305 \
+    itertools                       0.15.0  8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+    js-sys                         0.3.103  53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.177  2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976 \
-    libz-rs-sys                      0.5.2  840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd \
-    linux-raw-sys                   0.11.0  df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039 \
-    log                             0.4.28  34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432 \
-    memchr                           2.7.6  f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273 \
+    libc                           0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
+    linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
+    log                             0.4.33  0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad \
+    memchr                           2.8.3  cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98 \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    nonempty-collections             1.1.0  31a568c637fdf524897b05f5a1a7061e8cd95980a5385d6de2064cb2b4f1cb1c \
+    nonempty-collections             1.4.0  988fb92b275335f315a9bddf7a8881a02c79c6084e9a626f656f12c50776a045 \
+    normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
     nu-ansi-term                    0.50.3  7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
-    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
-    oneshot                         0.1.11  b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea \
+    oneshot                          0.2.1  cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c \
     pathfinding                     3.0.14  cb45190a18e771c500291c549959777a3be38d30113a860930bc1f2119f0cc13 \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
-    proc-macro2                    1.0.103  5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8 \
-    quote                           1.0.41  ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1 \
+    predicates                       3.1.4  ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
+    predicates-core                 1.0.10  cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144 \
+    predicates-tree                 1.0.13  d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
+    pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
+    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    quote                           1.0.46  dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
-    rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
+    r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
+    rand                             0.9.5  b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
-    rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
-    regex                           1.12.2  843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4 \
-    regex-automata                  0.4.13  5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c \
-    regex-syntax                     0.8.8  7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58 \
+    rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    regex                           1.13.1  f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d \
+    regex-automata                  0.4.16  8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad \
+    regex-syntax                    0.8.11  d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4 \
     relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
     rstest                          0.26.1  f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49 \
     rstest_macros                   0.26.1  9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
-    rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
+    rustc-hash                       2.1.3  6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                           1.1.2  cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e \
-    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
-    ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
-    semver                          1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
+    rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
+    rustversion                     1.0.23  cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f \
+    semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                     1.0.145  402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c \
-    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
-    simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
+    serde_json                     1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
+    shlex                            2.0.1  f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba \
+    simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
+    slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     stderrlog                        0.6.0  61c910772f992ab17d32d6760e167d2353f4130ed50e796752689556af07dc6b \
     streaming-iterator               0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
-    syn                            2.0.108  da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917 \
-    tempfile                        3.23.0  2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16 \
+    syn                            2.0.118  1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422 \
+    syn                              3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
+    tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
+    termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.17  f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8 \
+    thiserror                       2.0.20  ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.17  3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913 \
-    thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
+    thiserror-impl                  2.0.20  bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af \
+    thread_local                    1.1.10  1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070 \
     tree-edit-distance               0.4.0  c71cf959f76103341744494caf1ace7f105244b980b1a3b848d5b1a070c42c16 \
-    tree-sitter                    0.25.10  78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87 \
-    tree-sitter-c                   0.24.1  1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707 \
-    tree-sitter-c-sharp             0.23.1  67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0 \
-    tree-sitter-cmake                0.7.1  7c1b35d1dd7396d24b3e826bb0f975b915ec7e9125b989d5e9d24ebb6a08509a \
+    tree-sitter                    0.26.12  83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec \
+    tree-sitter-bash                0.25.1  9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062 \
+    tree-sitter-c                   0.24.2  a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728 \
+    tree-sitter-c-sharp             0.23.5  c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c \
+    tree-sitter-cmake                0.7.4  164e0c4f4236ec5ceff14824a5528615cf462e100467e49826442ff57d327061 \
     tree-sitter-cpp                 0.23.4  df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743 \
-    tree-sitter-dart-orchard         0.3.1  9382be910c3596d479867dc5fc4a1b9d18d01a211df351b49eabd86be2b10b66 \
-    tree-sitter-devicetree          0.14.1  b1e6874b59d8252cbaf9750f7152166e17ed162921a5f6d4e8bd2a2bc2aed46b \
-    tree-sitter-elixir               0.3.4  e45d444647b4fd53d8fd32474c1b8bedc1baa22669ce3a78d083e365fa9a2d3f \
+    tree-sitter-dart-orchard         0.6.0  5e9e47f28354ae26b1ecfe2b2baa157e5145665d78838fe189008e921c0971eb \
+    tree-sitter-devicetree          0.15.0  6264316c288e1d4fed3002fb6c2d7a8e90d65d519e2ecf64a60c5abd0ee35481 \
+    tree-sitter-elixir               0.3.5  66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40 \
+    tree-sitter-erlang              0.20.0  3107efc581d335488dc38d2f51ca8b7a6a98e36f07f95a8e963f031edda6f568 \
+    tree-sitter-fortran              0.6.0  ea5fea41363a9b59666001dc26c4b356d4e164da27c6ce31145e00aba6bf9b16 \
+    tree-sitter-gleam                1.0.0  f0175c53793bda5d444360dd5add25463d18d66afb7f521d6791e2fc61bf2fb3 \
     tree-sitter-go                  0.25.0  c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea \
-    tree-sitter-gomod-orchard        0.5.1  5df18b7761a386d4685294d92f4fb3d6e0f806884da5b3d2fbe05661a8cdbf7b \
-    tree-sitter-gosum-orchard        0.3.1  3fea12d0ce8972510fb914e540bda4c584519b74973d55b75fc3162193043e16 \
+    tree-sitter-gomod-orchard        0.5.3  8755c634adc6dafdd0c622920be61facd377b6583949ff7904eee577ce01645d \
+    tree-sitter-gosum-orchard        0.3.3  4a269f866df50eea3531a91b3603c951a2d9459a54f6b19bb89c86d3c0eb05b4 \
     tree-sitter-haskell             0.23.1  977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4 \
     tree-sitter-hcl                  1.1.0  5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012 \
     tree-sitter-html                0.23.2  261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee \
-    tree-sitter-ini                  1.3.0  125cb3c7c59dae9e5b2d97002d2022680db3de7474c3fc48d99eb810e4ec80bb \
-    tree-sitter-java-orchard         0.3.1  2b5095f8359c26425924ae2d9ef12c0758a1f5d8c5fef80c4e75452b9c928367 \
+    tree-sitter-ini                  1.4.0  387f79682cd53b7c0a5777c96e601a02b9965a787984ef86dbb8952bdab2d62f \
+    tree-sitter-java-orchard        0.5.15  d653f4d9f16496ec19de6bcb7b7688d3f6b203c9c0af979bd5294fc058a3e16f \
     tree-sitter-javascript          0.25.0  68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5 \
     tree-sitter-json                0.24.8  4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471 \
     tree-sitter-kotlin-ng            1.1.0  e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450 \
-    tree-sitter-language             0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
-    tree-sitter-lua                  0.2.0  5cdb9adf0965fec58e7660cbb3a059dbb12ebeec9459e6dcbae3db004739641e \
+    tree-sitter-language             0.1.7  009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782 \
+    tree-sitter-lua                  0.5.0  8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c \
     tree-sitter-make                 1.1.1  c5998dc7cbcbdab19fae8aefef982bf2d6544513d8d2e69cc44aec4c63810104 \
-    tree-sitter-md                   0.5.1  2b55ea8733e098490746a07d6f629d1f7820e8953a4aab1341ae39123bcdf93d \
+    tree-sitter-matlab               1.3.0  8e8d8831a78547f54860dd8467166b1ab0c466d03d43c4bb447af55c024281f7 \
+    tree-sitter-md                   0.5.3  2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882 \
     tree-sitter-nix                  0.3.0  4952a9733f3a98f6683a0ccd1035d84ab7a52f7e84eeed58548d86765ad92de3 \
-    tree-sitter-ocaml               0.24.2  7d19db582b3855f56b5f9ec484170fbfb9ee60b938ec7720d76d2ee788e8b640 \
+    tree-sitter-ocaml               0.25.0  0b943275476bac8f73e08bc4050e21d89d61ff68e1751b789ba74917b9147a85 \
     tree-sitter-php                 0.24.2  0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592 \
     tree-sitter-properties           0.3.0  0a6c2f38dea68abd782573bb6ec3dbd14175cce2953f693055743925d785ceeb \
-    tree-sitter-python-orchard       0.4.1  2463fdf17ca0fbb6fb3b281f52aaf99e94e4733a5befd080f99e6f4b486e61e6 \
+    tree-sitter-python-orchard       0.4.3  b8394188966e4b4f8f02ea2f1fa0dfc9f5af372673f7741bd3669373d6bd3a70 \
+    tree-sitter-r                    1.3.0  ffc9954ec870dcad6cffdd302b405306c68cf031ed79a78cd9746f6740d9fe20 \
+    tree-sitter-requirements         0.6.1  ed29064ba695cb72a992d9f3fd9678a1000fd619954f0bc62afd937c61d9bbba \
     tree-sitter-ruby                0.23.1  be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95 \
-    tree-sitter-rust-orchard        0.14.0  df0f382b36b185d8e785d0f129dda8d79e22737ae29c9b63639ffc458db59a5b \
-    tree-sitter-scala               0.24.0  7516aeb3d1f40ede8e3045b163e86993b3434514dd06c34c0b75e782d9a0b251 \
+    tree-sitter-rust-orchard        0.16.8  1ef7e314bea5898ba33a1018251f0c5330e812fe71f5950f874ffcd85ab1ff10 \
+    tree-sitter-scala               0.26.2  24e0ab4505990bfe30051761d40a7bf4033ce5a81c9eda9e20e987a5cdc84826 \
+    tree-sitter-scheme              0.24.7  8a7e7f156bdf38145f26705d1733185698845307d3e9d9c071ecce4375575131 \
     tree-sitter-solidity            1.2.13  4eacf8875b70879f0cb670c60b233ad0b68752d9e1474e6c3ef168eea8a90b25 \
     tree-sitter-starlark             1.3.0  8934f282d085cc4b9ee28aa688aa3fbe8aa3766201c2a6252f411d45b4c3a721 \
-    tree-sitter-systemverilog        0.2.1  6bbc6b0711f1ba6ca2531a737aec150d3ee776146b81f1a02d6122f786d0517f \
+    tree-sitter-systemverilog        0.4.0  cc40d99fa6fb0a24b9eb62082b5667d40359b5da175d17d44052b3b1bf9dcca9 \
     tree-sitter-toml-ng              0.7.0  e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1 \
     tree-sitter-typescript          0.23.2  6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff \
     tree-sitter-xml                  0.7.0  e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3 \
     tree-sitter-yaml                 0.7.2  53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97 \
     typed-arena                      2.0.2  6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a \
-    unicode-ident                   1.0.20  462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06 \
+    typed-path                      0.12.3  8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e \
+    unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    wasip2                1.0.1+wasi-0.2.4  0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7 \
-    wasm-bindgen                   0.2.104  c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d \
-    wasm-bindgen-backend           0.2.104  671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19 \
-    wasm-bindgen-macro             0.2.104  7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119 \
-    wasm-bindgen-macro-support     0.2.104  9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7 \
-    wasm-bindgen-shared            0.2.104  bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1 \
+    wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
+    wasip2               1.0.4+wasi-0.2.12  b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487 \
+    wasm-bindgen                   0.2.126  4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4 \
+    wasm-bindgen-macro             0.2.126  167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1 \
+    wasm-bindgen-macro-support     0.2.126  f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e \
+    wasm-bindgen-shared            0.2.126  dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24 \
     winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
     windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
     windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \
@@ -203,30 +226,12 @@ cargo.crates \
     windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
     windows-result                   0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                  0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
-    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
-    windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-sys                     0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
-    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                 0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
-    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
-    windows_aarch64_gnullvm         0.53.1  a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
-    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
-    windows_aarch64_msvc            0.53.1  b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
-    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
-    windows_i686_gnu                0.53.1  960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
-    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
-    windows_i686_gnullvm            0.53.1  fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
-    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
-    windows_i686_msvc               0.53.1  1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
-    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
-    windows_x86_64_gnu              0.53.1  9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
-    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_gnullvm          0.53.1  0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
-    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    wit-bindgen                     0.46.0  f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59 \
-    zerocopy                        0.8.27  0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c \
-    zerocopy-derive                 0.8.27  88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831 \
-    zip                              6.0.0  eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b \
-    zlib-rs                          0.5.2  2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2 \
-    zopfli                           0.8.2  edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7
+    wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
+    yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
+    zerocopy                        0.8.54  b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19 \
+    zerocopy-derive                 0.8.54  e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5 \
+    zip                              8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
+    zlib-rs                          0.6.6  b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5 \
+    zmij                            1.0.23  29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b \
+    zopfli                           0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249


### PR DESCRIPTION
#### Description

Update mergiraf to 0.19.1.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
