### PR TITLE
gemini-cli: update to 0.59.0

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                gemini-cli
-version             0.58.0
+version             0.59.0
 revision            0
 
 categories          llm
@@ -21,9 +21,9 @@ homepage            https://geminicli.com
 npm.rootname        @google/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  e473d5a992a95b5420b31f7f26cc54b528db7804 \
-                    sha256  8ffeb9e7edddffb054764d00749f39e8cc9804ca9b38b9093f906dd2157322ae \
-                    size    20720999
+checksums           rmd160  a05cdb01d7c5a5203153fe748e0aa0264d2875a0 \
+                    sha256  59dc2cdb098b3000d36e34a185fc873932df4fd9d00900e817f2b19cd349d98b \
+                    size    20727247
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to Gemini CLI 0.59.0.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?