### PR TITLE
pdf2json: Update to 0.71

### DIFF
--- a/textproc/pdf2json/Portfile
+++ b/textproc/pdf2json/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        flexpaper pdf2json 0.69 v
-categories          textproc pdf
-platforms           darwin
-maintainers         {@flexpaper devaldi.com:pdf2json}
+github.setup        flexpaper pdf2json 0.71
+revision            0
+categories          textproc
+maintainers         {@flexpaper devaldi.com:pdf2json} openmaintainer
 license             GPL-2
 
 description         PDF to JSON conversion utility
@@ -17,16 +17,11 @@ long_description    PDF2JSON is a conversion library based on XPDF (3.02) \
 
 github.tarball_from releases
 
-checksums           rmd160  f86436c47973bbd1c7c297f8047019c385602b08 \
-                    sha256  69394ef5d5d5504f7106e8b55e15bf491c48d906d611e6bc2e5952005a85b593 \
-                    size    1156853
+checksums           rmd160  0966109200f64d69201ca9f7f369f6c56b757965 \
+                    sha256  0acaeeceec95c3d9b3727ac7fbb73dbbbfb6e3e6e1f36abd192eb22ca1ac73f5 \
+                    size    1214231
 
 extract.mkdir       yes
-
-post-extract {
-    # DOS to UNIX line endings so we can patch
-    reinplace "s|\r||g" ${worksrcpath}/Makefile.in
-}
 
 patchfiles          patch-Makefiles.diff
 


### PR DESCRIPTION
#### Description

Update pdfjson to 0.71.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
