### PR TITLE
opencode: update to 1.18.30

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.18.26
+version             1.18.30
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  88618fe56110b7a2ec08bcea2ac706f3f78c2d42 \
-                    sha256  d3eabbc23b5ef7e9383697c689b3b919f504d2cba36dcabe1ccc8de67380acb5 \
-                    size    3046
+checksums           rmd160  31d60bafbc689257e6091f676698a30f4a231356 \
+                    sha256  3a97a99230d07fcbe6fd1ea2a001556297225d57f55d7880d3c9e6e29960ae90 \
+                    size    3051


### PR DESCRIPTION
#### Description

Update to OpenCode 1.18.30.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?