### PR TITLE
fish: update to 4.9.3

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -5,12 +5,12 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
-github.setup            fish-shell fish-shell 4.8.1
+github.setup            fish-shell fish-shell 4.9.3
 revision                0
 
-checksums               rmd160  44d6658ae3c46733f27638bc34ffbda6b10516c2 \
-                        sha256  0eb86a851e865e934a7c2091a73d7695225e78f0e00a7bb96d5f877d76c65782 \
-                        size    2619540
+checksums               rmd160  f0eac7a3f4270a75d3865b016f34a024dce17f6e \
+                        sha256  20998a25f73217ddcc19f499055fd587e9912d1ad6e7109120fbcf2871f0b98c \
+                        size    2628460
 
 name                    fish
 conflicts               fish3


### PR DESCRIPTION
#### Description

fish: update to 4.9.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.9 24G830 x86_64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
