### PR TITLE
java 1.0 PG: Add JDK 21 and 25 to default fallbacks

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -14,7 +14,8 @@
 #
 # - Java 8 and earlier are "1.8", etc.
 # - Java 9 and later are "9", etc.
-# - "+" and "*" wildcards are supported
+# - "+" and "*" wildcards are supported, e.g. "11+".
+# - X-Y ranges are supported, e.g. "1.8-11".
 #
 # If the required Java cannot be found, an error will be thrown at pre-fetch.
 
@@ -140,7 +141,11 @@ namespace eval java {
     proc java_get_default_fallback {} {
         global os.arch os.major java.version
         if {[option os.platform] eq "darwin"} {
-            if {${os.major} >= 18 && [vercmp ${java.version} < 18]} {
+            if {${os.major} >= 23 && [vercmp ${java.version} < 26]} {
+                return openjdk25
+            } else if {${os.major} >= 20 && [vercmp ${java.version} < 22]} {
+                return openjdk21
+            } else if {${os.major} >= 18 && [vercmp ${java.version} < 18]} {
                 return openjdk17
             } elseif {${os.major} >= 15 && [vercmp ${java.version} < 12]} {
                 return openjdk11


### PR DESCRIPTION
#### Description

Allow the `java` 1.0 PortGroup to set the default Java fallback to `openjdk21` or `openjdk25` if supported by the macOS system.  Support is judged based on whether the given macOS version was at one point a certified system configuration for [JDK 21](https://www.oracle.com/java/technologies/javase/products-doc-jdk21certconfig.html) or [JDK 25](https://www.oracle.com/java/technologies/javase/products-doc-jdk25certconfig.html), as I believe the other fallbacks (`openjdk8`, `openjdk11`, and `openjdk17`) are judged similarly.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?