### PR TITLE
glib2: sync with glib2-devel regarding dbus improvements

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -13,7 +13,7 @@ name                        glib2
 conflicts                   glib2-devel
 set my_name                 glib
 version                     2.88.3
-revision                    1
+revision                    2
 epoch                       1
 
 checksums                   rmd160  5237604ee7a76cbbd8e7dd6c7b2b4715a8f56a52 \
@@ -77,8 +77,7 @@ depends_build-append        port:gettext \
                             path:bin/pkg-config:pkgconfig \
                             port:gobject-introspection-bootstrap
 
-depends_lib-append          port:dbus \
-                            port:gettext-runtime \
+depends_lib-append          port:gettext-runtime \
                             port:libelf \
                             port:libffi \
                             port:libiconv \
@@ -133,6 +132,10 @@ if {${universal_possible} && [variant_isset universal]} {
         # strip the automatic setting of host, meson does not accept
         set merger_host(${my_arch}) ""
     }
+
+    # dbus is used for specific tests but isn't a hard build/library requirement. The build fails with +universal
+    # because dbus isn't guaranteed to be install with +universal
+    configure.args-append   -Dtests=false
 }
 
 post-patch {
@@ -227,6 +230,20 @@ if {![variant_isset quartz] && ![variant_isset x11]} {
     pre-configure {
         return -code error "Either +x11 or +quartz is required"
     }
+}
+
+variant dbus description {Build with dbus support} {
+    depends_lib-append      port:dbus
+}
+
+default_variants-append     +dbus
+
+if {![variant_isset dbus]} {
+    # Need to disable dbus to avoid crashes when dbus is installed
+    # https://gitlab.gnome.org/GNOME/gimp/-/issues/13672
+    depends_lib-delete      port:dbus
+    patchfiles-append       patch-gapplicationimpl-dbus.c.diff
+    configure.args-append   -Dtests=false
 }
 
 subport glib2-bootstrap {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
