### PR TITLE
micronaut: update to 5.1.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 5.1.3 v
+github.setup    micronaut-projects micronaut-starter 5.1.5 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  f6426946518c4770242c625db62780ab4b67aa61 \
-                 sha256  5bfd7aee1161f9a915bba748eee4e0d38027adc02375f8f3d7609fd2c33a1f23 \
-                 size    34085187
+    checksums    rmd160  6d2c0a63d57798315b9da9a2fa0b080e65c126ce \
+                 sha256  9526bfdeb0c5dc4e21b3cca8795e2e34faab9248453e3ed3effc4bec79fab432 \
+                 size    34122115
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  8ad2e91abd1af886caf968ea75468c71992f016d \
-                 sha256  31a42a2a82c4f6277f71f45ad588f3e2c3237cf8cbbade136b5785a82a8c8a89 \
-                 size    39147495
+    checksums    rmd160  2d2596569d1767a7d8441b02e7e6533d58ad41b7 \
+                 sha256  3a5abbdf5b9dde9c0a780546cdfb65869482e266c521dac9e16e049c43c51b7d \
+                 size    39219217
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 5.1.5.

###### Tested on

macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?