### PR TITLE
jujutsu: add missing runtime dependency on libiconv

### DIFF
--- a/devel/jujutsu/Portfile
+++ b/devel/jujutsu/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 github.setup        jj-vcs jj 0.45.1 v
 github.tarball_from archive
 name                jujutsu
-revision            0
+revision            1
 
 description         A Git-compatible DVCS that is both simple and powerful
 
@@ -29,6 +29,8 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 conflicts           jj
+
+depends_lib-append  port:libiconv
 
 checksums           ${distname}${extract.suffix} \
                     rmd160  0ff219f1edc54ff40db11910bbdb4f669ae35bd0 \


### PR DESCRIPTION
#### Description

The jujutsu binary dynamically links against `/opt/local/lib/libiconv.2.dylib`. Because `devel/jujutsu/Portfile` does not declare `libiconv` as a dependency, running `port reclaim` or `port uninstall leaves` removes `libiconv`. This causes `jj` to fail with:

```
dyld: Library not loaded: /opt/local/lib/libiconv.2.dylib
  Referenced from: /opt/local/bin/jj
  Reason: tried: '/opt/local/lib/libiconv.2.dylib' (no such file)
```

This PR adds `depends_lib-append port:libiconv` and increments `revision` from 0 to 1.

Maintainer timeout (>72 hours on Trac ticket). CC @herbygillot.

Closes: https://trac.macports.org/ticket/74408

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.9 24G830 x86_64
Command Line Tools 26.2.0.0.1.1764812424

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
