### PR TITLE
openspec: update to 1.13.0

### DIFF
--- a/llm/openspec/Portfile
+++ b/llm/openspec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                openspec
-version             1.11.0
+version             1.13.0
 revision            0
 
 categories          llm
@@ -23,6 +23,6 @@ homepage            https://openspec.dev
 npm.rootname        @fission-ai/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  a9ef8bb0cb155bb2c52de74b55e929d26512c1c7 \
-                    sha256  84820b173b57204bd7582a47ddae65e85fd492724172acc8e434e97ea1c05c3f \
-                    size    471694
+checksums           rmd160  347370b96c9086b7fda3f39e7507b456f137bb6a \
+                    sha256  f3c129f3f1e3aece105a4c1798301c7b6faeacec8a30eec8def63787e4d59ace \
+                    size    486144


### PR DESCRIPTION
#### Description

Update to OpenSpec 1.13.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?