### PR TITLE
ani-cli: update to 5.1, fixes streaming after anilist API outage

### DIFF
--- a/sysutils/fzfpp/Portfile
+++ b/sysutils/fzfpp/Portfile
@@ -9,8 +9,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 legacysupport.redirect_bins fzf
 
-github.setup        barracuda156 fzfpp 572639c4323115b5cd8579fded76463aaebb8899
-version             0.2.1
+github.setup        barracuda156 fzfpp 9073f6a4b96a678388da813c6202744942eb28c7
+version             0.4.0
 revision            0
 categories          sysutils
 license             BSD
@@ -21,23 +21,22 @@ long_description    fzf++ is a high-performance, API-compatible implementation \
                     It provides fuzzy matching with Smith-Waterman algorithm, \
                     interactive TUI with real-time filtering, multi-select mode, \
                     preview window with command execution and support for UTF-8.
-checksums           rmd160  52e12ab6bd79e677a910aba10ce081958cffa77b \
-                    sha256  dd56b9dda196731756a8bf1a39e09fdca14ee34e9a75d1c084aa97aaeece720e \
-                    size    112840
+checksums           rmd160  1e008a01c3ba4942bc5a10ef887c6373f945a1b7 \
+                    sha256  1437fe3e25f11b3e45824476cef8737a07475fd672fc4148b2caab19757f60d2 \
+                    size    223510
 github.tarball_from archive
 
 installs_libs       no
 conflicts           fzf
 
-depends_lib-append  port:CLI11 \
-                    port:utfcpp
+cmake.build_type    Release
+
+depends_lib-append  port:utfcpp
 
 configure.args-append \
-                    -DUSE_SYSTEM_CLI11=ON \
-                    -DUSE_SYSTEM_UTFCPP=ON \
-                    -DCMAKE_BUILD_TYPE=Release
+                    -DUSE_SYSTEM_UTFCPP=ON
 
-compiler.cxx_standard 2020
+compiler.cxx_standard   2020
 
 if {[string match *gcc* ${configure.compiler}] && ${configure.build_arch} in [list arm i386 ppc]} {
     configure.ldflags-append \

--- a/www/ani-cli/Portfile
+++ b/www/ani-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        pystardust ani-cli 5.0 v
+github.setup        pystardust ani-cli 5.1 v
 revision            0
 categories          www multimedia anime
 platforms           any
@@ -11,9 +11,9 @@ license             GPL-3
 maintainers         {@barracuda156 macos-powerpc.org:barracuda} openmaintainer
 description         CLI tool to browse and play anime
 long_description    {*}${description}
-checksums           rmd160  65685689613804c23272ca99f53ad4fbf490aacf \
-                    sha256  e4703d2f563eee27ea16d92f8e77e3f8a1f07ba8b2433598c3a1ce642841c35c \
-                    size    474006
+checksums           rmd160  ea613663dd605d1c1d130d61d14b2ce63cdfec0e \
+                    sha256  f7aa33b547b36ddb7e00ac23216b09ee08212161936d3b9e247bcce95fd2e041 \
+                    size    475554
 github.tarball_from archive
 supported_archs     noarch
 


### PR DESCRIPTION
#### Description

Fix `ani-cli` after recent anilist API breakage.
Update fallback for fzf to match closer to golang version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
