### PR TITLE
glib2: forgot to commit the .patch file

### DIFF
--- a/devel/glib2/files/patch-gapplicationimpl-dbus.c.diff
+++ b/devel/glib2/files/patch-gapplicationimpl-dbus.c.diff
@@ -1,0 +1,13 @@
+diff --git gio/gapplicationimpl-dbus.c gio/gapplicationimpl-dbus.c
+index d133f5a0e..50531fc1c 100644
+--- gio/gapplicationimpl-dbus.c
++++ gio/gapplicationimpl-dbus.c
+@@ -648,7 +648,7 @@ g_application_impl_register (GApplication        *application,
+   if (~flags & G_APPLICATION_NON_UNIQUE)
+     impl->bus_name = appid;
+ 
+-  impl->session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, cancellable, NULL);
++  impl->session_bus = NULL;
+ 
+   if (impl->session_bus == NULL)
+     {


### PR DESCRIPTION


#### Description

This completes a702f9b726d2a48092eed32bec5191d4499c74ff

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.6.2 25G83 arm64
Xcode 26.6 17F113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
