### PR TITLE
hwloc: Update to 2.14.0

### DIFF
--- a/devel/hwloc/Portfile
+++ b/devel/hwloc/Portfile
@@ -8,9 +8,9 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 8
 
 name                hwloc
-version             2.12.2
+version             2.14.0
 set branch          [join [lrange [split ${version} .] 0 [llength [split ${version} .] ]-2 ] .]
-revision            1
+revision            0
 epoch               1
 categories          devel
 maintainers         {i0ntempest @i0ntempest} openmaintainer
@@ -26,10 +26,11 @@ long_description \
 
 homepage            https://www.open-mpi.org/projects/hwloc/
 master_sites        https://www.open-mpi.org/software/hwloc/v${branch}/downloads/
+use_bzip2           yes
 
-checksums           rmd160  da945a71aebd13eea55c35a23fea093a3b8a32ef \
-                    sha256  ff7d309fdff7ceddfe15c1e79eaff25f3126a134f29f44d4e85571f187a6bab8 \
-                    size    6185554
+checksums           rmd160  35e235337aef80988b60e2e9d3134a3d2206c2b0 \
+                    sha256  966b9bb3e9f29f8d65ce8d106779e457f40e246a645e584b100772a42f9ae94b \
+                    size    5707694
 
 depends_build       path:bin/pkg-config:pkgconfig
 depends_lib-append  port:libxml2 \


### PR DESCRIPTION
#### Description

* Update hwloc 2.12.2 --> 2.14.0.
* Switch to bzip2 distfile from upstream.

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?