### PR TITLE
npm-1.0.tcl: reject a node older than npm.nodejs_version

### DIFF
--- a/_resources/port1.0/group/npm-1.0.tcl
+++ b/_resources/port1.0/group/npm-1.0.tcl
@@ -30,6 +30,35 @@ proc npm_add_dependencies {} {
 }
 port::register_callback npm_add_dependencies
 
+# A path: dependency is satisfied by ANY ${prefix}/bin/node, and the ten nodejs
+# ports all provide one while conflicting with each other. So a user holding
+# nodejs8 satisfies path:bin/node:nodejs22, no newer nodejs is pulled in, and the
+# port installs against a node it was never meant to run on -- silently, because
+# path: cannot express a minimum version. Fail early and say which port to
+# install instead.
+pre-fetch {
+    global npm.nodejs_version prefix name
+    set node ${prefix}/bin/node
+    # Not installed yet: the dependency will bring in the right one.
+    if {![file executable ${node}]} {
+        return
+    }
+    if {[catch {exec ${node} --version 2>@1} v]} {
+        ui_warn "could not determine the node version: ${v}"
+        return
+    }
+    if {![regexp {^v(\d+)\.} ${v} -> major]} {
+        ui_warn "could not parse the node version: ${v}"
+        return
+    }
+    if {${major} < ${npm.nodejs_version}} {
+        return -code error \
+            "${name} needs node ${npm.nodejs_version} or newer, but\
+             ${node} is ${v}. Install nodejs${npm.nodejs_version} first;\
+             the nodejs ports conflict, so the older one has to go."
+    }
+}
+
 # Pass the tarball distfile to 'npm install' directly, since running 'npm
 # install' from the extracted directory creates a symlink to the directory
 # (which gets removed). Since there's no need to extract the tarball, disable


### PR DESCRIPTION
#### Description

`path:bin/node:nodejs${npm.nodejs_version}` is satisfied by any `${prefix}/bin/node`, and the
ten nodejs ports each provide one while conflicting with each other. A user holding nodejs8
therefore satisfies `path:bin/node:nodejs22`: nothing newer is pulled in, and the port installs
against a node it was never meant to run on. `path:` cannot express a minimum version, so
nothing in the dependency graph catches it.

All 24 ports using the PortGroup are affected, not only the seven that set
`npm.nodejs_version`.

Verified in both directions: a port declaring 24 fetches normally under node 24.19.0, and the
same Portfile with 26 planted stops at fetch with exit 1 before downloading anything.

This is a mitigation rather than a fix: it is needed only because the nodejs ports conflict,
so `path:` has to accept whichever single one is installed. https://trac.macports.org/ticket/63035
tracks making them coexist, which would make the guard unnecessary.

cc @reneeotten, who raised this on https://github.com/macports/macports-ports/pull/34520

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

This changes a PortGroup rather than a Portfile, so the per-port items are left unticked:
`sudo port test`, a full install and binary/variant checks apply to a port, and this was
exercised through `graphics/vega` at `fetch` in both the passing and failing direction. Trace
mode is unavailable here — `darwintrace.dylib` has no `arm64e` slice — so `-vst` is not
something I can honestly tick.
