### PR TITLE
curl-impersonate: fix build with recent clang on macOS < 11

### DIFF
--- a/net/curl-impersonate/Portfile
+++ b/net/curl-impersonate/Portfile
@@ -151,8 +151,18 @@ patchfiles-append       0001-CMakeLists.patch \
                         0002-libiconv.patch \
                         0003-boringssl.patch
 
-if {${os.major} < 11 && [string match *gcc* ${configure.compiler}]} {
-    patchfiles-append   0004-zstd.patch
+platform darwin {
+    if {${os.major} < 11 && [string match *gcc* ${configure.compiler}]} {
+        patchfiles-append \
+                        0004-zstd.patch
+    }
+
+    # LLVM upstream deliberately breaks builds with -Werror when recent libc++ is used:
+    # availability.h:204:4: error: "The selected platform is no longer supported by libc++." [-Werror,-W#warnings]
+    if {${os.major} < 20 && ${configure.cxx_stdlib} eq "libc++"} {
+        patchfiles-append \
+                        0005-boringssl-no-werror.patch
+    }
 }
 
 post-patch {

--- a/net/curl-impersonate/files/0005-boringssl-no-werror.patch
+++ b/net/curl-impersonate/files/0005-boringssl-no-werror.patch
@@ -1,0 +1,11 @@
+--- a/deps/src/boringssl/CMakeLists.txt
++++ b/deps/src/boringssl/CMakeLists.txt	2026-09-12 12:09:44.000000000 +0800
+@@ -435,7 +435,7 @@
+ #
+ # TODO(crbug.com/389897612): Should these be set on a per-target basis?
+ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
+-  set(C_CXX_WARNINGS -Werror -Wformat=2 -Wmissing-field-initializers -Wshadow
++  set(C_CXX_WARNINGS -Wformat=2 -Wmissing-field-initializers -Wshadow
+       -Wsign-compare -Wtype-limits -Wvla -Wwrite-strings -Wimplicit-fallthrough)
+   set(C_WARNINGS -Wold-style-definition -Wstrict-prototypes)
+   set(CXX_WARNING -Wnon-virtual-dtor)


### PR DESCRIPTION
#### Description

Fix build with modern clang on pre-Big Sur macOS.
No revbump, this does not affect compiled code, only disables `-Werror` on older systems with `libc++`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.8
clang 22

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
