### PR TITLE
ocicl: update to 2.18.0

### DIFF
--- a/devel/ocicl/Portfile
+++ b/devel/ocicl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ocicl ocicl 2.17.0 v
+github.setup        ocicl ocicl 2.18.0 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ long_description    ${name} is a modern alternative to quicklisp. It is modern i
                     \n- All software packages are built and published transparently using hosted CI infrastructure \
                     \n- LLM-generated summaries of changes between versions are available for all packages.
 
-checksums           rmd160  29d2848070620071bc29febba9cacb8344bec06b \
-                    sha256  6cc0337bd96f37e91fbac0335e77aa824e603234e862d3fcad7d345ca01b3923 \
-                    size    34149545
+checksums           rmd160  a7c52d95947d7fd543cca6f11f45b489d5362f02 \
+                    sha256  010cac0707f23860407e5f24317968922203f72474248474bcf94734206b60b3 \
+                    size    35089841
 
 depends_build       port:sbcl
 


### PR DESCRIPTION
#### Description

Update `ocicl` to v2.18.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.10 20G1427 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
