### PR TITLE
mcp-inspector: update to 2.6.0

### DIFF
--- a/llm/mcp-inspector/Portfile
+++ b/llm/mcp-inspector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                mcp-inspector
-version             2.4.0
+version             2.6.0
 revision            0
 
 categories          llm
@@ -20,9 +20,9 @@ homepage            https://modelcontextprotocol.io/docs/tools/inspector
 npm.rootname        @modelcontextprotocol/inspector
 distname            inspector-${version}
 
-checksums           rmd160  7fd53ff0948737cc77ddeeb984dc03b51946c50a \
-                    sha256  8feb19f9bb47e76499738031285d3bbd6d64404c368320e7e26953facb7f1490 \
-                    size    1087450
+checksums           rmd160  dd0c7c03257933f775f240b5d0525008480f970a \
+                    sha256  e9bde03c45b62453d3b320b1dc2d2e8e997d172883b082b75deb938ef0c96a29 \
+                    size    1173987
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to MCP Inspector 2.6.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?