### PR TITLE
go ports: fetch renamed vendors from their current repo (part 2)

### DIFF
--- a/devel/gomodctl/Portfile
+++ b/devel/gomodctl/Portfile
@@ -156,10 +156,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/sirupsen/logrus \
                         lock    v1.2.0 \
                         rmd160  0b4ca1815b1dee5fd215d3b4bd316e082f6e7add \

--- a/devel/mos-devel/Portfile
+++ b/devel/mos-devel/Portfile
@@ -210,10 +210,11 @@ go.vendors          k8s.io/klog \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/skratchdot/open-golang \
                         lock    75fb7ed4208c \
                         rmd160  b13b1d27e33a2ee83b251bbdcc94b9cc2c81dab5 \
@@ -341,10 +342,11 @@ go.vendors          k8s.io/klog \
                         sha256  ce27afd2576a5bc82565c8aa2ef108b1bb3c4dd80ebb4939455cab2495b74a2f \
                         size    5943 \
                     github.com/imdario/mergo \
+                        repo    github.com/darccio/mergo \
                         lock    v0.3.9 \
-                        rmd160  7a66d9534dce8695eca218269e89837325aaea9c \
-                        sha256  ebfc936c04b3676e5ce8bb1bba848b94f1fe3d64af842451ff7b863841bb1286 \
-                        size    18920 \
+                        rmd160  38a09135d5b91ba7fd13c5a2614ee397ddf9e6c1 \
+                        sha256  abd17a0a8b34b0658e801546f3bc85cbf170f460f69440695d1ebf8285a0d339 \
+                        size    18924 \
                     github.com/gopherjs/gopherjs \
                         lock    0766667cb4d1 \
                         rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \

--- a/devel/mos/Portfile
+++ b/devel/mos/Portfile
@@ -209,10 +209,11 @@ go.vendors          k8s.io/klog \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/skratchdot/open-golang \
                         lock    75fb7ed4208c \
                         rmd160  b13b1d27e33a2ee83b251bbdcc94b9cc2c81dab5 \
@@ -340,10 +341,11 @@ go.vendors          k8s.io/klog \
                         sha256  ce27afd2576a5bc82565c8aa2ef108b1bb3c4dd80ebb4939455cab2495b74a2f \
                         size    5943 \
                     github.com/imdario/mergo \
+                        repo    github.com/darccio/mergo \
                         lock    v0.3.9 \
-                        rmd160  7a66d9534dce8695eca218269e89837325aaea9c \
-                        sha256  ebfc936c04b3676e5ce8bb1bba848b94f1fe3d64af842451ff7b863841bb1286 \
-                        size    18920 \
+                        rmd160  38a09135d5b91ba7fd13c5a2614ee397ddf9e6c1 \
+                        sha256  abd17a0a8b34b0658e801546f3bc85cbf170f460f69440695d1ebf8285a0d339 \
+                        size    18924 \
                     github.com/gopherjs/gopherjs \
                         lock    0766667cb4d1 \
                         rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \

--- a/sysutils/kubeval/Portfile
+++ b/sysutils/kubeval/Portfile
@@ -131,10 +131,11 @@ go.vendors          sigs.k8s.io/yaml \
                         sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
                         size    1478824 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \

--- a/sysutils/leaf/Portfile
+++ b/sysutils/leaf/Portfile
@@ -115,10 +115,11 @@ go.vendors          golang.org/x/xerrors \
                         sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
                         size    20992 \
                     github.com/smartystreets/assertions \
+                        repo    github.com/smarty/assertions \
                         lock    b2de0cb4f26d \
-                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
-                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
-                        size    52177 \
+                        rmd160  59a3d1fabff343e90465049f976996f6c306a582 \
+                        sha256  bf4819ccb9021d83e9b33e374f18d5bb752072b35b14ef800dded3c3a5dd4b02 \
+                        size    52210 \
                     github.com/spf13/cobra \
                         lock    v0.0.6 \
                         rmd160  ae15786490f8d48d0cb17b2c98fa55ef744f1c66 \
@@ -220,10 +221,11 @@ go.vendors          golang.org/x/xerrors \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/jtolds/gls \
+                        repo    github.com/jtolio/gls \
                         lock    v4.20.0 \
-                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
-                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
-                        size    7305 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
                     gopkg.in/ini.v1 \
                         lock    v1.52.0 \
                         rmd160  1854467781d01b8256bfbc9d3a3c96e7df213920 \


### PR DESCRIPTION
#### Description

The remaining five ports affected by the vendor renames handled in the
pull request below: github.com/smartystreets/assertions has moved to
smarty, imdario/mergo to darccio and jtolds/gls to jtolio. GitHub names a
tarball's top-level directory for the repo that currently owns it, so the
bytes changed while the pinned commit did not, and the recorded checksums
can no longer be obtained from upstream.

These five are separated because they do not build, for a reason this
change neither causes nor fixes: each pins a golang.org/x/sys revision
that the current Go toolchain rejects with "//go:linkname must refer to
declared function or variable". The buildbot has been failing mos and
mos-devel since 2026-02-06 and gomodctl, kubeval and leaf since
2026-08-26. Verified independently of MacPorts: the three pinned x/sys
revisions fail to compile under both Go 1.26 and Go 1.27, while the
revision trojan-go pins compiles cleanly.

The fetch fix is still correct and still needed -- it is what these ports
will need once they build again -- but expect CI to stay red here until

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

The install and test items cannot be ticked: these five ports do not build, for the
pre-existing toolchain reason described above, reported as
https://trac.macports.org/ticket/74410 (and https://trac.macports.org/ticket/72088 for
kubeval). Fetch and checksum verification pass for
all five on arm64, which is the whole of what this change affects. Trace mode is
unavailable on this machine (`darwintrace.dylib` has no arm64e slice), so `-vst` is not
something I can honestly claim.
