### PR TITLE
mq: update to 0.8.5, and run the test suite

### DIFF
--- a/textproc/mq/Portfile
+++ b/textproc/mq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        harehare mq 0.8.4 v
+github.setup        harehare mq 0.8.5 v
 github.tarball_from archive
 revision            0
 
@@ -24,14 +24,22 @@ maintainers         @jrjsmrtn openmaintainer
 homepage            https://mqlang.org
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ed2043eef78219f6bf72597ffaa37e03eab0613c \
-                    sha256  df0033bffa4886f927640d93f0aae7b175bb45b5de43b60cfa69924eb83a32bc \
-                    size    7564691
+                    rmd160  c61ea3030f557d13fa61bcb4c0fde7bfd0cfc797 \
+                    sha256  02e83968f7c63e0b9ae1e225dfeef43bf57bdb3932bd3286467827cebfd679ce \
+                    size    7724992
 
 # The upstream workspace also holds a WASM build, a web API, a language server
 # and a Zed extension. Only the CLI crate is built; its mq-dbg binary needs the
 # non-default "debugger" feature and is therefore not produced.
 build.args-append   -p mq-run
+
+# The workspace's other members (WASM, web API, language server, Zed
+# extension) are neither built nor tested here, so the suite is scoped to the
+# crates the CLI is made of.
+test.run            yes
+test.cmd            ${cargo.bin} test
+test.args           --target [cargo.rust_platform] \
+                    -p mq-run -p mq-lang -p mq-markdown
 
 post-build {
     # mq writes a completion script to stdout for each supported shell.
@@ -205,7 +213,7 @@ cargo.crates \
     fantoccini                      0.22.1  7737298823a6f9ca743e372e8cb03658d55354fbab843424f575706ba9563046 \
     fastrand                         2.5.0  da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223 \
     find-msvc-tools                 0.1.11  d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890 \
-    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    flate2                          1.1.10  6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb \
     fluent-uri                       0.4.1  bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
@@ -321,6 +329,7 @@ cargo.crates \
     minicov                          0.3.9  c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    miniz_oxide                      0.9.1  b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c \
     mio                              1.2.2  30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427 \
     new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
@@ -384,7 +393,7 @@ cargo.crates \
     prost-derive                    0.14.4  b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf \
     prost-types                     0.14.4  f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
-    quick-xml                       0.41.0  e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1 \
+    quick-xml                       0.42.0  41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b \
     quinn                          0.11.11  0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8 \
     quinn-proto                    0.11.17  04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83 \
     quinn-udp                       0.5.15  35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694 \
@@ -484,7 +493,7 @@ cargo.crates \
     supports-hyperlinks              3.2.0  e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91 \
     supports-unicode                 3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
     syn                            2.0.119  872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297 \
-    syn                              3.0.3  53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3 \
+    syn                              3.0.4  e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     system-configuration             0.7.0  a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
@@ -529,7 +538,7 @@ cargo.crates \
     topological-sort                 0.2.2  ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d \
     tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                      0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
-    tower-http                       0.7.0  b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233 \
+    tower-http                       0.7.1  08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-lsp-server                0.23.0  2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72 \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
@@ -564,7 +573,7 @@ cargo.crates \
     utoipa-gen                       5.5.0  6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8 \
     utoipa-swagger-ui                9.0.2  d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55 \
     utoipa-swagger-ui-vendored       0.1.2  e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d \
-    uuid                            1.24.1  2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9 \
+    uuid                            1.26.0  b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812 \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
@@ -590,7 +599,7 @@ cargo.crates \
     webdriver                       0.53.0  91d53921e1bef27512fa358179c9a22428d55778d2c2ae3c5c37a52b82ce6e92 \
     webpki-root-certs                1.0.9  b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b \
     webpki-roots                     1.0.9  7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a \
-    which                            8.0.5  8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c \
+    which                            8.0.6  bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f \
     winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
     windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
     windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \


### PR DESCRIPTION
#### Description

Update to 0.8.5. Crate manifest regenerated from the new `Cargo.lock` with `cargo2port`:
six crates bumped and `miniz_oxide` added.

Also declares the test suite, scoped to `mq-run`, `mq-lang` and `mq-markdown` — the crates
the CLI is built from. The workspace's other members (WASM, web API, language server, Zed
extension) are neither built nor shipped here.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`sudo port test` passes: 6456 tests across 13 binaries, 0 failed, resolved offline against
the vendored crates. Built from a cold distfile cache, which exercises the new tarball
checksums and all 598 regenerated crate entries; the staged binary reports `mq 0.8.5`.

Not a full `-vst install`: trace mode cannot run on this machine, as `darwintrace.dylib`
ships no arm64e slice, so that box and the binary-functionality box stay unticked rather
than claimed.
